### PR TITLE
fix: Use non-blocking locks in channel reads to prevent UI freeze

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -121,14 +121,20 @@ impl Channel {
     ///
     /// Messages are sorted by timestamp to ensure chronological order,
     /// regardless of the order they were written to the file.
+    ///
+    /// Uses a non-blocking lock to avoid freezing the UI when there's lock
+    /// contention from writers. If the lock can't be acquired immediately,
+    /// returns an error and the caller can retry later.
     pub fn read_all(&self) -> Result<Vec<Message>> {
         if !self.channel_file.exists() {
             return Ok(Vec::new());
         }
 
         let file = File::open(&self.channel_file)?;
-        // Acquire shared lock for reading
-        file.lock_shared()?;
+        // Try to acquire shared lock without blocking - avoids UI freeze when
+        // writers hold exclusive locks
+        file.try_lock_shared()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::WouldBlock, e.to_string()))?;
 
         let reader = BufReader::new(file);
         let mut messages = Vec::new();
@@ -150,6 +156,9 @@ impl Channel {
     /// Read messages since the agent's cursor position
     ///
     /// Returns new messages and updates the cursor.
+    ///
+    /// Uses a non-blocking lock to avoid blocking when there's lock contention.
+    /// If the lock can't be acquired immediately, returns an error.
     pub fn read_since_cursor(&self, agent: &str) -> Result<Vec<Message>> {
         if !self.channel_file.exists() {
             return Ok(Vec::new());
@@ -158,8 +167,9 @@ impl Channel {
         let mut cursor = Cursor::load_or_create(&self.base_dir, agent)?;
 
         let file = File::open(&self.channel_file)?;
-        // Acquire shared lock for reading
-        file.lock_shared()?;
+        // Try to acquire shared lock without blocking
+        file.try_lock_shared()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::WouldBlock, e.to_string()))?;
 
         let mut reader = BufReader::new(file);
 


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Fixed chat TUI showing messages delayed by using non-blocking `try_lock_shared()` instead of blocking `lock_shared()` in channel reads
- When writers hold exclusive locks, the read now fails fast and retries on the next refresh cycle (250ms later) instead of blocking indefinitely
- This prevents the UI from freezing when there's lock contention from multiple coworkers posting messages

## Root Cause
The `channel.read_all()` function used `file.lock_shared()` which is a blocking call. If another process held an exclusive lock (during a write), the entire chat TUI would freeze waiting for the lock to be released.

## Test plan
- [x] All existing channel tests pass
- [x] Full test suite passes
- [ ] Manual testing: Run chat TUI while multiple coworkers post messages simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)