### PR TITLE
fix: Scope daemon socket per project to fix Team panel isolation

### DIFF
--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -11,28 +11,28 @@ use crate::cli::Response;
 
 /// Get the tmux session name based on the repo name.
 /// Format: midtown-{repo_name}
+///
+/// Returns an error if not in a git repository, since a tmux session
+/// requires a valid project context.
 fn session_name() -> Result<String, String> {
-    let root = repo_root()?;
-    let repo_name = root
-        .file_name()
-        .map(|s| s.to_string_lossy().to_string())
-        .unwrap_or_else(|| "default".to_string());
+    let repo_name = midtown::paths::detect_repo_name().or_else(|| {
+        repo_root()
+            .ok()
+            .and_then(|r| r.file_name().map(|s| s.to_string_lossy().to_string()))
+    });
 
-    Ok(format!("midtown-{}", repo_name))
+    match repo_name {
+        Some(name) => Ok(format!("midtown-{}", name)),
+        None => Err(
+            "Not in a git repository. Run midtown from within a git repo or use --repo."
+                .to_string(),
+        ),
+    }
 }
 
 /// Get the socket path for the daemon.
 fn socket_path() -> PathBuf {
-    let state_dir = std::env::var("XDG_STATE_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            dirs::home_dir()
-                .unwrap_or_else(|| PathBuf::from("."))
-                .join(".local")
-                .join("state")
-        });
-
-    state_dir.join("midtown").join("daemon.sock")
+    midtown::paths::daemon_socket()
 }
 
 /// Check if the daemon is running by attempting to connect to its socket.

--- a/src/bin/midtown/cli/hooks.rs
+++ b/src/bin/midtown/cli/hooks.rs
@@ -204,15 +204,9 @@ fn get_active_coworkers() -> Vec<String> {
     Vec::new()
 }
 
-/// Get daemon socket path.
+/// Get daemon socket path for the current repository.
 fn get_daemon_socket_path() -> PathBuf {
-    let state_dir = std::env::var("XDG_STATE_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-            PathBuf::from(home).join(".local").join("state")
-        });
-    state_dir.join("midtown").join("daemon.sock")
+    midtown::paths::daemon_socket()
 }
 
 /// Get list of in_progress tasks with their owners.

--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -74,19 +74,12 @@ impl DaemonClient {
         Ok(DaemonClient { socket_path })
     }
 
