### PR TITLE
feat: Add PostToolUse hook for AskUserQuestion tool

### DIFF
--- a/src/bin/midtown/cli/coworker.rs
+++ b/src/bin/midtown/cli/coworker.rs
@@ -36,6 +36,11 @@ pub enum CoworkerCommand {
     TaskHook,
     /// Link this session's tasks to the Lead's task directory (SessionStart hook)
     LinkTasks,
+    /// Handle Claude Code PostToolUse hook for AskUserQuestion
+    ///
+    /// Reads tool use context from stdin and notifies daemon to nudge Lead.
+    /// Called automatically by Claude Code when AskUserQuestion tool is used.
+    AskHook,
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -68,6 +73,7 @@ pub fn handle(cmd: &CoworkerCommand, client: &DaemonClient) -> Result<Response, 
         CoworkerCommand::StopHook => handle_stop_hook_standalone(),
         CoworkerCommand::TaskHook => handle_task_hook_standalone(),
         CoworkerCommand::LinkTasks => handle_link_tasks_standalone(),
+        CoworkerCommand::AskHook => handle_ask_hook_standalone(),
     }
 }
 
@@ -331,6 +337,107 @@ pub fn handle_task_hook_standalone() -> Result<Response, String> {
     Ok(Response::Message {
         message: format!("Posted: * {} {}", agent, action_message),
     })
+}
+
+/// Handle the PostToolUse hook for AskUserQuestion.
+///
+/// This command is designed to be used as a Claude Code PostToolUse hook
+/// for the AskUserQuestion tool. It:
+/// 1. Reads tool use context from stdin (JSON)
+/// 2. Extracts the question(s) being asked
+/// 3. Notifies daemon via RPC to nudge the Lead with the question
+///
+/// Example: When a coworker uses AskUserQuestion to ask "Should I use REST or GraphQL?",
+/// this hook triggers and the Lead gets nudged with that question.
+pub fn handle_ask_hook_standalone() -> Result<Response, String> {
+    use std::io::Read;
+
+    // Read stdin for tool context
+    let mut input = String::new();
+    std::io::stdin()
+        .read_to_string(&mut input)
+        .map_err(|e| format!("Failed to read stdin: {}", e))?;
+
+    // Parse the JSON input
+    let context: serde_json::Value =
+        serde_json::from_str(&input).map_err(|e| format!("Failed to parse JSON: {}", e))?;
+
+    // Get agent name from environment
+    let agent = std::env::var("MIDTOWN_AGENT").unwrap_or_else(|_| "coworker".to_string());
+
+    // Extract questions from tool input
+    let tool_input = &context["tool_input"];
+    let questions = extract_questions(tool_input);
+
+    if questions.is_empty() {
+        return Ok(Response::Message {
+            message: "No questions found in tool input".to_string(),
+        });
+    }
+
+    // Format the question(s) for the nudge
+    let question_text = if questions.len() == 1 {
+        questions[0].clone()
+    } else {
+        questions.join("; ")
+    };
+
+    // Try to notify daemon via RPC
+    let client_result = crate::client::DaemonClient::connect();
+    match client_result {
+        Ok(client) => {
+            // Call daemon RPC to notify about the question
+            match client.coworker_asking(&agent, &question_text) {
+                Ok(_) => Ok(Response::Message {
+                    message: format!("Notified Lead: {} is asking: {}", agent, question_text),
+                }),
+                Err(e) => {
+                    // Fallback: post to channel directly if daemon call fails
+                    post_question_to_channel(&agent, &question_text)?;
+                    Ok(Response::Message {
+                        message: format!("Posted question to channel (daemon error: {})", e),
+                    })
+                }
+            }
+        }
+        Err(_) => {
+            // Fallback: post to channel directly if daemon not running
+            post_question_to_channel(&agent, &question_text)?;
+            Ok(Response::Message {
+                message: "Posted question to channel (daemon not running)".to_string(),
+            })
+        }
+    }
+}
+
+/// Extract questions from AskUserQuestion tool input.
+fn extract_questions(tool_input: &serde_json::Value) -> Vec<String> {
+    let mut questions = Vec::new();
+
+    // AskUserQuestion has a "questions" array with "question" fields
+    if let Some(qs) = tool_input.get("questions").and_then(|q| q.as_array()) {
+        for q in qs {
+            if let Some(text) = q.get("question").and_then(|t| t.as_str()) {
+                questions.push(text.to_string());
+            }
+        }
+    }
+
+    questions
+}
+
+/// Post a question to the channel as a fallback when daemon is unavailable.
+fn post_question_to_channel(agent: &str, question: &str) -> Result<(), String> {
+    let repo = detect_git_repo().ok_or("Not in a git repository")?;
+    let channel =
+        midtown::Channel::for_repo(&repo).map_err(|e| format!("Failed to open channel: {}", e))?;
+
+    let message = midtown::Message::text(agent, format!("Question for Lead: {}", question));
+    channel
+        .send(&message)
+        .map_err(|e| format!("Failed to post to channel: {}", e))?;
+
+    Ok(())
 }
 
 /// Read channel messages and return them.

--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -158,6 +158,13 @@ impl DaemonClient {
         self.send("coworker.nudge", Some(args))
     }
 
