### PR TITLE
feat: Auto-move chat pane to separate window on narrow screens

### DIFF
--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -469,25 +469,33 @@ pub fn handle_start(daemon_only: bool) -> Result<Response, String> {
         // Set up hook to update status bar color based on active window
         let _ = midtown::tmux::setup_status_bar_hook(&session);
 
-        // Split Lead window with chat TUI on the right (30% width)
-        let lead_target = format!("{}:lead", session);
-        let _ = Command::new("tmux")
-            .args(["split-window", "-h", "-t", &lead_target, "-p", "30"])
-            .status();
-
-        // Start chat TUI in the new pane (pane .1)
-        let chat_pane = format!("{}:lead.1", session);
+        // Set up chat TUI based on layout configuration
         let bin_command = midtown::config::get_bin_command();
-        let chat_cmd = format!("{} chat", bin_command);
-        let _ = Command::new("tmux")
-            .args(["send-keys", "-t", &chat_pane, &chat_cmd, "Enter"])
-            .status();
+        let (chat_layout, chat_min_width) = midtown::config::get_chat_layout();
 
-        // Keep focus on the main pane (Claude Code, pane .0)
-        let main_pane = format!("{}:lead.0", session);
-        let _ = Command::new("tmux")
-            .args(["select-pane", "-t", &main_pane])
-            .status();
+        // Determine whether to use split or window layout
+        let use_split = match chat_layout {
+            midtown::config::ChatLayout::Split => true,
+            midtown::config::ChatLayout::Window => false,
+            midtown::config::ChatLayout::Auto => {
+                // Check terminal width and use split if wide enough
+                midtown::tmux::get_session_width(&session)
+                    .map(|w| w >= chat_min_width)
+                    .unwrap_or(true) // Default to split if can't determine width
+            }
+        };
+
+        if use_split {
+            // Split layout: chat pane on the right (30% width)
+            if let Err(e) = midtown::tmux::create_chat_split(&session, &bin_command) {
+                eprintln!("Warning: Failed to create chat split: {}", e);
+            }
+        } else {
+            // Window layout: chat in separate window
+            if let Err(e) = midtown::tmux::create_chat_window(&session, &bin_command) {
+                eprintln!("Warning: Failed to create chat window: {}", e);
+            }
+        }
 
         // Write marker file indicating Lead was initialized by midtown
         let marker_path = lead_initialized_marker(&repo);

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,12 +14,37 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+/// Chat layout mode for the Lead session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ChatLayout {
+    /// Automatically choose based on terminal width
+    #[default]
+    Auto,
+    /// Always use split pane (side-by-side)
+    Split,
+    /// Always use separate window
+    Window,
+}
+
 /// Configuration for a single project.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ProjectConfig {
     /// Command to invoke midtown (e.g., "midtown" or "cargo run --release --")
     #[serde(default = "default_bin_command")]
     pub bin_command: String,
+
+    /// Chat pane layout mode (auto, split, or window)
+    #[serde(default)]
+    pub chat_layout: ChatLayout,
+
+    /// Minimum terminal width for split layout in auto mode (default: 160)
+    #[serde(default = "default_chat_min_width")]
+    pub chat_min_width: u16,
+}
+
+fn default_chat_min_width() -> u16 {
+    160
 }
 
 fn default_bin_command() -> String {
@@ -30,6 +55,8 @@ impl Default for ProjectConfig {
     fn default() -> Self {
         Self {
             bin_command: default_bin_command(),
+            chat_layout: ChatLayout::default(),
+            chat_min_width: default_chat_min_width(),
         }
     }
 }
@@ -95,6 +122,20 @@ pub fn get_bin_command() -> String {
     }
 }
 
+/// Get the chat layout configuration for the current project.
+pub fn get_chat_layout() -> (ChatLayout, u16) {
+    let config = Config::load();
+    let project_name = get_project_name().unwrap_or_default();
+
+    let project_config = if project_name.is_empty() {
+        &config.default
+    } else {
+        config.for_project(&project_name)
+    };
+
+    (project_config.chat_layout, project_config.chat_min_width)
+}
+
 /// Get the current project name from git repo root directory.
 fn get_project_name() -> Option<String> {
     let output = std::process::Command::new("git")
@@ -147,5 +188,44 @@ bin_command = "cargo run --release --"
         let path = config_path();
         assert!(path.to_string_lossy().contains(".midtown"));
         assert!(path.to_string_lossy().ends_with("config.toml"));
+    }
+
+    #[test]
+    fn test_chat_layout_default() {
+        let config = Config::default();
+        assert_eq!(config.default.chat_layout, ChatLayout::Auto);
+        assert_eq!(config.default.chat_min_width, 160);
+    }
+
+    #[test]
+    fn test_chat_layout_parse() {
+        let toml = r#"
+[default]
+chat_layout = "split"
+chat_min_width = 200
+
+[narrow-project]
+chat_layout = "window"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+
+        assert_eq!(config.default.chat_layout, ChatLayout::Split);
+        assert_eq!(config.default.chat_min_width, 200);
+        assert_eq!(
+            config.for_project("narrow-project").chat_layout,
+            ChatLayout::Window
+        );
+        // Narrow project should inherit default min_width
+        assert_eq!(config.for_project("narrow-project").chat_min_width, 160);
+    }
+
+    #[test]
+    fn test_chat_layout_auto() {
+        let toml = r#"
+[default]
+chat_layout = "auto"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.default.chat_layout, ChatLayout::Auto);
     }
 }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -815,6 +815,95 @@ pub fn session_exists(name: &str) -> crate::Result<bool> {
     Ok(status.success())
 }
 