-    /// Get the default socket path.
+    /// Get the socket path for the current repository.
+    ///
+    /// Uses git-aware repo detection to ensure clients connect to the
+    /// correct daemon for their project.
     fn socket_path() -> PathBuf {
-        // Try XDG_STATE_HOME first, then fall back to ~/.local/state
-        let state_dir = std::env::var("XDG_STATE_HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| {
-                dirs::home_dir()
-                    .unwrap_or_else(|| PathBuf::from("."))
-                    .join(".local")
-                    .join("state")
-            });
-
-        state_dir.join("midtown").join("daemon.sock")
+        midtown::paths::daemon_socket()
     }
 
     /// Send a JSON-RPC request to the daemon and get a response.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -45,15 +45,6 @@ pub const DEFAULT_WEBHOOK_PORT: u16 = 47022;
 
 impl Default for DaemonConfig {
     fn default() -> Self {
-        let state_dir = std::env::var("XDG_STATE_HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| {
-                dirs::home_dir()
-                    .unwrap_or_else(|| PathBuf::from("."))
-                    .join(".local")
-                    .join("state")
-            });
-
         // Check env vars for webhook config (can override or disable with MIDTOWN_WEBHOOK_PORT=0)
         let webhook_port = std::env::var("MIDTOWN_WEBHOOK_PORT")
             .ok()
@@ -67,7 +58,8 @@ impl Default for DaemonConfig {
             .unwrap_or(DEFAULT_WEBHOOK_RESTART_INTERVAL_SECS);
 
         Self {
-            socket_path: state_dir.join("midtown").join("daemon.sock"),
+            // Use repo-specific socket path to isolate daemons per project
+            socket_path: crate::paths::daemon_socket(),
             workdir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
             verbose: false,
             webhook_port,
@@ -86,11 +78,13 @@ struct DaemonState {
 
 impl DaemonState {
     fn new(socket_path: PathBuf, workdir: PathBuf, channel: Channel) -> crate::Result<Self> {
-        // Derive the tmux session name from the workdir (repo name)
-        let repo_name = workdir
-            .file_name()
-            .map(|s| s.to_string_lossy().to_string())
-            .unwrap_or_else(|| "default".to_string());
+        // Derive the tmux session name using git-aware repo detection
+        let repo_name = crate::paths::detect_repo_name().unwrap_or_else(|| {
+            workdir
+                .file_name()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_else(|| "default".to_string())
+        });
         let session_name = format!("midtown-{}", repo_name);
 
         // Create worktree manager for coworker isolation
@@ -124,12 +118,15 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
         std::fs::create_dir_all(parent)?;
     }
 
-    // Derive repo name from workdir
-    let repo_name = config
-        .workdir
-        .file_name()
-        .map(|s| s.to_string_lossy().to_string())
-        .unwrap_or_else(|| "default".to_string());
+    // Derive repo name using git-aware detection (handles worktrees correctly)
+    let repo_name = crate::paths::detect_repo_name().unwrap_or_else(|| {
+        // Fallback to workdir name if not in a git repo
+        config
+            .workdir
+            .file_name()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| "default".to_string())
+    });
 
     // Create channel for the repo
     let channel = Channel::for_repo(&repo_name)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,9 @@ pub mod config;
 // Agent system prompts
 pub mod agents;
 
+// Path utilities (socket paths, repo detection)
+pub mod paths;
+
 pub use channel::Channel;
 pub use coworker::{Coworker, CoworkerManager, CoworkerStatus};
 pub use cursor::Cursor;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,122 @@
+//! Path utilities for midtown daemon and clients.
+//!
+//! Provides consistent path handling for daemon sockets, channels, and other
+//! resources, with proper support for git worktrees.
+
+use std::path::PathBuf;
+
+/// Detect the current git repository name.
+///
+/// Uses `git rev-parse --git-common-dir` to handle worktrees correctly,
+/// since worktrees share the main repo's .git directory.
+///
+/// Returns `None` if not in a git repository.
+pub fn detect_repo_name() -> Option<String> {
+    // First try git-common-dir which works correctly for worktrees
+    let common_dir = std::process::Command::new("git")
+        .args(["rev-parse", "--git-common-dir"])
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+            } else {
+                None
+            }
+        });
+
+    if let Some(git_dir) = common_dir {
+        let git_path = std::path::Path::new(&git_dir);
+        // The git-common-dir is the .git folder - get its parent's name
+        if let Some(parent) = git_path.parent() {
+            // Handle relative ".git" by getting the actual toplevel
+            if git_dir == ".git" {
+                return std::process::Command::new("git")
+                    .args(["rev-parse", "--show-toplevel"])
+                    .output()
+                    .ok()
+                    .and_then(|output| {
+                        if output.status.success() {
+                            let path = String::from_utf8_lossy(&output.stdout);
+                            std::path::Path::new(path.trim())
+                                .file_name()
+                                .map(|s| s.to_string_lossy().to_string())
+                        } else {
+                            None
+                        }
+                    });
+            }
+            // For worktrees, parent is the main repo directory
+            return parent.file_name().map(|s| s.to_string_lossy().to_string());
+        }
+    }
+
+    // Fallback: try show-toplevel for regular repos
+    std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout);
+                std::path::Path::new(path.trim())
+                    .file_name()
+                    .map(|s| s.to_string_lossy().to_string())
+            } else {
+                None
+            }
+        })
+}
+
+/// Get the state directory for midtown.
+///
+/// Uses `XDG_STATE_HOME` if set, otherwise `~/.local/state`.
+fn state_dir() -> PathBuf {
+    std::env::var("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs::home_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(".local")
+                .join("state")
+        })
+}
+
+/// Get the daemon socket path for a specific repository.
+///
+/// Returns `~/.local/state/midtown/<repo>/daemon.sock`.
+///
+/// This ensures each project has its own daemon, preventing coworkers
+/// from different projects from being mixed.
+pub fn daemon_socket_for_repo(repo: &str) -> PathBuf {
+    state_dir().join("midtown").join(repo).join("daemon.sock")
+}
+
+/// Get the daemon socket path for the current repository.
+///
+/// Detects the repo name from the current git working directory.
+/// Falls back to "default" if not in a git repository.
+pub fn daemon_socket() -> PathBuf {
+    let repo = detect_repo_name().unwrap_or_else(|| "default".to_string());
+    daemon_socket_for_repo(&repo)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_daemon_socket_for_repo() {
+        let path = daemon_socket_for_repo("myproject");
+        assert!(path.to_string_lossy().contains("midtown"));
+        assert!(path.to_string_lossy().contains("myproject"));
+        assert!(path.to_string_lossy().ends_with("daemon.sock"));
+    }
+
+    #[test]
+    fn test_daemon_socket_different_repos() {
+        let path1 = daemon_socket_for_repo("project-a");
+        let path2 = daemon_socket_for_repo("project-b");
+        assert_ne!(path1, path2);
+    }
+}


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Fixed Team panel showing coworkers from other projects
- Made daemon socket path per-project: `~/.local/state/midtown/<repo>/daemon.sock`
- Added `src/paths.rs` module for centralized, worktree-aware path handling
- Updated daemon, client, and hooks to use shared path logic

## Root Cause
The daemon socket was global (`~/.local/state/midtown/daemon.sock`), meaning all clients connected to whatever daemon was running, regardless of which project started it. This caused coworker lists to leak across projects.

## Test plan
- [x] All 143 existing tests pass
- [x] Clippy and fmt checks pass
- [ ] Manual test: Start daemons in two different projects, verify each shows only its own coworkers

🤖 Generated with [Claude Code](https://claude.com/claude-code)