### PR TITLE
feat: Add granular workflow phase status updates to coworker prompt

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -18,12 +18,21 @@ midtown channel post "/me running test suite"
 midtown channel post "/me opening PR for task 3"
 ```
 
-Your `/me` status appears in the team sidebar, so keep it current.
+Your `/me` status appears in the tmux tab bar, so **keep it current at each phase**.
 
-Post when:
-- Starting work: `/me claiming task 5`
-- Making progress: `/me found the issue in auth.rs`
-- PR ready: `/me requesting review of PR #42` (GitHub already announces the PR, just request review)
+### Workflow Phases
+Post a `/me` update when you transition between phases:
+
+| Phase | Status Example |
+|-------|----------------|
+| **Claiming** | `/me claiming task 5` |
+| **Developing** | `/me developing task 5 - adding auth endpoint` |
+| **Testing** | `/me testing task 5 - running integration tests` |
+| **Opening PR** | `/me opening PR for task 5` |
+| **Awaiting review** | `/me requesting review of PR #42` |
+
+### Other Updates
+- Progress milestones: `/me found the root cause in auth.rs`
 - Blocked: `blocked on task 3, need API spec clarified`
 - Questions: `@Lead should this handle the edge case?`
 
@@ -33,10 +42,14 @@ Use Claude Code's built-in task tools to manage tasks:
 - `TaskGet` - Get task details
 - `TaskUpdate` - Update task status (in_progress, completed)
 
-After updating a task status, announce it to the team via the channel:
+After updating a task status, announce it to the team via the channel. **Update your `/me` status as you progress through each phase** so teammates can see your current state in the tmux tabs:
+
 ```bash
-midtown channel post "/me claiming task 5"      # When starting work
-midtown channel post "/me completed task 5"     # When finishing
+midtown channel post "/me claiming task 5"
+midtown channel post "/me developing task 5 - implementing feature X"
+midtown channel post "/me testing task 5"
+midtown channel post "/me opening PR for task 5"
+midtown channel post "/me completed task 5"
 ```
 
 Don't hoard tasks - claim one, finish it, then claim another.


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Updated coworker.md to encourage posting `/me` status updates at each workflow phase
- Added a clear table showing the expected status format for each phase: claiming, developing, testing, opening PR, awaiting review
- Status updates now appear in tmux tabs, so teammates can see at a glance what phase each coworker is in

## Test plan
- [x] Changes reviewed in coworker.md
- [x] Passed cargo clippy and cargo fmt checks

Closes #3