### PR TITLE
feat: Add IRC-style hooks and prompts for coworker communication

### DIFF
--- a/src/bin/midtown/cli/coworker.rs
+++ b/src/bin/midtown/cli/coworker.rs
@@ -29,6 +29,11 @@ pub enum CoworkerCommand {
     },
     /// Handle Claude Code stop hook (checks for unclaimed tasks)
     StopHook,
+    /// Handle Claude Code PostToolUse hook for task operations
+    ///
+    /// Reads tool use context from stdin and posts task activity to channel.
+    /// Called automatically by Claude Code when TaskUpdate or TaskCreate tools are used.
+    TaskHook,
     /// Link this session's tasks to the Lead's task directory (SessionStart hook)
     LinkTasks,
 }
@@ -61,6 +66,7 @@ pub fn handle(cmd: &CoworkerCommand, client: &DaemonClient) -> Result<Response, 
         CoworkerCommand::Nudge { name, message } => client.coworker_nudge(name, message.as_deref()),
         CoworkerCommand::NudgeConfig { command } => handle_nudge_config(command, client),
         CoworkerCommand::StopHook => handle_stop_hook_standalone(),
+        CoworkerCommand::TaskHook => handle_task_hook_standalone(),
         CoworkerCommand::LinkTasks => handle_link_tasks_standalone(),
     }
 }
@@ -101,6 +107,97 @@ pub fn handle_stop_hook_standalone() -> Result<Response, String> {
             reason: "No unclaimed tasks".to_string(),
         })
     }
