### PR TITLE
feat: Lead stop hook detects idle coworkers with no tasks

### DIFF
--- a/src/bin/midtown/cli/hooks.rs
+++ b/src/bin/midtown/cli/hooks.rs
@@ -100,20 +100,19 @@ fn handle_insight_hook() -> Result<Response, String> {
     })
 }
 
-/// Handle the Lead stop hook - read channel and check for orphaned tasks.
+/// Handle the Lead stop hook - read channel and check for orphaned tasks and idle coworkers.
 fn handle_lead_stop_hook() -> Result<Response, String> {
     // First, read channel messages to sync
     let _ = read_channel_messages();
+
+    let repo = detect_git_repo().ok_or("Not in a git repository")?;
+    let channel =
+        midtown::Channel::for_repo(&repo).map_err(|e| format!("Failed to open channel: {}", e))?;
 
     // Check for orphaned tasks (in_progress but owned by dead coworkers)
     let orphaned = find_orphaned_tasks();
 
     if !orphaned.is_empty() {
-        // Post warning to channel
-        let repo = detect_git_repo().ok_or("Not in a git repository")?;
-        let channel = midtown::Channel::for_repo(&repo)
-            .map_err(|e| format!("Failed to open channel: {}", e))?;
-
         for (task_id, owner) in &orphaned {
             let message = midtown::Message::text(
                 "Lead",
@@ -127,6 +126,29 @@ fn handle_lead_stop_hook() -> Result<Response, String> {
 
         return Ok(Response::Message {
             message: format!("Warning: {} orphaned task(s) found", orphaned.len()),
+        });
+    }
+
+    // Check for idle coworkers with no remaining work
+    let idle_coworkers = find_idle_coworkers();
+    let pending_tasks = get_pending_tasks();
+
+    if !idle_coworkers.is_empty() && pending_tasks.is_empty() {
+        let coworker_list = idle_coworkers.join(", ");
+        let message = midtown::Message::text(
+            "Lead",
+            format!(
+                "💤 Coworkers [{}] are idle with no remaining tasks. Consider shutting them down.",
+                coworker_list
+            ),
+        );
+        let _ = channel.send(&message);
+
+        return Ok(Response::Message {
+            message: format!(
+                "Coworkers {} are idle with no remaining tasks. Consider: midtown stop",
+                coworker_list
+            ),
         });
     }
 
@@ -160,6 +182,57 @@ fn find_orphaned_tasks() -> Vec<(String, String)> {
     }
 
     orphaned
+}
+
+/// Find coworkers that are running but not actively working on any task.
+fn find_idle_coworkers() -> Vec<String> {
+    let active_coworkers = get_active_coworkers();
+    let in_progress = get_in_progress_tasks();
+
+    // Build set of coworkers who own in_progress tasks
+    let busy_coworkers: HashSet<String> = in_progress
+        .iter()
+        .map(|(_, owner)| owner.to_lowercase())
+        .collect();
+
+    // Return coworkers who are active but not busy
+    active_coworkers
+        .into_iter()
+        .filter(|cw| !busy_coworkers.contains(&cw.to_lowercase()))
+        .collect()
+}
+
+/// Get list of pending tasks (tasks that can still be claimed).
+fn get_pending_tasks() -> Vec<String> {
+    let output = std::process::Command::new("bd")
+        .args(["list", "--json"])
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if let Ok(tasks) = serde_json::from_str::<Vec<serde_json::Value>>(&stdout) {
+                return tasks
+                    .iter()
+                    .filter(|task| {
+                        task.get("status")
+                            .and_then(|s| s.as_str())
+                            .map(|s| s == "pending")
+                            .unwrap_or(false)
+                    })
+                    .filter_map(|task| {
+                        task.get("id").and_then(|i| {
+                            i.as_str()
+                                .map(|s| s.to_string())
+                                .or_else(|| i.as_u64().map(|n| n.to_string()))
+                        })
+                    })
+                    .collect();
+            }
+            Vec::new()
+        }
+        _ => Vec::new(),
+    }
 }
 
 /// Get list of active coworker names from daemon.


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- When Lead's stop hook runs, now checks for idle coworkers (active but not working on any task)
- If idle coworkers exist AND no pending tasks remain, posts a message to channel and suggests shutdown
- Adds `find_idle_coworkers()` to detect active coworkers not owning in_progress tasks
- Adds `get_pending_tasks()` to check if there's work remaining to be claimed

This prevents coworkers from sitting idle consuming resources when all work is done.

## Test plan
- [x] `cargo build` compiles successfully
- [x] `cargo test` - all 122 tests pass
- [x] `cargo clippy` - no warnings
- [x] `cargo fmt --check` - no formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)