### PR TITLE
fix: Correct lead window name case in nudge_lead

### DIFF
--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -432,16 +432,16 @@ impl CoworkerManager {
     ///
     /// This is used to notify the Lead about coworker feedback requests.
     pub fn nudge_lead(&self, message: &str) -> crate::Result<()> {
-        // Check if Lead window exists
-        if !tmux::window_exists(&self.session_name, "Lead")? {
+        // Check if lead window exists
+        if !tmux::window_exists(&self.session_name, "lead")? {
             return Err(crate::Error::Rpc {
                 code: -32602,
                 message: "Lead session not found".to_string(),
             });
         }
 
-        // Send keys to the Lead window
-        tmux::send_keys(&self.session_name, "Lead", message)
+        // Send keys to the lead window
+        tmux::send_keys(&self.session_name, "lead", message)
     }
 
     /// Spawn a coworker with a specific name.


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Fix case mismatch: change "Lead" to "lead" in `nudge_lead()` function
- The lead tmux window is named "lead" (lowercase) but the code was looking for "Lead"

## Test plan
- [x] Coworker tests pass
- [x] Clippy passes

🤖 Generated with [Claude Code](https://claude.ai/code)