### PR TITLE
feat: Add duration display (Xm) to In Progress kanban column

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -20,6 +20,8 @@ pub struct KanbanTask {
     pub subject: String,
     pub owner: Option<String>,
     pub status: TaskStatus,
+    /// When the task file was last modified (used as proxy for status change time)
+    pub modified_at: Option<DateTime<Utc>>,
 }
 
 /// Task status for kanban columns
@@ -331,12 +333,19 @@ fn fetch_tasks() -> Vec<KanbanTask> {
                 _ => TaskStatus::Pending,
             };
 
+            // Get file modification time as proxy for when status changed
+            let modified_at = std::fs::metadata(&path)
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .map(DateTime::<Utc>::from);
+
             if !id.is_empty() {
                 tasks.push(KanbanTask {
                     id,
                     subject,
                     owner,
                     status,
+                    modified_at,
                 });
             }
         }
@@ -508,6 +517,7 @@ mod tests {
             subject: "Test task".to_string(),
             owner: Some("park".to_string()),
             status: TaskStatus::InProgress,
+            modified_at: None,
         };
         let cloned = task.clone();
         assert_eq!(cloned.id, "1");
@@ -530,18 +540,21 @@ mod tests {
                     subject: "Pending task".to_string(),
                     owner: None,
                     status: TaskStatus::Pending,
+                    modified_at: None,
                 },
                 KanbanTask {
                     id: "2".to_string(),
                     subject: "In progress task".to_string(),
                     owner: Some("park".to_string()),
                     status: TaskStatus::InProgress,
+                    modified_at: None,
                 },
                 KanbanTask {
                     id: "3".to_string(),
                     subject: "Completed task".to_string(),
                     owner: Some("lexington".to_string()),
                     status: TaskStatus::Completed,
+                    modified_at: None,
                 },
             ],
             prs: Vec::new(),

--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -128,8 +128,11 @@ fn draw_kanban_panel(f: &mut Frame, app: &App, area: Rect) {
         .map(|t| {
             let line1 = format!("#{} {}", t.id, t.subject);
             let owner = t.owner.as_deref().unwrap_or("?");
-            // TODO: Track when task became in_progress for accurate duration
-            let line2 = format!("  └ {}", owner);
+            let duration = t
+                .modified_at
+                .map(format_duration_minutes)
+                .unwrap_or_default();
+            let line2 = format!("  └ {} {}", owner, duration);
             KanbanItem {
                 lines: vec![line1, line2],
                 url: None,


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Adds duration display to In Progress kanban column showing how long each task has been worked on
- Uses task file modification time as proxy for when status last changed
- Format matches Review column: `owner (Xm)` or `owner (Xh)` for longer durations

## Test plan
- [x] All tests pass (`cargo test --bin midtown -- chat`)
- [x] Clippy and format checks pass
- [ ] Visual verification in `midtown chat` UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)