### PR TITLE
feat: Add repo status line above kanban board

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -13,6 +13,31 @@ struct KanbanData {
     merged_prs: Vec<MergedPr>,
 }
 
+/// CI status for the repo status line
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum CiStatus {
+    #[default]
+    Unknown,
+    Running,
+    Passed,
+    Failed,
+}
+
+/// Repository status data for the status line above kanban
+#[derive(Debug, Clone, Default)]
+pub struct RepoStatus {
+    /// Short commit hash (7 chars)
+    pub commit_hash: String,
+    /// Time since last commit
+    pub commit_time: Option<DateTime<Utc>>,
+    /// CI status
+    pub ci_status: CiStatus,
+    /// Latest release tag (e.g., "v0.1.0")
+    pub release_tag: Option<String>,
+    /// Time of latest release
+    pub release_time: Option<DateTime<Utc>>,
+}
+
 /// A task item for the kanban board
 #[derive(Debug, Clone)]
 pub struct KanbanTask {
@@ -69,16 +94,24 @@ pub struct App {
     pub merged_prs: Vec<MergedPr>,
     /// Repository name with owner (e.g., "btucker/midtown")
     /// Used for constructing GitHub PR URLs in kanban hyperlinks
-    #[allow(dead_code)]
     pub repo_name: String,
     /// Last time kanban data was refreshed
     kanban_last_refresh: Instant,
     /// Receiver for async kanban data from background thread
     kanban_receiver: Option<Receiver<KanbanData>>,
+    /// Repository status (commit, CI, release info)
+    pub repo_status: RepoStatus,
+    /// Last time repo status was refreshed
+    repo_status_last_refresh: Instant,
+    /// Receiver for async repo status from background thread
+    repo_status_receiver: Option<Receiver<RepoStatus>>,
 }
 
 /// Interval between kanban data refreshes (30 seconds)
 const KANBAN_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Interval between repo status refreshes (60 seconds)
+const REPO_STATUS_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 
 impl App {
     pub fn new() -> Self {
@@ -105,6 +138,9 @@ impl App {
             repo_name,
             kanban_last_refresh: Instant::now() - KANBAN_REFRESH_INTERVAL, // Force initial refresh
             kanban_receiver: None,
+            repo_status: RepoStatus::default(),
+            repo_status_last_refresh: Instant::now() - REPO_STATUS_REFRESH_INTERVAL, // Force initial refresh
+            repo_status_receiver: None,
         };
 
         // Initial load
@@ -166,6 +202,30 @@ impl App {
             self.refresh_kanban();
             self.kanban_last_refresh = Instant::now();
         }
+
+        // Check for repo status data from background thread (non-blocking)
+        if let Some(ref receiver) = self.repo_status_receiver {
+            match receiver.try_recv() {
+                Ok(status) => {
+                    self.repo_status = status;
+                    self.repo_status_receiver = None;
+                }
+                Err(TryRecvError::Empty) => {
+                    // Still waiting for data
+                }
+                Err(TryRecvError::Disconnected) => {
+                    self.repo_status_receiver = None;
+                }
+            }
+        }
+
+        // Refresh repo status less frequently
+        if self.repo_status_last_refresh.elapsed() >= REPO_STATUS_REFRESH_INTERVAL
+            && self.repo_status_receiver.is_none()
+        {
+            self.refresh_repo_status();
+            self.repo_status_last_refresh = Instant::now();
+        }
     }
 
     /// Refresh kanban board data (tasks and PRs)
@@ -182,6 +242,17 @@ impl App {
             let merged_prs = fetch_merged_prs();
             // Ignore send error if receiver dropped (app closed)
             let _ = tx.send(KanbanData { prs, merged_prs });
+        });
+    }
+
+    /// Refresh repository status (commit, CI, release)
+    fn refresh_repo_status(&mut self) {
+        let (tx, rx) = mpsc::channel();
+        self.repo_status_receiver = Some(rx);
+
+        thread::spawn(move || {
+            let status = fetch_repo_status();
+            let _ = tx.send(status);
         });
     }
 
@@ -508,6 +579,87 @@ fn fetch_merged_prs() -> Vec<MergedPr> {
     prs
 }
 
