### PR TITLE
fix: Narrow kanban hyperlink to just PR#XX text

### DIFF
--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -438,17 +438,31 @@ fn draw_kanban_column(
 
             // Only apply hyperlink to the first line of items that have URLs
             if let (0, Some(url)) = (line_idx, item.url.as_ref()) {
-                // Extract just the "PR#XX" portion as the clickable target
-                if let Some(pr_start) = truncated.find("PR#") {
-                    let pr_text: String = truncated[pr_start..]
+                // Extract the PR identifier as the clickable target.
+                // Prefer "PR#XX" but fall back to "#XX" for narrow columns
+                // where truncate_str strips the "PR" prefix.
+                let (link_start, link_text) = if let Some(start) = truncated.find("PR#") {
+                    let text: String = truncated[start..]
                         .chars()
                         .take_while(|c| *c != ' ')
                         .collect();
-                    let char_offset = truncated[..pr_start].chars().count() as u16;
+                    (start, text)
+                } else if let Some(start) = truncated.find('#') {
+                    let text: String = truncated[start..]
+                        .chars()
+                        .take_while(|c| *c != ' ')
+                        .collect();
+                    (start, text)
+                } else {
+                    (0, String::new())
+                };
+
+                if !link_text.is_empty() {
+                    let char_offset = truncated[..link_start].chars().count() as u16;
                     hyperlinks.push(Hyperlink {
                         x: inner.x + char_offset,
                         y,
-                        text: pr_text,
+                        text: link_text,
                         url: url.clone(),
                         first_char_color: None,
                     });


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Narrows the clickable hyperlink area in kanban Review/Done columns to just the `PR#XX` text instead of the entire line
- Addresses user feedback on PR #190

## Changes
- Extract `PR#XX` substring from the kanban card text and use only that as the OSC 8 hyperlink target
- Adjust x-coordinate offset so the hyperlink is positioned at the `PR#` start position
- CI status dot and title text remain visible but are no longer part of the clickable area

## Test plan
- [x] All 177 tests pass
- [x] Clippy clean
- [ ] Manual: verify `PR#XX` is clickable in Review column
- [ ] Manual: verify `PR#XX` is clickable in Done column
- [ ] Manual: verify CI status dots still show correct colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)