### PR TITLE
fix: Collapse redundant nested if in test

### DIFF
--- a/tests/task_sharing.rs
+++ b/tests/task_sharing.rs
@@ -66,10 +66,8 @@ impl TaskSharingFixture {
         fs::create_dir_all(&lead_tasks).unwrap();
 
         // Remove existing symlink if present
-        if coworker_tasks.exists() || coworker_tasks.is_symlink() {
-            if coworker_tasks.is_symlink() {
-                fs::remove_file(&coworker_tasks).unwrap();
-            }
+        if coworker_tasks.is_symlink() {
+            fs::remove_file(&coworker_tasks).unwrap();
         }
 
         // Create symlink: coworker -> lead


### PR DESCRIPTION
## Summary
- Simplify if statement in `tests/task_sharing.rs` to just check `is_symlink()` directly
- Removes redundant outer `exists() || is_symlink()` check
- Fixes clippy `collapsible_if` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)