### PR TITLE
docs: Tell coworkers not to claim PR reviews and check for duplicate claims

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -60,7 +60,24 @@ midtown channel post "/me opening PR for task 5"
 midtown channel post "/me completed task 5"
 ```
 
+### Avoiding Duplicate Claims
+After claiming a task, **wait 10 seconds** then read the channel to check if another coworker also claimed it:
+
+```bash
+# After claiming, wait and check for collisions
+sleep 10
+midtown channel read
+```
+
+If you see another coworker also claimed the same task:
+- **First to notice** should post: `@{other} you continue with task #X, I'll abandon and find another`
+- Then pick a different task from the list
+
+This prevents wasted effort from duplicate work.
+
 Don't hoard tasks - claim one, finish it, then claim another.
+
+**Exception:** Do NOT claim "Code review PR #X" tasks from the task list. PR reviews are assigned directly by the daemon to prevent duplicate reviews. Only review PRs when specifically nudged to do so.
 
 ## Git Workflow
 - You're in an isolated worktree (detached HEAD at the Lead's current commit)
@@ -123,7 +140,10 @@ midtown channel post "/me requesting review of PR #42"
 This ensures your PR doesn't get stuck waiting - another coworker will claim the review task.
 
 ### Reviewing PRs
-When you pick up a code review task:
+
+**IMPORTANT:** Only review PRs that are specifically assigned to you via a nudge or task. Do NOT proactively look for PRs to review or claim review tasks from the task list. The daemon assigns reviews directly to coworkers to prevent duplicate reviews.
+
+When you are assigned a PR review:
 
 1. **Use the code-review:code-review skill** to analyze the PR:
 ```


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Added instructions to avoid duplicate task claims by waiting 10 seconds after claiming and checking the channel for collisions
- Added explicit guidance that PR review tasks should NOT be claimed from the task list - the daemon assigns reviews directly to prevent duplicates
- Updated the "Reviewing PRs" section to emphasize only reviewing PRs when specifically nudged

## Test plan
- [x] Documentation change only - no functional code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)