+/// Fetch repository status (commit, CI status, release) from GitHub using gh CLI
+fn fetch_repo_status() -> RepoStatus {
+    let mut status = RepoStatus::default();
+
+    // Fetch latest commit on default branch
+    if let Ok(output) = std::process::Command::new("gh")
+        .args([
+            "api",
+            "repos/{owner}/{repo}/commits/{branch}",
+            "--jq",
+            r#"{sha: .sha[0:7], date: .commit.author.date}"#,
+        ])
+        .output()
+        && output.status.success()
+    {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if let Ok(data) = serde_json::from_str::<serde_json::Value>(&stdout) {
+            if let Some(sha) = data.get("sha").and_then(|v| v.as_str()) {
+                status.commit_hash = sha.to_string();
+            }
+            if let Some(date_str) = data.get("date").and_then(|v| v.as_str()) {
+                status.commit_time = DateTime::parse_from_rfc3339(date_str)
+                    .ok()
+                    .map(|dt| dt.with_timezone(&Utc));
+            }
+        }
+    }
+
+    // Fetch CI status from latest workflow run
+    if let Ok(output) = std::process::Command::new("gh")
+        .args([
+            "api",
+            "repos/{owner}/{repo}/actions/runs",
+            "--jq",
+            ".workflow_runs[0] | {status: .status, conclusion: .conclusion}",
+        ])
+        .output()
+        && output.status.success()
+    {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if let Ok(data) = serde_json::from_str::<serde_json::Value>(&stdout) {
+            let run_status = data.get("status").and_then(|v| v.as_str()).unwrap_or("");
+            let conclusion = data.get("conclusion").and_then(|v| v.as_str());
+
+            status.ci_status = match (run_status, conclusion) {
+                ("completed", Some("success")) => CiStatus::Passed,
+                ("completed", Some("failure")) => CiStatus::Failed,
+                ("completed", Some("cancelled")) => CiStatus::Failed,
+                ("in_progress", _) | ("queued", _) | ("waiting", _) => CiStatus::Running,
+                _ => CiStatus::Unknown,
+            };
+        }
+    }
+
+    // Fetch latest release
+    if let Ok(output) = std::process::Command::new("gh")
+        .args([
+            "api",
+            "repos/{owner}/{repo}/releases/latest",
+            "--jq",
+            "{tag: .tag_name, published_at: .published_at}",
+        ])
+        .output()
+        && output.status.success()
+    {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if let Ok(data) = serde_json::from_str::<serde_json::Value>(&stdout) {
+            if let Some(tag) = data.get("tag").and_then(|v| v.as_str()) {
+                status.release_tag = Some(tag.to_string());
+            }
+            if let Some(date_str) = data.get("published_at").and_then(|v| v.as_str()) {
+                status.release_time = DateTime::parse_from_rfc3339(date_str)
+                    .ok()
+                    .map(|dt| dt.with_timezone(&Utc));
+            }
+        }
+    }
+
+    status
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -593,6 +745,9 @@ mod tests {
             repo_name: "test".to_string(),
             kanban_last_refresh: Instant::now(),
             kanban_receiver: None,
+            repo_status: RepoStatus::default(),
+            repo_status_last_refresh: Instant::now(),
+            repo_status_receiver: None,
         };
 
         let (pending, in_progress, completed) = app.tasks_by_status();
@@ -630,6 +785,9 @@ mod tests {
             repo_name: "test".to_string(),
             kanban_last_refresh: Instant::now(),
             kanban_receiver: None,
+            repo_status: RepoStatus::default(),
+            repo_status_last_refresh: Instant::now(),
+            repo_status_receiver: None,
         };
 
         let visible = app.visible_messages();

--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -12,7 +12,7 @@ use ratatui::{
 
 use midtown::{Message, MessageType};
 
-use super::app::App;
+use super::app::{App, CiStatus};
 
 /// Format duration as (Xm) or (Xh) for display
 fn format_duration_minutes(since: DateTime<Utc>) -> String {
@@ -73,20 +73,117 @@ fn get_sender_color(name: &str) -> Color {
 /// Increased to accommodate 2-line items in In Progress and Review columns
 const KANBAN_HEIGHT: u16 = 9;
 
+/// Height of the repo status line
+const REPO_STATUS_HEIGHT: u16 = 1;
+
 /// Draw the main UI
 ///
 /// Note: The Team panel has been removed - coworker status is now shown
 /// in tmux tab names instead, providing better visibility even when the
 /// chat TUI is not in focus.
 pub fn draw(f: &mut Frame, app: &mut App) {
-    // Split into kanban (top) and chat (bottom) panels
+    // Split into repo status (top), kanban (middle), and chat (bottom) panels
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(KANBAN_HEIGHT), Constraint::Min(10)])
+        .constraints([
+            Constraint::Length(REPO_STATUS_HEIGHT),
+            Constraint::Length(KANBAN_HEIGHT),
+            Constraint::Min(10),
+        ])
         .split(f.area());
 
-    draw_kanban_panel(f, app, chunks[0]);
-    draw_chat_panel(f, app, chunks[1]);
+    draw_repo_status_line(f, app, chunks[0]);
+    draw_kanban_panel(f, app, chunks[1]);
+    draw_chat_panel(f, app, chunks[2]);
+}
+
+/// Format relative time (e.g., "3 minutes ago", "2 hours ago", "1 day ago")
+fn format_relative_time(time: DateTime<Utc>) -> String {
+    let now = Utc::now();
+    let duration = now.signed_duration_since(time);
+    let minutes = duration.num_minutes();
+    let hours = duration.num_hours();
+    let days = duration.num_days();
+
+    if days > 0 {
+        if days == 1 {
+            "1 day ago".to_string()
+        } else {
+            format!("{} days ago", days)
+        }
+    } else if hours > 0 {
+        if hours == 1 {
+            "1 hour ago".to_string()
+        } else {
+            format!("{} hours ago", hours)
+        }
+    } else if minutes > 0 {
+        if minutes == 1 {
+            "1 minute ago".to_string()
+        } else {
+            format!("{} minutes ago", minutes)
+        }
+    } else {
+        "just now".to_string()
+    }
+}
+
+/// Draw the repo status line showing commit, CI status, and release info
+fn draw_repo_status_line(f: &mut Frame, app: &App, area: Rect) {
+    let status = &app.repo_status;
+
+    let mut spans = Vec::new();
+
+    // Repo name (dim)
+    spans.push(Span::styled(
+        format!(" {}  ", app.repo_name),
+        Style::default().fg(Color::DarkGray),
+    ));
+
+    // Commit hash and time
+    if !status.commit_hash.is_empty() {
+        spans.push(Span::styled(
+            status.commit_hash.clone(),
+            Style::default().fg(Color::Yellow),
+        ));
+        if let Some(commit_time) = status.commit_time {
+            spans.push(Span::styled(
+                format!("  {}  ", format_relative_time(commit_time)),
+                Style::default().fg(Color::DarkGray),
+            ));
+        } else {
+            spans.push(Span::raw("  "));
+        }
+    }
+
+    // CI status dot
+    let (ci_char, ci_color) = match status.ci_status {
+        CiStatus::Passed => ("●", Color::Green),
+        CiStatus::Failed => ("●", Color::Red),
+        CiStatus::Running => ("●", Color::Yellow),
+        CiStatus::Unknown => ("○", Color::DarkGray),
+    };
+    spans.push(Span::styled(ci_char, Style::default().fg(ci_color)));
+    spans.push(Span::raw("  "));
+
+    // Release info
+    if let Some(ref tag) = status.release_tag {
+        spans.push(Span::styled(
+            "Releases: ",
+            Style::default().fg(Color::DarkGray),
+        ));
+        spans.push(Span::styled(tag.clone(), Style::default().fg(Color::Cyan)));
+        if let Some(release_time) = status.release_time {
+            spans.push(Span::styled(
+                format!("  {}", format_relative_time(release_time)),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+    }
+
+    let line = Line::from(spans);
+    let paragraph = Paragraph::new(line);
+    f.render_widget(paragraph, area);
 }
 
 /// A kanban item that may span multiple lines
@@ -950,5 +1047,44 @@ mod tests {
 
         // Verify gray color (DarkGray)
         assert_eq!(lines[0].spans[0].style.fg, Some(Color::DarkGray));
+    }
+
+    #[test]
+    fn test_format_relative_time() {
+        use chrono::{Duration, Utc};
+
+        let now = Utc::now();
+
+        // Just now (less than a minute ago)
+        assert_eq!(format_relative_time(now), "just now");
+
+        // Minutes ago
+        assert_eq!(
+            format_relative_time(now - Duration::minutes(1)),
+            "1 minute ago"
+        );
+        assert_eq!(
+            format_relative_time(now - Duration::minutes(30)),
+            "30 minutes ago"
+        );
+        assert_eq!(
+            format_relative_time(now - Duration::minutes(59)),
+            "59 minutes ago"
+        );
+
+        // Hours ago
+        assert_eq!(format_relative_time(now - Duration::hours(1)), "1 hour ago");
+        assert_eq!(
+            format_relative_time(now - Duration::hours(5)),
+            "5 hours ago"
+        );
+        assert_eq!(
+            format_relative_time(now - Duration::hours(23)),
+            "23 hours ago"
+        );
+
+        // Days ago
+        assert_eq!(format_relative_time(now - Duration::days(1)), "1 day ago");
+        assert_eq!(format_relative_time(now - Duration::days(7)), "7 days ago");
     }
 }


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Added repo status line above the kanban board in the chat TUI
- Displays: repo name, latest commit hash + time, CI status dot, latest release tag + time
- Data fetched asynchronously via gh CLI (60s refresh interval)
- CI status dot colors: green (passed), red (failed), yellow (running), gray (unknown)

## Test plan
- [x] All existing tests pass
- [x] New test for `format_relative_time` function
- [x] Manual verification of layout and rendering
- [x] Clippy and format checks pass