### PR TITLE
fix: Read enabledPlugins instead of plugins from settings.json

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -660,7 +660,7 @@ fn read_user_plugins() -> Option<serde_json::Value> {
         .join("settings.json");
     let content = std::fs::read_to_string(settings_path).ok()?;
     let settings: serde_json::Value = serde_json::from_str(&content).ok()?;
-    settings.get("plugins").cloned()
+    settings.get("enabledPlugins").cloned()
 }
 
 /// JSON settings for coworker Claude Code sessions.


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Fixed `read_user_plugins()` in `src/tmux.rs` to read the correct key from user's settings
- Changed `settings.get("plugins")` to `settings.get("enabledPlugins")`

## Root Cause
The user's `~/.claude/settings.json` uses `enabledPlugins` as the key for configured plugins, but the code was reading `plugins`. This prevented coworkers from receiving the user's configured plugins.

## Test plan
- [x] Code compiles without warnings
- [x] Clippy passes
- [x] All 171 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)