### PR TITLE
fix: Use DarkGray for github message content in chat TUI

### DIFF
--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -162,9 +162,11 @@ fn render_message(msg: &Message, width: usize) -> Vec<Line<'static>> {
 
     for (i, content) in content_lines.into_iter().enumerate() {
         // Determine base style for content based on message type
+        // For github/system senders, use DarkGray for both name and content
         let content_style = match msg.message_type {
             MessageType::Action => Style::default().fg(color),
             MessageType::System => Style::default().fg(Color::DarkGray),
+            _ if msg.from == "github" => Style::default().fg(Color::DarkGray),
             _ => Style::default().fg(Color::White),
         };
 


### PR DESCRIPTION
## Summary
Match the content color to the sender color for github messages, making the entire message appear in DarkGray for visual consistency.

**Before:** `<github>` in gray, message text in white
**After:** Both `<github>` and message text in DarkGray

## Test plan
- [x] Build succeeds
- [ ] View chat TUI with github messages - entire line should be gray

🤖 Generated with [Claude Code](https://claude.com/claude-code)