### PR TITLE
feat: Improve chat TUI scrolling

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -70,8 +70,19 @@ impl App {
 
             // Update messages if count changed
             if new_count != self.last_count {
+                let added = new_count.saturating_sub(self.last_count);
+                let was_at_bottom = self.scroll_offset == 0;
+
                 self.messages = messages;
                 self.last_count = new_count;
+
+                if was_at_bottom {
+                    // User was at bottom - stay at bottom (auto-scroll)
+                    self.scroll_offset = 0;
+                } else {
+                    // User had scrolled up - adjust offset to stay viewing same messages
+                    self.scroll_offset += added;
+                }
 
                 // Update last actions from Action messages
                 self.update_last_actions();

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -10,7 +10,9 @@ use std::io;
 use std::time::Duration;
 
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
+    event::{
+        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, MouseEventKind,
+    },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
@@ -53,18 +55,23 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App)
         terminal.draw(|f| ui::draw(f, app))?;
 
         // Poll for events with a timeout to allow periodic updates
-        if event::poll(Duration::from_millis(250))?
-            && let Event::Key(key) = event::read()?
-            && key.kind == KeyEventKind::Press
-        {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
-                KeyCode::Up | KeyCode::Char('k') => app.scroll_up(),
-                KeyCode::Down | KeyCode::Char('j') => app.scroll_down(),
-                KeyCode::PageUp => app.page_up(),
-                KeyCode::PageDown => app.page_down(),
-                KeyCode::Home | KeyCode::Char('g') => app.scroll_to_top(),
-                KeyCode::End | KeyCode::Char('G') => app.scroll_to_bottom(),
+        if event::poll(Duration::from_millis(250))? {
+            match event::read()? {
+                Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                    KeyCode::Up | KeyCode::Char('k') => app.scroll_up(),
+                    KeyCode::Down | KeyCode::Char('j') => app.scroll_down(),
+                    KeyCode::PageUp => app.page_up(),
+                    KeyCode::PageDown => app.page_down(),
+                    KeyCode::Home | KeyCode::Char('g') => app.scroll_to_top(),
+                    KeyCode::End | KeyCode::Char('G') => app.scroll_to_bottom(),
+                    _ => {}
+                },
+                Event::Mouse(mouse) => match mouse.kind {
+                    MouseEventKind::ScrollUp => app.scroll_up(),
+                    MouseEventKind::ScrollDown => app.scroll_down(),
+                    _ => {}
+                },
                 _ => {}
             }
         }


### PR DESCRIPTION
## Summary
- Auto-scroll to bottom when new messages arrive (if user was already at bottom)
- Maintain scroll position when user has scrolled up to read history
- Add mouse scroll wheel support for scrolling up/down

## Test plan
- [x] All tests pass (132 tests)
- [ ] Open chat TUI and verify new messages appear at bottom automatically
- [ ] Scroll up to read history, verify new messages don't disrupt view
- [ ] Test mouse scroll wheel works for scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)