### PR TITLE
feat: Redesign chat TUI message format with current task display

### DIFF
--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -774,13 +774,17 @@ fn build_sender_line(
             // Add current task if available
             if let Some(task) = current_task {
                 // Calculate available space for task (width - name - " - ")
-                let prefix_len = msg.from.len() + 3; // " - " = 3 chars
+                // Use chars().count() for UTF-8 safe length calculation
+                let prefix_len = msg.from.chars().count() + 3; // " - " = 3 chars
                 let available = width.saturating_sub(prefix_len);
 
                 if available > 5 {
                     // Only show if we have reasonable space
-                    let truncated_task = if task.len() > available {
-                        format!("{}…", &task[..available.saturating_sub(1)])
+                    // Use chars() for UTF-8 safe truncation to avoid panics on multi-byte chars
+                    let truncated_task = if task.chars().count() > available {
+                        let truncated: String =
+                            task.chars().take(available.saturating_sub(1)).collect();
+                        format!("{}…", truncated)
                     } else {
                         task.clone()
                     };


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Show coworker's current task after actor name on sender line (e.g., "park - Fix chat TUI formatting")
- Update `/me` messages to follow standard format with `* ` prefix before message content
- Actor name line only shown when sender changes (collapses consecutive messages)
- Blank line before each new sender block
- Case-insensitive task lookup by owner name
- Task title truncated with ellipsis if too long

## Format Example
```
park - Fix chat TUI formatting
 09:45 * is thinking...
 09:46 finished the task

daemon - System
 09:47 ⏱️ Auto-shutting down idle...
```

## Test plan
- [x] All existing chat UI tests pass (23 tests)
- [x] New tests for current task display
- [x] New tests for case-insensitive lookup
- [x] New tests for task truncation
- [x] Updated action message format test

🤖 Generated with [Claude Code](https://claude.com/claude-code)