### PR TITLE
feat: Replace Team panel with tmux tab status display

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -1,17 +1,6 @@
 //! Application state and logic for the chat TUI
 
-use std::collections::HashMap;
-
-use midtown::{Channel, Message, MessageType};
-
-use crate::client::DaemonClient;
-
-/// Coworker information for the team panel
-#[derive(Debug, Clone)]
-pub struct CoworkerInfo {
-    pub name: String,
-    pub last_action: Option<String>,
-}
+use midtown::{Channel, Message};
 
 /// Application state
 pub struct App {
@@ -21,16 +10,10 @@ pub struct App {
     pub scroll_offset: usize,
     /// Visible height for chat panel (updated during render)
     pub visible_height: usize,
-    /// Active coworkers with their last /me action
-    pub coworkers: Vec<CoworkerInfo>,
     /// Channel for reading messages
     channel: Option<Channel>,
-    /// Daemon client for querying coworker status
-    daemon: Option<DaemonClient>,
     /// Last known message count (for detecting new messages)
     last_count: usize,
-    /// Cache of last actions by coworker name
-    last_actions: HashMap<String, String>,
 }
 
 impl App {
@@ -42,17 +25,13 @@ impl App {
             .unwrap_or_else(|| "default".to_string());
 
         let channel = Channel::for_repo(&repo_name).ok();
-        let daemon = DaemonClient::connect().ok();
 
         let mut app = Self {
             messages: Vec::new(),
             scroll_offset: 0,
             visible_height: 20,
-            coworkers: Vec::new(),
             channel,
-            daemon,
             last_count: 0,
-            last_actions: HashMap::new(),
         };
 
         // Initial load
@@ -60,7 +39,7 @@ impl App {
         app
     }
 
-    /// Refresh messages and coworker state
+    /// Refresh messages from the channel
     pub fn refresh(&mut self) {
         // Read all messages from channel
         if let Some(ref channel) = self.channel
@@ -83,72 +62,8 @@ impl App {
                     // User had scrolled up - adjust offset to stay viewing same messages
                     self.scroll_offset += added;
                 }
-
-                // Update last actions from Action messages
-                self.update_last_actions();
             }
         }
-
-        // Update coworker list from daemon (could poll RPC, for now use channel data)
-        self.update_coworkers();
-    }
-
-    /// Extract last /me actions from messages
-    fn update_last_actions(&mut self) {
-        self.last_actions.clear();
-
-        for msg in &self.messages {
-            if msg.message_type == MessageType::Action {
-                self.last_actions
-                    .insert(msg.from.clone(), msg.content.clone());
-            }
-        }
-    }
-
-    /// Update team list (Lead + coworkers)
-    fn update_coworkers(&mut self) {
-        // Always include Lead at the top
-        self.coworkers = vec![CoworkerInfo {
-            name: "Lead".to_string(),
-            last_action: self.last_actions.get("Lead").cloned(),
-        }];
-
-        // Try to get coworker list from daemon
-        if let Some(ref daemon) = self.daemon
-            && let Ok(crate::cli::Response::Coworkers { coworkers }) = daemon.coworker_list()
-        {
-            let mut cw_list: Vec<CoworkerInfo> = coworkers
-                .into_iter()
-                .map(|cw| CoworkerInfo {
-                    name: cw.name.clone(),
-                    last_action: self.last_actions.get(&cw.name).cloned(),
-                })
-                .collect();
-            cw_list.sort_by(|a, b| a.name.cmp(&b.name));
-            self.coworkers.extend(cw_list);
-            return;
-        }
-
-        // Fall back to building coworker list from message senders
-        let mut seen: HashMap<String, bool> = HashMap::new();
-        let excluded = ["system", "github", "Lead"];
-
-        for msg in &self.messages {
-            if !excluded.contains(&msg.from.as_str()) && !seen.contains_key(&msg.from) {
-                seen.insert(msg.from.clone(), true);
-            }
-        }
-
-        // Add coworkers from messages
-        let mut cw_list: Vec<CoworkerInfo> = seen
-            .keys()
-            .map(|name| CoworkerInfo {
-                name: name.clone(),
-                last_action: self.last_actions.get(name).cloned(),
-            })
-            .collect();
-        cw_list.sort_by(|a, b| a.name.cmp(&b.name));
-        self.coworkers.extend(cw_list);
     }
 
     /// Scroll up one line

--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -2,10 +2,10 @@
 
 use ratatui::{
     Frame,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, Paragraph},
+    widgets::{Block, Borders, Paragraph},
 };
 
 use midtown::{Message, MessageType};
@@ -42,61 +42,13 @@ fn get_sender_color(name: &str) -> Color {
 }
 
 /// Draw the main UI
+///
+/// Note: The Team panel has been removed - coworker status is now shown
+/// in tmux tab names instead, providing better visibility even when the
+/// chat TUI is not in focus.
 pub fn draw(f: &mut Frame, app: &mut App) {
-    // Split into team panel (30%) and chat panel (70%)
-    let chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(30), Constraint::Percentage(70)])
-        .split(f.area());
-
-    draw_team_panel(f, app, chunks[0]);
-    draw_chat_panel(f, app, chunks[1]);
-}
-
-/// Draw the team panel showing coworkers and their status
-fn draw_team_panel(f: &mut Frame, app: &App, area: Rect) {
-    let block = Block::default()
-        .title(" Team ")
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::DarkGray));
-
-    let inner = block.inner(area);
-
-    // Build list items for coworkers
-    let items: Vec<ListItem> = app
-        .coworkers
-        .iter()
-        .flat_map(|cw| {
-            let color = get_sender_color(&cw.name);
-            let name_line = Line::from(Span::styled(
-                &cw.name,
-                Style::default().fg(color).add_modifier(Modifier::BOLD),
-            ));
-
-            let status_line = match &cw.last_action {
-                Some(action) => {
-                    // Truncate long actions
-                    let display = if action.len() > 25 {
-                        format!("  {}...", &action[..22])
-                    } else {
-                        format!("  {}", action)
-                    };
-                    Line::from(Span::styled(display, Style::default().fg(Color::DarkGray)))
-                }
-                None => Line::from(Span::styled(
-                    "  (idle)",
-                    Style::default().fg(Color::DarkGray),
-                )),
-            };
-
-            vec![ListItem::new(name_line), ListItem::new(status_line)]
-        })
-        .collect();
-
-    let list = List::new(items);
-
-    f.render_widget(block, area);
-    f.render_widget(list, inner);
+    // Full width for chat panel - team status shown in tmux tabs instead
+    draw_chat_panel(f, app, f.area());
 }
 
 /// Draw the chat panel showing messages

