### PR TITLE
feat: Set terminal title to 'Midtown: <project>'

### DIFF
--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -352,6 +352,20 @@ pub fn handle_start(daemon_only: bool) -> Result<Response, String> {
             ])
             .status();
 
+        // Set terminal title to "Midtown: <project>" instead of showing the command
+        let _ = Command::new("tmux")
+            .args(["set-option", "-t", &session, "set-titles", "on"])
+            .status();
+        let _ = Command::new("tmux")
+            .args([
+                "set-option",
+                "-t",
+                &session,
+                "set-titles-string",
+                &format!("Midtown: {}", project_name),
+            ])
+            .status();
+
         // Set Lead window tab color (yellow to match chat TUI team panel)
         let lead_window = format!("{}:Lead", session);
         let _ = Command::new("tmux")


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Add tmux `set-titles on` and `set-titles-string` options in `handle_start()` 
- Terminal title now shows "Midtown: PROJECT" instead of the command being run
- Uses the same uppercase project name as the status bar for consistency

## Test plan
- [x] `cargo check` passes
- [x] All 161 tests pass
- [x] Run `midtown restart` and verify terminal tab shows "Midtown: <project>"

🤖 Generated with [Claude Code](https://claude.com/claude-code)