### PR TITLE
fix: Update PostToolUse hook matcher format

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -275,13 +275,13 @@ fn coworker_settings_json(bin_command: &str) -> serde_json::Value {
                 }]
             }],
             "PostToolUse": [{
-                "matcher": {"tools": ["TaskUpdate"]},
+                "matcher": "TaskUpdate",
                 "hooks": [{
                     "type": "command",
                     "command": format!("{} coworker task-hook", bin_command)
                 }]
             }, {
-                "matcher": {"tools": ["TaskCreate"]},
+                "matcher": "TaskCreate",
                 "hooks": [{
                     "type": "command",
                     "command": format!("{} coworker task-hook", bin_command)
@@ -558,14 +558,14 @@ mod tests {
         assert_eq!(post_tool_hooks.as_array().unwrap().len(), 2);
 
         // TaskUpdate hook
-        assert_eq!(post_tool_hooks[0]["matcher"]["tools"][0], "TaskUpdate");
+        assert_eq!(post_tool_hooks[0]["matcher"], "TaskUpdate");
         assert_eq!(
             post_tool_hooks[0]["hooks"][0]["command"],
             "midtown coworker task-hook"
         );
 
         // TaskCreate hook
-        assert_eq!(post_tool_hooks[1]["matcher"]["tools"][0], "TaskCreate");
+        assert_eq!(post_tool_hooks[1]["matcher"], "TaskCreate");
         assert_eq!(
             post_tool_hooks[1]["hooks"][0]["command"],
             "midtown coworker task-hook"


### PR DESCRIPTION
## Summary
- Changes hook matcher from object `{"tools": ["TaskUpdate"]}` to string `"TaskUpdate"`
- Claude Code's hook validator expects matcher to be a string, not an object

This was causing coworker windows to immediately close due to settings validation error.

## Test plan
- [x] Coworker windows now stay open
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)