### PR TITLE
fix: Use MIDTOWN_AGENT for channel post sender

### DIFF
--- a/src/bin/midtown/cli/channel.rs
+++ b/src/bin/midtown/cli/channel.rs
@@ -20,7 +20,11 @@ pub enum ChannelCommand {
 
 pub fn handle(cmd: &ChannelCommand, client: &DaemonClient) -> Result<Response, String> {
     match cmd {
-        ChannelCommand::Post { message } => client.channel_post(message),
+        ChannelCommand::Post { message } => {
+            // Get sender from MIDTOWN_AGENT env var (set for coworkers)
+            let from = std::env::var("MIDTOWN_AGENT").ok();
+            client.channel_post(message, from.as_deref())
+        }
         ChannelCommand::Read { all } => client.channel_read(*all),
     }
 }

--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -127,11 +127,12 @@ impl DaemonClient {
 
     // Channel commands
 
-    pub fn channel_post(&self, message: &str) -> Result<Response, String> {
-        self.send(
-            "channel.post",
-            Some(serde_json::json!({ "message": message })),
-        )
+    pub fn channel_post(&self, message: &str, from: Option<&str>) -> Result<Response, String> {
+        let mut params = serde_json::json!({ "message": message });
+        if let Some(sender) = from {
+            params["from"] = serde_json::json!(sender);
+        }
+        self.send("channel.post", Some(params))
     }
 
     pub fn channel_read(&self, all: bool) -> Result<Response, String> {


### PR DESCRIPTION
## Summary
- When coworkers use `midtown channel post`, the message sender now correctly uses the MIDTOWN_AGENT environment variable instead of always defaulting to "Lead"
- Updated DaemonClient.channel_post to accept optional `from` parameter
- Channel handler now reads MIDTOWN_AGENT and passes it to the client

## Test plan
- [x] All tests pass (129 tests)
- [ ] Spawn a coworker and have it post to channel
- [ ] Verify the message shows the coworker name, not "Lead"

🤖 Generated with [Claude Code](https://claude.com/claude-code)