+    pub fn coworker_asking(&self, name: &str, question: &str) -> Result<Response, String> {
+        self.send(
+            "coworker.asking",
+            Some(serde_json::json!({ "name": name, "question": question })),
+        )
+    }
+
     // Nudge configuration commands
 
     pub fn nudge_config_show(&self) -> Result<Response, String> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -510,6 +510,21 @@ fn handle_request(line: &str, state: &DaemonState) -> Response {
             }
         }
 
+        "coworker.asking" => {
+            let params = request.params.as_ref();
+            let name = params.and_then(|p| p.get("name")).and_then(|v| v.as_str());
+            let question = params
+                .and_then(|p| p.get("question"))
+                .and_then(|v| v.as_str());
+
+            match (name, question) {
+                (Some(name), Some(question)) => {
+                    handle_coworker_asking(request.id, name, question, state)
+                }
+                _ => Response::error(request.id, RpcError::invalid_params()),
+            }
+        }
+
         "status" => handle_status(request.id, state),
 
         "channel.post" => {
@@ -639,6 +654,49 @@ fn handle_coworker_nudge(
             Response::error(id, RpcError::new(-32603, e.to_string()))
         }
     }
+}
+
+/// Handle coworker.asking RPC method.
+///
+/// Called when a coworker uses AskUserQuestion tool. This:
+/// 1. Posts the question to the channel
+/// 2. Nudges the Lead with the question
+/// 3. Marks the coworker as waiting for feedback
+fn handle_coworker_asking(
+    id: RequestId,
+    name: &str,
+    question: &str,
+    state: &DaemonState,
+) -> Response {
+    // Post question to channel
+    let msg = Message::text(name, format!("Question for Lead: {}", question));
+    if let Err(e) = state.channel.send(&msg) {
+        error!("Failed to post question to channel: {}", e);
+    }
+
+    // Nudge the Lead with the question
+    let nudge_message = format!("{} is asking: {}", name, question);
+    if let Err(e) = state.coworkers.nudge("Lead", &nudge_message) {
+        // Log but don't fail - Lead might not be in a tmux window
+        debug!("Failed to nudge Lead: {}", e);
+    }
+
+    // Update coworker status to show they're waiting
+    if let Err(e) = state
+        .coworkers
+        .update_status_display(name, Some("waiting for feedback"))
+    {
+        debug!("Failed to update coworker status: {}", e);
+    }
+
+    info!("Coworker {} asking: {}", name, question);
+    Response::success(
+        id,
+        serde_json::json!({
+            "success": true,
+            "message": format!("Notified Lead about question from {}", name),
+        }),
+    )
 }
 
 /// Handle channel.post RPC method.

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -557,6 +557,12 @@ fn coworker_settings_json(bin_command: &str) -> serde_json::Value {
                     "command": format!("{} coworker task-hook", bin_command)
                 }]
             }, {
+                "matcher": "AskUserQuestion",
+                "hooks": [{
+                    "type": "command",
+                    "command": format!("{} coworker ask-hook", bin_command)
+                }]
+            }, {
                 // No matcher = runs on every tool use
                 "hooks": [{
                     "type": "command",
@@ -757,10 +763,10 @@ mod tests {
             "midtown --format json coworker stop-hook"
         );
 
-        // Verify PostToolUse hooks for task operations and insights
+        // Verify PostToolUse hooks for task operations, questions, and insights
         let post_tool_hooks = &settings["hooks"]["PostToolUse"];
         assert!(post_tool_hooks.is_array());
-        assert_eq!(post_tool_hooks.as_array().unwrap().len(), 3);
+        assert_eq!(post_tool_hooks.as_array().unwrap().len(), 4);
 
         // TaskUpdate hook
         assert_eq!(post_tool_hooks[0]["matcher"], "TaskUpdate");
@@ -776,10 +782,17 @@ mod tests {
             "midtown coworker task-hook"
         );
 
-        // Insight hook (no matcher)
-        assert!(post_tool_hooks[2]["matcher"].is_null());
+        // AskUserQuestion hook
+        assert_eq!(post_tool_hooks[2]["matcher"], "AskUserQuestion");
         assert_eq!(
             post_tool_hooks[2]["hooks"][0]["command"],
+            "midtown coworker ask-hook"
+        );
+
+        // Insight hook (no matcher)
+        assert!(post_tool_hooks[3]["matcher"].is_null());
+        assert_eq!(
+            post_tool_hooks[3]["hooks"][0]["command"],
             "midtown hook insight"
         );
 


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Adds a PostToolUse hook that fires when coworkers use `AskUserQuestion`
- Hook notifies daemon via RPC, which then:
  - Posts the question to the channel
  - Nudges the Lead with the question
  - Updates the coworker's tmux tab to show "waiting for feedback"

## Implementation
- `src/tmux.rs`: Add AskUserQuestion matcher to PostToolUse hooks config
- `src/bin/midtown/cli/coworker.rs`: Add `ask-hook` command that reads stdin JSON and calls daemon
- `src/bin/midtown/client/mod.rs`: Add `coworker_asking` RPC method
- `src/daemon.rs`: Add `coworker.asking` RPC handler

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy` passes
- [ ] Manual test: spawn coworker, have it use AskUserQuestion, verify Lead gets nudged

🤖 Generated with [Claude Code](https://claude.com/claude-code)