### PR TITLE
fix: Don't pass --session-id with --continue in spawn_claude

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -652,12 +652,6 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
     info!("Stopping chat monitor task...");
     let _ = chat_monitor_shutdown_tx.send(true);
 
-    // Shutdown all coworkers
-    info!("Shutting down coworkers...");
-    if let Err(e) = state.coworkers.shutdown_all() {
-        warn!("Error shutting down coworkers: {}", e);
-    }
-
     // Clean up socket file
     if config.socket_path.exists() {
         std::fs::remove_file(&config.socket_path)?;

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -730,13 +730,16 @@ pub fn spawn_claude(
     // Set CLAUDE_CODE_TASK_LIST_ID so all coworkers share the same task list
     // Use --setting-sources project,local (plugins are now in --settings file)
     // Add --continue flag if resuming a previous session
-    let continue_flag = if resume { " --continue" } else { "" };
+    let session_flag = if resume {
+        " --continue".to_string()
+    } else {
+        format!(" --session-id {}", coworker_session_id)
+    };
     let command = format!(
-        "export MIDTOWN_AGENT='{}' CLAUDE_CODE_TASK_LIST_ID='{}'; claude --dangerously-skip-permissions --session-id {}{} --setting-sources project,local --settings {} --append-system-prompt \"$(cat {})\"",
+        "export MIDTOWN_AGENT='{}' CLAUDE_CODE_TASK_LIST_ID='{}'; claude --dangerously-skip-permissions{} --setting-sources project,local --settings {} --append-system-prompt \"$(cat {})\"",
         name,
         task_list_id,
-        coworker_session_id,
-        continue_flag,
+        session_flag,
         settings_file.display(),
         prompt_file.display()
     );


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- When `resume=true` in `spawn_claude`, use `--continue` alone instead of combining it with `--session-id`, which caused a crash
- Remove `shutdown_all()` call from daemon shutdown so coworkers survive daemon restarts (prevents window flashing from orphan recovery)

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes
- [ ] Verify `midtown coworker resume <name>` no longer crashes
- [ ] Verify daemon restart preserves running coworker windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)