### PR TITLE
fix: Atomically assign task ownership before spawning coworker

### DIFF
--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -100,7 +100,10 @@ impl CoworkerManager {
     ///
     /// Randomly selects from available primary avenue names first.
     /// Falls back to overflow names only when all primary names are in use.
-    fn next_name(&self) -> Option<String> {
+    ///
+    /// This can be used to get a name before spawning, e.g., to assign
+    /// task ownership atomically before the coworker starts.
+    pub fn next_available_name(&self) -> Option<String> {
         let coworkers = self.coworkers.read().unwrap();
 
         // Collect available primary avenue names
@@ -142,10 +145,12 @@ impl CoworkerManager {
     /// If `resume` is true, passes `--continue` to claude to resume the previous
     /// session from this worktree (useful for recovering orphaned tasks).
     pub fn spawn(&self, resume: bool) -> crate::Result<String> {
-        let name = self.next_name().ok_or_else(|| crate::Error::Rpc {
-            code: -32603,
-            message: "No available coworker slots (all avenue names in use)".to_string(),
-        })?;
+        let name = self
+            .next_available_name()
+            .ok_or_else(|| crate::Error::Rpc {
+                code: -32603,
+                message: "No available coworker slots (all avenue names in use)".to_string(),
+            })?;
 
         // Try to create an isolated worktree for this coworker
         let worktree_path = match self.worktree_manager.create(&name) {
@@ -598,16 +603,16 @@ mod tests {
     }
 
     #[test]
-    fn test_next_name_empty() {
+    fn test_next_available_name_empty() {
         let (manager, _temp_dir) = test_manager();
-        let name = manager.next_name();
+        let name = manager.next_available_name();
         assert!(name.is_some());
         // Should be one of the primary avenue names
         assert!(AVENUE_NAMES.contains(&name.as_ref().unwrap().as_str()));
     }
 
     #[test]
-    fn test_next_name_with_used_names() {
+    fn test_next_available_name_with_used_names() {
         let (manager, _temp_dir) = test_manager();
 
         // Manually insert a coworker to simulate "lexington" being in use
@@ -627,7 +632,7 @@ mod tests {
         }
 
         // Should return a name that is NOT "lexington"
-        let name = manager.next_name();
+        let name = manager.next_available_name();
         assert!(name.is_some());
         let name = name.unwrap();
         assert_ne!(name, "lexington");
@@ -636,7 +641,7 @@ mod tests {
     }
 
     #[test]
-    fn test_next_name_overflow() {
+    fn test_next_available_name_overflow() {
         let (manager, _temp_dir) = test_manager();
 
         // Fill all primary avenue names
@@ -658,13 +663,13 @@ mod tests {
         }
 
         // Should return an overflow name (randomized)
-        let name = manager.next_name();
+        let name = manager.next_available_name();
         assert!(name.is_some());
         assert!(OVERFLOW_NAMES.contains(&name.as_ref().unwrap().as_str()));
     }
 
     #[test]
-    fn test_next_name_exhausted() {
+    fn test_next_available_name_exhausted() {
         let (manager, _temp_dir) = test_manager();
 
         // Fill all names (primary and overflow)
@@ -686,7 +691,7 @@ mod tests {
         }
 
         // Should return None when all names exhausted
-        assert_eq!(manager.next_name(), None);
+        assert_eq!(manager.next_available_name(), None);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2787,31 +2787,44 @@ fn spawn_for_pending_tasks(state: &DaemonState) {
         }
     }
 
-    // Case 2: Pending tasks without owners - spawn a new coworker and assign
+    // Case 2: Pending tasks without owners - assign ownership atomically, then spawn
     let pending_unowned = crate::tasks::get_pending_tasks_without_owners();
     for task in pending_unowned {
-        // Spawn a new coworker
-        match state.coworkers.spawn(false) {
-            Ok(coworker_name) => {
+        // Step 1: Get the next available coworker name (without spawning yet)
+        let Some(coworker_name) = state.coworkers.next_available_name() else {
+            debug!("No available coworker slots for unowned task #{}", task.id);
+            // Stop trying - if we're out of slots we'll try again next tick
+            break;
+        };
+
+        // Step 2: Atomically assign task ownership BEFORE spawning
+        // This prevents race conditions where multiple coworkers could claim the same task
+        if let Err(e) = crate::tasks::update_task_owner(&task.id, &coworker_name) {
+            warn!(
+                "Failed to assign task #{} to {}: {}",
+                task.id, coworker_name, e
+            );
+            continue;
+        }
+
+        info!(
+            "Assigned task #{} to {} (pre-spawn)",
+            task.id, coworker_name
+        );
+
+        // Step 3: Now spawn the coworker with the pre-assigned name
+        match state.coworkers.spawn_with_name(&coworker_name, false) {
+            Ok(_) => {
                 info!(
-                    "Spawned new coworker {} for unowned task #{}",
+                    "Spawned coworker {} for pre-assigned task #{}",
                     coworker_name, task.id
                 );
-
-                // Assign the task to this coworker
-                if let Err(e) = crate::tasks::update_task_owner(&task.id, &coworker_name) {
-                    warn!(
-                        "Failed to assign task #{} to {}: {}",
-                        task.id, coworker_name, e
-                    );
-                    continue;
-                }
 
                 // Post to channel
                 let msg = Message::text(
                     "daemon",
                     format!(
-                        "🚀 Spawned coworker {} and assigned task #{}: {}",
+                        "🚀 Spawned coworker {} for assigned task #{}: {}",
                         coworker_name, task.id, task.subject
                     ),
                 );
@@ -2822,7 +2835,7 @@ fn spawn_for_pending_tasks(state: &DaemonState) {
                 // Give coworker time to start
                 std::thread::sleep(std::time::Duration::from_secs(2));
 
-                // Nudge them about the task
+                // Nudge them about their assigned task
                 let nudge_msg = format!(
                     "You've been assigned task #{}: {}. Get started!",
                     task.id, task.subject
@@ -2835,19 +2848,18 @@ fn spawn_for_pending_tasks(state: &DaemonState) {
                     );
                 } else {
                     info!(
-                        "Nudged {} about newly assigned task #{}",
+                        "Nudged {} about their assigned task #{}",
                         coworker_name, task.id
                     );
                 }
             }
             Err(e) => {
-                // Could not spawn - might be out of coworker slots
-                debug!(
-                    "Could not spawn coworker for unowned task #{}: {}",
-                    task.id, e
+                // Spawn failed but task is already assigned - that's okay,
+                // the next daemon tick will see the assigned task and try to spawn again
+                warn!(
+                    "Failed to spawn {} for pre-assigned task #{}: {}",
+                    coworker_name, task.id, e
                 );
-                // Stop trying - if we're out of slots we'll try again next tick
-                break;
             }
         }
     }


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Fixes race condition where multiple coworkers could claim the same task (#51 was worked on by both lexington and park simultaneously)
- Now assigns task ownership BEFORE spawning the coworker, not after
- Makes `next_available_name()` public so daemon can get a name before spawning

## Changes
- **coworker.rs**: Renamed `next_name()` to `next_available_name()` and made it public with documentation
- **daemon.rs**: Reordered `spawn_for_pending_tasks()` Case 2 to:
  1. Get available name first
  2. Atomically assign task ownership
  3. Spawn coworker with pre-assigned name

## Test plan
- [x] All existing tests pass
- [x] Code compiles with no clippy warnings
- [ ] Manual verification: spawn multiple coworkers with pending tasks to confirm no duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)