### PR TITLE
docs: Add code review accountability to coworker prompt

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -107,9 +107,9 @@ This ensures your PR doesn't get stuck waiting - another coworker will claim the
 ### Reviewing PRs
 When you pick up a code review task:
 
-1. **Use the code-review skill** to analyze the PR:
+1. **Use the code-review:code-review skill** to analyze the PR:
 ```
-/code-review <PR number>
+/code-review:code-review <PR number>
 ```
 
 2. **Post your review as a GitHub comment** on the PR. The skill will guide you through this, but you MUST ensure your review is posted to GitHub (not just the channel).


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Added explicit requirements for code reviews to be posted as GitHub PR comments
- Added requirement to confirm completion with comment URL in channel
- Added "Reviewing" phase to workflow phases table
- Clarified that reviews are not complete until GitHub comment is posted

This addresses the issue where a coworker claimed to do a code review but never actually posted it. The new instructions make accountability explicit.

## Test plan
- [x] Verify coworker prompt renders correctly
- [x] Instructions are clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)