### PR TITLE
feat: Add daemon auto-installation of required plugins

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,12 @@
 //! [default]
 //! bin_command = "midtown"
 //!
+//! [plugins]
+//! required = [
+//!     "superpowers@claude-plugins-official",
+//!     "code-review@claude-plugins-official",
+//! ]
+//!
 //! [midtown]  # project name from repo
 //! bin_command = "cargo run --release --"
 //! ```
@@ -61,12 +67,24 @@ impl Default for ProjectConfig {
     }
 }
 
+/// Configuration for Claude Code plugins.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct PluginsConfig {
+    /// List of required plugin names (e.g., "superpowers@claude-plugins-official")
+    #[serde(default)]
+    pub required: Vec<String>,
+}
+
 /// Root configuration containing default and per-project settings.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct Config {
     /// Default settings for all projects
     #[serde(default)]
     pub default: ProjectConfig,
+
+    /// Plugin configuration
+    #[serde(default)]
+    pub plugins: PluginsConfig,
 
     /// Per-project settings (key is project/repo name)
     #[serde(flatten)]
@@ -95,6 +113,11 @@ impl Config {
     /// Falls back to default if no project-specific config exists.
     pub fn for_project(&self, project_name: &str) -> &ProjectConfig {
         self.projects.get(project_name).unwrap_or(&self.default)
+    }
+
+    /// Get the list of required plugins.
+    pub fn required_plugins(&self) -> &[String] {
+        &self.plugins.required
     }
 }
 
@@ -134,6 +157,12 @@ pub fn get_chat_layout() -> (ChatLayout, u16) {
     };
 
     (project_config.chat_layout, project_config.chat_min_width)
+}
+
+/// Get the list of required plugins from config.
+pub fn get_required_plugins() -> Vec<String> {
+    let config = Config::load();
+    config.plugins.required.clone()
 }
 
 /// Get the current project name from git repo root directory.
@@ -227,5 +256,54 @@ chat_layout = "auto"
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert_eq!(config.default.chat_layout, ChatLayout::Auto);
+    }
+
+    #[test]
+    fn test_plugins_config_default() {
+        let config = Config::default();
+        assert!(config.plugins.required.is_empty());
+        assert!(config.required_plugins().is_empty());
+    }
+
+    #[test]
+    fn test_plugins_config_parse() {
+        let toml = r#"
+[plugins]
+required = [
+    "superpowers@claude-plugins-official",
+    "code-review@claude-plugins-official",
+    "commit-commands@claude-plugins-official",
+]
+
+[default]
+bin_command = "midtown"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+
+        assert_eq!(config.plugins.required.len(), 3);
+        assert_eq!(
+            config.plugins.required[0],
+            "superpowers@claude-plugins-official"
+        );
+        assert_eq!(
+            config.required_plugins(),
+            &[
+                "superpowers@claude-plugins-official",
+                "code-review@claude-plugins-official",
+                "commit-commands@claude-plugins-official",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_plugins_config_empty() {
+        let toml = r#"
+[plugins]
+
+[default]
+bin_command = "midtown"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(config.plugins.required.is_empty());
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -186,6 +186,94 @@ const ORPHAN_CHECK_INTERVAL_SECS: u64 = 30;
 /// Interval for checking Lead session changes (10 seconds)
 const SESSION_CHECK_INTERVAL_SECS: u64 = 10;
 
+/// Ensure required Claude Code plugins are installed.
+///
+/// Reads the required plugins list from config, checks which are already
+/// installed, and installs any missing ones. Failures are logged as warnings
+/// but don't block daemon startup.
+async fn ensure_plugins_installed() {
+    let required = crate::config::get_required_plugins();
+    if required.is_empty() {
+        debug!("No required plugins configured");
+        return;
+    }
+
+    info!("Checking {} required plugins", required.len());
+
+    // Get list of installed plugins
+    let installed = match get_installed_plugins().await {
+        Ok(plugins) => plugins,
+        Err(e) => {
+            warn!("Failed to check installed plugins: {}", e);
+            return;
+        }
+    };
+
+    // Find missing plugins
+    let missing: Vec<_> = required
+        .iter()
+        .filter(|p| !installed.contains(*p))
+        .collect();
+
+    if missing.is_empty() {
+        info!("All required plugins are installed");
+        return;
+    }
+
+    info!("Installing {} missing plugins", missing.len());
+
+    // Install missing plugins
+    for plugin in missing {
+        match install_plugin(plugin).await {
+            Ok(()) => info!("Installed plugin: {}", plugin),
+            Err(e) => warn!("Failed to install plugin {}: {}", plugin, e),
+        }
+    }
+}
+
+/// Get list of installed plugin IDs.
+async fn get_installed_plugins() -> Result<HashSet<String>, String> {
+    let output = tokio::process::Command::new("claude")
+        .args(["plugin", "list", "--json"])
+        .output()
+        .await
+        .map_err(|e| format!("Failed to run claude plugin list: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("claude plugin list failed: {}", stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Parse JSON output - it's an array of objects with "id" field
+    let plugins: Vec<serde_json::Value> = serde_json::from_str(&stdout)
+        .map_err(|e| format!("Failed to parse plugin list JSON: {}", e))?;
+
+    let ids: HashSet<String> = plugins
+        .iter()
+        .filter_map(|p| p.get("id").and_then(|id| id.as_str()).map(String::from))
+        .collect();
+
+    Ok(ids)
+}
+
+/// Install a plugin by name.
+async fn install_plugin(name: &str) -> Result<(), String> {
+    let output = tokio::process::Command::new("claude")
+        .args(["plugin", "add", name])
+        .output()
+        .await
+        .map_err(|e| format!("Failed to run claude plugin add: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(stderr.to_string());
+    }
+
+    Ok(())
+}
+
 /// Tracks which PRs have been assigned for review to avoid duplicates.
 #[derive(Debug, Default)]
 pub struct PrReviewTracker {
@@ -375,6 +463,9 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
         .with_env_filter(filter)
         .with_target(false)
         .init();
+
+    // Ensure required plugins are installed (non-blocking, logs warnings on failure)
+    ensure_plugins_installed().await;
 
     // Acquire exclusive lock on PID file to enforce singleton behavior
     let pid_file = acquire_pid_lock(&config.pid_file_path)?;


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Add `[plugins]` config section with `required` list in config.toml
- Daemon automatically installs missing plugins on startup via `claude plugin add`
- Uses JSON output from `claude plugin list` for accurate detection
- Failures are logged as warnings without blocking daemon startup

## Implementation
1. Added `PluginsConfig` struct with `required: Vec<String>` field to `src/config.rs`
2. Added `plugins` field to main `Config` struct
3. Added `ensure_plugins_installed()` async function in `src/daemon.rs` that:
   - Reads required plugins from config
   - Runs `claude plugin list --json` to check installed plugins
   - Installs missing plugins with `claude plugin add`
4. Called during daemon startup after logging is initialized

## Config format
```toml
[plugins]
required = [
    "superpowers@claude-plugins-official",
    "code-review@claude-plugins-official",
    # ...
]
```

## Test plan
- [x] Unit tests for config parsing
- [x] All existing tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)