### PR TITLE
feat: Add IRC-style chat TUI with team panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +174,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +265,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +303,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.3",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +353,62 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]
@@ -301,6 +444,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +485,12 @@ name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -411,6 +575,17 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -547,13 +722,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -561,6 +764,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -602,9 +814,21 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -620,6 +844,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "matchers"
@@ -650,10 +883,12 @@ dependencies = [
  "cargo-husky",
  "chrono",
  "clap",
+ "crossterm 0.29.0",
  "dirs",
  "fs2",
  "hex",
  "hmac",
+ "ratatui",
  "serde",
  "serde_json",
  "sha2",
@@ -680,6 +915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -744,6 +980,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +1028,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +1086,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,7 +1116,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -852,6 +1137,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -955,6 +1246,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,10 +1293,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1018,7 +1358,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -1237,6 +1577,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,11 +1777,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1426,20 +1804,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1449,9 +1849,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1461,9 +1873,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1473,15 +1897,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ hex = "0.4"
 dirs = "6.0"
 toml = "0.9.11"
 
+# TUI for chat interface
+ratatui = "0.29"
+crossterm = "0.29"
+
 [dev-dependencies]
 tempfile = "3.0"
 
@@ -50,10 +54,15 @@ version = "1"
 default-features = false
 features = ["precommit-hook", "run-cargo-fmt", "run-cargo-clippy"]
 
-# Single unified binary
+# Main CLI binary
 [[bin]]
 name = "midtown"
 path = "src/bin/midtown/main.rs"
+
+# Chat TUI binary
+[[bin]]
+name = "midtown-chat"
+path = "src/bin/midtown-chat/main.rs"
 
 [lib]
 name = "midtown"

--- a/src/bin/midtown-chat/app.rs
+++ b/src/bin/midtown-chat/app.rs
@@ -1,0 +1,172 @@
+//! Application state and logic for the chat TUI
+
+use std::collections::HashMap;
+
+use midtown::{Channel, Message, MessageType};
+
+/// Coworker information for the team panel
+#[derive(Debug, Clone)]
+pub struct CoworkerInfo {
+    pub name: String,
+    pub last_action: Option<String>,
+}
+
+/// Application state
+pub struct App {
+    /// All messages from the channel
+    pub messages: Vec<Message>,
+    /// Current scroll offset (0 = most recent at bottom)
+    pub scroll_offset: usize,
+    /// Visible height for chat panel (updated during render)
+    pub visible_height: usize,
+    /// Active coworkers with their last /me action
+    pub coworkers: Vec<CoworkerInfo>,
+    /// Channel for reading messages
+    channel: Option<Channel>,
+    /// Last known message count (for detecting new messages)
+    last_count: usize,
+    /// Cache of last actions by coworker name
+    last_actions: HashMap<String, String>,
+}
+
+impl App {
+    pub fn new() -> Self {
+        // Determine the repo name from current directory
+        let repo_name = std::env::current_dir()
+            .ok()
+            .and_then(|p| p.file_name().map(|s| s.to_string_lossy().to_string()))
+            .unwrap_or_else(|| "default".to_string());
+
+        let channel = Channel::for_repo(&repo_name).ok();
+        let mut app = Self {
+            messages: Vec::new(),
+            scroll_offset: 0,
+            visible_height: 20,
+            coworkers: Vec::new(),
+            channel,
+            last_count: 0,
+            last_actions: HashMap::new(),
+        };
+
+        // Initial load
+        app.refresh();
+        app
+    }
+
+    /// Refresh messages and coworker state
+    pub fn refresh(&mut self) {
+        // Read all messages from channel
+        if let Some(ref channel) = self.channel
+            && let Ok(messages) = channel.read_all()
+        {
+            let new_count = messages.len();
+
+            // Update messages if count changed
+            if new_count != self.last_count {
+                self.messages = messages;
+                self.last_count = new_count;
+
+                // Update last actions from Action messages
+                self.update_last_actions();
+            }
+        }
+
+        // Update coworker list from daemon (could poll RPC, for now use channel data)
+        self.update_coworkers();
+    }
+
+    /// Extract last /me actions from messages
+    fn update_last_actions(&mut self) {
+        self.last_actions.clear();
+
+        for msg in &self.messages {
+            if msg.message_type == MessageType::Action {
+                self.last_actions
+                    .insert(msg.from.clone(), msg.content.clone());
+            }
+        }
+    }
+
+    /// Update coworker list based on message senders
+    fn update_coworkers(&mut self) {
+        // Build coworker list from message senders (excluding system, github, Lead)
+        let mut seen: HashMap<String, bool> = HashMap::new();
+        let excluded = ["system", "github", "Lead"];
+
+        for msg in &self.messages {
+            if !excluded.contains(&msg.from.as_str()) && !seen.contains_key(&msg.from) {
+                seen.insert(msg.from.clone(), true);
+            }
+        }
+
+        // Convert to CoworkerInfo list
+        self.coworkers = seen
+            .keys()
+            .map(|name| CoworkerInfo {
+                name: name.clone(),
+                last_action: self.last_actions.get(name).cloned(),
+            })
+            .collect();
+
+        // Sort by name for consistent display
+        self.coworkers.sort_by(|a, b| a.name.cmp(&b.name));
+    }
+
+    /// Scroll up one line
+    pub fn scroll_up(&mut self) {
+        let max_scroll = self.max_scroll();
+        if self.scroll_offset < max_scroll {
+            self.scroll_offset += 1;
+        }
+    }
+
+    /// Scroll down one line
+    pub fn scroll_down(&mut self) {
+        if self.scroll_offset > 0 {
+            self.scroll_offset -= 1;
+        }
+    }
+
+    /// Page up
+    pub fn page_up(&mut self) {
+        let page_size = self.visible_height.saturating_sub(2);
+        let max_scroll = self.max_scroll();
+        self.scroll_offset = (self.scroll_offset + page_size).min(max_scroll);
+    }
+
+    /// Page down
+    pub fn page_down(&mut self) {
+        let page_size = self.visible_height.saturating_sub(2);
+        self.scroll_offset = self.scroll_offset.saturating_sub(page_size);
+    }
+
+    /// Scroll to top (oldest messages)
+    pub fn scroll_to_top(&mut self) {
+        self.scroll_offset = self.max_scroll();
+    }
+
+    /// Scroll to bottom (newest messages)
+    pub fn scroll_to_bottom(&mut self) {
+        self.scroll_offset = 0;
+    }
+
+    /// Maximum scroll offset
+    fn max_scroll(&self) -> usize {
+        self.messages.len().saturating_sub(self.visible_height)
+    }
+
+    /// Get messages visible in the current scroll position
+    pub fn visible_messages(&self) -> &[Message] {
+        let total = self.messages.len();
+        if total == 0 {
+            return &[];
+        }
+
+        // scroll_offset=0 means we show the most recent messages (end of list)
+        // Higher scroll_offset means we show older messages
+        let end = total.saturating_sub(self.scroll_offset);
+        let start = end.saturating_sub(self.visible_height);
+
+        &self.messages[start..end]
+    }
+}

--- a/src/bin/midtown-chat/main.rs
+++ b/src/bin/midtown-chat/main.rs
@@ -1,0 +1,77 @@
+//! midtown-chat - IRC-style TUI for team communication
+//!
+//! This binary provides a read-only chat interface showing team activity
+//! and coworker status in a split-pane layout.
+
+mod app;
+mod ui;
+
+use std::io;
+use std::time::Duration;
+
+use crossterm::{
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{Terminal, prelude::CrosstermBackend};
+
+use app::App;
+
+fn main() -> io::Result<()> {
+    // Setup terminal
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    // Create app state
+    let mut app = App::new();
+
+    // Run the main loop
+    let result = run_app(&mut terminal, &mut app);
+
+    // Restore terminal
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    terminal.show_cursor()?;
+
+    if let Err(e) = result {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App) -> io::Result<()> {
+    loop {
+        // Draw UI
+        terminal.draw(|f| ui::draw(f, app))?;
+
+        // Poll for events with a timeout to allow periodic updates
+        if event::poll(Duration::from_millis(250))?
+            && let Event::Key(key) = event::read()?
+            && key.kind == KeyEventKind::Press
+        {
+            match key.code {
+                KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                KeyCode::Up | KeyCode::Char('k') => app.scroll_up(),
+                KeyCode::Down | KeyCode::Char('j') => app.scroll_down(),
+                KeyCode::PageUp => app.page_up(),
+                KeyCode::PageDown => app.page_down(),
+                KeyCode::Home | KeyCode::Char('g') => app.scroll_to_top(),
+                KeyCode::End | KeyCode::Char('G') => app.scroll_to_bottom(),
+                _ => {}
+            }
+        }
+
+        // Check for new messages
+        app.refresh();
+    }
+}

--- a/src/bin/midtown-chat/ui.rs
+++ b/src/bin/midtown-chat/ui.rs
@@ -1,0 +1,166 @@
+//! UI rendering for the chat TUI
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
+};
+
+use midtown::MessageType;
+
+use crate::app::App;
+
+/// Avenue names mapped to colors (position-based assignment)
+const AVENUE_COLORS: &[(&str, Color)] = &[
+    ("lexington", Color::Cyan),
+    ("park", Color::Green),
+    ("madison", Color::Yellow),
+    ("broadway", Color::Magenta),
+    ("amsterdam", Color::Blue),
+    ("columbus", Color::Red),
+];
+
+/// Get color for a sender name
+fn get_sender_color(name: &str) -> Color {
+    match name.to_lowercase().as_str() {
+        "lead" => Color::White,
+        "github" => Color::DarkGray,
+        "system" => Color::DarkGray,
+        _ => {
+            // Check avenue colors
+            for (avenue, color) in AVENUE_COLORS {
+                if name.to_lowercase() == *avenue {
+                    return *color;
+                }
+            }
+            // Default for unknown names
+            Color::White
+        }
+    }
+}
+
+/// Draw the main UI
+pub fn draw(f: &mut Frame, app: &mut App) {
+    // Split into team panel (30%) and chat panel (70%)
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(30), Constraint::Percentage(70)])
+        .split(f.area());
+
+    draw_team_panel(f, app, chunks[0]);
+    draw_chat_panel(f, app, chunks[1]);
+}
+
+/// Draw the team panel showing coworkers and their status
+fn draw_team_panel(f: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .title(" Team ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray));
+
+    let inner = block.inner(area);
+
+    // Build list items for coworkers
+    let items: Vec<ListItem> = app
+        .coworkers
+        .iter()
+        .flat_map(|cw| {
+            let color = get_sender_color(&cw.name);
+            let name_line = Line::from(Span::styled(
+                &cw.name,
+                Style::default().fg(color).add_modifier(Modifier::BOLD),
+            ));
+
+            let status_line = match &cw.last_action {
+                Some(action) => {
+                    // Truncate long actions
+                    let display = if action.len() > 25 {
+                        format!("  {}...", &action[..22])
+                    } else {
+                        format!("  {}", action)
+                    };
+                    Line::from(Span::styled(display, Style::default().fg(Color::DarkGray)))
+                }
+                None => Line::from(Span::styled(
+                    "  (idle)",
+                    Style::default().fg(Color::DarkGray),
+                )),
+            };
+
+            vec![ListItem::new(name_line), ListItem::new(status_line)]
+        })
+        .collect();
+
+    let list = List::new(items);
+
+    f.render_widget(block, area);
+    f.render_widget(list, inner);
+}
+
+/// Draw the chat panel showing messages
+fn draw_chat_panel(f: &mut Frame, app: &mut App, area: Rect) {
+    let block = Block::default()
+        .title(" #midtown ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray));
+
+    let inner = block.inner(area);
+
+    // Update visible height for scroll calculations
+    app.visible_height = inner.height as usize;
+
+    // Get visible messages
+    let visible = app.visible_messages();
+
+    // Build lines for messages
+    let lines: Vec<Line> = visible
+        .iter()
+        .map(|msg| {
+            let time = msg.timestamp.format("%H:%M").to_string();
+            let color = get_sender_color(&msg.from);
+
+            match msg.message_type {
+                MessageType::Action => {
+                    // IRC-style action: HH:MM * name action
+                    Line::from(vec![
+                        Span::styled(format!("{} ", time), Style::default().fg(Color::DarkGray)),
+                        Span::styled("* ", Style::default().fg(color)),
+                        Span::styled(
+                            format!("{} ", msg.from),
+                            Style::default().fg(color).add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled(&msg.content, Style::default().fg(color)),
+                    ])
+                }
+                MessageType::System => {
+                    // System message: HH:MM <system> message
+                    Line::from(vec![
+                        Span::styled(format!("{} ", time), Style::default().fg(Color::DarkGray)),
+                        Span::styled("<system> ", Style::default().fg(Color::DarkGray)),
+                        Span::styled(&msg.content, Style::default().fg(Color::DarkGray)),
+                    ])
+                }
+                _ => {
+                    // Regular message: HH:MM <name> message
+                    Line::from(vec![
+                        Span::styled(format!("{} ", time), Style::default().fg(Color::DarkGray)),
+                        Span::styled("<", Style::default().fg(Color::DarkGray)),
+                        Span::styled(
+                            &msg.from,
+                            Style::default().fg(color).add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled("> ", Style::default().fg(Color::DarkGray)),
+                        Span::styled(&msg.content, Style::default().fg(Color::White)),
+                    ])
+                }
+            }
+        })
+        .collect();
+
+    let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
+
+    f.render_widget(block, area);
+    f.render_widget(paragraph, inner);
+}

--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -340,6 +340,24 @@ pub fn handle_start(daemon_only: bool) -> Result<Response, String> {
             ])
             .status();
 
+        // Split Lead window with chat TUI on the right (30% width)
+        let lead_target = format!("{}:Lead", session);
+        let _ = Command::new("tmux")
+            .args(["split-window", "-h", "-t", &lead_target, "-p", "30"])
+            .status();
+
+        // Start chat TUI in the new pane (pane .1)
+        let chat_pane = format!("{}:Lead.1", session);
+        let _ = Command::new("tmux")
+            .args(["send-keys", "-t", &chat_pane, "midtown-chat", "Enter"])
+            .status();
+
+        // Keep focus on the main pane (Claude Code, pane .0)
+        let main_pane = format!("{}:Lead.0", session);
+        let _ = Command::new("tmux")
+            .args(["select-pane", "-t", &main_pane])
+            .status();
+
         if is_existing {
             messages.push(format!("Resumed Lead session in '{}'", session));
         } else {


### PR DESCRIPTION
## Summary
- Add `midtown-chat` binary with ratatui/crossterm for TUI rendering
- Split-pane layout: Team panel (30% left), Chat panel (70% right)
- Integrate into daemon startup: split Lead window, launch chat in pane

## Details
This implements tasks #7 and #8 from the IRC Chat UI plan (`docs/plans/2026-01-26-irc-chat-ui-design.md`).

### Features
- **Team Panel**: Shows active coworkers with their last `/me` action
- **Chat Panel**: Scrolling chat log with IRC-style formatting
- **Color coding**: Each avenue name gets a distinct color (lexington=cyan, park=green, madison=yellow, etc.)
- **Keyboard navigation**: j/k, PgUp/PgDn, Home/End for scrolling
- **Auto-scroll**: New messages appear at bottom, auto-scrolls when at bottom

### Message Formats
- Regular: `HH:MM <name> message`
- Action: `HH:MM * name action`
- System: `HH:MM <system> message`

## Test plan
- [x] All 115 tests pass
- [x] Cargo clippy passes
- [ ] Manual testing: `midtown start` creates split Lead window with chat pane
- [ ] Manual testing: Messages appear in chat TUI when posted via `midtown channel post`

Generated with [Claude Code](https://claude.com/claude-code)