### PR TITLE
feat: Add project-level config for bin_command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +412,12 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -535,6 +547,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +660,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "toml",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -885,6 +908,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1078,45 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.9.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tower"
@@ -1417,6 +1488,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ hex = "0.4"
 
 # CLI utilities
 dirs = "6.0"
+toml = "0.9.11"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,151 @@
+//! Project-level configuration for midtown.
+//!
+//! Reads from `~/.midtown/config.toml` with per-project sections:
+//!
+//! ```toml
+//! [default]
+//! bin_command = "midtown"
+//!
+//! [midtown]  # project name from repo
+//! bin_command = "cargo run --release --"
+//! ```
+
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Configuration for a single project.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProjectConfig {
+    /// Command to invoke midtown (e.g., "midtown" or "cargo run --release --")
+    #[serde(default = "default_bin_command")]
+    pub bin_command: String,
+}
+
+fn default_bin_command() -> String {
+    "midtown".to_string()
+}
+
+impl Default for ProjectConfig {
+    fn default() -> Self {
+        Self {
+            bin_command: default_bin_command(),
+        }
+    }
+}
+
+/// Root configuration containing default and per-project settings.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct Config {
+    /// Default settings for all projects
+    #[serde(default)]
+    pub default: ProjectConfig,
+
+    /// Per-project settings (key is project/repo name)
+    #[serde(flatten)]
+    pub projects: HashMap<String, ProjectConfig>,
+}
+
+impl Config {
+    /// Load configuration from `~/.midtown/config.toml`.
+    ///
+    /// Returns default config if file doesn't exist or can't be parsed.
+    pub fn load() -> Self {
+        let path = config_path();
+
+        if !path.exists() {
+            return Self::default();
+        }
+
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => toml::from_str(&contents).unwrap_or_default(),
+            Err(_) => Self::default(),
+        }
+    }
+
+    /// Get configuration for a specific project.
+    ///
+    /// Falls back to default if no project-specific config exists.
+    pub fn for_project(&self, project_name: &str) -> &ProjectConfig {
+        self.projects.get(project_name).unwrap_or(&self.default)
+    }
+}
+
+/// Get the path to the config file.
+pub fn config_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".midtown")
+        .join("config.toml")
+}
+
+/// Get the bin_command for the current project.
+///
+/// Determines project name from the current git repo and looks up config.
+pub fn get_bin_command() -> String {
+    let config = Config::load();
+
+    // Try to get project name from git repo
+    let project_name = get_project_name().unwrap_or_default();
+
+    if project_name.is_empty() {
+        config.default.bin_command.clone()
+    } else {
+        config.for_project(&project_name).bin_command.clone()
+    }
+}
+
+/// Get the current project name from git repo root directory.
+fn get_project_name() -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let path = String::from_utf8_lossy(&output.stdout);
+    let path = PathBuf::from(path.trim());
+
+    path.file_name().map(|s| s.to_string_lossy().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = Config::default();
+        assert_eq!(config.default.bin_command, "midtown");
+    }
+
+    #[test]
+    fn test_parse_config() {
+        let toml = r#"
+[default]
+bin_command = "midtown"
+
+[my-project]
+bin_command = "cargo run --release --"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+
+        assert_eq!(config.default.bin_command, "midtown");
+        assert_eq!(
+            config.for_project("my-project").bin_command,
+            "cargo run --release --"
+        );
+        // Unknown project falls back to default
+        assert_eq!(config.for_project("unknown").bin_command, "midtown");
+    }
+
+    #[test]
+    fn test_config_path() {
+        let path = config_path();
+        assert!(path.to_string_lossy().contains(".midtown"));
+        assert!(path.to_string_lossy().ends_with("config.toml"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,9 @@ pub mod webhook;
 // Agent nudging subsystem (dementus)
 pub mod nudge;
 
+// Project configuration
+pub mod config;
+
 pub use channel::Channel;
 pub use coworker::{Coworker, CoworkerManager, CoworkerStatus};
 pub use cursor::Cursor;

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -265,14 +265,14 @@ pub fn window_exists(session: &str, name: &str) -> crate::Result<bool> {
 /// 1. Read channel messages (sync pending updates)
 /// 2. Check for unclaimed tasks
 /// 3. Block stopping if unclaimed tasks exist (keeps coworker working)
-fn coworker_settings_json() -> serde_json::Value {
+fn coworker_settings_json(bin_command: &str) -> serde_json::Value {
     serde_json::json!({
         "editorMode": "normal",
         "hooks": {
             "Stop": [{
                 "hooks": [{
                     "type": "command",
-                    "command": "cargo run --release -- --format json coworker stop-hook"
+                    "command": format!("{} --format json coworker stop-hook", bin_command)
                 }]
             }]
         }
@@ -281,12 +281,12 @@ fn coworker_settings_json() -> serde_json::Value {
 
 /// Write coworker settings to a shared file and return the path.
 /// All coworkers use the same settings file.
-fn write_coworker_settings_file() -> crate::Result<PathBuf> {
+fn write_coworker_settings_file(bin_command: &str) -> crate::Result<PathBuf> {
     let dir = state_dir();
     std::fs::create_dir_all(&dir).map_err(Error::Io)?;
 
     let path = dir.join("coworker-settings.json");
-    let settings = coworker_settings_json();
+    let settings = coworker_settings_json(bin_command);
     std::fs::write(&path, settings.to_string()).map_err(Error::Io)?;
 
     Ok(path)
@@ -362,13 +362,16 @@ pub fn spawn_claude(
     working_dir: &str,
     repo_name: Option<&str>,
 ) -> crate::Result<()> {
+    // Get bin_command from project config
+    let bin_command = crate::config::get_bin_command();
+
     // Build the claude command with settings for channel synchronization
     // and a system prompt for coworker identity and instructions
     let system_prompt = coworker_system_prompt(name);
 
     // Write system prompt and settings to files (avoids quoting issues)
     let prompt_file = write_coworker_prompt_file(name, &system_prompt)?;
-    let settings_file = write_coworker_settings_file()?;
+    let settings_file = write_coworker_settings_file(&bin_command)?;
 
     // Generate a unique session ID for this coworker
     let coworker_session_id = uuid::Uuid::new_v4().to_string();
@@ -492,7 +495,7 @@ mod tests {
 
     #[test]
     fn test_coworker_settings_json_is_valid() {
-        let settings = coworker_settings_json();
+        let settings = coworker_settings_json("midtown");
 
         // Verify editorMode is normal (not vim)
         assert_eq!(settings["editorMode"], "normal");
@@ -502,6 +505,17 @@ mod tests {
         let stop_hooks = &settings["hooks"]["Stop"][0]["hooks"];
         assert!(stop_hooks.is_array());
         assert_eq!(stop_hooks[0]["type"], "command");
+        assert_eq!(
+            stop_hooks[0]["command"],
+            "midtown --format json coworker stop-hook"
+        );
+    }
+
+    #[test]
+    fn test_coworker_settings_json_custom_bin() {
+        let settings = coworker_settings_json("cargo run --release --");
+
+        let stop_hooks = &settings["hooks"]["Stop"][0]["hooks"];
         assert_eq!(
             stop_hooks[0]["command"],
             "cargo run --release -- --format json coworker stop-hook"


### PR DESCRIPTION
## Summary
Adds `~/.midtown/config.toml` for per-project configuration, starting with `bin_command`.

## Problem
During development, coworker hooks fail because `midtown` isn't in PATH. We need a way to configure hooks to use `cargo run --release --` instead.

## Solution
Project-level config file at `~/.midtown/config.toml`:

```toml
[default]
bin_command = "midtown"

[midtown]  # matches repo name
bin_command = "cargo run --release --"

[other-project]
bin_command = "/usr/local/bin/midtown"
```

The project name is determined from the git repo root directory name.

## Changes
- Add `src/config.rs` with `Config` and `ProjectConfig` types
- Update `coworker_settings_json()` to accept `bin_command` parameter
- Update `spawn_claude()` to read config and pass `bin_command`
- Add `toml` dependency for config parsing

## Test plan
- [x] Unit tests for config parsing and defaults
- [x] All existing tests pass
- [ ] Manual: Create config, spawn coworker, verify hook uses correct command

🤖 Generated with [Claude Code](https://claude.com/claude-code)