### PR TITLE
fix: Optimize chat TUI rendering performance

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -57,8 +57,8 @@ pub struct App {
     pub visible_height: usize,
     /// Channel for reading messages
     channel: Option<Channel>,
-    /// Last known message count (for detecting new messages)
-    last_count: usize,
+    /// Last known file size (for cheap change detection)
+    last_file_size: u64,
     /// Tasks for the kanban board
     pub tasks: Vec<KanbanTask>,
     /// Open PRs for the kanban board (Review column)
@@ -96,7 +96,7 @@ impl App {
             scroll_offset: 0,
             visible_height: 20,
             channel,
-            last_count: 0,
+            last_file_size: 0,
             tasks: Vec::new(),
             prs: Vec::new(),
             merged_prs: Vec::new(),
@@ -112,19 +112,22 @@ impl App {
 
     /// Refresh messages from the channel and kanban data
     pub fn refresh(&mut self) {
-        // Read all messages from channel
-        if let Some(ref channel) = self.channel
-            && let Ok(messages) = channel.read_all()
-        {
-            let new_count = messages.len();
+        // Check if channel file has changed using file size (O(1) operation)
+        // This avoids reading and parsing all messages when nothing changed
+        if let Some(ref channel) = self.channel {
+            let current_size = channel.file_size();
 
-            // Update messages if count changed
-            if new_count != self.last_count {
-                let added = new_count.saturating_sub(self.last_count);
+            // Only read messages if file size changed
+            if current_size != self.last_file_size
+                && let Ok(messages) = channel.read_all()
+            {
+                let old_count = self.messages.len();
+                let new_count = messages.len();
+                let added = new_count.saturating_sub(old_count);
                 let was_at_bottom = self.scroll_offset == 0;
 
                 self.messages = messages;
-                self.last_count = new_count;
+                self.last_file_size = current_size;
 
                 if was_at_bottom {
                     // User was at bottom - stay at bottom (auto-scroll)
@@ -520,7 +523,7 @@ mod tests {
             scroll_offset: 0,
             visible_height: 20,
             channel: None,
-            last_count: 0,
+            last_file_size: 0,
             tasks: vec![
                 KanbanTask {
                     id: "1".to_string(),

--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -232,30 +232,25 @@ fn draw_kanban_column(f: &mut Frame, area: Rect, title: &str, color: Color, item
     }
 }
 
-/// Render a line with OSC 8 hyperlink escape sequences
+/// Render a line as plain text
 ///
-/// Uses the OSC 8 format: \x1B]8;;{url}\x07{text}\x1B]8;;\x07
-/// to create clickable hyperlinks in supported terminals.
+/// Previously used OSC 8 hyperlinks, but wrapping each character in escape
+/// sequences caused severe performance issues (21,000+ extra chars per frame).
+/// Now renders as plain text for fast, reliable display.
 fn render_hyperlink_line(
     buffer: &mut Buffer,
     x: u16,
     y: u16,
     text: &str,
-    url: &str,
+    _url: &str,
     max_width: usize,
 ) {
-    // Render each character with hyperlink escape sequence
-    // We use OSC 8 format: ESC ] 8 ; ; URL ST text ESC ] 8 ; ; ST
-    // where ST (String Terminator) is BEL (\x07) or ESC \ (\x1B\\)
+    // Render plain text - OSC 8 per-character was too slow
     for (i, ch) in text.chars().enumerate() {
         if i >= max_width {
             break;
         }
-        // Create the hyperlink-wrapped character
-        let hyperlink = format!("\x1B]8;;{}\x07{}\x1B]8;;\x07", url, ch);
-        buffer[(x + i as u16, y)]
-            .set_symbol(&hyperlink)
-            .set_fg(Color::White);
+        buffer[(x + i as u16, y)].set_char(ch).set_fg(Color::White);
     }
 }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -226,6 +226,17 @@ impl Channel {
     pub fn exists(&self) -> bool {
         self.channel_file.exists()
     }
+
+    /// Get the current file size in bytes
+    ///
+    /// This is a cheap O(1) operation that can be used to detect if new
+    /// messages have been added without reading the entire file.
+    /// Returns 0 if the file doesn't exist.
+    pub fn file_size(&self) -> u64 {
+        fs::metadata(&self.channel_file)
+            .map(|m| m.len())
+            .unwrap_or(0)
+    }
 }
 
 #[cfg(test)]
@@ -315,6 +326,28 @@ mod tests {
         channel.send(&Message::text("agent1", "3")).unwrap();
 
         assert_eq!(channel.message_count().unwrap(), 3);
+    }
+
+    #[test]
+    fn test_file_size_increases_with_messages() {
+        let temp_dir = TempDir::new().unwrap();
+        let channel = Channel::new(temp_dir.path()).unwrap();
+
+        // Empty channel has size 0
+        assert_eq!(channel.file_size(), 0);
+
+        // Sending a message increases file size
+        channel.send(&Message::text("agent1", "Hello")).unwrap();
+        let size1 = channel.file_size();
+        assert!(size1 > 0);
+
+        // Sending another message increases it further
+        channel.send(&Message::text("agent1", "World")).unwrap();
+        let size2 = channel.file_size();
+        assert!(size2 > size1);
+
+        // Size stays the same when no messages are added
+        assert_eq!(channel.file_size(), size2);
     }
 
     #[test]


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
Fixes extremely slow chat TUI rendering (was ~3 seconds per line with 1428 messages).

Two key optimizations:

1. **Add Channel::file_size() for O(1) change detection**
   - Previously `read_all()` was called every 250ms, parsing all 1428 messages
   - Now checks file size first (stat call) and only reads if changed
   - Common case (no new messages) goes from O(n) to O(1)

2. **Remove per-character OSC 8 hyperlink wrapping**
   - Each character was wrapped in its own escape sequence with full URL
   - For 10 PRs with 30-char titles and 50-char URLs = 21,000+ extra chars/frame
   - Now renders plain text for fast, reliable display

## Test plan
- [x] Unit tests pass
- [x] New test for `file_size()` method
- [ ] Manual test with large channel file (1400+ messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)