### PR TITLE
fix: Use lowercase "lead" in nudge_lead() to match tmux window name

### DIFF
--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -406,16 +406,16 @@ impl CoworkerManager {
     ///
     /// This is used to notify the Lead about coworker feedback requests.
     pub fn nudge_lead(&self, message: &str) -> crate::Result<()> {
-        // Check if Lead window exists
-        if !tmux::window_exists(&self.session_name, "Lead")? {
+        // Check if lead window exists
+        if !tmux::window_exists(&self.session_name, "lead")? {
             return Err(crate::Error::Rpc {
                 code: -32602,
                 message: "Lead session not found".to_string(),
             });
         }
 
-        // Send keys to the Lead window
-        tmux::send_keys(&self.session_name, "Lead", message)
+        // Send keys to the lead window
+        tmux::send_keys(&self.session_name, "lead", message)
     }
 
     /// Spawn a coworker with a specific name.


### PR DESCRIPTION
<!-- midtown: canal -->

## Summary
- Fixed case mismatch where `nudge_lead()` looked for "Lead" but the window is created as "lead"
- Changed both `tmux::window_exists()` and `tmux::send_keys()` calls to use lowercase "lead"

## Root cause
The lead window is created in `daemon.rs:394` with `-n "lead"` (lowercase), but `nudge_lead()` in `coworker.rs` was looking for "Lead" (capitalized).

## Test plan
- [x] All coworker tests pass
- [x] cargo check passes
- [x] Pre-commit hooks (clippy, fmt) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)