### PR TITLE
fix: Use pane-focus-in hook instead of non-existent window-focus-in

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -295,7 +295,7 @@ fi"#,
             "set-hook",
             "-t",
             session,
-            "window-focus-in",
+            "pane-focus-in",
             &format!("run-shell '{}'", script),
         ])
         .status()


### PR DESCRIPTION
## Summary
- tmux doesn't have a `window-focus-in` hook - it was causing "invalid option" errors on restart
- The correct hook is `pane-focus-in`, which fires when switching windows since the new window's pane receives focus

## Test plan
- [x] `cargo build` passes
- [ ] Run `midtown restart` - should not show warning about failed hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)