+/// Get the width of a tmux session's terminal in columns.
+///
+/// Uses `tmux display-message` to query the client width.
+/// Returns None if the session doesn't exist or width can't be determined.
+pub fn get_session_width(session: &str) -> Option<u16> {
+    let output = Command::new("tmux")
+        .args(["display-message", "-t", session, "-p", "#{client_width}"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let width_str = String::from_utf8_lossy(&output.stdout);
+    width_str.trim().parse().ok()
+}
+
+/// Create a new window in the session for the chat TUI.
+///
+/// This is used when the terminal is too narrow for a split layout.
+/// The window is named "chat" and starts the chat command.
+pub fn create_chat_window(session: &str, bin_command: &str) -> crate::Result<()> {
+    let chat_cmd = format!("{} chat", bin_command);
+
+    // Create a new window named "chat"
+    let status = Command::new("tmux")
+        .args([
+            "new-window",
+            "-d", // Don't switch to it
+            "-t",
+            session,
+            "-n",
+            "chat",
+        ])
+        .status()
+        .map_err(Error::Io)?;
+
+    if !status.success() {
+        return Err(Error::Rpc {
+            code: -32603,
+            message: format!("Failed to create chat window in session {}", session),
+        });
+    }
+
+    // Start chat TUI in the new window
+    let chat_target = format!("{}:chat", session);
+    let _ = Command::new("tmux")
+        .args(["send-keys", "-t", &chat_target, &chat_cmd, "Enter"])
+        .status();
+
+    Ok(())
+}
+
+/// Create a split pane for the chat TUI in the lead window.
+///
+/// Splits the lead window horizontally with chat on the right (30% width).
+pub fn create_chat_split(session: &str, bin_command: &str) -> crate::Result<()> {
+    let lead_target = format!("{}:lead", session);
+    let chat_cmd = format!("{} chat", bin_command);
+
+    // Split the lead window horizontally with 30% for chat
+    let status = Command::new("tmux")
+        .args(["split-window", "-h", "-t", &lead_target, "-p", "30"])
+        .status()
+        .map_err(Error::Io)?;
+
+    if !status.success() {
+        return Err(Error::Rpc {
+            code: -32603,
+            message: format!("Failed to split lead window in session {}", session),
+        });
+    }
+
+    // Start chat TUI in the new pane (pane .1)
+    let chat_pane = format!("{}:lead.1", session);
+    let _ = Command::new("tmux")
+        .args(["send-keys", "-t", &chat_pane, &chat_cmd, "Enter"])
+        .status();
+
+    // Keep focus on the main pane (Claude Code, pane .0)
+    let main_pane = format!("{}:lead.0", session);
+    let _ = Command::new("tmux")
+        .args(["select-pane", "-t", &main_pane])
+        .status();
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Add configurable chat layout that adapts to terminal width
- Three modes: `auto` (default), `split`, or `window`
- In auto mode, uses split pane if terminal >= 160 columns, otherwise separate window
- User can switch between windows with tmux shortcuts (Ctrl-b n/p)

## Config Options
```toml
[default]
chat_layout = "auto"  # "auto" | "split" | "window"
chat_min_width = 160  # threshold for auto mode (columns)
```

## Changes
- `src/config.rs`: Add `ChatLayout` enum and config options
- `src/tmux.rs`: Add helper functions for width detection and chat window/pane creation
- `src/bin/midtown/cli/daemon.rs`: Use new config to choose layout on startup

## Test plan
- [x] All tests pass (`cargo test`)
- [x] Clippy passes
- [x] Config parsing tests for new options
- [ ] Manual test: Start daemon on narrow terminal, verify chat is in separate window
- [ ] Manual test: Start daemon on wide terminal, verify chat is split pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)