### PR TITLE
refactor: Replace per-project config sections with separate files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,23 +1,29 @@
 //! Project-level configuration for midtown.
 //!
-//! Reads from `~/.midtown/config.toml` with per-project sections:
+//! Configuration is loaded from two sources:
 //!
-//! ```toml
-//! [default]
-//! bin_command = "midtown"
+//! 1. **Global config** at `~/.midtown/config.toml`:
+//!    ```toml
+//!    [default]
+//!    bin_command = "midtown"
+//!    chat_layout = "auto"
 //!
-//! [plugins]
-//! required = [
-//!     "superpowers@claude-plugins-official",
-//!     "code-review@claude-plugins-official",
-//! ]
+//!    [plugins]
+//!    required = [
+//!        "superpowers@claude-plugins-official",
+//!    ]
+//!    ```
 //!
-//! [midtown]  # project name from repo
-//! bin_command = "cargo run --release --"
-//! ```
+//! 2. **Project config** at `~/.midtown/projects/<project>/config.toml`:
+//!    ```toml
+//!    # All fields are optional - only override what you need
+//!    bin_command = "cargo run --release --"
+//!    chat_layout = "split"
+//!    ```
+//!
+//! Project config takes precedence over global defaults.
 
 use serde::Deserialize;
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 /// Chat layout mode for the Lead session.
@@ -34,36 +40,51 @@ pub enum ChatLayout {
 }
 
 /// Configuration for a single project.
-#[derive(Debug, Clone, Deserialize)]
+///
+/// Used both as global defaults and project-specific overrides.
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct ProjectConfig {
     /// Command to invoke midtown (e.g., "midtown" or "cargo run --release --")
-    #[serde(default = "default_bin_command")]
-    pub bin_command: String,
+    #[serde(default)]
+    pub bin_command: Option<String>,
 
     /// Chat pane layout mode (auto, split, or window)
     #[serde(default)]
-    pub chat_layout: ChatLayout,
+    pub chat_layout: Option<ChatLayout>,
 
     /// Minimum terminal width for split layout in auto mode (default: 160)
-    #[serde(default = "default_chat_min_width")]
-    pub chat_min_width: u16,
+    #[serde(default)]
+    pub chat_min_width: Option<u16>,
 }
 
