### PR TITLE
fix: Enable clickable PR hyperlinks in kanban Review and Done columns

### DIFF
--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -9,15 +9,17 @@
 mod app;
 mod ui;
 
-use std::io;
+use std::io::{self, Write};
 use std::time::Duration;
 
 use crossterm::{
+    cursor::MoveTo,
     event::{
         DisableMouseCapture, EnableMouseCapture, Event, EventStream, KeyCode, KeyEventKind,
         MouseEventKind,
     },
     execute,
+    style::{Color as CrosstermColor, Print, ResetColor, SetForegroundColor},
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use futures::StreamExt;
@@ -25,6 +27,8 @@ use ratatui::{Terminal, prelude::CrosstermBackend};
 use tokio::time::interval;
 
 use app::App;
+use ratatui::style::Color as RatatuiColor;
+use ui::Hyperlink;
 
 /// Run the chat TUI
 pub fn run() -> Result<(), String> {
@@ -80,8 +84,15 @@ async fn run_app_async(
     let mut refresh_interval = interval(Duration::from_secs(1));
 
     loop {
-        // Draw UI
-        terminal.draw(|f| ui::draw(f, app))?;
+        // Draw UI and collect hyperlinks
+        let mut hyperlinks = Vec::new();
+        terminal.draw(|f| {
+            hyperlinks = ui::draw(f, app);
+        })?;
+
+        // Write hyperlinks using OSC 8 sequences (after ratatui draws)
+        // This bypasses ratatui's buffer system which doesn't support escape sequences
+        render_hyperlinks(terminal.backend_mut(), &hyperlinks)?;
 
         // Use tokio::select! to wait for either:
         // 1. Terminal events (keyboard/mouse)
@@ -133,6 +144,87 @@ async fn run_app_async(
                 app.refresh();
             }
         }
+    }
+}
+
+/// Render hyperlinks using OSC 8 escape sequences
+///
+/// This function writes hyperlinks directly to the terminal, bypassing ratatui's
+/// buffer system. OSC 8 hyperlinks work by wrapping text in escape sequences:
+/// - Start: \x1b]8;;URL\x07
+/// - End: \x1b]8;;\x07
+///
+/// Requirements for clickable links:
+/// - tmux 3.4+ with `allow-passthrough on`
+/// - Terminal with OSC 8 support (iTerm2, kitty, WezTerm, etc.)
+fn render_hyperlinks<W: io::Write>(
+    backend: &mut CrosstermBackend<W>,
+    hyperlinks: &[Hyperlink],
+) -> io::Result<()> {
+    for link in hyperlinks {
+        // Move cursor to the hyperlink position
+        execute!(backend, MoveTo(link.x, link.y))?;
+
+        // Write OSC 8 start sequence
+        write!(backend, "\x1b]8;;{}\x07", link.url)?;
+
+        // Write the text with optional first-char coloring for CI status dots
+        let mut chars = link.text.chars().peekable();
+        if let Some(first_char) = chars.next() {
+            // Handle CI status dot coloring for first character
+            if let Some(color) = link.first_char_color {
+                if first_char == '●' || first_char == '○' {
+                    let crossterm_color = ratatui_to_crossterm_color(color);
+                    execute!(
+                        backend,
+                        SetForegroundColor(crossterm_color),
+                        Print(first_char),
+                        ResetColor
+                    )?;
+                } else {
+                    write!(backend, "{}", first_char)?;
+                }
+            } else {
+                write!(backend, "{}", first_char)?;
+            }
+            // Write remaining characters
+            for ch in chars {
+                write!(backend, "{}", ch)?;
+            }
+        }
+
+        // Write OSC 8 end sequence
+        write!(backend, "\x1b]8;;\x07")?;
+    }
+
+    // Flush to ensure sequences are written
+    backend.flush()?;
+
+    Ok(())
+}
+
+/// Convert ratatui Color to crossterm Color
+fn ratatui_to_crossterm_color(color: RatatuiColor) -> CrosstermColor {
+    match color {
+        RatatuiColor::Reset => CrosstermColor::Reset,
+        RatatuiColor::Black => CrosstermColor::Black,
+        RatatuiColor::Red => CrosstermColor::DarkRed,
+        RatatuiColor::Green => CrosstermColor::DarkGreen,
+        RatatuiColor::Yellow => CrosstermColor::DarkYellow,
+        RatatuiColor::Blue => CrosstermColor::DarkBlue,
+        RatatuiColor::Magenta => CrosstermColor::DarkMagenta,
+        RatatuiColor::Cyan => CrosstermColor::DarkCyan,
+        RatatuiColor::Gray => CrosstermColor::Grey,
+        RatatuiColor::DarkGray => CrosstermColor::DarkGrey,
+        RatatuiColor::LightRed => CrosstermColor::Red,
+        RatatuiColor::LightGreen => CrosstermColor::Green,
+        RatatuiColor::LightYellow => CrosstermColor::Yellow,
+        RatatuiColor::LightBlue => CrosstermColor::Blue,
+        RatatuiColor::LightMagenta => CrosstermColor::Magenta,
+        RatatuiColor::LightCyan => CrosstermColor::Cyan,
+        RatatuiColor::White => CrosstermColor::White,
+        RatatuiColor::Rgb(r, g, b) => CrosstermColor::Rgb { r, g, b },
+        RatatuiColor::Indexed(i) => CrosstermColor::AnsiValue(i),
     }
 }
 

--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -14,6 +14,21 @@ use midtown::{Message, MessageType};
 
 use super::app::{App, CiStatus};
 
+/// A hyperlink to be rendered after ratatui draws (using OSC 8 sequences)
+#[derive(Debug, Clone)]
+pub struct Hyperlink {
+    /// Screen x coordinate
+    pub x: u16,
+    /// Screen y coordinate
+    pub y: u16,
+    /// Text to display (will be rewritten with OSC 8 wrapping)
+    pub text: String,
+    /// URL to link to
+    pub url: String,
+    /// Optional color for the first character (CI status dot)
+    pub first_char_color: Option<Color>,
+}
+
 /// Format duration as (Xm) or (Xh) for display
 fn format_duration_minutes(since: DateTime<Utc>) -> String {
     let now = Utc::now();
@@ -98,10 +113,14 @@ const REPO_STATUS_HEIGHT: u16 = 1;
 
 /// Draw the main UI
 ///
+/// Returns a list of hyperlinks that should be rendered after ratatui draws.
+/// These hyperlinks need to be written directly to the terminal using OSC 8
+/// sequences, bypassing ratatui's buffer system (which doesn't support hyperlinks).
+///
 /// Note: The Team panel has been removed - coworker status is now shown
 /// in tmux tab names instead, providing better visibility even when the
 /// chat TUI is not in focus.
-pub fn draw(f: &mut Frame, app: &mut App) {
+pub fn draw(f: &mut Frame, app: &mut App) -> Vec<Hyperlink> {
     // Calculate dynamic kanban height based on In Progress and Review columns
     let (_pending, in_progress, _completed) = app.tasks_by_status();
     let kanban_height = calculate_kanban_height(in_progress.len(), app.prs.len());
@@ -117,8 +136,10 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         .split(f.area());
 
     draw_repo_status_line(f, app, chunks[0]);
-    draw_kanban_panel(f, app, chunks[1]);
+    let hyperlinks = draw_kanban_panel(f, app, chunks[1]);
     draw_chat_panel(f, app, chunks[2]);
+
+    hyperlinks
 }
 
 /// Format relative time (e.g., "3 minutes ago", "2 hours ago", "1 day ago")
@@ -256,7 +277,9 @@ fn ci_status_color(status: &CiStatus) -> Color {
 }
 
 /// Draw the kanban board with 4 columns
-fn draw_kanban_panel(f: &mut Frame, app: &App, area: Rect) {
+///
+/// Returns hyperlinks for PR items in Review and Done columns
+fn draw_kanban_panel(f: &mut Frame, app: &App, area: Rect) -> Vec<Hyperlink> {
     // Split into 4 equal columns
     let columns = Layout::default()
         .direction(Direction::Horizontal)
@@ -307,6 +330,8 @@ fn draw_kanban_panel(f: &mut Frame, app: &App, area: Rect) {
         &in_progress_items,
     );
 
+    let mut hyperlinks = Vec::new();
+
     // Review column (open PRs with repo#XX format, CI status dot, and duration) - 2-line items
     let review_items: Vec<KanbanItem> = app
         .prs
@@ -324,7 +349,9 @@ fn draw_kanban_panel(f: &mut Frame, app: &App, area: Rect) {
             }
         })
         .collect();
-    draw_kanban_column(f, columns[2], "Review", Color::Magenta, &review_items);
+    let review_hyperlinks =
+        draw_kanban_column(f, columns[2], "Review", Color::Magenta, &review_items);
+    hyperlinks.extend(review_hyperlinks);
 
     // Done column (merged PRs with repo#XX format) - single line, reverse chronological, max 10
     let done_items: Vec<KanbanItem> = app
@@ -340,11 +367,24 @@ fn draw_kanban_panel(f: &mut Frame, app: &App, area: Rect) {
             }
         })
         .collect();
-    draw_kanban_column(f, columns[3], "Done", Color::Green, &done_items);
+    let done_hyperlinks = draw_kanban_column(f, columns[3], "Done", Color::Green, &done_items);
+    hyperlinks.extend(done_hyperlinks);
+
+    hyperlinks
 }
 
 /// Draw a single kanban column with multi-line item support and optional hyperlinks
