### PR TITLE
feat: Add task sharing between Lead and coworkers

### DIFF
--- a/src/bin/midtown/cli/coworker.rs
+++ b/src/bin/midtown/cli/coworker.rs
@@ -29,6 +29,8 @@ pub enum CoworkerCommand {
     },
     /// Handle Claude Code stop hook (checks for unclaimed tasks)
     StopHook,
+    /// Link this session's tasks to the Lead's task directory (SessionStart hook)
+    LinkTasks,
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -59,6 +61,7 @@ pub fn handle(cmd: &CoworkerCommand, client: &DaemonClient) -> Result<Response, 
         CoworkerCommand::Nudge { name, message } => client.coworker_nudge(name, message.as_deref()),
         CoworkerCommand::NudgeConfig { command } => handle_nudge_config(command, client),
         CoworkerCommand::StopHook => handle_stop_hook_standalone(),
+        CoworkerCommand::LinkTasks => handle_link_tasks_standalone(),
     }
 }
 
@@ -172,4 +175,81 @@ fn handle_nudge_config(
         NudgeConfigCommand::Enable => client.nudge_config_enable(true),
         NudgeConfigCommand::Disable => client.nudge_config_enable(false),
     }
+}
+
+/// Link this coworker's task directory to the Lead's.
+///
+/// Called by SessionStart hook to share tasks across sessions.
+pub fn handle_link_tasks_standalone() -> Result<Response, String> {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    // Get repo name to find Lead's session file
+    let repo = detect_git_repo().ok_or("Not in a git repository")?;
+
+    // Read Lead's session UUID from ~/.midtown/<repo>/lead-session
+    let home = dirs::home_dir().ok_or("Cannot determine home directory")?;
+    let lead_session_file = home.join(".midtown").join(&repo).join("lead-session");
+
+    let lead_uuid = fs::read_to_string(&lead_session_file)
+        .map_err(|_| {
+            format!(
+                "Lead session not found at {:?}. Is midtown running?",
+                lead_session_file
+            )
+        })?
+        .trim()
+        .to_string();
+
+    // Find this session's task directory (newest in ~/.claude/tasks/)
+    let tasks_dir = home.join(".claude").join("tasks");
+    let my_uuid = find_newest_task_dir(&tasks_dir)?;
+
+    // Don't link to ourselves
+    if my_uuid == lead_uuid {
+        return Ok(Response::Message {
+            message: "Already using Lead's task directory".to_string(),
+        });
+    }
+
+    let my_task_dir = tasks_dir.join(&my_uuid);
+    let lead_task_dir = tasks_dir.join(&lead_uuid);
+
+    // Verify Lead's task dir exists
+    if !lead_task_dir.exists() {
+        return Err(format!(
+            "Lead's task directory not found: {:?}",
+            lead_task_dir
+        ));
+    }
+
+    // Remove our task dir and replace with symlink
+    if my_task_dir.exists() {
+        fs::remove_dir_all(&my_task_dir)
+            .map_err(|e| format!("Failed to remove task directory: {}", e))?;
+    }
+
+    symlink(&lead_task_dir, &my_task_dir)
+        .map_err(|e| format!("Failed to create symlink: {}", e))?;
+
+    Ok(Response::Message {
+        message: format!("Linked tasks: {} -> {}", my_uuid, lead_uuid),
+    })
+}
+
+/// Find the most recently created directory in the given path.
+fn find_newest_task_dir(tasks_dir: &std::path::Path) -> Result<String, String> {
+    use std::fs;
+
+    let entries: Vec<_> = fs::read_dir(tasks_dir)
+        .map_err(|e| format!("Cannot read tasks directory: {}", e))?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .collect();
+
+    entries
+        .iter()
+        .max_by_key(|e| e.metadata().and_then(|m| m.created()).ok())
+        .and_then(|e| e.file_name().to_str().map(|s| s.to_string()))
+        .ok_or_else(|| "No task directories found".to_string())
 }

--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -358,6 +358,67 @@ pub fn get_session_status() -> (bool, bool) {
     (daemon_is_running(), exists)
 }
 
