### PR TITLE
feat: Add GitHub Action to publish releases to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish to crates.io
+
+on:
+  release:
+    types: [published]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-publish-
+
+      - name: Verify version matches release tag
+        run: |
+          CARGO_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          RELEASE_TAG="${{ github.event.release.tag_name }}"
+          # Strip 'v' prefix if present
+          RELEASE_VERSION="${RELEASE_TAG#v}"
+          if [ "$CARGO_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "Error: Cargo.toml version ($CARGO_VERSION) does not match release tag ($RELEASE_VERSION)"
+            exit 1
+          fi
+          echo "Version verified: $CARGO_VERSION"
+
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2024"
 description = "Midtown daemon - multi-agent workspace manager for Gas Town"
 license = "Apache-2.0"
+repository = "https://github.com/btucker/midtown"
+readme = "README.md"
 
 [dependencies]
 # Async runtime


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Add `.github/workflows/publish.yml` that triggers on release published event
- Include version verification step to ensure Cargo.toml version matches release tag
- Add `repository` and `readme` fields to Cargo.toml (recommended for crates.io)
- Uses `CARGO_REGISTRY_TOKEN` secret for authentication

## Setup Required
After merging, add `CARGO_REGISTRY_TOKEN` secret to the repository:
1. Go to Settings → Secrets and variables → Actions
2. Add a new repository secret named `CARGO_REGISTRY_TOKEN`
3. Value should be a crates.io API token with publish permissions

## Test plan
- [x] `cargo check` passes
- [x] `cargo publish --dry-run` passes (requires clean working directory)
- [x] Workflow file syntax validated
- [ ] Manual: Create a test release to verify the workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)