### PR TITLE
fix: Filter CI status query to main branch only

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -754,11 +754,11 @@ fn fetch_repo_status() -> RepoStatus {
         }
     }
 
-    // Fetch CI status from latest workflow run
+    // Fetch CI status from latest workflow run on main branch
     if let Ok(output) = std::process::Command::new("gh")
         .args([
             "api",
-            "repos/{owner}/{repo}/actions/runs",
+            "repos/{owner}/{repo}/actions/runs?branch=main&per_page=1",
             "--jq",
             ".workflow_runs[0] | {status: .status, conclusion: .conclusion}",
         ])


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Filter GitHub Actions workflow runs API query to main branch only
- Prevents CI status from showing results from feature branches

## Problem
The `repos/{owner}/{repo}/actions/runs` query was returning the latest run from ANY branch, so the CI status could show a failing feature branch instead of main's actual status.

## Solution
Add `?branch=main&per_page=1` query parameters to filter for main branch.

## Test plan
- [x] Code compiles without warnings
- [ ] Manual verification: CI status reflects main branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)