### PR TITLE
refactor: Use per-project config files instead of sections in global config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,23 +1,29 @@
 //! Project-level configuration for midtown.
 //!
-//! Reads from `~/.midtown/config.toml` with per-project sections:
+//! Configuration is loaded from two places:
 //!
+//! 1. Global defaults: `~/.midtown/config.toml`
 //! ```toml
 //! [default]
 //! bin_command = "midtown"
+//! chat_layout = "auto"
 //!
 //! [plugins]
 //! required = [
 //!     "superpowers@claude-plugins-official",
 //!     "code-review@claude-plugins-official",
 //! ]
-//!
-//! [midtown]  # project name from repo
-//! bin_command = "cargo run --release --"
 //! ```
+//!
+//! 2. Per-project overrides: `~/.midtown/projects/<project>/config.toml`
+//! ```toml
+//! bin_command = "cargo run --release --"
+//! chat_layout = "split"
+//! ```
+//!
+//! Project-specific settings take precedence over global defaults.
 
 use serde::Deserialize;
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 /// Chat layout mode for the Lead session.
@@ -34,6 +40,8 @@ pub enum ChatLayout {
 }
 
 /// Configuration for a single project.
+///
+/// Used both for global defaults and per-project overrides.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ProjectConfig {
     /// Command to invoke midtown (e.g., "midtown" or "cargo run --release --")
@@ -67,6 +75,24 @@ impl Default for ProjectConfig {
     }
 }
 
+impl ProjectConfig {
+    /// Merge another config into this one, taking values from `other` where set.
+    ///
+    /// This is used to layer project-specific config on top of global defaults.
+    fn merge_from(&mut self, other: &ProjectConfig) {
+        // Only override if the other value is not the default
+        if other.bin_command != default_bin_command() {
+            self.bin_command = other.bin_command.clone();
+        }
+        if other.chat_layout != ChatLayout::default() {
+            self.chat_layout = other.chat_layout;
+        }
+        if other.chat_min_width != default_chat_min_width() {
+            self.chat_min_width = other.chat_min_width;
+        }
+    }
+}
+
 /// Configuration for Claude Code plugins.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct PluginsConfig {
@@ -75,7 +101,7 @@ pub struct PluginsConfig {
     pub required: Vec<String>,
 }
 
-/// Root configuration containing default and per-project settings.
+/// Root configuration containing default settings and plugin config.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct Config {
     /// Default settings for all projects
@@ -85,10 +111,6 @@ pub struct Config {
     /// Plugin configuration
     #[serde(default)]
     pub plugins: PluginsConfig,
-
-    /// Per-project settings (key is project/repo name)
-    #[serde(flatten)]
-    pub projects: HashMap<String, ProjectConfig>,
 }
 
 impl Config {
@@ -110,9 +132,17 @@ impl Config {
 
     /// Get configuration for a specific project.
     ///
-    /// Falls back to default if no project-specific config exists.
-    pub fn for_project(&self, project_name: &str) -> &ProjectConfig {
-        self.projects.get(project_name).unwrap_or(&self.default)
+    /// Loads project-specific config from `~/.midtown/projects/<project>/config.toml`
+    /// and merges it with global defaults. Project settings take precedence.
+    pub fn for_project(&self, project_name: &str) -> ProjectConfig {
+        let mut config = self.default.clone();
+
+        // Try to load project-specific config
+        if let Some(project_config) = load_project_config(project_name) {
+            config.merge_from(&project_config);
+        }
+
+        config
     }
 
     /// Get the list of required plugins.
@@ -121,12 +151,32 @@ impl Config {
     }
 }
 
-/// Get the path to the config file.
+/// Get the path to the global config file.
 pub fn config_path() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".midtown")
         .join("config.toml")
+}
+
+/// Get the path to a project-specific config file.
+pub fn project_config_path(project_name: &str) -> PathBuf {
+    crate::paths::projects_dir_for_repo(project_name).join("config.toml")
+}
+
+/// Load project-specific configuration.
+///
+/// Returns None if the file doesn't exist or can't be parsed.
+fn load_project_config(project_name: &str) -> Option<ProjectConfig> {
+    let path = project_config_path(project_name);
+
+    if !path.exists() {
+        return None;
+    }
+
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|contents| toml::from_str(&contents).ok())
 }
 
 /// Get the bin_command for the current project.
@@ -141,7 +191,7 @@ pub fn get_bin_command() -> String {
     if project_name.is_empty() {
         config.default.bin_command.clone()
     } else {
-        config.for_project(&project_name).bin_command.clone()
+        config.for_project(&project_name).bin_command
     }
 }
 
