### PR TITLE
fix: Prefix nudges with 'i ' to handle vim mode

### DIFF
--- a/src/nudge/tmux.rs
+++ b/src/nudge/tmux.rs
@@ -45,8 +45,9 @@ pub fn send_nudge(session: &str, window: &str, message: &str) -> Result<(), Nudg
     }
 
     // Send the message as a comment (prefixed with #) so it doesn't execute
-    // anything harmful, followed by a newline
-    let comment_message = format!("# {}", message);
+    // anything harmful, followed by a newline.
+    // Prefix with "i " to enter insert mode if coworker is in vim mode.
+    let comment_message = format!("i # {}", message);
 
     let output = Command::new("tmux")
         .args(["send-keys", "-t", &target, &comment_message, "Enter"])


### PR DESCRIPTION
## Summary
If a coworker is in vim normal mode, nudge text wasn't received properly because vim interprets keystrokes as commands.

**Fix:** Prefix nudge messages with `i ` to enter insert mode first.
- If in vim normal mode: `i` enters insert mode, then message is typed
- If already in insert mode or not in vim: `i ` is harmless as part of the comment

## Test plan
- [x] Build succeeds
- [x] All nudge tests pass
- [ ] Nudge a coworker in vim mode - message received correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)