### PR TITLE
docs: Add guidance for forwarding user suggestions to coworkers

### DIFF
--- a/agents/lead.md
+++ b/agents/lead.md
@@ -84,6 +84,16 @@ Coworkers start with no context - they need a nudge to know what to do.
 - Monitor overall progress via `midtown status`
 - Check channel for updates: `midtown channel read`
 
+## Forwarding User Suggestions
+When the human makes a suggestion or provides feedback related to an in-progress task, **nudge it to the coworker working on that task**:
+
+```bash
+# User suggests something about task #3 that park is working on:
+midtown coworker nudge park -m "User feedback: <their suggestion>"
+```
+
+This ensures coworkers get real-time input without the Lead needing to context-switch into the implementation details.
+
 ## Assigning Tasks
 When assigning a task to a specific coworker, use `TaskUpdate` to set the `owner` field:
 ```


### PR DESCRIPTION
<!-- midtown: lead -->

## Summary
- When the human makes a suggestion related to an in-progress task, the Lead should nudge it to the coworker working on that task
- Ensures coworkers get real-time feedback without Lead context-switching

## Test plan
- [x] Documentation change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)