### PR TITLE
fix: Remove non-existent midtown task commands from coworker prompt

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -33,10 +33,10 @@ Use Claude Code's built-in task tools to manage tasks:
 - `TaskGet` - Get task details
 - `TaskUpdate` - Update task status (in_progress, completed)
 
-After updating a task, announce it to the team:
+After updating a task status, announce it to the team via the channel:
 ```bash
-midtown task claim <id>     # Announce you're working on a task
-midtown task done <id>      # Announce task completion
+midtown channel post "/me claiming task 5"      # When starting work
+midtown channel post "/me completed task 5"     # When finishing
 ```
 
 Don't hoard tasks - claim one, finish it, then claim another.


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Removed references to non-existent `midtown task claim` and `midtown task done` commands from the coworker system prompt
- Replaced with `midtown channel post` calls, which is the actual way to announce task status changes to the team

The coworker prompt already correctly instructs use of Claude Code's native task tools (`TaskList`, `TaskGet`, `TaskUpdate`), but the announcement section was pointing to CLI commands that don't exist.

## Test plan
- [x] Verified the updated prompt makes sense and is consistent with actual available commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)