### PR TITLE
fix: Pass repo_name to get_busy_coworkers in daemon context

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -733,7 +733,7 @@ async fn check_and_shutdown_idle_coworkers(state: &DaemonState) {
     }
 
     // Get in_progress tasks to determine who is busy
-    let busy_coworkers = get_busy_coworkers();
+    let busy_coworkers = get_busy_coworkers(&state.repo_name);
 
     // Get coworkers with open PRs - they should NEVER be auto-killed
     let coworkers_with_open_prs = get_coworkers_with_open_prs();
@@ -834,9 +834,12 @@ async fn check_and_shutdown_idle_coworkers(state: &DaemonState) {
     }
 }
 
-/// Get list of coworker names who have in_progress tasks.
-fn get_busy_coworkers() -> Vec<String> {
-    crate::tasks::get_busy_coworkers()
+/// Get list of coworker names who have in_progress tasks for a specific repo.
+///
+/// This explicitly passes the repo_name rather than relying on detect_repo_name(),
+/// which may not work correctly from the daemon's async context.
+fn get_busy_coworkers(repo_name: &str) -> Vec<String> {
+    crate::tasks::get_busy_coworkers_for_repo(repo_name)
 }
 
 /// Get list of coworker names who have open PRs.
@@ -1620,7 +1623,7 @@ async fn find_available_reviewer(
     }
 
     // Get coworkers who are busy (have in_progress tasks)
-    let busy_coworkers = get_busy_coworkers();
+    let busy_coworkers = get_busy_coworkers(&state.repo_name);
 
     // Get coworkers who are already assigned to review PRs
     let reviewing_coworkers: HashSet<String> = {

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -160,6 +160,17 @@ pub fn get_busy_coworkers() -> Vec<String> {
         .collect()
 }
 
+/// Get names of coworkers who have in_progress tasks for a specific repo.
+///
+/// Use this from daemon context where detect_repo_name() may not work correctly.
+pub fn get_busy_coworkers_for_repo(repo_name: &str) -> Vec<String> {
+    read_tasks_for_repo(Some(repo_name))
+        .into_iter()
+        .filter(|t| t.status == TaskStatus::InProgress)
+        .filter_map(|t| t.owner)
+        .collect()
+}
+
 /// Get in_progress tasks with their owners.
 ///
 /// Returns tuples of (task_id, owner_name).


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Fixed idle shutdown incorrectly killing coworkers with active tasks
- Added `get_busy_coworkers_for_repo(repo_name)` to tasks.rs that explicitly accepts the repo name
- Updated daemon's `get_busy_coworkers()` to accept repo_name parameter and use the new function
- Both call sites (idle shutdown check and reviewer assignment) now pass `state.repo_name`

## Root Cause
The daemon was calling `get_busy_coworkers()` which internally relied on `detect_repo_name()` to find the current repository. However, from the daemon's async context, `detect_repo_name()` may not work correctly since it runs git commands that depend on the current working directory.

The daemon already stores `repo_name` in `DaemonState`, so we just needed to pass it through to the task lookup functions.

## Test plan
- [x] All unit tests pass
- [x] Code compiles without warnings
- [x] Clippy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)