+/// Handle `midtown lead register-session` command.
+///
+/// Detects the Lead's Claude Code session UUID and saves it so coworkers
+/// can link their task directories to share tasks.
+pub fn handle_register_session() -> Result<Response, String> {
+    use std::fs;
+
+    let repo = repo_root()?;
+    let repo_name = repo
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| "default".to_string());
+
+    // Find the Lead's session UUID (most recently modified task directory)
+    let home = dirs::home_dir().ok_or("Cannot determine home directory")?;
+    let tasks_dir = home.join(".claude").join("tasks");
+
+    if !tasks_dir.exists() {
+        return Err(
+            "No Claude Code task directories found. Create a task first with TaskCreate."
+                .to_string(),
+        );
+    }
+
+    let lead_uuid = find_newest_dir(&tasks_dir)?;
+
+    // Save to ~/.midtown/<repo>/lead-session
+    let midtown_dir = home.join(".midtown").join(&repo_name);
+    fs::create_dir_all(&midtown_dir)
+        .map_err(|e| format!("Failed to create midtown directory: {}", e))?;
+
+    let session_file = midtown_dir.join("lead-session");
+    fs::write(&session_file, &lead_uuid)
+        .map_err(|e| format!("Failed to write session file: {}", e))?;
+
+    Ok(Response::Message {
+        message: format!("Registered Lead session: {}", lead_uuid),
+    })
+}
+
+/// Find the most recently modified directory in the given path.
+fn find_newest_dir(dir: &std::path::Path) -> Result<String, String> {
+    use std::fs;
+
+    let entries: Vec<_> = fs::read_dir(dir)
+        .map_err(|e| format!("Cannot read directory: {}", e))?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir() && !e.path().is_symlink())
+        .collect();
+
+    if entries.is_empty() {
+        return Err("No directories found".to_string());
+    }
+
+    entries
+        .iter()
+        .max_by_key(|e| e.metadata().and_then(|m| m.modified()).ok())
+        .and_then(|e| e.file_name().to_str().map(|s| s.to_string()))
+        .ok_or_else(|| "Failed to determine newest directory".to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/bin/midtown/cli/mod.rs
+++ b/src/bin/midtown/cli/mod.rs
@@ -36,6 +36,11 @@ pub fn handle_coworker_stop_hook() -> Result<Response, String> {
     coworker::handle_stop_hook_standalone()
 }
 
+/// Handle coworker link-tasks directly (no daemon required)
+pub fn handle_coworker_link_tasks() -> Result<Response, String> {
+    coworker::handle_link_tasks_standalone()
+}
+
 pub fn handle_status(client: &DaemonClient) -> Result<Response, String> {
     client.status()
 }
@@ -62,4 +67,9 @@ pub fn handle_restart() -> Result<Response, String> {
 /// Handle attach command (no daemon required - just attaches to tmux)
 pub fn handle_attach() -> Result<Response, String> {
     daemon::handle_attach()
+}
+
+/// Handle lead register-session command (no daemon required)
+pub fn handle_register_session() -> Result<Response, String> {
+    daemon::handle_register_session()
 }

--- a/src/bin/midtown/main.rs
+++ b/src/bin/midtown/main.rs
@@ -92,6 +92,17 @@ enum Commands {
         #[command(subcommand)]
         command: PrCommand,
     },
+    /// Lead-specific commands
+    Lead {
+        #[command(subcommand)]
+        command: LeadCommand,
+    },
+}
+
+#[derive(Subcommand, Clone)]
+enum LeadCommand {
+    /// Register this session for task sharing with coworkers
+    RegisterSession,
 }
 
 fn main() {
@@ -131,6 +142,16 @@ fn main() {
     } = &command
     {
         let result = cli::handle_coworker_stop_hook();
+        handle_result(format, result);
+        return;
+    }
+
+    // Link tasks also works standalone (SessionStart hook)
+    if let Commands::Coworker {
+        command: CoworkerCommand::LinkTasks,
+    } = &command
+    {
+        let result = cli::handle_coworker_link_tasks();
         handle_result(format, result);
         return;
     }
@@ -193,6 +214,15 @@ fn main() {
         return;
     }
 
+    // Lead commands (no daemon required)
+    if let Commands::Lead { command } = &command {
+        let result = match command {
+            LeadCommand::RegisterSession => cli::handle_register_session(),
+        };
+        handle_result(format, result);
+        return;
+    }
+
     // All other commands require daemon connection
     let client = match DaemonClient::connect() {
         Ok(c) => c,
@@ -214,7 +244,8 @@ fn main() {
         | Commands::Start { .. }
         | Commands::Stop { .. }
         | Commands::Restart
-        | Commands::Attach => unreachable!(),
+        | Commands::Attach
+        | Commands::Lead { .. } => unreachable!(),
     };
 
     handle_result(format, result);


### PR DESCRIPTION
## Summary
- Adds `midtown lead register-session` to save Lead's Claude Code session UUID to `~/.midtown/<repo>/lead-session`
- Adds `midtown coworker link-tasks` to symlink coworker's task directory to Lead's
- Enables shared task visibility across all team members while maintaining isolated git worktrees

## Test plan
- [ ] Start midtown and register Lead session with `midtown lead register-session`
- [ ] Spawn a coworker with `midtown coworker spawn`
- [ ] In coworker session, run `midtown coworker link-tasks` after first TaskList call
- [ ] Verify tasks created in Lead are visible to coworker

🤖 Generated with [Claude Code](https://claude.com/claude-code)