### PR TITLE
fix: Remove Escape key that was canceling nudge input

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -419,13 +419,11 @@ pub fn send_keys(session: &str, name: &str, keys: &str) -> crate::Result<()> {
     // 2. Wait 500ms for paste to complete (critical - tested in gastown)
     thread::sleep(Duration::from_millis(500));
 
-    // 3. Send Escape to exit vim INSERT mode if enabled (harmless in normal mode)
-    let _ = Command::new("tmux")
-        .args(["send-keys", "-t", &target, "Escape"])
-        .status();
-    thread::sleep(Duration::from_millis(100));
+    // NOTE: Previously sent Escape here to exit vim INSERT mode, but this
+    // cancels input in Claude's prompt, causing nudge messages to be lost.
+    // Removed to fix daemon orchestration.
 
-    // 4. Send Enter key
+    // 3. Send Enter key
     let status = Command::new("tmux")
         .args(["send-keys", "-t", &target, "Enter"])
         .status()


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
**CRITICAL FIX**: Remove Escape key from send_keys() that was canceling nudge messages.

## Problem
The `send_keys()` function was:
1. Sending text (nudge message)
2. Sending Escape ← **This canceled the input!**
3. Sending Enter (but text was already gone)

## Solution
Remove the Escape key entirely. The sequence is now:
1. Send text
2. Wait 500ms
3. Send Enter

## Why the Escape was wrong
The Escape was added to "exit vim INSERT mode" but Claude doesn't use vim mode. In Claude's prompt, Escape cancels pending input.

## Test plan
- [x] Build passes
- [x] Clippy passes
- [ ] Manual test: daemon nudges now reach Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)