### PR TITLE
fix: Standardize on lead-session-id filename

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -262,7 +262,7 @@ impl App {
 /// Fetch tasks from Claude Code's task storage.
 ///
 /// Reads tasks from `~/.claude/tasks/<lead_session_id>/` where the lead session ID
-/// is stored in `~/.midtown/<repo>/lead-session`.
+/// is stored in `~/.midtown/<repo>/lead-session-id`.
 fn fetch_tasks() -> Vec<KanbanTask> {
     let mut tasks = Vec::new();
 
@@ -275,8 +275,11 @@ fn fetch_tasks() -> Vec<KanbanTask> {
         None => return tasks,
     };
 
-    // Read the lead session ID from ~/.midtown/<repo>/lead-session
-    let lead_session_file = home.join(".midtown").join(&repo_name).join("lead-session");
+    // Read the lead session ID from ~/.midtown/<repo>/lead-session-id
+    let lead_session_file = home
+        .join(".midtown")
+        .join(&repo_name)
+        .join("lead-session-id");
     let lead_session_id = match std::fs::read_to_string(&lead_session_file) {
         Ok(id) => id.trim().to_string(),
         Err(_) => return tasks,

--- a/src/bin/midtown/cli/coworker.rs
+++ b/src/bin/midtown/cli/coworker.rs
@@ -517,9 +517,9 @@ pub fn handle_link_tasks_standalone() -> Result<Response, String> {
     // Get repo name to find Lead's session file
     let repo = detect_git_repo().ok_or("Not in a git repository")?;
 
-    // Read Lead's session UUID from ~/.midtown/<repo>/lead-session
+    // Read Lead's session UUID from ~/.midtown/<repo>/lead-session-id
     let home = dirs::home_dir().ok_or("Cannot determine home directory")?;
-    let lead_session_file = home.join(".midtown").join(&repo).join("lead-session");
+    let lead_session_file = home.join(".midtown").join(&repo).join("lead-session-id");
 
     let lead_uuid = fs::read_to_string(&lead_session_file)
         .map_err(|_| {

--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -736,12 +736,12 @@ pub fn handle_register_session() -> Result<Response, String> {
 
     let lead_uuid = find_newest_dir(&tasks_dir)?;
 
-    // Save to ~/.midtown/<repo>/lead-session
+    // Save to ~/.midtown/<repo>/lead-session-id
     let midtown_dir = home.join(".midtown").join(&repo_name);
     fs::create_dir_all(&midtown_dir)
         .map_err(|e| format!("Failed to create midtown directory: {}", e))?;
 
-    let session_file = midtown_dir.join("lead-session");
+    let session_file = midtown_dir.join("lead-session-id");
     fs::write(&session_file, &lead_uuid)
         .map_err(|e| format!("Failed to write session file: {}", e))?;
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -219,7 +219,7 @@ fn read_lead_session_id(repo_name: &str) -> Option<String> {
     let session_file = std::path::PathBuf::from(home)
         .join(".midtown")
         .join(repo_name)
-        .join("lead-session");
+        .join("lead-session-id");
 
     std::fs::read_to_string(&session_file)
         .ok()

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -31,7 +31,7 @@ pub enum TaskStatus {
 
 /// Read all tasks from Claude Code's task storage for the current session.
 ///
-/// Looks up the lead session ID from `~/.midtown/<repo>/lead-session` and
+/// Looks up the lead session ID from `~/.midtown/<repo>/lead-session-id` and
 /// reads all task JSON files from `~/.claude/tasks/<session_id>/`.
 pub fn read_tasks() -> Vec<Task> {
     read_tasks_for_repo(None)
@@ -50,8 +50,8 @@ pub fn read_tasks_for_repo(repo_name: Option<&str>) -> Vec<Task> {
         return Vec::new();
     };
 
-    // Read the lead session ID from ~/.midtown/<repo>/lead-session
-    let lead_session_file = home.join(".midtown").join(&repo).join("lead-session");
+    // Read the lead session ID from ~/.midtown/<repo>/lead-session-id
+    let lead_session_file = home.join(".midtown").join(&repo).join("lead-session-id");
     let Ok(lead_session_id) = std::fs::read_to_string(&lead_session_file) else {
         return Vec::new();
     };


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Standardized all code to use `lead-session-id` filename consistently
- Fixed bug where kanban "In Progress" column wasn't showing tasks
- Root cause: writes used `lead-session` but reads used `lead-session-id`

Fixes task #3.

## Test plan
- [x] All tests pass
- [x] Clippy and fmt checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)