### PR TITLE
fix: Use enabledPlugins key in coworker settings

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -676,7 +676,7 @@ fn coworker_settings_json(bin_command: &str) -> serde_json::Value {
 
     serde_json::json!({
         "editorMode": "normal",
-        "plugins": user_plugins,
+        "enabledPlugins": user_plugins,
         "hooks": {
             "Stop": [{
                 "hooks": [{


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Changed the settings key from `"plugins"` to `"enabledPlugins"` in `coworker_settings_json()` so Claude Code actually reads the plugins

This fixes an issue where plugins weren't being loaded for coworkers because the wrong key name was being used.

## Test plan
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)