### PR TITLE
refactor: Remove bd (beads) dependency, use Claude Code task storage

### DIFF
--- a/src/bin/midtown/cli/coworker.rs
+++ b/src/bin/midtown/cli/coworker.rs
@@ -81,7 +81,7 @@ pub fn handle(cmd: &CoworkerCommand, client: &DaemonClient) -> Result<Response, 
 ///
 /// This command is designed to be used as a Claude Code stop hook. It:
 /// 1. Reads channel messages (syncs any pending messages)
-/// 2. Checks for unclaimed tasks via `bd ready`
+/// 2. Checks for unclaimed tasks from Claude Code task storage
 /// 3. Checks for PRs needing review (that this coworker didn't create)
 /// 4. Checks if this coworker's PRs have been approved and can be merged
 /// 5. Returns JSON to indicate whether Claude should continue or stop
@@ -471,31 +471,9 @@ fn format_channel_messages(messages: &[midtown::Message]) -> String {
         .join("\n- ")
 }
 
-/// Count unclaimed tasks from the beads system.
+/// Count unclaimed tasks from Claude Code task storage.
 fn count_unclaimed_tasks() -> usize {
-    let output = std::process::Command::new("bd")
-        .args(["ready", "--json"])
-        .output();
-
-    match output {
-        Ok(output) if output.status.success() => {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            if let Ok(tasks) = serde_json::from_str::<Vec<serde_json::Value>>(&stdout) {
-                // Filter to tasks that don't have an owner/assignee
-                tasks
-                    .iter()
-                    .filter(|task| {
-                        let owner = task.get("owner").and_then(|o| o.as_str());
-                        let assignee = task.get("assignee").and_then(|a| a.as_str());
-                        owner.is_none() && assignee.is_none()
-                    })
-                    .count()
-            } else {
-                0
-            }
-        }
-        _ => 0,
-    }
+    midtown::tasks::count_unclaimed_tasks()
 }
 
 /// Try to detect the current git repository name.

