### PR TITLE
feat: Add 30-second timeout to e2e tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -283,7 +283,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -419,7 +419,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -430,7 +430,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -458,7 +458,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -617,7 +617,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -868,7 +868,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1003,6 +1003,7 @@ dependencies = [
  "futures",
  "hex",
  "hmac",
+ "ntest",
  "once_cell",
  "ratatui",
  "serde",
@@ -1045,6 +1046,39 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ntest"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54d1aa56874c2152c24681ed0df95ee155cc06c5c61b78e2d1e8c0cae8bc5326"
+dependencies = [
+ "ntest_test_cases",
+ "ntest_timeout",
+]
+
+[[package]]
+name = "ntest_test_cases"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6913433c6319ef9b2df316bb8e3db864a41724c2bb8f12555e07dc4ec69d3db1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ntest_timeout"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9224be3459a0c1d6e9b0f42ab0e76e98b29aef5aba33c0487dfcf47ea08b5150"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1146,7 +1180,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1346,7 +1389,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1515,7 +1558,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1523,6 +1566,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1581,7 +1635,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1618,7 +1672,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1668,6 +1722,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -1759,7 +1825,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1947,7 +2013,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -2003,7 +2069,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2014,7 +2080,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2202,6 +2268,9 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -2226,7 +2295,7 @@ checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ futures = "0.3"
 
 [dev-dependencies]
 tempfile = "3.0"
+ntest = "0.9"  # Test utilities including timeout attribute
 
 # Git hooks - runs on cargo test
 [dev-dependencies.cargo-husky]

--- a/tests/chat_e2e.rs
+++ b/tests/chat_e2e.rs
@@ -8,7 +8,10 @@
 //! - Scroll behavior
 //!
 //! Run with `cargo test -- --ignored` as these require tmux.
+//!
+//! All tests have a 30-second timeout to prevent CI from hanging.
 
+use ntest::timeout;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
@@ -186,6 +189,7 @@ impl Drop for TestFixture {
 /// This catches the bug where Review/Done columns show only single characters
 /// when the terminal is narrow.
 #[test]
+#[timeout(30000)]
 #[ignore] // Requires tmux
 fn test_kanban_column_minimum_width_rendering() {
     if !tmux_available() {
@@ -222,6 +226,7 @@ fn test_kanban_column_minimum_width_rendering() {
 ///
 /// When a column is narrow, "PR#97 Fix bug" should show "#97" not "P" or "PR".
 #[test]
+#[timeout(30000)]
 #[ignore] // Requires tmux
 fn test_pr_identifier_preserved_in_narrow_column() {
     // This test documents expected behavior for identifier-preserving truncation.
@@ -236,6 +241,7 @@ fn test_pr_identifier_preserved_in_narrow_column() {
 /// This catches the 15-minute delay bug by writing a message and verifying
 /// it appears in the TUI output.
 #[test]
+#[timeout(30000)]
 #[ignore] // Requires tmux
 fn test_message_appears_promptly() {
     if !tmux_available() {
@@ -275,6 +281,7 @@ fn test_message_appears_promptly() {
 ///
 /// This is a smoke test that the chat subcommand works at all.
 #[test]
+#[timeout(30000)]
 #[ignore] // Requires tmux and built binary
 fn test_chat_tui_starts() {
     if !tmux_available() {
@@ -313,6 +320,7 @@ fn test_chat_tui_starts() {
 
 /// Test kanban board with multiple items to verify layout.
 #[test]
+#[timeout(30000)]
 #[ignore] // Requires tmux
 fn test_kanban_multi_item_layout() {
     if !tmux_available() {
@@ -383,6 +391,7 @@ fn test_truncate_str_identifier_behavior() {
 
 /// Test that multiple messages from the same sender are grouped.
 #[test]
+#[timeout(30000)]
 #[ignore] // Requires tmux
 fn test_message_grouping() {
     if !tmux_available() {
@@ -420,6 +429,7 @@ fn test_message_grouping() {
 
 /// Test action messages (IRC /me style).
 #[test]
+#[timeout(30000)]
 #[ignore] // Requires tmux
 fn test_action_message_format() {
     if !tmux_available() {
@@ -464,6 +474,7 @@ fn test_action_message_format() {
 /// - Message display delays
 /// - Scroll position issues
 #[test]
+#[timeout(30000)]
 #[ignore] // Requires tmux and built binary
 fn test_full_tui_rendering() {
     if !tmux_available() {
@@ -552,6 +563,7 @@ fn test_full_tui_rendering() {
 
 /// Test that very narrow terminals don't panic and show useful content.
 #[test]
+#[timeout(30000)]
 #[ignore] // Requires tmux
 fn test_narrow_terminal_no_panic() {
     if !tmux_available() {
@@ -643,6 +655,7 @@ fn test_task_json_schema() {
 ///
 /// The poll interval is 250ms, so messages should appear within 500ms typically.
 #[test]
+#[timeout(30000)]
 #[ignore] // Requires tmux and built binary
 fn test_message_appears_in_tui_promptly() {
     if !tmux_available() {
@@ -775,6 +788,7 @@ fn test_message_appears_in_tui_promptly() {
 /// - Lock contention prevents reading
 /// - Sorting causes messages to appear in wrong position
 #[test]
+#[timeout(30000)]
 #[ignore] // Requires tmux and built binary
 fn test_message_update_in_existing_channel() {
     if !tmux_available() {

--- a/tests/nudge_e2e.rs
+++ b/tests/nudge_e2e.rs
@@ -3,7 +3,10 @@
 //! These tests require tmux to be running and are marked as ignored
 //! by default for CI environments. Run with `cargo test -- --ignored`
 //! to execute them locally.
+//!
+//! All tests have a 30-second timeout to prevent CI from hanging.
 
+use ntest::timeout;
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
@@ -68,6 +71,7 @@ fn tmux_available() -> bool {
 }
 
 #[test]
+#[timeout(30000)]
 #[ignore] // Requires tmux to be running
 fn test_nudge_verification_success() {
     if !tmux_available() {
@@ -121,6 +125,7 @@ fn test_nudge_verification_success() {
 }
 
 #[test]
+#[timeout(30000)]
 #[ignore] // Requires tmux to be running
 fn test_nudge_verification_returns_error_for_missing_message() {
     if !tmux_available() {
@@ -164,6 +169,7 @@ fn test_nudge_verification_returns_error_for_missing_message() {
 }
 
 #[test]
+#[timeout(30000)]
 #[ignore] // Requires tmux to be running
 fn test_nudge_pane_verification_with_special_characters() {
     if !tmux_available() {


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Add `ntest` crate for test timeout attribute support
- Add `#[timeout(30000)]` (30 seconds) to all tmux-based e2e tests
- Prevents CI from hanging indefinitely if a test gets stuck

## Changes
- `Cargo.toml`: Add `ntest = "0.9"` to dev-dependencies
- `tests/nudge_e2e.rs`: Add timeout to 3 tests
- `tests/chat_e2e.rs`: Add timeout to 11 tests

## Notes
- The `tailf_integration.rs` tests already use `tokio::time::timeout` internally
- The `task_sharing.rs` tests are fast file-system tests that don't need timeouts
- 30 seconds is generous enough for tmux operations while still catching hangs

## Test plan
- [x] All tests pass (`cargo test`)
- [x] Clippy passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)