### PR TITLE
fix: Pass repo_name to get_busy_coworkers in daemon

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -733,7 +733,7 @@ async fn check_and_shutdown_idle_coworkers(state: &DaemonState) {
     }
 
     // Get in_progress tasks to determine who is busy
-    let busy_coworkers = get_busy_coworkers();
+    let busy_coworkers = get_busy_coworkers(&state.repo_name);
 
     // Get coworkers with open PRs - they should NEVER be auto-killed
     let coworkers_with_open_prs = get_coworkers_with_open_prs();
@@ -835,8 +835,11 @@ async fn check_and_shutdown_idle_coworkers(state: &DaemonState) {
 }
 
 /// Get list of coworker names who have in_progress tasks.
-fn get_busy_coworkers() -> Vec<String> {
-    crate::tasks::get_busy_coworkers()
+///
+/// Takes the repo name explicitly to avoid relying on git detection,
+/// which may fail in daemon background processes.
+fn get_busy_coworkers(repo_name: &str) -> Vec<String> {
+    crate::tasks::get_busy_coworkers_for_repo(repo_name)
 }
 
 /// Get list of coworker names who have open PRs.
@@ -1620,7 +1623,7 @@ async fn find_available_reviewer(
     }
 
     // Get coworkers who are busy (have in_progress tasks)
-    let busy_coworkers = get_busy_coworkers();
+    let busy_coworkers = get_busy_coworkers(&state.repo_name);
 
     // Get coworkers who are already assigned to review PRs
     let reviewing_coworkers: HashSet<String> = {

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -160,6 +160,18 @@ pub fn get_busy_coworkers() -> Vec<String> {
         .collect()
 }
 
+/// Get names of coworkers who have in_progress tasks for a specific repo.
+///
+/// This is the preferred version for daemon usage where the repo name is already known,
+/// avoiding the need to detect it via git commands which may fail in background processes.
+pub fn get_busy_coworkers_for_repo(repo_name: &str) -> Vec<String> {
+    read_tasks_for_repo(Some(repo_name))
+        .into_iter()
+        .filter(|t| t.status == TaskStatus::InProgress)
+        .filter_map(|t| t.owner)
+        .collect()
+}
+
 /// Get in_progress tasks with their owners.
 ///
 /// Returns tuples of (task_id, owner_name).
@@ -353,5 +365,34 @@ mod tests {
         assert_eq!(pending_without_owners.len(), 2);
         assert_eq!(pending_without_owners[0].id, "1");
         assert_eq!(pending_without_owners[1].id, "3");
+    }
+
+    #[test]
+    fn test_busy_coworkers_from_in_progress_tasks() {
+        let temp_dir = TempDir::new().unwrap();
+        let tasks_dir = temp_dir.path().to_path_buf();
+
+        // Create various tasks - only in_progress with owners should count as busy
+        create_task_file(&tasks_dir, "1", "pending", Some("alice")); // Not busy (pending)
+        create_task_file(&tasks_dir, "2", "in_progress", Some("bob")); // Busy
+        create_task_file(&tasks_dir, "3", "in_progress", Some("carol")); // Busy
+        create_task_file(&tasks_dir, "4", "completed", Some("dave")); // Not busy (completed)
+        create_task_file(&tasks_dir, "5", "in_progress", None); // Not counted (no owner)
+
+        let tasks = read_tasks_from_dir(&tasks_dir);
+
+        // Simulate get_busy_coworkers logic
+        let busy_coworkers: Vec<String> = tasks
+            .into_iter()
+            .filter(|t| t.status == TaskStatus::InProgress)
+            .filter_map(|t| t.owner)
+            .collect();
+
+        assert_eq!(busy_coworkers.len(), 2);
+        assert!(busy_coworkers.contains(&"bob".to_string()));
+        assert!(busy_coworkers.contains(&"carol".to_string()));
+        // alice, dave should NOT be in list (pending, completed respectively)
+        assert!(!busy_coworkers.contains(&"alice".to_string()));
+        assert!(!busy_coworkers.contains(&"dave".to_string()));
     }
 }


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Fixed idle shutdown incorrectly killing coworkers who had in_progress tasks
- Root cause: `get_busy_coworkers()` called `detect_repo_name()` which runs git commands that may fail in daemon's background process context
- Solution: Pass the repo_name from `DaemonState` (already known) through to task reading functions

## Changes
- Add `get_busy_coworkers_for_repo(repo: &str)` in tasks.rs that takes explicit repo name
- Update daemon's `get_busy_coworkers()` wrapper to accept repo_name parameter
- Update both call sites (idle check, reviewer finder) to pass `state.repo_name`
- Add test for busy coworkers filtering logic

## Test plan
- [x] All existing tests pass (282 tests)
- [x] New test verifies filtering logic for busy coworkers
- [x] Clippy and fmt checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)