+}
+
+/// Handle the PostToolUse hook for task operations.
+///
+/// This command is designed to be used as a Claude Code PostToolUse hook
+/// for TaskUpdate and TaskCreate tools. It:
+/// 1. Reads tool use context from stdin (JSON)
+/// 2. Parses the task operation (claim, complete, create)
+/// 3. Posts appropriate action message to channel
+///
+/// Example outputs:
+/// - `* lexington claimed task 5: Fix auth middleware`
+/// - `* lexington completed task 5`
+/// - `* Lead created task 7: Add unit tests`
+pub fn handle_task_hook_standalone() -> Result<Response, String> {
+    use std::io::Read;
+
+    // Read stdin for tool context
+    let mut input = String::new();
+    std::io::stdin()
+        .read_to_string(&mut input)
+        .map_err(|e| format!("Failed to read stdin: {}", e))?;
+
+    // Parse the JSON input
+    let context: serde_json::Value =
+        serde_json::from_str(&input).map_err(|e| format!("Failed to parse JSON: {}", e))?;
+
+    // Get agent name from environment or use "coworker"
+    let agent = std::env::var("MIDTOWN_AGENT").unwrap_or_else(|_| "coworker".to_string());
+
+    // Detect repo and open channel
+    let repo = detect_git_repo().ok_or("Not in a git repository")?;
+    let channel =
+        midtown::Channel::for_repo(&repo).map_err(|e| format!("Failed to open channel: {}", e))?;
+
+    // Parse tool input to determine the operation
+    let tool_name = context["tool_name"]
+        .as_str()
+        .or_else(|| context["toolName"].as_str())
+        .unwrap_or("");
+    let tool_input = &context["tool_input"];
+
+    let action_message = match tool_name {
+        "TaskCreate" => {
+            // Extract subject from tool input
+            let subject = tool_input["subject"].as_str().unwrap_or("new task");
+            format!("created task: {}", subject)
+        }
+        "TaskUpdate" => {
+            // Parse task update - check for status changes
+            let task_id = tool_input["taskId"]
+                .as_str()
+                .unwrap_or(tool_input["task_id"].as_str().unwrap_or("?"));
+
+            if let Some(new_status) = tool_input["status"].as_str() {
+                match new_status {
+                    "in_progress" => {
+                        // Check if owner was also set (claiming)
+                        if tool_input.get("owner").is_some() {
+                            format!("claimed task {}", task_id)
+                        } else {
+                            format!("started task {}", task_id)
+                        }
+                    }
+                    "completed" => format!("completed task {}", task_id),
+                    _ => format!("updated task {} to {}", task_id, new_status),
+                }
+            } else if tool_input.get("owner").is_some() {
+                format!("claimed task {}", task_id)
+            } else {
+                // Generic update
+                format!("updated task {}", task_id)
+            }
+        }
+        _ => {
+            // Unknown tool - silently succeed
+            return Ok(Response::Message {
+                message: "OK".to_string(),
+            });
+        }
+    };
+
+    // Post action message to channel
+    let message = midtown::Message::action(&agent, &action_message);
+    channel
+        .send(&message)
+        .map_err(|e| format!("Failed to post to channel: {}", e))?;
+
+    Ok(Response::Message {
+        message: format!("Posted: * {} {}", agent, action_message),
+    })
 }
 
 /// Read channel messages silently (for stop hook sync).

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -261,10 +261,9 @@ pub fn window_exists(session: &str, name: &str) -> crate::Result<bool> {
 
 /// JSON settings for coworker Claude Code sessions.
 ///
-/// Configures the Stop hook to:
-/// 1. Read channel messages (sync pending updates)
-/// 2. Check for unclaimed tasks
-/// 3. Block stopping if unclaimed tasks exist (keeps coworker working)
+/// Configures hooks for:
+/// - Stop: Sync channel, check for unclaimed tasks, block if more work available
+/// - PostToolUse: Broadcast task operations (claim, complete, create) to channel
 fn coworker_settings_json(bin_command: &str) -> serde_json::Value {
     serde_json::json!({
         "editorMode": "normal",
@@ -273,6 +272,19 @@ fn coworker_settings_json(bin_command: &str) -> serde_json::Value {
                 "hooks": [{
                     "type": "command",
                     "command": format!("{} --format json coworker stop-hook", bin_command)
+                }]
+            }],
+            "PostToolUse": [{
+                "matcher": {"toolName": "TaskUpdate"},
+                "hooks": [{
+                    "type": "command",
+                    "command": format!("{} coworker task-hook", bin_command)
+                }]
+            }, {
+                "matcher": {"toolName": "TaskCreate"},
+                "hooks": [{
+                    "type": "command",
+                    "command": format!("{} coworker task-hook", bin_command)
                 }]
             }]
         }
@@ -295,7 +307,7 @@ fn write_coworker_settings_file(bin_command: &str) -> crate::Result<PathBuf> {
 /// Generate the system prompt for a coworker.
 ///
 /// This prompt gives the coworker instructions for operating in the midtown
-/// environment, including channel usage, task workflow, and coordination.
+/// environment, including IRC-style channel usage, task workflow, and coordination.
 fn coworker_system_prompt(name: &str) -> String {
     format!(
         r#"# Coworker System Prompt
@@ -306,16 +318,26 @@ fn coworker_system_prompt(name: &str) -> String {
 - You work in your own git worktree
 
 ## Channel Usage
-Post updates to the team channel:
+The channel works like IRC. Post updates to keep the team informed:
 ```bash
 midtown channel post "your message here"
 ```
 
-The channel is like Slack - keep teammates informed. Post when:
-- Starting work on a task
-- Hitting blockers
-- Finishing tasks
-- Needing review
+Use `/me` to indicate what you're currently doing:
+```bash
+midtown channel post "/me investigating the auth bug"
+midtown channel post "/me running test suite"
+midtown channel post "/me opening PR for task 3"
+```
+
+Your `/me` status appears in the team sidebar, so keep it current.
+
+Post when:
+- Starting work: `/me claiming task 5`
+- Making progress: `/me found the issue in auth.rs`
+- Finishing: `/me opened PR #42 for review`
+- Blocked: `blocked on task 3, need API spec clarified`
+- Questions: `@Lead should this handle the edge case?`
 
 ## Task Workflow
 Use Claude Code's built-in task tools to manage tasks:
@@ -500,7 +522,7 @@ mod tests {
         // Verify editorMode is normal (not vim)
         assert_eq!(settings["editorMode"], "normal");
 
-        // Verify hook structure
+        // Verify Stop hook structure
         assert!(settings["hooks"]["Stop"].is_array());
         let stop_hooks = &settings["hooks"]["Stop"][0]["hooks"];
         assert!(stop_hooks.is_array());
@@ -508,6 +530,25 @@ mod tests {
         assert_eq!(
             stop_hooks[0]["command"],
             "midtown --format json coworker stop-hook"
+        );
+
+        // Verify PostToolUse hooks for task operations
+        let post_tool_hooks = &settings["hooks"]["PostToolUse"];
+        assert!(post_tool_hooks.is_array());
+        assert_eq!(post_tool_hooks.as_array().unwrap().len(), 2);
+
+        // TaskUpdate hook
+        assert_eq!(post_tool_hooks[0]["matcher"]["toolName"], "TaskUpdate");
+        assert_eq!(
+            post_tool_hooks[0]["hooks"][0]["command"],
+            "midtown coworker task-hook"
+        );
+
+        // TaskCreate hook
+        assert_eq!(post_tool_hooks[1]["matcher"]["toolName"], "TaskCreate");
+        assert_eq!(
+            post_tool_hooks[1]["hooks"][0]["command"],
+            "midtown coworker task-hook"
         );
     }
 
@@ -554,6 +595,17 @@ mod tests {
         // Verify Claude Code task tools are mentioned
         assert!(prompt.contains("TaskList"));
         assert!(prompt.contains("TaskUpdate"));
+    }
+
+    #[test]
+    fn test_coworker_system_prompt_contains_irc_style_guidance() {
+        let prompt = coworker_system_prompt("lexington");
+
+        // Verify IRC-style /me usage is documented
+        assert!(prompt.contains("/me"));
+        assert!(prompt.contains("works like IRC"));
+        assert!(prompt.contains("/me investigating"));
+        assert!(prompt.contains("team sidebar"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add PostToolUse hooks for TaskUpdate and TaskCreate to auto-broadcast task operations to the team channel
- Add `midtown coworker task-hook` subcommand that reads tool context from stdin and posts action messages (e.g., `* park claimed task 5`)
- Update coworker system prompt to encourage IRC-style `/me` usage for status updates

## Changes
**src/tmux.rs:**
- Extended `coworker_settings_json()` with PostToolUse hooks for TaskUpdate/TaskCreate
- Updated `coworker_system_prompt()` to document IRC-style `/me` usage
- Added test for IRC guidance in prompts

**src/bin/midtown/cli/coworker.rs:**
- Added `TaskHook` subcommand to `CoworkerCommand` enum
- Implemented `handle_task_hook_standalone()` to parse tool context and post action messages

## Test plan
- [x] All 116 tests pass
- [x] Build succeeds with clippy and fmt checks
- [ ] Manual test: spawn coworker, claim task, verify action message posted to channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)