--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -260,6 +260,27 @@ impl CoworkerManager {
         coworkers.get(name).cloned()
     }
 
+    /// Update a coworker's status display in their tmux tab.
+    ///
+    /// This is called when a coworker posts a /me action to the channel,
+    /// updating their tmux window name to show their current activity.
+    ///
+    /// # Arguments
+    /// * `name` - The coworker name
+    /// * `status` - The status text (or None to clear/show idle)
+    pub fn update_status_display(&self, name: &str, status: Option<&str>) -> crate::Result<()> {
+        // Only update if this is a known coworker
+        {
+            let coworkers = self.coworkers.read().unwrap();
+            if !coworkers.contains_key(name) {
+                // Not a coworker we're managing - might be Lead or external
+                return Ok(());
+            }
+        }
+
+        tmux::rename_window(&self.session_name, name, status)
+    }
+
     /// Send a nudge (input) to a coworker.
     pub fn nudge(&self, name: &str, message: &str) -> crate::Result<()> {
         // Verify coworker exists

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -648,6 +648,7 @@ fn handle_coworker_nudge(
 ///
 /// Supports IRC-style `/me` actions. If the message starts with `/me `,
 /// the prefix is stripped and the message is stored as an Action type.
+/// For coworkers, the action text is also reflected in their tmux tab name.
 fn handle_channel_post(id: RequestId, from: &str, message: &str, state: &DaemonState) -> Response {
     // Check for /me prefix (IRC-style action)
     let (content, msg_type) = if let Some(action) = message.strip_prefix("/me ") {
@@ -656,11 +657,20 @@ fn handle_channel_post(id: RequestId, from: &str, message: &str, state: &DaemonS
         (message.to_string(), MessageType::Text)
     };
 
-    let msg = Message::new(from, content, msg_type);
+    let msg = Message::new(from, content.clone(), msg_type.clone());
 
     match state.channel.send(&msg) {
         Ok(()) => {
             info!("Channel post from {}: {}", from, message);
+
+            // Update tmux tab for coworkers when they post /me actions
+            if msg_type == MessageType::Action {
+                // Update the coworker's tmux tab to show their status
+                if let Err(e) = state.coworkers.update_status_display(from, Some(&content)) {
+                    debug!("Failed to update tmux tab for {}: {}", from, e);
+                }
+            }
+
             Response::success(
                 id,
                 serde_json::json!({

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -257,6 +257,51 @@ pub fn send_keys(session: &str, name: &str, keys: &str) -> crate::Result<()> {
     Ok(())
 }
 
+/// Rename a tmux window to show coworker status.
+///
+/// Updates the window name to include the coworker's current status,
+/// providing visibility even when the chat TUI is not in focus.
+///
+/// # Arguments
+/// * `session` - The tmux session name
+/// * `name` - The coworker name (window name)
+/// * `status` - The status to display (e.g., "investigating auth bug")
+///
+/// # Window Name Format
+/// - With status: "lexington: investigating..."
+/// - Without status (idle): "lexington"
+///
+/// Status is truncated to keep the tab readable (max 20 chars).
+pub fn rename_window(session: &str, name: &str, status: Option<&str>) -> crate::Result<()> {
+    let target = format!("{}:{}", session, name);
+
+    // Build the new window name
+    let new_name = match status {
+        Some(s) if !s.is_empty() => {
+            // Truncate status to keep tab readable
+            let truncated = if s.len() > 20 {
+                format!("{}...", &s[..17])
+            } else {
+                s.to_string()
+            };
+            format!("{}: {}", name, truncated)
+        }
+        _ => name.to_string(),
+    };
+
+    let status = Command::new("tmux")
+        .args(["rename-window", "-t", &target, &new_name])
+        .status()
+        .map_err(Error::Io)?;
+
+    if !status.success() {
+        // Non-fatal - window might not exist yet
+        tracing::debug!("Failed to rename tmux window {} to {}", target, new_name);
+    }
+
+    Ok(())
+}
+
 /// Send raw keys without appending Enter.
 pub fn send_keys_raw(session: &str, name: &str, keys: &str) -> crate::Result<()> {
     let target = format!("{}:{}", session, name);


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Remove Team panel from chat TUI - now uses full width for messages
- Add `tmux::rename_window()` for updating window titles with coworker status
- Update tmux tabs when coworkers post `/me` actions via the daemon
- Clean up unused `CoworkerInfo` struct and related code from `app.rs`

## Motivation
The Team panel was taking 30% of screen width and showing information that's better displayed in tmux tabs. Now:
- Coworker status is visible even when not in the chat TUI
- Chat has more room for messages
- Status updates appear directly in tmux tabs (e.g., "lexington: investigating...")

## Test plan
- [x] All 141 tests pass
- [x] `cargo build` succeeds with no warnings
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)