### PR TITLE
fix: Improve daemon reliability with daemonize crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "daemonize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,6 +893,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm 0.29.0",
+ "daemonize",
  "dirs",
  "fastrand",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ toml = "0.9.11"
 # Random number generation (for coworker name selection)
 fastrand = "2"
 
+# Daemon process management
+daemonize = "0.5"
+
 # TUI for chat interface
 ratatui = "0.29"
 crossterm = "0.29"

--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -45,6 +45,82 @@ fn daemon_is_running() -> bool {
     UnixStream::connect(&path).is_ok()
 }
 
+/// Wait for the daemon socket to become available with retries.
+///
+/// Polls the socket every `interval_ms` milliseconds, up to `max_attempts` times.
+/// Returns true if the socket became available, false if we timed out.
+fn wait_for_daemon_socket(max_attempts: u32, interval_ms: u64) -> bool {
+    for _ in 0..max_attempts {
+        std::thread::sleep(std::time::Duration::from_millis(interval_ms));
+        if daemon_is_running() {
+            return true;
+        }
+    }
+    false
+}
+
+/// Clean up stale daemon state before starting a new daemon.
+///
+/// This handles the case where a previous daemon crashed or was killed
+/// without cleaning up its PID file. It reads the PID file, checks if
+/// that process is still running, and kills it if so.
+fn cleanup_stale_daemon() {
+    let pid_path = midtown::paths::daemon_pid_file();
+
+    // Read the PID file if it exists
+    let pid_str = match std::fs::read_to_string(&pid_path) {
+        Ok(s) => s,
+        Err(_) => return, // No PID file, nothing to clean up
+    };
+
+    // Parse the PID
+    let pid: u32 = match pid_str.trim().parse() {
+        Ok(p) => p,
+        Err(_) => {
+            // Invalid PID file, remove it
+            let _ = std::fs::remove_file(&pid_path);
+            return;
+        }
+    };
+
+    // Check if the process is still running using kill -0 (suppress stderr)
+    let status = Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .stderr(Stdio::null())
+        .status();
+
+    if status.map(|s| s.success()).unwrap_or(false) {
+        // Process is still running, try to kill it gracefully
+        eprintln!("Cleaning up stale daemon process (PID {})", pid);
+        let _ = Command::new("kill")
+            .arg(pid.to_string())
+            .stderr(Stdio::null())
+            .status();
+
+        // Wait briefly for it to exit
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Force kill if still running
+        let still_running = Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        if still_running {
+            let _ = Command::new("kill")
+                .args(["-9", &pid.to_string()])
+                .stderr(Stdio::null())
+                .status();
+        }
+    }
+
+    // Clean up stale files
+    let _ = std::fs::remove_file(&pid_path);
+    let _ = std::fs::remove_file(socket_path());
+}
+
 /// Check if the project's tmux session exists.
 fn session_exists(session: &str) -> bool {
     let output = Command::new("tmux")
@@ -262,6 +338,9 @@ pub fn handle_start(daemon_only: bool) -> Result<Response, String> {
     if daemon_is_running() {
         messages.push("Daemon already running".to_string());
     } else {
+        // Clean up any stale PID file or orphaned daemon before starting
+        cleanup_stale_daemon();
+
         // Start the daemon in the background using `midtown daemon`
         let exe = std::env::current_exe()
             .map_err(|e| format!("Failed to get current executable: {}", e))?;
@@ -279,10 +358,10 @@ pub fn handle_start(daemon_only: bool) -> Result<Response, String> {
         cmd.spawn()
             .map_err(|e| format!("Failed to start daemon: {}", e))?;
 
-        // Wait briefly for daemon to start
-        std::thread::sleep(std::time::Duration::from_millis(500));
+        // Wait for daemon to start, polling the socket with retries
+        let started = wait_for_daemon_socket(5, 200);
 
-        if daemon_is_running() {
+        if started {
             messages.push("Started daemon".to_string());
         } else {
             return Err("Daemon failed to start".to_string());
@@ -463,7 +542,22 @@ pub fn handle_stop(keep_session: bool) -> Result<Response, String> {
 
     // Step 2: Stop daemon
     if daemon_is_running() {
-        // Remove the socket file - daemon will detect this and exit
+        // Read the PID and send SIGTERM for a clean shutdown
+        let pid_path = midtown::paths::daemon_pid_file();
+        if let Ok(pid_str) = std::fs::read_to_string(&pid_path)
+            && let Ok(pid) = pid_str.trim().parse::<u32>()
+        {
+            // Send SIGTERM for graceful shutdown
+            let _ = Command::new("kill")
+                .arg(pid.to_string())
+                .stderr(Stdio::null())
+                .status();
+
+            // Wait briefly for daemon to exit and clean up
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+
+        // Also remove socket file as a fallback
         let path = socket_path();
         if path.exists() {
             let _ = std::fs::remove_file(&path);

--- a/src/bin/midtown/main.rs
+++ b/src/bin/midtown/main.rs
@@ -53,6 +53,10 @@ enum Commands {
         /// Port for GitHub webhook server (disabled if not set)
         #[arg(long)]
         webhook_port: Option<u16>,
+
+        /// Run in foreground (don't daemonize) - for debugging
+        #[arg(long)]
+        foreground: bool,
     },
     /// Start midtown (daemon + tmux session)
     Start {
@@ -169,6 +173,7 @@ fn main() {
         workdir,
         verbose,
         webhook_port,
+        foreground,
     } = &command
     {
         let mut config = midtown::daemon::DaemonConfig::default();
@@ -182,6 +187,73 @@ fn main() {
         // CLI flag overrides env var
         if webhook_port.is_some() {
             config.webhook_port = *webhook_port;
+        }
+
+        // Daemonize unless --foreground is set
+        if !foreground {
+            use daemonize::Daemonize;
+            use std::os::unix::net::UnixStream;
+
+            // Check if daemon is already running BEFORE forking
+            // This allows us to print the error to the terminal
+            if config.socket_path.exists() && UnixStream::connect(&config.socket_path).is_ok() {
+                // Try to get the PID for a helpful message
+                let pid_msg = std::fs::read_to_string(&config.pid_file_path)
+                    .ok()
+                    .and_then(|s| s.trim().parse::<u32>().ok())
+                    .map(|pid| format!(" (PID {})", pid))
+                    .unwrap_or_default();
+                eprintln!(
+                    "Error: Daemon is already running{}. Stop it first with 'midtown stop'.",
+                    pid_msg
+                );
+                std::process::exit(1);
+            }
+
+            // Create log directory for daemon output
+            let log_dir = midtown::paths::daemon_log_dir();
+            if let Err(e) = std::fs::create_dir_all(&log_dir) {
+                eprintln!("Failed to create log directory: {}", e);
+                std::process::exit(1);
+            }
+
+            // Open log files for stdout/stderr
+            let stdout_path = log_dir.join("daemon.out");
+            let stderr_path = log_dir.join("daemon.err");
+
+            let stdout = match std::fs::File::create(&stdout_path) {
+                Ok(f) => f,
+                Err(e) => {
+                    eprintln!("Failed to create stdout log: {}", e);
+                    std::process::exit(1);
+                }
+            };
+            let stderr = match std::fs::File::create(&stderr_path) {
+                Ok(f) => f,
+                Err(e) => {
+                    eprintln!("Failed to create stderr log: {}", e);
+                    std::process::exit(1);
+                }
+            };
+
+            // Note: We don't use daemonize's pid_file feature because we have
+            // our own PID file with flock-based locking for singleton enforcement.
+            // The daemon::run() function handles the PID file.
+            let daemonize = Daemonize::new()
+                .working_directory(&config.workdir)
+                .stdout(stdout)
+                .stderr(stderr);
+
+            match daemonize.start() {
+                Ok(_) => {
+                    // We are now in the daemon child process
+                    // Continue to run the daemon server below
+                }
+                Err(e) => {
+                    eprintln!("Failed to daemonize: {}", e);
+                    std::process::exit(1);
+                }
+            }
         }
 
         // Run the daemon (this blocks until shutdown)

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -131,6 +131,15 @@ pub fn daemon_pid_file() -> PathBuf {
     daemon_pid_file_for_repo(&repo)
 }
 
+/// Get the daemon log directory for the current repository.
+///
+/// Returns `~/.midtown/<repo>/logs/`.
+/// This is where daemon stdout/stderr are redirected when daemonized.
+pub fn daemon_log_dir() -> PathBuf {
+    let repo = detect_repo_name().unwrap_or_else(|| "default".to_string());
+    midtown_dir_for_repo(&repo).join("logs")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -280,16 +280,20 @@ pub fn setup_status_bar_hook(session: &str) -> crate::Result<()> {
     // 2. Convert to lowercase for case-insensitive matching
     // 3. Look up color with case statement
     // 4. If found, set status-style with that color
+    //
+    // Note: We use double quotes for the run-shell argument and escape inner
+    // double quotes. This avoids complex single-quote escaping for tr's character
+    // class arguments like '[:upper:]'.
     let script = format!(
         r#"window_name=$(tmux display-message -p '#{{window_name}}'); \
-base_name=$(echo "$window_name" | cut -d: -f1); \
-lower_name=$(echo "$base_name" | tr '[:upper:]' '[:lower:]'); \
-color=""; \
-case "$lower_name" in
+base_name=$(echo \"$window_name\" | cut -d: -f1); \
+lower_name=$(echo \"$base_name\" | tr [:upper:] [:lower:]); \
+color=\"\"; \
+case \"$lower_name\" in
 {}
-        *) color="" ;;
+        *) color=\"\" ;;
 esac; \
-if [ -n "$color" ]; then \
+if [ -n \"$color\" ]; then \
     tmux set-option -t {} status-style bg=colour236,fg=$color; \
 fi"#,
         case_statement, session
@@ -301,7 +305,7 @@ fi"#,
             "-t",
             session,
             "pane-focus-in",
-            &format!("run-shell '{}'", script),
+            &format!("run-shell \"{}\"", script),
         ])
         .status()
         .map_err(Error::Io)?;


### PR DESCRIPTION
## Summary

- Integrate `daemonize` crate for proper UNIX daemon forking (double-fork pattern)
- Fix tmux status bar hook shell quoting that caused "syntax error" on start
- Improve stop/start reliability with SIGTERM-based shutdown and socket polling
- Add early check for existing daemon to show errors on terminal (not just logs)

## Changes

- **Cargo.toml**: Add `daemonize = "0.5"` dependency
- **src/bin/midtown/main.rs**: Integrate daemonize with pre-fork validation
- **src/bin/midtown/cli/daemon.rs**: Add stale PID cleanup, SIGTERM shutdown, socket retry
- **src/paths.rs**: Add `daemon_log_dir()` for log file location
- **src/tmux.rs**: Fix shell quoting in status bar hook script

## Test plan

- [x] `midtown start` / `midtown stop` cycles work reliably
- [x] Attempting to start a second daemon shows error on terminal
- [x] Daemon logs go to `~/.midtown/<repo>/logs/daemon.{out,err}`
- [x] `--foreground` flag works for debugging
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)