### PR TITLE
fix: Reset orphaned tasks to pending when coworker respawn fails

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2697,12 +2697,39 @@ async fn check_and_recover_orphans(state: &DaemonState) {
                 break;
             }
             Err(e) => {
-                // Could not respawn - log and continue to next orphan
-                // This might happen if the worktree doesn't exist
-                debug!(
-                    "Could not respawn {} for orphaned task #{}: {}",
+                // Could not respawn - reset task to pending so another coworker can claim it
+                // This might happen if the worktree doesn't exist after restart
+                warn!(
+                    "Could not respawn {} for orphaned task #{}: {} - resetting task to pending",
                     owner, task_id, e
                 );
+
+                // Reset the task so it can be picked up by another coworker
+                if let Err(reset_err) =
+                    crate::tasks::reset_task_to_pending_for_repo(&task_id, &state.repo_name)
+                {
+                    warn!(
+                        "Failed to reset orphaned task #{} to pending: {}",
+                        task_id, reset_err
+                    );
+                } else {
+                    info!(
+                        "Reset orphaned task #{} to pending (original owner {} could not be respawned)",
+                        task_id, owner
+                    );
+
+                    // Post to channel so team knows the task is available
+                    let msg = Message::text(
+                        "daemon",
+                        format!(
+                            "🔄 Task #{} reset to pending - {} could not be respawned",
+                            task_id, owner
+                        ),
+                    );
+                    if let Err(e) = state.channel.send(&msg) {
+                        warn!("Failed to post task reset message: {}", e);
+                    }
+                }
             }
         }
     }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -280,6 +280,62 @@ pub fn update_task_owner(task_id: &str, owner: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Reset a task to pending status and clear its owner.
+///
+/// Used when orphan recovery fails to respawn a coworker - the task is reset
+/// so another coworker can claim it instead of being stuck forever.
+pub fn reset_task_to_pending(task_id: &str) -> Result<(), String> {
+    let repo = crate::paths::detect_repo_name().unwrap_or_else(|| "default".to_string());
+    reset_task_to_pending_for_repo(task_id, &repo)
+}
+
+/// Reset a task to pending status and clear its owner for a specific repo.
+///
+/// This is the preferred version for daemon usage where the repo name is already known.
+pub fn reset_task_to_pending_for_repo(task_id: &str, repo_name: &str) -> Result<(), String> {
+    let Some(home) = dirs::home_dir() else {
+        return Err("Could not determine home directory".to_string());
+    };
+
+    // Get the lead session ID
+    let lead_session_file = crate::paths::lead_session_file_for_repo(repo_name);
+    let lead_session_id = std::fs::read_to_string(&lead_session_file)
+        .map_err(|e| format!("Failed to read lead session ID: {}", e))?
+        .trim()
+        .to_string();
+
+    if lead_session_id.is_empty() {
+        return Err("Lead session ID is empty".to_string());
+    }
+
+    // Read the task file
+    let task_file = home
+        .join(".claude")
+        .join("tasks")
+        .join(&lead_session_id)
+        .join(format!("{}.json", task_id));
+
+    let content =
+        std::fs::read_to_string(&task_file).map_err(|e| format!("Failed to read task: {}", e))?;
+
+    // Parse and update
+    let mut task: serde_json::Value =
+        serde_json::from_str(&content).map_err(|e| format!("Failed to parse task: {}", e))?;
+
+    // Reset to pending and clear owner
+    task["status"] = serde_json::json!("pending");
+    task["owner"] = serde_json::Value::Null;
+
+    // Write back
+    let updated_content = serde_json::to_string_pretty(&task)
+        .map_err(|e| format!("Failed to serialize task: {}", e))?;
+
+    std::fs::write(&task_file, updated_content)
+        .map_err(|e| format!("Failed to write task: {}", e))?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Fix bug where orphaned tasks get stuck when coworker respawn fails
- Reset task to pending status so another coworker can claim it
- Post channel message to notify team the task is available

## Problem
When orphan recovery detects an in_progress task whose coworker isn't running, it tries to respawn the coworker. If respawn fails (e.g., worktree doesn't exist after restart), the task was left stuck as in_progress with a dead owner. The daemon would keep trying to respawn on every tick, causing window flickering.

## Solution
When respawn fails:
1. Reset task status to "pending"
2. Clear the task owner
3. Post channel message: "🔄 Task #X reset to pending - owner could not be respawned"

## Changes
- Add `reset_task_to_pending()` and `reset_task_to_pending_for_repo()` in tasks.rs
- Update `check_and_recover_orphans()` to reset task on respawn failure
- Post channel message when task is reset

## Test plan
- [x] All tests pass
- [x] Clippy and fmt checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)