--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -574,16 +574,32 @@ pub fn handle_stop(keep_session: bool) -> Result<Response, String> {
 
 /// Handle `midtown restart` command.
 ///
-/// Stops and then starts midtown.
+/// Gracefully restarts the daemon while preserving the tmux session and all
+/// running Claude processes (Lead and coworkers). Only the daemon process is
+/// restarted, which allows updating daemon code without losing work in progress.
+///
+/// For a full fresh start, use `midtown stop && midtown start`.
 pub fn handle_restart() -> Result<Response, String> {
-    // Stop everything (ignore errors if not running)
-    let _ = handle_stop(false);
+    // Stop daemon only, keep the tmux session running
+    let _ = handle_stop(true);
 
     // Brief pause for cleanup
     std::thread::sleep(std::time::Duration::from_millis(300));
 
-    // Start fresh
-    handle_start(false)
+    // Start daemon (session already exists, so it will re-discover coworkers)
+    let result = handle_start(false)?;
+
+    // Enhance the message to clarify graceful restart
+    match result {
+        Response::Message { message } => Ok(Response::Message {
+            message: format!(
+                "{}. Resumed Lead session in '{}'. Attach with: midtown attach",
+                message,
+                session_name().unwrap_or_else(|_| "midtown".to_string())
+            ),
+        }),
+        other => Ok(other),
+    }
 }
 
 /// Handle `midtown attach` command.

--- a/src/bin/midtown/cli/hooks.rs
+++ b/src/bin/midtown/cli/hooks.rs
@@ -354,45 +354,7 @@ fn get_daemon_socket_path() -> PathBuf {
 
 /// Get list of in_progress tasks with their owners.
 fn get_in_progress_tasks() -> Vec<(String, String)> {
-    // Use bd (beads) to get task list
-    let output = std::process::Command::new("bd")
-        .args(["list", "--json"])
-        .output();
-
-    match output {
-        Ok(output) if output.status.success() => {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            if let Ok(tasks) = serde_json::from_str::<Vec<serde_json::Value>>(&stdout) {
-                return tasks
-                    .iter()
-                    .filter(|task| {
-                        task.get("status")
-                            .and_then(|s| s.as_str())
-                            .map(|s| s == "in_progress")
-                            .unwrap_or(false)
-                    })
-                    .map(|task| {
-                        let id = task
-                            .get("id")
-                            .and_then(|i| {
-                                i.as_str()
-                                    .map(|s| s.to_string())
-                                    .or_else(|| i.as_u64().map(|n| n.to_string()))
-                            })
-                            .unwrap_or_else(|| "?".to_string());
-                        let owner = task
-                            .get("owner")
-                            .and_then(|o| o.as_str())
-                            .unwrap_or("")
-                            .to_string();
-                        (id, owner)
-                    })
-                    .collect();
-            }
-            Vec::new()
-        }
-        _ => Vec::new(),
-    }
+    midtown::tasks::get_in_progress_tasks()
 }
 
 /// Read channel messages and return them (for stop hook sync).

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -616,64 +616,9 @@ async fn check_and_shutdown_idle_coworkers(state: &DaemonState) {
     }
 }
 
-/// Read tasks from Claude Code's task storage.
-///
-/// Reads from `~/.claude/tasks/<lead_session_id>/` where the lead session ID
-/// is stored in `~/.midtown/<repo>/lead-session`.
-fn read_claude_tasks(repo_name: &str) -> Vec<serde_json::Value> {
-    let home = match std::env::var("HOME").ok() {
-        Some(h) => std::path::PathBuf::from(h),
-        None => return Vec::new(),
-    };
-
-    // Read the lead session ID
-    let lead_session_id = match read_lead_session_id(repo_name) {
-        Some(id) => id,
-        None => return Vec::new(),
-    };
-
-    // Read tasks from ~/.claude/tasks/<lead_session_id>/
-    let tasks_dir = home.join(".claude").join("tasks").join(&lead_session_id);
-    let entries = match std::fs::read_dir(&tasks_dir) {
-        Ok(e) => e,
-        Err(_) => return Vec::new(),
-    };
-
-    let mut tasks = Vec::new();
-    for entry in entries.filter_map(|e| e.ok()) {
-        let path = entry.path();
-        if path.extension().is_some_and(|ext| ext == "json")
-            && let Ok(content) = std::fs::read_to_string(&path)
-            && let Ok(task_data) = serde_json::from_str::<serde_json::Value>(&content)
-        {
-            tasks.push(task_data);
-        }
-    }
-
-    tasks
-}
-
 /// Get list of coworker names who have in_progress tasks.
 fn get_busy_coworkers() -> Vec<String> {
-    // Get repo name for reading tasks
-    let repo_name = crate::paths::detect_repo_name().unwrap_or_else(|| "default".to_string());
-    let tasks = read_claude_tasks(&repo_name);
-
-    tasks
-        .iter()
-        .filter(|task| {
-            task.get("status")
-                .and_then(|s| s.as_str())
-                .map(|s| s == "in_progress")
-                .unwrap_or(false)
-        })
-        .filter_map(|task| {
-            task.get("owner")
-                .and_then(|o| o.as_str())
-                .filter(|o| !o.is_empty())
-                .map(|o| o.to_string())
-        })
-        .collect()
+    crate::tasks::get_busy_coworkers()
 }
 
 /// Get list of coworker names who have open PRs.
@@ -1605,7 +1550,7 @@ fn handle_status(id: RequestId, state: &DaemonState) -> Response {
     // Get open PRs from GitHub via gh CLI
     let pull_requests = get_open_prs();
 
-    // Get open tasks from beads system
+    // Get pending tasks from Claude Code task storage
     let tasks = get_open_tasks();
 
     // Get recent channel activity
@@ -1684,27 +1629,16 @@ fn format_pr_status(pr: &serde_json::Value) -> String {
     }
 }
 
-/// Get open tasks from Claude Code task storage.
+/// Get pending tasks from Claude Code task storage.
 fn get_open_tasks() -> Vec<serde_json::Value> {
-    let repo_name = crate::paths::detect_repo_name().unwrap_or_else(|| "default".to_string());
-    let tasks = read_claude_tasks(&repo_name);
-
-    // Return tasks that are not completed (pending or in_progress)
-    tasks
+    crate::tasks::get_pending_tasks()
         .into_iter()
-        .filter(|task| {
-            let status = task
-                .get("status")
-                .and_then(|s| s.as_str())
-                .unwrap_or("pending");
-            status != "completed"
-        })
         .map(|task| {
             serde_json::json!({
-                "id": task.get("id").and_then(|i| i.as_str()).unwrap_or(""),
-                "subject": task.get("subject").and_then(|s| s.as_str()).unwrap_or(""),
-                "status": task.get("status").and_then(|s| s.as_str()).unwrap_or("pending"),
-                "assignee": task.get("owner").and_then(|o| o.as_str()),
+                "id": task.id,
+                "subject": task.subject,
+                "status": "pending",
+                "assignee": task.owner,
             })
         })
         .collect()
@@ -1950,39 +1884,7 @@ fn check_and_recover_orphans(state: &DaemonState) {
 
 /// Get list of in_progress tasks with their owners and subjects.
 fn get_in_progress_tasks_with_owners() -> Vec<(String, String, String)> {
-    let repo_name = crate::paths::detect_repo_name().unwrap_or_else(|| "default".to_string());
-    let tasks = read_claude_tasks(&repo_name);
-
-    tasks
-        .iter()
-        .filter(|task| {
-            task.get("status")
-                .and_then(|s| s.as_str())
-                .map(|s| s == "in_progress")
-                .unwrap_or(false)
-        })
-        .map(|task| {
-            let id = task
-                .get("id")
-                .and_then(|i| {
-                    i.as_str()
-                        .map(|s| s.to_string())
-                        .or_else(|| i.as_u64().map(|n| n.to_string()))
-                })
-                .unwrap_or_else(|| "?".to_string());
-            let subject = task
-                .get("subject")
-                .and_then(|s| s.as_str())
-                .unwrap_or("Unknown task")
-                .to_string();
-            let owner = task
-                .get("owner")
-                .and_then(|o| o.as_str())
-                .unwrap_or("")
-                .to_string();
-            (id, subject, owner)
-        })
-        .collect()
+    crate::tasks::get_in_progress_tasks_with_subjects()
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,9 @@ pub mod config;
 // Agent system prompts
 pub mod agents;
 
+// Claude Code task storage integration
+pub mod tasks;
+
 // Path utilities (socket paths, repo detection)
 pub mod paths;
 

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,0 +1,253 @@
+//! Claude Code task storage integration.
+//!
+//! Claude Code stores tasks in `~/.claude/tasks/<session_id>/` as JSON files.
+//! This module provides utilities to read and query these tasks without
+//! requiring external CLI tools.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// A task from Claude Code's task storage.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Task {
+    pub id: String,
+    pub subject: String,
+    pub status: TaskStatus,
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// Task status matching Claude Code's TaskList tool.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    #[default]
+    Pending,
+    InProgress,
+    Completed,
+}
+
+/// Read all tasks from Claude Code's task storage for the current session.
+///
+/// Looks up the lead session ID from `~/.midtown/<repo>/lead-session` and
+/// reads all task JSON files from `~/.claude/tasks/<session_id>/`.
+pub fn read_tasks() -> Vec<Task> {
+    read_tasks_for_repo(None)
+}
+
+/// Read all tasks for a specific repository.
+///
+/// If `repo_name` is None, attempts to detect the current repository.
+pub fn read_tasks_for_repo(repo_name: Option<&str>) -> Vec<Task> {
+    let repo = repo_name
+        .map(String::from)
+        .or_else(crate::paths::detect_repo_name)
+        .unwrap_or_else(|| "default".to_string());
+
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+
+    // Read the lead session ID from ~/.midtown/<repo>/lead-session
+    let lead_session_file = home.join(".midtown").join(&repo).join("lead-session");
+    let Ok(lead_session_id) = std::fs::read_to_string(&lead_session_file) else {
+        return Vec::new();
+    };
+    let lead_session_id = lead_session_id.trim();
+
+    if lead_session_id.is_empty() {
+        return Vec::new();
+    }
+
+    read_tasks_for_session(lead_session_id)
+}
+
+/// Read all tasks for a specific Claude Code session ID.
+pub fn read_tasks_for_session(session_id: &str) -> Vec<Task> {
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+
+    let tasks_dir = home.join(".claude").join("tasks").join(session_id);
+    read_tasks_from_dir(&tasks_dir)
+}
+
+/// Read all tasks from a directory containing task JSON files.
+fn read_tasks_from_dir(tasks_dir: &PathBuf) -> Vec<Task> {
+    let Ok(entries) = std::fs::read_dir(tasks_dir) else {
+        return Vec::new();
+    };
+
+    let mut tasks = Vec::new();
+
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "json")
+            && let Ok(content) = std::fs::read_to_string(&path)
+            && let Ok(task) = parse_task_json(&content)
+        {
+            tasks.push(task);
+        }
+    }
+
+    // Sort by ID for consistent ordering
+    tasks.sort_by(|a, b| {
+        let a_num: i32 = a.id.parse().unwrap_or(i32::MAX);
+        let b_num: i32 = b.id.parse().unwrap_or(i32::MAX);
+        a_num.cmp(&b_num)
+    });
+
+    tasks
+}
+
+/// Parse a task from JSON, handling various ID formats.
+fn parse_task_json(content: &str) -> Result<Task, serde_json::Error> {
+    let value: serde_json::Value = serde_json::from_str(content)?;
+
+    // Handle ID as either string or number
+    let id = value
+        .get("id")
+        .and_then(|v| {
+            v.as_str()
+                .map(String::from)
+                .or_else(|| v.as_u64().map(|n| n.to_string()))
+        })
+        .unwrap_or_default();
+
+    let subject = value
+        .get("subject")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let status_str = value
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("pending");
+
+    let status = match status_str {
+        "in_progress" => TaskStatus::InProgress,
+        "completed" => TaskStatus::Completed,
+        _ => TaskStatus::Pending,
+    };
+
+    let owner = value
+        .get("owner")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+
+    let description = value
+        .get("description")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    Ok(Task {
+        id,
+        subject,
+        status,
+        owner,
+        description,
+    })
+}
+
+// Convenience query functions
+
+/// Get names of coworkers who have in_progress tasks.
+pub fn get_busy_coworkers() -> Vec<String> {
+    read_tasks()
+        .into_iter()
+        .filter(|t| t.status == TaskStatus::InProgress)
+        .filter_map(|t| t.owner)
+        .collect()
+}
+
+/// Get in_progress tasks with their owners.
+///
+/// Returns tuples of (task_id, owner_name).
+pub fn get_in_progress_tasks() -> Vec<(String, String)> {
+    read_tasks()
+        .into_iter()
+        .filter(|t| t.status == TaskStatus::InProgress)
+        .map(|t| (t.id, t.owner.unwrap_or_default()))
+        .collect()
+}
+
+/// Get in_progress tasks with full details.
+///
+/// Returns tuples of (task_id, subject, owner_name).
+pub fn get_in_progress_tasks_with_subjects() -> Vec<(String, String, String)> {
+    read_tasks()
+        .into_iter()
+        .filter(|t| t.status == TaskStatus::InProgress)
+        .map(|t| (t.id, t.subject, t.owner.unwrap_or_default()))
+        .collect()
+}
+
+/// Get pending tasks that have no owner (unclaimed).
+pub fn get_unclaimed_tasks() -> Vec<Task> {
+    read_tasks()
+        .into_iter()
+        .filter(|t| t.status == TaskStatus::Pending && t.owner.is_none())
+        .collect()
+}
+
+/// Count unclaimed pending tasks.
+pub fn count_unclaimed_tasks() -> usize {
+    get_unclaimed_tasks().len()
+}
+
+/// Get pending tasks (ready to work on).
+pub fn get_pending_tasks() -> Vec<Task> {
+    read_tasks()
+        .into_iter()
+        .filter(|t| t.status == TaskStatus::Pending)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn create_task_file(dir: &std::path::Path, id: &str, status: &str, owner: Option<&str>) {
+        let task = serde_json::json!({
+            "id": id,
+            "subject": format!("Task {}", id),
+            "status": status,
+            "owner": owner,
+        });
+        let path = dir.join(format!("{}.json", id));
+        let mut file = std::fs::File::create(path).unwrap();
+        writeln!(file, "{}", serde_json::to_string(&task).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn test_read_tasks_from_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        let tasks_dir = temp_dir.path().to_path_buf();
+
+        create_task_file(&tasks_dir, "1", "pending", None);
+        create_task_file(&tasks_dir, "2", "in_progress", Some("alice"));
+        create_task_file(&tasks_dir, "3", "completed", Some("bob"));
+
+        let tasks = read_tasks_from_dir(&tasks_dir);
+        assert_eq!(tasks.len(), 3);
+        assert_eq!(tasks[0].id, "1");
+        assert_eq!(tasks[0].status, TaskStatus::Pending);
+        assert!(tasks[0].owner.is_none());
+        assert_eq!(tasks[1].id, "2");
+        assert_eq!(tasks[1].status, TaskStatus::InProgress);
+        assert_eq!(tasks[1].owner, Some("alice".to_string()));
+    }
+
+    #[test]
+    fn test_parse_numeric_id() {
+        let json = r#"{"id": 42, "subject": "Test", "status": "pending"}"#;
+        let task = parse_task_json(json).unwrap();
+        assert_eq!(task.id, "42");
+    }
+}


### PR DESCRIPTION
## Summary
- Add new `tasks` module with reusable task reading functions for Claude Code storage
- Replace all `bd` CLI calls with direct reads from `~/.claude/tasks/<session_id>/`
- Fix daemon idle check which was incorrectly killing coworkers (bd wasn't tracking their tasks)
- Add graceful daemon restart that preserves tmux session

## Test plan
- [x] All unit tests pass
- [x] Clippy passes
- [x] Build succeeds
- [ ] Manual testing with `midtown restart` preserves session
- [ ] Verify coworkers with in-progress tasks are not killed

🤖 Generated with [Claude Code](https://claude.com/claude-code)