-fn default_chat_min_width() -> u16 {
-    160
-}
-
-fn default_bin_command() -> String {
-    "midtown".to_string()
-}
-
-impl Default for ProjectConfig {
-    fn default() -> Self {
-        Self {
-            bin_command: default_bin_command(),
-            chat_layout: ChatLayout::default(),
-            chat_min_width: default_chat_min_width(),
+impl ProjectConfig {
+    /// Merge another config into this one, with `other` taking precedence.
+    fn merge(&self, other: &ProjectConfig) -> ProjectConfig {
+        ProjectConfig {
+            bin_command: other
+                .bin_command
+                .clone()
+                .or_else(|| self.bin_command.clone()),
+            chat_layout: other.chat_layout.or(self.chat_layout),
+            chat_min_width: other.chat_min_width.or(self.chat_min_width),
         }
+    }
+
+    /// Get bin_command with fallback to default.
+    pub fn bin_command(&self) -> String {
+        self.bin_command
+            .clone()
+            .unwrap_or_else(|| "midtown".to_string())
+    }
+
+    /// Get chat_layout with fallback to default.
+    pub fn chat_layout(&self) -> ChatLayout {
+        self.chat_layout.unwrap_or_default()
+    }
+
+    /// Get chat_min_width with fallback to default.
+    pub fn chat_min_width(&self) -> u16 {
+        self.chat_min_width.unwrap_or(160)
     }
 }
 
@@ -75,9 +96,9 @@ pub struct PluginsConfig {
     pub required: Vec<String>,
 }
 
-/// Root configuration containing default and per-project settings.
+/// Global configuration from `~/.midtown/config.toml`.
 #[derive(Debug, Clone, Deserialize, Default)]
-pub struct Config {
+pub struct GlobalConfig {
     /// Default settings for all projects
     #[serde(default)]
     pub default: ProjectConfig,
@@ -85,18 +106,14 @@ pub struct Config {
     /// Plugin configuration
     #[serde(default)]
     pub plugins: PluginsConfig,
-
-    /// Per-project settings (key is project/repo name)
-    #[serde(flatten)]
-    pub projects: HashMap<String, ProjectConfig>,
 }
 
-impl Config {
-    /// Load configuration from `~/.midtown/config.toml`.
+impl GlobalConfig {
+    /// Load global configuration from `~/.midtown/config.toml`.
     ///
     /// Returns default config if file doesn't exist or can't be parsed.
     pub fn load() -> Self {
-        let path = config_path();
+        let path = global_config_path();
 
         if !path.exists() {
             return Self::default();
@@ -108,78 +125,92 @@ impl Config {
         }
     }
 
-    /// Get configuration for a specific project.
-    ///
-    /// Falls back to default if no project-specific config exists.
-    pub fn for_project(&self, project_name: &str) -> &ProjectConfig {
-        self.projects.get(project_name).unwrap_or(&self.default)
-    }
-
     /// Get the list of required plugins.
     pub fn required_plugins(&self) -> &[String] {
         &self.plugins.required
     }
 }
 
-/// Get the path to the config file.
-pub fn config_path() -> PathBuf {
+/// Load project-specific configuration from `~/.midtown/projects/<project>/config.toml`.
+///
+/// Returns None if the file doesn't exist.
+fn load_project_config(project_name: &str) -> Option<ProjectConfig> {
+    let path = project_config_path(project_name);
+
+    if !path.exists() {
+        return None;
+    }
+
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|contents| toml::from_str(&contents).ok())
+}
+
+/// Get the effective configuration for a project.
+///
+/// Merges global defaults with project-specific overrides.
+pub fn get_project_config(project_name: &str) -> ProjectConfig {
+    let global = GlobalConfig::load();
+
+    match load_project_config(project_name) {
+        Some(project) => global.default.merge(&project),
+        None => global.default,
+    }
+}
+
+/// Get the path to the global config file.
+pub fn global_config_path() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".midtown")
         .join("config.toml")
 }
 
+/// Get the path to a project-specific config file.
+pub fn project_config_path(project_name: &str) -> PathBuf {
+    crate::paths::projects_dir_for_repo(project_name).join("config.toml")
+}
+
 /// Get the bin_command for the current project.
 ///
 /// Determines project name from the current git repo and looks up config.
 pub fn get_bin_command() -> String {
-    let config = Config::load();
-
-    // Try to get project name from git repo
     let project_name = get_project_name().unwrap_or_default();
 
     if project_name.is_empty() {
-        config.default.bin_command.clone()
+        GlobalConfig::load().default.bin_command()
     } else {
-        config.for_project(&project_name).bin_command.clone()
+        get_project_config(&project_name).bin_command()
     }
 }
 
 /// Get the chat layout configuration for the current project.
 pub fn get_chat_layout() -> (ChatLayout, u16) {
-    let config = Config::load();
     let project_name = get_project_name().unwrap_or_default();
 
-    let project_config = if project_name.is_empty() {
-        &config.default
+    let config = if project_name.is_empty() {
+        GlobalConfig::load().default
     } else {
-        config.for_project(&project_name)
+        get_project_config(&project_name)
     };
 
-    (project_config.chat_layout, project_config.chat_min_width)
+    (config.chat_layout(), config.chat_min_width())
 }
 
 /// Get the list of required plugins from config.
 pub fn get_required_plugins() -> Vec<String> {
-    let config = Config::load();
-    config.plugins.required.clone()
+    GlobalConfig::load().plugins.required.clone()
 }
 
 /// Get the current project name from git repo root directory.
 fn get_project_name() -> Option<String> {
-    let output = std::process::Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .ok()?;
+    crate::paths::detect_repo_name()
+}
 
-    if !output.status.success() {
-        return None;
-    }
-
-    let path = String::from_utf8_lossy(&output.stdout);
-    let path = PathBuf::from(path.trim());
-
-    path.file_name().map(|s| s.to_string_lossy().to_string())
+// Legacy alias for backwards compatibility
+#[deprecated(note = "Use global_config_path() instead")]
+pub fn config_path() -> PathBuf {
+    global_config_path()
 }
 
 #[cfg(test)]
@@ -188,42 +219,95 @@ mod tests {
 
     #[test]
     fn test_default_config() {
-        let config = Config::default();
-        assert_eq!(config.default.bin_command, "midtown");
+        let config = GlobalConfig::default();
+        assert_eq!(config.default.bin_command(), "midtown");
     }
 
     #[test]
-    fn test_parse_config() {
+    fn test_parse_global_config() {
         let toml = r#"
 [default]
 bin_command = "midtown"
+chat_layout = "split"
 
-[my-project]
-bin_command = "cargo run --release --"
+[plugins]
+required = ["test-plugin"]
 "#;
-        let config: Config = toml::from_str(toml).unwrap();
+        let config: GlobalConfig = toml::from_str(toml).unwrap();
 
-        assert_eq!(config.default.bin_command, "midtown");
-        assert_eq!(
-            config.for_project("my-project").bin_command,
-            "cargo run --release --"
-        );
-        // Unknown project falls back to default
-        assert_eq!(config.for_project("unknown").bin_command, "midtown");
+        assert_eq!(config.default.bin_command(), "midtown");
+        assert_eq!(config.default.chat_layout(), ChatLayout::Split);
+        assert_eq!(config.required_plugins(), &["test-plugin"]);
     }
 
     #[test]
-    fn test_config_path() {
-        let path = config_path();
+    fn test_parse_project_config() {
+        let toml = r#"
+bin_command = "cargo run --release --"
+chat_layout = "window"
+"#;
+        let config: ProjectConfig = toml::from_str(toml).unwrap();
+
+        assert_eq!(config.bin_command(), "cargo run --release --");
+        assert_eq!(config.chat_layout(), ChatLayout::Window);
+    }
+
+    #[test]
+    fn test_project_config_partial() {
+        // Project config can specify only some fields
+        let toml = r#"
+bin_command = "custom-command"
+"#;
+        let config: ProjectConfig = toml::from_str(toml).unwrap();
+
+        assert_eq!(config.bin_command(), "custom-command");
+        // Uses defaults for unspecified fields
+        assert_eq!(config.chat_layout(), ChatLayout::Auto);
+        assert_eq!(config.chat_min_width(), 160);
+    }
+
+    #[test]
+    fn test_merge_configs() {
+        let global = ProjectConfig {
+            bin_command: Some("midtown".to_string()),
+            chat_layout: Some(ChatLayout::Auto),
+            chat_min_width: Some(160),
+        };
+
+        let project = ProjectConfig {
+            bin_command: Some("custom".to_string()),
+            chat_layout: None, // Not overridden
+            chat_min_width: Some(200),
+        };
+
+        let merged = global.merge(&project);
+
+        assert_eq!(merged.bin_command(), "custom"); // Overridden
+        assert_eq!(merged.chat_layout(), ChatLayout::Auto); // From global
+        assert_eq!(merged.chat_min_width(), 200); // Overridden
+    }
+
+    #[test]
+    fn test_global_config_path() {
+        let path = global_config_path();
         assert!(path.to_string_lossy().contains(".midtown"));
         assert!(path.to_string_lossy().ends_with("config.toml"));
     }
 
     #[test]
+    fn test_project_config_path() {
+        let path = project_config_path("myproject");
+        assert!(path.to_string_lossy().contains(".midtown"));
+        assert!(path.to_string_lossy().contains("projects"));
+        assert!(path.to_string_lossy().contains("myproject"));
+        assert!(path.to_string_lossy().ends_with("config.toml"));
+    }
+
+    #[test]
     fn test_chat_layout_default() {
-        let config = Config::default();
-        assert_eq!(config.default.chat_layout, ChatLayout::Auto);
-        assert_eq!(config.default.chat_min_width, 160);
+        let config = ProjectConfig::default();
+        assert_eq!(config.chat_layout(), ChatLayout::Auto);
+        assert_eq!(config.chat_min_width(), 160);
     }
 
     #[test]
@@ -232,20 +316,11 @@ bin_command = "cargo run --release --"
 [default]
 chat_layout = "split"
 chat_min_width = 200
-
-[narrow-project]
-chat_layout = "window"
 "#;
-        let config: Config = toml::from_str(toml).unwrap();
+        let config: GlobalConfig = toml::from_str(toml).unwrap();
 
-        assert_eq!(config.default.chat_layout, ChatLayout::Split);
-        assert_eq!(config.default.chat_min_width, 200);
-        assert_eq!(
-            config.for_project("narrow-project").chat_layout,
-            ChatLayout::Window
-        );
-        // Narrow project should inherit default min_width
-        assert_eq!(config.for_project("narrow-project").chat_min_width, 160);
+        assert_eq!(config.default.chat_layout(), ChatLayout::Split);
+        assert_eq!(config.default.chat_min_width(), 200);
     }
 
     #[test]
@@ -254,13 +329,13 @@ chat_layout = "window"
 [default]
 chat_layout = "auto"
 "#;
-        let config: Config = toml::from_str(toml).unwrap();
-        assert_eq!(config.default.chat_layout, ChatLayout::Auto);
+        let config: GlobalConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.default.chat_layout(), ChatLayout::Auto);
     }
 
     #[test]
     fn test_plugins_config_default() {
-        let config = Config::default();
+        let config = GlobalConfig::default();
         assert!(config.plugins.required.is_empty());
         assert!(config.required_plugins().is_empty());
     }
@@ -278,7 +353,7 @@ required = [
 [default]
 bin_command = "midtown"
 "#;
-        let config: Config = toml::from_str(toml).unwrap();
+        let config: GlobalConfig = toml::from_str(toml).unwrap();
 
         assert_eq!(config.plugins.required.len(), 3);
         assert_eq!(
@@ -303,7 +378,7 @@ bin_command = "midtown"
 [default]
 bin_command = "midtown"
 "#;
-        let config: Config = toml::from_str(toml).unwrap();
+        let config: GlobalConfig = toml::from_str(toml).unwrap();
         assert!(config.plugins.required.is_empty());
     }
 }


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Replaces `[project-name]` sections in global config with separate project config files
- Global config stays at `~/.midtown/config.toml` with `[default]` and `[plugins]`  
- Project configs go in `~/.midtown/projects/<project>/config.toml`
- Project config takes precedence and can override any subset of fields

## Background
Previously, project-specific settings used `#[serde(flatten)]` with a HashMap:
```toml
# ~/.midtown/config.toml
[default]
bin_command = "midtown"

[my-project]  # project-specific override
bin_command = "cargo run --release --"
```

This approach was problematic:
- Config file grew with each project
- Settings were scattered in one file
- The `#[serde(flatten)]` approach was fragile with serde

## New Approach
```toml
# ~/.midtown/config.toml (global)
[default]
bin_command = "midtown"

[plugins]
required = ["superpowers@claude-plugins-official"]
```

```toml  
# ~/.midtown/projects/my-project/config.toml
bin_command = "cargo run --release --"
```

## Changes
- Rename `Config` to `GlobalConfig` (only handles global settings)
- Remove `#[serde(flatten)] projects: HashMap` from GlobalConfig
- Add `load_project_config()` to load from projects dir
- Add `get_project_config()` to merge global + project configs
- Update `ProjectConfig` fields to use `Option<T>` for proper merging
- Deprecate `config_path()` in favor of `global_config_path()`

## Test plan
- [x] All existing tests pass
- [x] New tests for project config parsing and merging
- [ ] Manual verification: Create project config and verify it takes precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)