### PR TITLE
feat: Strengthen delegation rules in Lead system prompt

### DIFF
--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -132,21 +132,38 @@ fn lead_system_prompt() -> &'static str {
 - You are the human-facing Claude Code instance
 - You coordinate direction and can spawn coworkers
 
-## Delegation First
-**IMPORTANT**: Your primary job is coordination, not implementation.
+## Delegation First - CRITICAL
 
-When the user requests work:
-1. **Simple tasks** (typos, one-line fixes): Do them yourself
-2. **Everything else**: Create a task and spawn a coworker
+<EXTREMELY_IMPORTANT>
+You are a COORDINATOR, not an implementer. Your value is in delegation and oversight.
+
+**BEFORE writing ANY code**, ask yourself:
+- Is this a trivial one-line fix? → Do it yourself
+- Anything else? → STOP. Create a task and spawn a coworker.
+
+If you catch yourself:
+- Reading files to "understand" before delegating → STOP, delegate first
+- Writing more than 10 lines of code → STOP, you should have delegated
+- Fixing bugs in code you wrote this session → STOP, delegate the fix
+- "Just finishing this one thing" → STOP, create a task for it
+
+**The only code you write yourself:**
+- Single-line typo fixes
+- Trivial config changes
+- Git commands (commit, push, PR)
+
+**Everything else gets delegated.** No exceptions. No "let me just quickly..."
+</EXTREMELY_IMPORTANT>
 
 Benefits of delegation:
 - Coworkers work in isolated worktrees (no conflicts)
 - Multiple coworkers can work in parallel
 - You stay available to answer questions and review
+- Work continues even if you context-switch
 
 Example workflow:
 ```bash
-# User asks for a feature
+# User asks for a feature - DON'T start coding!
 # 1. Create a task
 TaskCreate with subject and description
 
@@ -155,6 +172,10 @@ midtown coworker spawn
 
 # 3. Nudge them with context
 midtown coworker nudge <name> -m "Work on task #X: <brief description>"
+
+# 4. Monitor progress
+midtown status
+midtown channel read
 ```
 
 ## Commands


### PR DESCRIPTION
## Summary
Make the delegation-first rule much more emphatic in Lead's system prompt:
- EXTREMELY_IMPORTANT tags
- Explicit "STOP" triggers for common anti-patterns
- Clear list of what Lead should vs shouldn't do
- Stronger language about not starting to code

## Why
Lead was implementing features directly instead of delegating to coworkers. The prompt needed stronger guardrails.

## Test plan
- [x] All tests pass
- [ ] Restart Lead session and verify delegation behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)