### PR TITLE
docs: Update Lead prompt to prefer reusing idle coworkers

### DIFF
--- a/agents/lead.md
+++ b/agents/lead.md
@@ -62,8 +62,16 @@ midtown channel read         # Read recent channel messages
 ```
 
 ## Spawning Coworkers
-After spawning a coworker, immediately nudge them with context:
+**Prefer reusing idle coworkers over spawning new ones.** Check `midtown status` first - if a coworker is idle (no current task), nudge them with the new work instead of spawning.
+
 ```bash
+# First, check for idle coworkers
+midtown status
+
+# If idle coworker exists, reuse them:
+midtown coworker nudge <idle-name> -m "Work on task #X: <brief description>"
+
+# Only spawn if all coworkers are busy:
 midtown coworker spawn
 midtown coworker nudge <name> -m "Work on task #X: <brief description>"
 ```


### PR DESCRIPTION
## Summary
- Updated Lead system prompt to prefer reusing idle coworkers over spawning new ones
- Added guidance to check `midtown status` first and nudge idle coworkers with new work

This reduces resource usage and makes better use of existing coworker sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)