### PR TITLE
feat: Add --resume flag to coworker spawn

### DIFF
--- a/src/bin/midtown/cli/coworker.rs
+++ b/src/bin/midtown/cli/coworker.rs
@@ -6,7 +6,11 @@ use crate::client::DaemonClient;
 #[derive(Subcommand, Debug, Clone)]
 pub enum CoworkerCommand {
     /// Spawn a new coworker
-    Spawn,
+    Spawn {
+        /// Resume the previous Claude session (passes --continue to claude)
+        #[arg(long)]
+        resume: bool,
+    },
     /// Shutdown a coworker
     Shutdown {
         /// Name of the coworker to shutdown
@@ -65,7 +69,7 @@ pub enum NudgeConfigCommand {
 
 pub fn handle(cmd: &CoworkerCommand, client: &DaemonClient) -> Result<Response, String> {
     match cmd {
-        CoworkerCommand::Spawn => client.coworker_spawn(),
+        CoworkerCommand::Spawn { resume } => client.coworker_spawn(*resume),
         CoworkerCommand::Shutdown { name } => client.coworker_shutdown(name),
         CoworkerCommand::List => client.coworker_list(),
         CoworkerCommand::Nudge { name, message } => client.coworker_nudge(name, message.as_deref()),

--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -135,8 +135,11 @@ impl DaemonClient {
 
     // Coworker commands
 
-    pub fn coworker_spawn(&self) -> Result<Response, String> {
-        self.send("coworker.spawn", None)
+    pub fn coworker_spawn(&self, resume: bool) -> Result<Response, String> {
+        self.send(
+            "coworker.spawn",
+            Some(serde_json::json!({ "resume": resume })),
+        )
     }
 
     pub fn coworker_shutdown(&self, name: &str) -> Result<Response, String> {

--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -138,7 +138,10 @@ impl CoworkerManager {
     ///
     /// If a worktree already exists but no tmux window is running (stale worktree),
     /// the worktree is automatically cleaned up and the spawn is retried.
-    pub fn spawn(&self) -> crate::Result<String> {
+    ///
+    /// If `resume` is true, passes `--continue` to claude to resume the previous
+    /// session from this worktree (useful for recovering orphaned tasks).
+    pub fn spawn(&self, resume: bool) -> crate::Result<String> {
         let name = self.next_name().ok_or_else(|| crate::Error::Rpc {
             code: -32603,
             message: "No available coworker slots (all avenue names in use)".to_string(),
@@ -201,8 +204,13 @@ impl CoworkerManager {
         // Create the tmux window and spawn claude in the worktree
         // Pass repo_name so the coworker's tasks can be symlinked to the Lead's tasks
         let repo_name = self.worktree_manager.repo_name();
-        let session_id =
-            tmux::spawn_claude(&self.session_name, &name, &working_dir, Some(repo_name))?;
+        let session_id = tmux::spawn_claude(
+            &self.session_name,
+            &name,
+            &working_dir,
+            Some(repo_name),
+            resume,
+        )?;
 
         // Record the coworker with their session ID for symlink management
         let coworker = Coworker {
@@ -371,10 +379,16 @@ impl CoworkerManager {
             })?
             .to_string();
 
-        // Spawn Claude in the existing worktree
+        // Spawn Claude in the existing worktree, resuming the previous session
+        // so the coworker picks up where they left off
         let repo_name = self.worktree_manager.repo_name();
-        let session_id =
-            tmux::spawn_claude(&self.session_name, name, &working_dir, Some(repo_name))?;
+        let session_id = tmux::spawn_claude(
+            &self.session_name,
+            name,
+            &working_dir,
+            Some(repo_name),
+            true,
+        )?;
 
         // Record the coworker with their session ID for symlink management
         let coworker = Coworker {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1135,7 +1135,15 @@ fn handle_request(line: &str, state: &DaemonState) -> Response {
             Response::success(request.id, serde_json::json!({"status": "shutting_down"}))
         }
 
-        "coworker.spawn" => handle_coworker_spawn(request.id, state),
+        "coworker.spawn" => {
+            let resume = request
+                .params
+                .as_ref()
+                .and_then(|p| p.get("resume"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            handle_coworker_spawn(request.id, state, resume)
+        }
 
         "coworker.shutdown" => {
             let name = request
@@ -1222,8 +1230,8 @@ fn handle_request(line: &str, state: &DaemonState) -> Response {
 }
 
 /// Handle coworker.spawn RPC method.
-fn handle_coworker_spawn(id: RequestId, state: &DaemonState) -> Response {
-    match state.coworkers.spawn() {
+fn handle_coworker_spawn(id: RequestId, state: &DaemonState, resume: bool) -> Response {
+    match state.coworkers.spawn(resume) {
         Ok(name) => {
             info!("Spawned coworker: {}", name);
             Response::success(

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -625,11 +625,15 @@ fn write_coworker_settings_file(bin_command: &str) -> crate::Result<PathBuf> {
 /// Spawn Claude Code in a tmux window, returning the coworker's session ID.
 ///
 /// Returns the generated session UUID for use in task symlink management.
+///
+/// If `resume` is true, passes `--continue` to claude to resume the previous
+/// session from this worktree, preserving context from the last session.
 pub fn spawn_claude(
     session: &str,
     name: &str,
     working_dir: &str,
     repo_name: Option<&str>,
+    resume: bool,
 ) -> crate::Result<String> {
     // Get bin_command from project config
     let bin_command = crate::config::get_bin_command();
@@ -660,10 +664,13 @@ pub fn spawn_claude(
     // Use file paths for settings and prompt to avoid shell quoting issues
     // Set MIDTOWN_AGENT env var so the coworker's name appears in messages
     // Use --setting-sources project,local to use project settings (no vim mode)
+    // Add --continue flag if resuming a previous session
+    let continue_flag = if resume { " --continue" } else { "" };
     let command = format!(
-        "export MIDTOWN_AGENT={}; claude --dangerously-skip-permissions --session-id {} --setting-sources project,local --settings {} --append-system-prompt \"$(cat {})\"",
+        "export MIDTOWN_AGENT={}; claude --dangerously-skip-permissions --session-id {}{} --setting-sources project,local --settings {} --append-system-prompt \"$(cat {})\"",
         name,
         coworker_session_id,
+        continue_flag,
         settings_file.display(),
         prompt_file.display()
     );


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Adds `--resume` flag to `midtown coworker spawn` command
- When enabled, passes `--continue` to claude to resume the previous session from the worktree
- Useful for recovering orphaned tasks when a coworker session was interrupted
- Also updates `coworker respawn` to always resume (expected behavior when restoring a crashed coworker)

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` passes (123 tests)
- [x] `cargo clippy` passes
- [x] `midtown coworker spawn --help` shows the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)