### PR TITLE
fix: Ensure chat scrolls to bottom on initial load

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -146,6 +146,8 @@ impl App {
 
         // Initial load
         app.refresh();
+        // Ensure we start at the bottom (most recent messages)
+        app.scroll_to_bottom();
         app
     }
 


### PR DESCRIPTION
## Summary
- Adds explicit `scroll_to_bottom()` call after initial message load
- Ensures users see the most recent messages when chat starts

<!-- midtown: lead -->

🤖 Generated with [Claude Code](https://claude.ai/code)