### PR TITLE
fix: Don't kill coworkers on daemon shutdown

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -652,12 +652,6 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
     info!("Stopping chat monitor task...");
     let _ = chat_monitor_shutdown_tx.send(true);
 
-    // Shutdown all coworkers
-    info!("Shutting down coworkers...");
-    if let Err(e) = state.coworkers.shutdown_all() {
-        warn!("Error shutting down coworkers: {}", e);
-    }
-
     // Clean up socket file
     if config.socket_path.exists() {
         std::fs::remove_file(&config.socket_path)?;


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Remove the `shutdown_all()` call from SIGTERM/SIGINT handling in daemon shutdown
- Fixes window flashing on daemon restart caused by orphan recovery logic trying to respawn killed coworkers

## Context
The daemon doesn't need to kill coworkers on its own shutdown because:
- `midtown stop` kills the entire tmux session (which kills coworkers)
- `midtown restart` preserves the session - coworkers should keep running
- Idle auto-shutdown handles cleanup of unused coworkers
- Explicit `midtown coworker shutdown <name>` for manual kills

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [ ] Manual test: `midtown restart` should not cause coworker windows to flash