### PR TITLE
fix: Add dark gray tmux status bar background and Lead tab color

### DIFF
--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -417,7 +417,12 @@ pub fn handle_start(daemon_only: bool) -> Result<Response, String> {
             return Err(format!("Failed to create session '{}'", session));
         }
 
-        // Configure status bar to show project name
+        // Configure status bar with dark gray background for visibility
+        let _ = Command::new("tmux")
+            .args(["set-option", "-t", &session, "status-style", "bg=colour236"])
+            .status();
+
+        // Set status-left with project name
         let _ = Command::new("tmux")
             .args([
                 "set-option",
@@ -425,6 +430,27 @@ pub fn handle_start(daemon_only: bool) -> Result<Response, String> {
                 &session,
                 "status-left",
                 &format!(" {} ", project_name),
+            ])
+            .status();
+
+        // Set Lead window tab color (yellow to match chat TUI team panel)
+        let lead_window = format!("{}:Lead", session);
+        let _ = Command::new("tmux")
+            .args([
+                "set-window-option",
+                "-t",
+                &lead_window,
+                "window-status-style",
+                "fg=yellow",
+            ])
+            .status();
+        let _ = Command::new("tmux")
+            .args([
+                "set-window-option",
+                "-t",
+                &lead_window,
+                "window-status-current-style",
+                "fg=yellow,bold",
             ])
             .status();
 


### PR DESCRIPTION
## Summary
- Set status-style with `bg=colour236` (dark gray) for visibility with colored tabs
- Add window-status-style for Lead window with `fg=yellow`
- Add window-status-current-style for active Lead tab with `yellow,bold`

This fixes the visibility issue where colored tab text was invisible against the default black status bar, and makes the Lead tab match the yellow color used in the chat TUI team panel.

## Test plan
- [ ] Start a new midtown session
- [ ] Verify status bar has dark gray background
- [ ] Verify Lead tab shows yellow text
- [ ] Verify colored coworker tabs are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)