### PR TITLE
feat: Refactor chat TUI to async I/O with tailf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234655ec178edd82b891e262ea7cf71f6584bcd09eff94db786be23f1821825c"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ec27229c38ed0eb3c0feee3d2c1d6a4379ae44f418a29a658890e062d8f365"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +353,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
+ "futures-core",
  "mio",
  "parking_lot",
  "rustix 1.1.3",
@@ -521,12 +547,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -534,6 +576,40 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -547,10 +623,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -897,6 +979,7 @@ dependencies = [
  "dirs",
  "fastrand",
  "fs2",
+ "futures",
  "hex",
  "hmac",
  "once_cell",
@@ -904,6 +987,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tailf",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1014,6 +1098,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1289,6 +1383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1460,16 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "tailf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d8fddaad13d98a99b3579b0a3684708e5cb448a98a850755b4becb1c034e274"
+dependencies = [
+ "bon",
+ "tokio",
+]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,11 @@ daemonize = "0.5"
 
 # TUI for chat interface
 ratatui = "0.29"
-crossterm = "0.29"
+crossterm = { version = "0.29", features = ["event-stream"] }
+
+# Async file tailing for instant message updates
+tailf = "0.1"
+futures = "0.3"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -154,7 +154,8 @@ impl App {
         // Use cursor-based reading for efficient tailing
         // The cursor tracks byte position in the file, so we only read new content
         if let Some(ref channel) = self.channel {
-            if !self.initial_load_done {
+            let is_initial_load = !self.initial_load_done;
+            if is_initial_load {
                 // First load: reset cursor to start of file, then read all via cursor
                 // This ensures the cursor position is updated correctly
                 let _ = channel.reset_cursor("chat-tui");
@@ -173,7 +174,10 @@ impl App {
                 // Append new messages (they're already in chronological order)
                 self.messages.extend(new_messages);
 
-                if was_at_bottom {
+                if is_initial_load {
+                    // On initial load, always scroll to bottom (most recent messages)
+                    self.scroll_offset = 0;
+                } else if was_at_bottom {
                     // User was at bottom - stay at bottom (auto-scroll)
                     self.scroll_offset = 0;
                 } else {
@@ -323,6 +327,13 @@ impl App {
     /// Maximum scroll offset
     fn max_scroll(&self) -> usize {
         self.messages.len().saturating_sub(self.visible_height)
+    }
+
+    /// Get the channel file path for file watching
+    pub fn channel_file_path(&self) -> Option<std::path::PathBuf> {
+        self.channel
+            .as_ref()
+            .map(|c| c.channel_file_path().to_path_buf())
     }
 
     /// Get messages visible in the current scroll position

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -2,6 +2,9 @@
 //!
 //! This module provides a read-only chat interface showing team activity
 //! and coworker status in a split-pane layout.
+//!
+//! Uses async I/O with the `tailf` crate for instant message updates when
+//! the channel.jsonl file changes, rather than polling.
 
 mod app;
 mod ui;
@@ -11,12 +14,15 @@ use std::time::Duration;
 
 use crossterm::{
     event::{
-        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, MouseEventKind,
+        DisableMouseCapture, EnableMouseCapture, Event, EventStream, KeyCode, KeyEventKind,
+        MouseEventKind,
     },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
+use futures::StreamExt;
 use ratatui::{Terminal, prelude::CrosstermBackend};
+use tokio::time::interval;
 
 use app::App;
 
@@ -34,8 +40,12 @@ pub fn run() -> Result<(), String> {
     // Create app state
     let mut app = App::new();
 
-    // Run the main loop
-    let result = run_app(&mut terminal, &mut app);
+    // Run the async main loop using tokio
+    let result = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("Failed to create tokio runtime: {}", e))?
+        .block_on(run_app_async(&mut terminal, &mut app));
 
     // Restore terminal (always attempt cleanup)
     let _ = disable_raw_mode();
@@ -49,34 +59,90 @@ pub fn run() -> Result<(), String> {
     result.map_err(|e| format!("TUI error: {}", e))
 }
 
-fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App) -> io::Result<()> {
+async fn run_app_async(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut App,
+) -> io::Result<()> {
+    // Set up async event stream for terminal events
+    let mut event_stream = EventStream::new();
+
+    // Set up file tailer for channel.jsonl if available
+    // We start from line 0 because we use cursor-based reading for message parsing
+    let mut tailer = app
+        .channel_file_path()
+        .and_then(|path| tailf::tailf(&path, Some(0)).ok());
+
+    // Fallback timer for kanban/repo status refresh (30 seconds)
+    // This ensures periodic refreshes even without file activity
+    let mut refresh_interval = interval(Duration::from_secs(30));
+
     loop {
         // Draw UI
         terminal.draw(|f| ui::draw(f, app))?;
 
-        // Poll for events with a timeout to allow periodic updates
-        if event::poll(Duration::from_millis(250))? {
-            match event::read()? {
-                Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
-                    KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
-                    KeyCode::Up | KeyCode::Char('k') => app.scroll_up(),
-                    KeyCode::Down | KeyCode::Char('j') => app.scroll_down(),
-                    KeyCode::PageUp => app.page_up(),
-                    KeyCode::PageDown => app.page_down(),
-                    KeyCode::Home | KeyCode::Char('g') => app.scroll_to_top(),
-                    KeyCode::End | KeyCode::Char('G') => app.scroll_to_bottom(),
-                    _ => {}
-                },
-                Event::Mouse(mouse) => match mouse.kind {
-                    MouseEventKind::ScrollUp => app.scroll_up(),
-                    MouseEventKind::ScrollDown => app.scroll_down(),
-                    _ => {}
-                },
-                _ => {}
+        // Use tokio::select! to wait for either:
+        // 1. Terminal events (keyboard/mouse)
+        // 2. File changes from tailf
+        // 3. Periodic refresh timer
+        tokio::select! {
+            // Handle terminal events (keyboard, mouse)
+            maybe_event = event_stream.next() => {
+                match maybe_event {
+                    Some(Ok(event)) => {
+                        if handle_event(app, event) {
+                            return Ok(());
+                        }
+                    }
+                    Some(Err(_)) => {
+                        // Event stream error, continue
+                    }
+                    None => {
+                        // Event stream closed
+                        return Ok(());
+                    }
+                }
+            }
+
+            // Handle file changes from tailf - instant message updates
+            Some(result) = async {
+                match &mut tailer {
+                    Some(t) => Some(t.next().await),
+                    None => None,
+                }
+            } => {
+                if let Ok(Some(_)) = result {
+                    // New content in channel.jsonl - refresh messages
+                    app.refresh();
+                }
+            }
+
+            // Periodic refresh for kanban and repo status
+            _ = refresh_interval.tick() => {
+                app.refresh();
             }
         }
-
-        // Check for new messages
-        app.refresh();
     }
+}
+
+/// Handle a terminal event, returns true if the app should exit
+fn handle_event(app: &mut App, event: Event) -> bool {
+    match event {
+        Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => return true,
+            KeyCode::Up | KeyCode::Char('k') => app.scroll_up(),
+            KeyCode::Down | KeyCode::Char('j') => app.scroll_down(),
+            KeyCode::PageUp => app.page_up(),
+            KeyCode::PageDown => app.page_down(),
+            KeyCode::Home | KeyCode::Char('g') => app.scroll_to_top(),
+            KeyCode::End | KeyCode::Char('G') => app.scroll_to_bottom(),
+            _ => {}
+        },
+        Event::Mouse(mouse) => match mouse.kind {
+            MouseEventKind::ScrollUp => app.scroll_up(),
+            MouseEventKind::ScrollDown => app.scroll_down(),
+            _ => {}
+        },
+        _ => {}
+    }
+    false
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -95,6 +95,11 @@ impl Channel {
         &self.base_dir
     }
 
+    /// Get the path to the channel.jsonl file
+    pub fn channel_file_path(&self) -> &Path {
+        &self.channel_file
+    }
+
     /// Append a message to the channel
     ///
     /// Uses file locking to ensure atomic append operations.


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Replace 250ms polling loop with async I/O using the `tailf` crate
- Use `crossterm::event::EventStream` for async terminal event handling
- Use `tokio::select!` to multiplex file changes and user input
- Ensure chat pane scrolls to bottom on initial load

This gives instant message updates when `channel.jsonl` changes, rather than waiting up to 250ms.

## Test plan
- [x] All existing tests pass
- [x] Clippy passes with no warnings
- [ ] Manual test: Open chat TUI, post message in another terminal, verify instant appearance

🤖 Generated with [Claude Code](https://claude.ai/code)