### PR TITLE
feat: Show nudges in chat as @mention messages

### DIFF
--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -151,7 +151,9 @@ impl DaemonClient {
     }
 
     pub fn coworker_nudge(&self, name: &str, message: Option<&str>) -> Result<Response, String> {
-        let mut args = serde_json::json!({ "name": name });
+        // Use MIDTOWN_AGENT env var for sender, defaulting to "lead"
+        let from = std::env::var("MIDTOWN_AGENT").unwrap_or_else(|_| "lead".to_string());
+        let mut args = serde_json::json!({ "name": name, "from": from });
         if let Some(msg) = message {
             args["message"] = serde_json::json!(msg);
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1158,10 +1158,14 @@ fn handle_request(line: &str, state: &DaemonState) -> Response {
             let message = params
                 .and_then(|p| p.get("message"))
                 .and_then(|v| v.as_str());
+            let from = params
+                .and_then(|p| p.get("from"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("lead");
 
             match (name, message) {
                 (Some(name), Some(message)) => {
-                    handle_coworker_nudge(request.id, name, message, state)
+                    handle_coworker_nudge(request.id, from, name, message, state)
                 }
                 _ => Response::error(request.id, RpcError::invalid_params()),
             }
@@ -1289,12 +1293,23 @@ fn handle_coworker_list(id: RequestId, state: &DaemonState) -> Response {
 }
 
 /// Handle coworker.nudge RPC method.
+///
+/// Posts the nudge as a channel message in the format `from: @name message`
+/// so nudges are visible in the chat, then sends the nudge to the coworker's tmux window.
 fn handle_coworker_nudge(
     id: RequestId,
+    from: &str,
     name: &str,
     message: &str,
     state: &DaemonState,
 ) -> Response {
+    // Post to channel first as an @mention message
+    let channel_content = format!("@{} {}", name, message);
+    let channel_msg = Message::new(from, channel_content, MessageType::Text);
+    if let Err(e) = state.channel.send(&channel_msg) {
+        warn!("Failed to post nudge to channel: {}", e);
+    }
+
     match state.coworkers.nudge(name, message) {
         Ok(()) => {
             info!("Nudged coworker {}: {}", name, message);


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- When a nudge is sent to a coworker, it now appears in the channel as a message with @mention format
- Format: `sender: @target message` (e.g., `lead: @pleasant Please work on task 5`)
- Client passes `from` parameter from MIDTOWN_AGENT env var to identify the sender
- Daemon posts the nudge to channel before sending to coworker's tmux window

## Test plan
- [x] Build passes
- [x] All tests pass
- [x] Clippy and fmt checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)