### PR TITLE
fix: Remove manual review task creation to prevent duplicates

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -127,17 +127,12 @@ EOF
 ## Requesting PR Reviews
 When your PR is ready for review:
 
-1. **Create a review task** so another coworker can pick it up:
-```
-TaskCreate with subject: "Code review PR #<number>", description: "<PR title and summary>"
-```
-
-2. **Post to channel** requesting review:
+**Post to channel** requesting review:
 ```bash
 midtown channel post "/me requesting review of PR #42"
 ```
 
-This ensures your PR doesn't get stuck waiting - another coworker will claim the review task.
+The daemon automatically detects new PRs and assigns reviewers - you don't need to create review tasks manually. The daemon will nudge an idle coworker or spawn a new one to review your PR.
 
 ### Reviewing PRs
 


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Removes TaskCreate instruction from coworker instructions for requesting PR reviews
- The daemon already directly nudges/spawns coworkers for PR reviews
- Having both mechanisms caused race conditions where multiple coworkers reviewed the same PR

## Root Cause
The daemon's `spawn_reviewers_for_prs()` function already does direct nudge/spawn for PR reviews. But `agents/coworker.md` also instructed coworkers to create "Code review PR #X" tasks. This created a race condition:

1. Coworker A opens a PR
2. Coworker A follows instructions and creates a "Code review PR #123" task
3. Daemon detects the new PR and directly assigns coworker B to review it
4. Coworker C sees the task and claims it
5. Both B and C review the same PR!

## Fix
Remove the TaskCreate instruction from the "Requesting PR Reviews" section. The daemon handles review assignment automatically via direct nudge/spawn.

## Test plan
- [x] All 175 tests pass
- [x] Verified daemon code already does direct nudge/spawn (no task creation)
- [x] Verified change only affects coworker instructions, not daemon logic

🤖 Generated with [Claude Code](https://claude.ai/code)