### PR TITLE
feat: Add timestamp to /me action messages in chat TUI

### DIFF
--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -570,7 +570,7 @@ fn draw_chat_panel(f: &mut Frame, app: &mut App, area: Rect) {
 /// Render a single message into one or more Lines
 ///
 /// Layout for action messages:
-/// - " HH:MM * name message" all on one line
+/// - "* HH:MM:SS name message" all on one line
 ///
 /// Layout for regular messages when sender changes:
 /// - Line 1: Actor name alone


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Adds timestamp to `/me` action messages in the chat TUI
- Updated format from `* name message` to `* HH:MM:SS name message`
- Timestamp is shown in gray for visual distinction from the actor's name and message

**Before:**
```
* madison is rebasing PR #158
```

**After:**
```
* 14:44:00 madison is rebasing PR #158
```

## Test plan
- [x] Updated `test_action_message_format` test to verify new format
- [x] All 19 chat UI tests pass
- [x] All tests pass (cargo test)
- [x] No clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)