-fn draw_kanban_column(f: &mut Frame, area: Rect, title: &str, color: Color, items: &[KanbanItem]) {
+///
+/// Returns hyperlinks for items that have URLs (these will be rendered post-draw)
+fn draw_kanban_column(
+    f: &mut Frame,
+    area: Rect,
+    title: &str,
+    color: Color,
+    items: &[KanbanItem],
+) -> Vec<Hyperlink> {
+    let mut hyperlinks = Vec::new();
+
     let block = Block::default()
         .title(format!(" {} ({}) ", title, items.len()))
         .borders(Borders::ALL)
@@ -356,7 +396,7 @@ fn draw_kanban_column(f: &mut Frame, area: Rect, title: &str, color: Color, item
     if items.is_empty() {
         let paragraph = Paragraph::new("-").style(Style::default().fg(Color::White));
         f.render_widget(paragraph, inner);
-        return;
+        return hyperlinks;
     }
 
     let available_width = inner.width as usize;
@@ -388,6 +428,16 @@ fn draw_kanban_column(f: &mut Frame, area: Rect, title: &str, color: Color, item
 
             // Only apply hyperlink to the first line of items that have URLs
             if let (0, Some(url)) = (line_idx, item.url.as_ref()) {
+                // Record hyperlink for post-render writing
+                hyperlinks.push(Hyperlink {
+                    x: inner.x,
+                    y,
+                    text: truncated.clone(),
+                    url: url.clone(),
+                    first_char_color: ci_dot_color,
+                });
+
+                // Still render to ratatui's buffer (will be overwritten post-render)
                 render_hyperlink_line(
                     buffer,
                     inner.x,
@@ -412,6 +462,8 @@ fn draw_kanban_column(f: &mut Frame, area: Rect, title: &str, color: Color, item
             lines_used += 1;
         }
     }
+
+    hyperlinks
 }
 
 /// Render a plain text line with optional CI status dot coloring


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Fixed PR links not clickable in Review and Done kanban cards (task #107)
- Uses OSC 8 escape sequences written after ratatui renders, bypassing buffer limitations
- Preserves CI status dot coloring on the first character of hyperlink text

## Approach
The previous implementation tried to embed OSC 8 escape sequences directly in ratatui's cell symbols, which caused display corruption (e.g., "PR#140" appearing as "P #140"). This happened because ratatui's cell/buffer system isn't designed for arbitrary escape sequences.

This fix uses a **post-render approach**:
1. During `terminal.draw()`, collect hyperlink metadata (x, y, text, URL)
2. After ratatui finishes rendering, write OSC 8 sequences directly to the terminal using crossterm
3. This bypasses ratatui's buffer system entirely

## Test plan
- [x] All existing tests pass (176 tests)
- [x] Code compiles without warnings (clippy clean)
- [ ] Manual testing with OSC 8-compatible terminal (iTerm2/kitty/WezTerm)
- [ ] Verify PR links in Review column are clickable
- [ ] Verify PR links in Done column are clickable
- [ ] Verify CI status dots still show correct colors

## Requirements for clickable links
- tmux 3.4+ with `allow-passthrough on`
- Terminal with OSC 8 support (iTerm2, kitty, WezTerm, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)