### PR TITLE
feat: Daemon auto-recovers orphaned in-progress tasks

### DIFF
--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -310,6 +310,69 @@ impl CoworkerManager {
         tmux::send_keys(&self.session_name, name, message)
     }
 
+    /// Respawn a coworker with a specific name.
+    ///
+    /// This is used to recover orphaned coworkers whose tmux windows died but
+    /// whose worktrees still exist. Unlike `spawn()`, this uses a specific name
+    /// rather than selecting a random available name.
+    ///
+    /// The worktree is reused if it exists, allowing the coworker to resume
+    /// where they left off.
+    pub fn respawn(&self, name: &str) -> crate::Result<()> {
+        // Check if already running
+        {
+            let coworkers = self.coworkers.read().unwrap();
+            if coworkers.contains_key(name) {
+                return Err(crate::Error::Rpc {
+                    code: -32603,
+                    message: format!("Coworker {} is already running", name),
+                });
+            }
+        }
+
+        // Check if there's a worktree - respawn requires an existing worktree
+        let worktree_path = self.worktree_manager.worktree_path(name);
+        if !worktree_path.exists() {
+            return Err(crate::Error::Rpc {
+                code: -32603,
+                message: format!(
+                    "Cannot respawn {}: no existing worktree at {}",
+                    name,
+                    worktree_path.display()
+                ),
+            });
+        }
+
+        let working_dir = worktree_path
+            .to_str()
+            .ok_or_else(|| crate::Error::Rpc {
+                code: -32603,
+                message: "Worktree path is not valid UTF-8".to_string(),
+            })?
+            .to_string();
+
+        // Spawn Claude in the existing worktree
+        let repo_name = self.worktree_manager.repo_name();
+        tmux::spawn_claude(&self.session_name, name, &working_dir, Some(repo_name))?;
+
+        // Record the coworker
+        let coworker = Coworker {
+            name: name.to_string(),
+            status: CoworkerStatus::Running,
+            working_dir,
+            started_at: Utc::now(),
+            current_task: None,
+        };
+
+        {
+            let mut coworkers = self.coworkers.write().unwrap();
+            coworkers.insert(name.to_string(), coworker);
+        }
+
+        tracing::info!("Respawned coworker {} in existing worktree", name);
+        Ok(())
+    }
+
     /// Sync state with actual tmux windows.
     ///
     /// Removes coworkers whose tmux windows no longer exist.
@@ -471,5 +534,45 @@ mod tests {
 
         // Should return None when all names exhausted
         assert_eq!(manager.next_name(), None);
+    }
+
+    #[test]
+    fn test_respawn_fails_without_worktree() {
+        let (manager, _temp_dir) = test_manager();
+
+        // Respawn should fail if no worktree exists
+        let result = manager.respawn("nonexistent");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("no existing worktree")
+        );
+    }
+
+    #[test]
+    fn test_respawn_fails_if_already_running() {
+        let (manager, _temp_dir) = test_manager();
+
+        // Manually insert a running coworker
+        {
+            let mut coworkers = manager.coworkers.write().unwrap();
+            coworkers.insert(
+                "lexington".to_string(),
+                Coworker {
+                    name: "lexington".to_string(),
+                    status: CoworkerStatus::Running,
+                    working_dir: "/tmp".to_string(),
+                    started_at: Utc::now(),
+                    current_task: None,
+                },
+            );
+        }
+
+        // Respawn should fail if coworker is already running
+        let result = manager.respawn("lexington");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("already running"));
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -143,6 +143,9 @@ impl Default for DaemonConfig {
     }
 }
 
+/// Interval for checking orphaned tasks (30 seconds)
+const ORPHAN_CHECK_INTERVAL_SECS: u64 = 30;
+
 /// Shared daemon state.
 struct DaemonState {
     coworkers: CoworkerManager,
@@ -275,6 +278,12 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
         );
     }
 
+    // Timer for periodic orphan checking
+    let mut orphan_check_interval =
+        tokio::time::interval(std::time::Duration::from_secs(ORPHAN_CHECK_INTERVAL_SECS));
+    // Skip the first tick (which fires immediately)
+    orphan_check_interval.tick().await;
+
     // Main accept loop
     loop {
         let shutdown_rx = shutdown_tx.subscribe();
@@ -305,6 +314,11 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                 if let Err(e) = state.channel.send(&msg) {
                     error!("Failed to forward webhook message to channel: {}", e);
                 }
+            }
+
+            // Periodic orphan check
+            _ = orphan_check_interval.tick() => {
+                check_and_recover_orphans(&state);
             }
 
             // Handle SIGTERM
