### PR TITLE
fix: Remove quotes causing syntax error in status bar hook

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -285,7 +285,7 @@ case "$lower_name" in
         *) color="" ;;
 esac; \
 if [ -n "$color" ]; then \
-    tmux set-option -t {} status-style "bg=colour236,fg=$color"; \
+    tmux set-option -t {} status-style bg=colour236,fg=$color; \
 fi"#,
         case_statement, session
     );


### PR DESCRIPTION
## Summary
- Fixed syntax error in tmux status bar hook
- Removed unnecessary double quotes from `"bg=colour236,fg=$color"` that caused shell syntax error when wrapped in single quotes for `run-shell`

## Test plan
- [x] `cargo build` passes
- [ ] `midtown restart` should not show "syntax error" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)