@@ -151,7 +201,7 @@ pub fn get_chat_layout() -> (ChatLayout, u16) {
     let project_name = get_project_name().unwrap_or_default();
 
     let project_config = if project_name.is_empty() {
-        &config.default
+        config.default.clone()
     } else {
         config.for_project(&project_name)
     };
@@ -167,19 +217,7 @@ pub fn get_required_plugins() -> Vec<String> {
 
 /// Get the current project name from git repo root directory.
 fn get_project_name() -> Option<String> {
-    let output = std::process::Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let path = String::from_utf8_lossy(&output.stdout);
-    let path = PathBuf::from(path.trim());
-
-    path.file_name().map(|s| s.to_string_lossy().to_string())
+    crate::paths::detect_repo_name()
 }
 
 #[cfg(test)]
@@ -193,29 +231,35 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_config() {
+    fn test_parse_global_config() {
         let toml = r#"
 [default]
 bin_command = "midtown"
+chat_layout = "split"
 
-[my-project]
-bin_command = "cargo run --release --"
+[plugins]
+required = ["superpowers@claude-plugins-official"]
 "#;
         let config: Config = toml::from_str(toml).unwrap();
 
         assert_eq!(config.default.bin_command, "midtown");
-        assert_eq!(
-            config.for_project("my-project").bin_command,
-            "cargo run --release --"
-        );
-        // Unknown project falls back to default
-        assert_eq!(config.for_project("unknown").bin_command, "midtown");
+        assert_eq!(config.default.chat_layout, ChatLayout::Split);
+        assert_eq!(config.plugins.required.len(), 1);
     }
 
     #[test]
     fn test_config_path() {
         let path = config_path();
         assert!(path.to_string_lossy().contains(".midtown"));
+        assert!(path.to_string_lossy().ends_with("config.toml"));
+    }
+
+    #[test]
+    fn test_project_config_path() {
+        let path = project_config_path("my-project");
+        assert!(path.to_string_lossy().contains(".midtown"));
+        assert!(path.to_string_lossy().contains("projects"));
+        assert!(path.to_string_lossy().contains("my-project"));
         assert!(path.to_string_lossy().ends_with("config.toml"));
     }
 
@@ -232,20 +276,11 @@ bin_command = "cargo run --release --"
 [default]
 chat_layout = "split"
 chat_min_width = 200
-
-[narrow-project]
-chat_layout = "window"
 "#;
         let config: Config = toml::from_str(toml).unwrap();
 
         assert_eq!(config.default.chat_layout, ChatLayout::Split);
         assert_eq!(config.default.chat_min_width, 200);
-        assert_eq!(
-            config.for_project("narrow-project").chat_layout,
-            ChatLayout::Window
-        );
-        // Narrow project should inherit default min_width
-        assert_eq!(config.for_project("narrow-project").chat_min_width, 160);
     }
 
     #[test]
@@ -305,5 +340,47 @@ bin_command = "midtown"
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert!(config.plugins.required.is_empty());
+    }
+
+    #[test]
+    fn test_project_config_merge() {
+        let mut base = ProjectConfig::default();
+        assert_eq!(base.bin_command, "midtown");
+        assert_eq!(base.chat_layout, ChatLayout::Auto);
+
+        // Create a project config with overrides
+        let project = ProjectConfig {
+            bin_command: "cargo run --release --".to_string(),
+            chat_layout: ChatLayout::Window,
+            chat_min_width: default_chat_min_width(), // Keep default
+        };
+
+        base.merge_from(&project);
+
+        assert_eq!(base.bin_command, "cargo run --release --");
+        assert_eq!(base.chat_layout, ChatLayout::Window);
+        assert_eq!(base.chat_min_width, 160); // Should keep default
+    }
+
+    #[test]
+    fn test_for_project_returns_defaults_when_no_project_config() {
+        let config = Config::default();
+        let project = config.for_project("nonexistent-project");
+
+        assert_eq!(project.bin_command, "midtown");
+        assert_eq!(project.chat_layout, ChatLayout::Auto);
+    }
+
+    #[test]
+    fn test_parse_project_config_file() {
+        // Test parsing a flat project config (no sections)
+        let toml = r#"
+bin_command = "cargo run --release --"
+chat_layout = "split"
+"#;
+        let config: ProjectConfig = toml::from_str(toml).unwrap();
+
+        assert_eq!(config.bin_command, "cargo run --release --");
+        assert_eq!(config.chat_layout, ChatLayout::Split);
     }
 }


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Refactors config system from per-project sections in a single file to separate project config files
- Global defaults stay at `~/.midtown/config.toml` with `[default]` and `[plugins]` sections
- Project overrides go to `~/.midtown/projects/<project>/config.toml` (flat file, no sections)

## Before
```toml
# ~/.midtown/config.toml
[default]
bin_command = "midtown"

[my-project]  # project-specific override
bin_command = "cargo run --release --"
```

## After
```toml
# ~/.midtown/config.toml (global defaults)
[default]
bin_command = "midtown"

[plugins]
required = ["superpowers@claude-plugins-official"]
```

```toml
# ~/.midtown/projects/my-project/config.toml (project-specific)
bin_command = "cargo run --release --"
chat_layout = "split"
```

## Changes
- Remove `HashMap<String, ProjectConfig>` for per-project sections
- Add `project_config_path()` to get project config file location
- Add `load_project_config()` to load project-specific config
- Add `ProjectConfig::merge_from()` to layer project config over defaults
- Update `for_project()` to merge global defaults with project config
- Use `paths::detect_repo_name()` instead of duplicating git logic
- Update tests for new structure (17 tests)

## Test plan
- [x] All 17 config tests pass
- [x] All tests pass
- [x] Clippy and fmt checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)