### PR TITLE
fix: Use full skill name /code-review:code-review in daemon instructions

### DIFF
--- a/src/bin/midtown/cli/coworker.rs
+++ b/src/bin/midtown/cli/coworker.rs
@@ -129,7 +129,7 @@ pub fn handle_stop_hook_standalone() -> Result<Response, String> {
     let prs_needing_review = get_prs_needing_review(&agent);
     if !prs_needing_review.is_empty() {
         work_items.push(format!(
-            "{} PR{} needing review (use /code-review): {}",
+            "{} PR{} needing review (use /code-review:code-review): {}",
             prs_needing_review.len(),
             if prs_needing_review.len() == 1 {
                 ""

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1318,7 +1318,7 @@ async fn poll_prs_for_issues(
 /// - Aren't owned by the potential reviewer (no self-reviews)
 ///
 /// For each eligible PR, it spawns a new coworker (or uses an idle one) and
-/// nudges them to run `/code-review <pr-number>`.
+/// nudges them to run `/code-review:code-review <pr-number>`.
 async fn spawn_reviewers_for_prs(
     state: &DaemonState,
     prs: &[serde_json::Value],
@@ -1401,9 +1401,9 @@ async fn spawn_reviewers_for_prs(
                     tracker.assign(pr_number, &reviewer_name);
                 }
 
-                // Nudge the reviewer to run /code-review
+                // Nudge the reviewer to run /code-review:code-review
                 let nudge_msg = format!(
-                    "Please review PR #{}: {}. Run: /code-review {}",
+                    "Please review PR #{}: {}. Run: /code-review:code-review {}",
                     pr_number,
                     truncate_str(title, 50),
                     pr_number
@@ -1463,9 +1463,9 @@ async fn spawn_reviewers_for_prs(
                         // Give the new coworker time to start (async sleep)
                         tokio::time::sleep(Duration::from_secs(3)).await;
 
-                        // Nudge the new reviewer to run /code-review
+                        // Nudge the new reviewer to run /code-review:code-review
                         let nudge_msg = format!(
-                            "Please review PR #{}: {}. Run: /code-review {}",
+                            "Please review PR #{}: {}. Run: /code-review:code-review {}",
                             pr_number,
                             truncate_str(title, 50),
                             pr_number


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Updates daemon nudge messages to use the full skill name `/code-review:code-review` instead of the short form `/code-review`
- The short form doesn't work with the Skill tool, which requires the fully qualified plugin:skill name

## Test plan
- [x] Code compiles
- [x] Changes are straightforward string replacements
- [ ] Manual verification that coworkers receive correct instructions