### PR TITLE
fix: Reduce chat refresh fallback interval from 30s to 1s

### DIFF
--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -72,9 +72,9 @@ async fn run_app_async(
         .channel_file_path()
         .and_then(|path| tailf::tailf(&path, Some(0)).ok());
 
-    // Fallback timer for kanban/repo status refresh (30 seconds)
-    // This ensures periodic refreshes even without file activity
-    let mut refresh_interval = interval(Duration::from_secs(30));
+    // Fallback timer for message/kanban/repo status refresh (1 second)
+    // This ensures responsive updates if tailf isn't triggering
+    let mut refresh_interval = interval(Duration::from_secs(1));
 
     loop {
         // Draw UI


### PR DESCRIPTION
## Summary
- Reduces the fallback refresh interval from 30 seconds to 1 second
- The tailf file watching may not always trigger correctly
- This ensures messages appear within a reasonable time even if tailf fails

## Root cause
The 30-second interval was too long when tailf doesn't detect file changes.

<!-- midtown: lead -->

🤖 Generated with [Claude Code](https://claude.ai/code)