### PR TITLE
Remove idle coworker mention from Lead stop hook

### DIFF
--- a/src/bin/midtown/cli/hooks.rs
+++ b/src/bin/midtown/cli/hooks.rs
@@ -175,8 +175,7 @@ fn handle_lead_stop_hook() -> Result<Response, String> {
 
     if status_items.is_empty() {
         Ok(Response::Message {
-            message: "Channel synced, no orphaned tasks, no idle coworkers, no mergeable PRs"
-                .to_string(),
+            message: "Channel synced, no orphaned tasks, no mergeable PRs".to_string(),
         })
     } else {
         Ok(Response::Message {


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Removed "no idle coworkers" from the Lead stop hook success message
- The idle coworker check logic was already removed (daemon handles auto-shutdown after 5 minutes)
- This just cleans up the leftover message text for consistency

## Test plan
- [x] Build passes
- [x] Pre-commit hooks pass (clippy, fmt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)