### PR TITLE
fix: Look up coworker tasks from task storage in status RPC

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1269,15 +1269,30 @@ fn handle_coworker_shutdown(id: RequestId, name: &str, state: &DaemonState) -> R
 
 /// Handle coworker.list RPC method.
 fn handle_coworker_list(id: RequestId, state: &DaemonState) -> Response {
+    // Build a map of coworker name -> task subject from in_progress tasks
+    let coworker_tasks: std::collections::HashMap<String, String> =
+        crate::tasks::get_in_progress_tasks_with_subjects()
+            .into_iter()
+            .filter_map(|(_task_id, subject, owner)| {
+                if owner.is_empty() {
+                    None
+                } else {
+                    Some((owner.to_lowercase(), subject))
+                }
+            })
+            .collect();
+
     let coworkers: Vec<serde_json::Value> = state
         .coworkers
         .list()
         .iter()
         .map(|cw| {
+            // Look up current task from task storage (case-insensitive)
+            let current_task = coworker_tasks.get(&cw.name.to_lowercase()).cloned();
             serde_json::json!({
                 "name": cw.name,
                 "status": cw.status.to_string(),
-                "current_task": cw.current_task,
+                "current_task": current_task,
                 "started_at": cw.started_at.to_rfc3339(),
             })
         })


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Fixed `midtown status` showing all coworkers as "idle" even when they had claimed tasks
- The `current_task` field in the Coworker struct was never being updated after spawn
- Now looks up each coworker's in_progress task from the task storage (source of truth)

## Root Cause
The `handle_status` function was using `cw.current_task` from the Coworker struct, which is initialized to `None` when a coworker spawns and never updated when they claim tasks. The task ownership is stored in the task storage (Claude Code's `~/.claude/tasks/`), not in the Coworker struct.

## Test plan
- [x] All 123 existing tests pass
- [x] Daemon tests pass
- [ ] Manual test: Spawn a coworker, have them claim a task, run `midtown status` - should show them as "working on: <task subject>"

Fixes #113