### PR TITLE
fix: Update PostToolUse hook matcher format

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -275,13 +275,13 @@ fn coworker_settings_json(bin_command: &str) -> serde_json::Value {
                 }]
             }],
             "PostToolUse": [{
-                "matcher": {"toolName": "TaskUpdate"},
+                "matcher": {"tools": ["TaskUpdate"]},
                 "hooks": [{
                     "type": "command",
                     "command": format!("{} coworker task-hook", bin_command)
                 }]
             }, {
-                "matcher": {"toolName": "TaskCreate"},
+                "matcher": {"tools": ["TaskCreate"]},
                 "hooks": [{
                     "type": "command",
                     "command": format!("{} coworker task-hook", bin_command)


### PR DESCRIPTION
## Summary
- Updates hook matcher from `{"toolName": "X"}` to `{"tools": ["X"]}`
- Fixes coworker spawn failure due to Claude Code settings validation error

The hook format changed in a recent Claude Code update.

## Test plan
- [ ] `midtown coworker spawn` creates a working coworker window

🤖 Generated with [Claude Code](https://claude.com/claude-code)