### PR TITLE
feat: Convert channel timestamps to local timezone

### DIFF
--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -1,5 +1,6 @@
 //! UI rendering for the chat TUI
 
+use chrono::Local;
 use ratatui::{
     Frame,
     layout::Rect,
@@ -91,7 +92,11 @@ fn draw_chat_panel(f: &mut Frame, app: &mut App, area: Rect) {
 /// - Long lines that need wrapping to fit the panel width
 /// - Markdown formatting (**bold**, *italic*, `code`)
 fn render_message(msg: &Message, width: usize) -> Vec<Line<'static>> {
-    let time = msg.timestamp.format("%H:%M").to_string();
+    let time = msg
+        .timestamp
+        .with_timezone(&Local)
+        .format("%H:%M")
+        .to_string();
     let color = get_sender_color(&msg.from);
 
     // Calculate the prefix length for continuation line indentation


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Convert UTC timestamps to local timezone in the chat TUI using `chrono::Local`
- Makes timestamps more intuitive for users regardless of their timezone

## Test plan
- [x] All existing ui module tests pass
- [x] `cargo check` passes
- [x] `cargo clippy` passes
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)