@@ -1266,6 +1280,137 @@ fn truncate_message(msg: &str, max_len: usize) -> String {
         first_line.to_string()
     } else {
         format!("{}...", &first_line[..max_len])
+    }
+}
+
+/// Check for orphaned tasks and auto-recover coworkers.
+///
+/// An orphaned task is one that is `in_progress` but the owning coworker
+/// is no longer active (no tmux window). If the coworker's worktree still
+/// exists, we respawn them and nudge them to resume work.
+fn check_and_recover_orphans(state: &DaemonState) {
+    // Get in_progress tasks with their owners
+    let in_progress = get_in_progress_tasks_with_owners();
+
+    if in_progress.is_empty() {
+        return;
+    }
+
+    // Get list of currently active coworkers
+    let active_names: std::collections::HashSet<String> = state
+        .coworkers
+        .list()
+        .iter()
+        .map(|cw| cw.name.to_lowercase())
+        .collect();
+
+    // Find orphaned tasks (in_progress with owner not in active list)
+    for (task_id, task_subject, owner) in in_progress {
+        // Skip if owner is Lead or empty
+        if owner.is_empty() || owner.eq_ignore_ascii_case("lead") {
+            continue;
+        }
+
+        // Skip if coworker is already active
+        if active_names.contains(&owner.to_lowercase()) {
+            continue;
+        }
+
+        // This is an orphaned task - try to recover the coworker
+        info!(
+            "Detected orphaned task #{} owned by {} - attempting recovery",
+            task_id, owner
+        );
+
+        // Try to respawn the coworker
+        match state.coworkers.respawn(&owner) {
+            Ok(()) => {
+                info!("Respawned coworker {} successfully", owner);
+
+                // Post to channel about the recovery
+                let recovery_msg = Message::text(
+                    "daemon",
+                    format!(
+                        "♻️ Recovered coworker {} for orphaned task #{}",
+                        owner, task_id
+                    ),
+                );
+                if let Err(e) = state.channel.send(&recovery_msg) {
+                    warn!("Failed to post recovery message: {}", e);
+                }
+
+                // Give the coworker a moment to start up
+                std::thread::sleep(std::time::Duration::from_secs(2));
+
+                // Nudge them to resume their task
+                let nudge_msg = format!(
+                    "Resume task #{}: {}. You were working on this task before your session was interrupted. Check your git status and continue where you left off.",
+                    task_id, task_subject
+                );
+
+                if let Err(e) = state.coworkers.nudge(&owner, &nudge_msg) {
+                    warn!("Failed to nudge {} to resume: {}", owner, e);
+                } else {
+                    info!("Nudged {} to resume task #{}", owner, task_id);
+                }
+            }
+            Err(e) => {
+                // Could not respawn - log and continue
+                // This might happen if the worktree doesn't exist
+                debug!(
+                    "Could not respawn {} for orphaned task #{}: {}",
+                    owner, task_id, e
+                );
+            }
+        }
+    }
+}
+
+/// Get list of in_progress tasks with their owners and subjects.
+fn get_in_progress_tasks_with_owners() -> Vec<(String, String, String)> {
+    // Use bd (beads) to get task list
+    let output = std::process::Command::new("bd")
+        .args(["list", "--json"])
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if let Ok(tasks) = serde_json::from_str::<Vec<serde_json::Value>>(&stdout) {
+                return tasks
+                    .iter()
+                    .filter(|task| {
+                        task.get("status")
+                            .and_then(|s| s.as_str())
+                            .map(|s| s == "in_progress")
+                            .unwrap_or(false)
+                    })
+                    .map(|task| {
+                        let id = task
+                            .get("id")
+                            .and_then(|i| {
+                                i.as_str()
+                                    .map(|s| s.to_string())
+                                    .or_else(|| i.as_u64().map(|n| n.to_string()))
+                            })
+                            .unwrap_or_else(|| "?".to_string());
+                        let subject = task
+                            .get("subject")
+                            .and_then(|s| s.as_str())
+                            .unwrap_or("Unknown task")
+                            .to_string();
+                        let owner = task
+                            .get("owner")
+                            .and_then(|o| o.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        (id, subject, owner)
+                    })
+                    .collect();
+            }
+            Vec::new()
+        }
+        _ => Vec::new(),
     }
 }
 


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Daemon now detects orphaned tasks (in_progress but owner's tmux window is gone)
- Auto-respawns coworkers using their original name and existing worktree
- Nudges respawned coworkers with context about their interrupted task
- Posts recovery notification to the channel

## Implementation Details
- Added `CoworkerManager::respawn()` method to spawn with a specific name
- Added periodic orphan check every 30 seconds in daemon main loop  
- Added `check_and_recover_orphans()` function for detection and recovery

## Test plan
- [x] All 162 existing tests pass
- [x] Added unit tests for respawn() error cases
- [ ] Manual test: kill a coworker tmux window, verify daemon respawns them

🤖 Generated with [Claude Code](https://claude.com/claude-code)