### PR TITLE
fix: Verify tmux window exists after spawn_claude creates it

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -681,6 +681,22 @@ pub fn spawn_claude(
     // Set window tab color to match chat TUI team panel
     set_window_color(session, name)?;
 
+    // Brief delay to let the window start up and potentially fail
+    // This is necessary because tmux new-window returns success immediately,
+    // even if the command inside fails and the window closes right away
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    // Verify the window actually exists (it may have died if the command failed)
+    if !window_exists(session, name)? {
+        return Err(Error::Rpc {
+            code: -32603,
+            message: format!(
+                "Tmux window {}:{} was created but immediately closed (command likely failed)",
+                session, name
+            ),
+        });
+    }
+
     Ok(coworker_session_id)
 }
 


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Fix bug where daemon recovery logs success but doesn't actually spawn a tmux window
- Add 500ms delay after window creation to let command start
- Verify window exists before reporting success
- Return clear error if window immediately died (command failed)

## Problem
When the daemon recovered an orphaned coworker, it would log "♻️ Recovered coworker vernon for orphaned task #1" even though no tmux window was actually created. This happened because `tmux new-window` returns exit code 0 immediately, even if the command inside fails and the window closes.

## Solution
After calling `create_window()`, we now:
1. Wait 500ms for the command to start and potentially fail
2. Verify the window still exists using `window_exists()`
3. Return an error with a clear message if the window died

This ensures the daemon only reports success when the coworker window actually exists.

## Test plan
- [x] Build passes
- [x] All tests pass
- [x] Code passes clippy and fmt checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)