### PR TITLE
fix: Use lowercase 'lead' window name in nudge_lead

### DIFF
--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -432,16 +432,16 @@ impl CoworkerManager {
     ///
     /// This is used to notify the Lead about coworker feedback requests.
     pub fn nudge_lead(&self, message: &str) -> crate::Result<()> {
-        // Check if Lead window exists
-        if !tmux::window_exists(&self.session_name, "Lead")? {
+        // Check if lead window exists
+        if !tmux::window_exists(&self.session_name, "lead")? {
             return Err(crate::Error::Rpc {
                 code: -32602,
                 message: "Lead session not found".to_string(),
             });
         }
 
-        // Send keys to the Lead window
-        tmux::send_keys(&self.session_name, "Lead", message)
+        // Send keys to the lead window
+        tmux::send_keys(&self.session_name, "lead", message)
     }
 
     /// Spawn a coworker with a specific name.


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Fixed case mismatch in `nudge_lead()` function
- The lead window is named "lead" (lowercase) but the code was looking for "Lead" (capitalized)
- This prevented the daemon from successfully nudging the Lead session for coworker feedback requests

## Test plan
- [x] Code compiles (`cargo check`)
- [x] Passes clippy and fmt checks
- [ ] Manual testing: verify daemon can now nudge the lead session

🤖 Generated with [Claude Code](https://claude.com/claude-code)