### PR TITLE
docs: Add crates.io installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ All agents run as windows within a single tmux session. Use `Ctrl-b w` to see ev
 
 ### 1. Install
 
+From [crates.io](https://crates.io/crates/midtown):
+
+```bash
+cargo install midtown
+```
+
+Or from source:
+
 ```bash
 cargo install --path .
 ```


### PR DESCRIPTION
<!-- midtown: spring -->

## Summary
- Added `cargo install midtown` as primary installation method with link to crates.io
- Kept `cargo install --path .` as alternative for building from source

## Test plan
- [x] README renders correctly with new installation section
- [x] Link to crates.io is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)