### PR TITLE
fix: Remove nudge references from lead and coworker system prompts

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -77,7 +77,7 @@ This prevents wasted effort from duplicate work.
 
 Don't hoard tasks - claim one, finish it, then claim another.
 
-**Exception:** Do NOT claim "Code review PR #X" tasks from the task list. PR reviews are assigned directly by the daemon to prevent duplicate reviews. Only review PRs when specifically nudged to do so.
+**Exception:** Do NOT claim "Code review PR #X" tasks from the task list. PR reviews are assigned directly by the daemon to prevent duplicate reviews. Only review PRs when specifically assigned to do so.
 
 ## Git Workflow
 - You're in an isolated worktree (detached HEAD at the Lead's current commit)
@@ -132,11 +132,11 @@ When your PR is ready for review:
 midtown channel post "/me requesting review of PR #42"
 ```
 
-The daemon automatically detects new PRs and assigns reviewers - you don't need to create review tasks manually. The daemon will nudge an idle coworker or spawn a new one to review your PR.
+The daemon automatically detects new PRs and assigns reviewers - you don't need to create review tasks manually. The daemon will assign an idle coworker or spawn a new one to review your PR.
 
 ### Reviewing PRs
 
-**IMPORTANT:** Only review PRs that are specifically assigned to you via a nudge or task. Do NOT proactively look for PRs to review or claim review tasks from the task list. The daemon assigns reviews directly to coworkers to prevent duplicate reviews.
+**IMPORTANT:** Only review PRs that are specifically assigned to you via a task. Do NOT proactively look for PRs to review or claim review tasks from the task list. The daemon assigns reviews directly to coworkers to prevent duplicate reviews.
 
 When you are assigned a PR review:
 

--- a/agents/lead.md
+++ b/agents/lead.md
@@ -49,16 +49,10 @@ Benefits of delegation:
 Example workflow:
 ```bash
 # User asks for a feature - DON'T start coding!
-# 1. Create a task
+# 1. Create a task - the daemon will automatically assign it to a coworker
 TaskCreate with subject and description
 
-# 2. Spawn a coworker
-midtown coworker spawn
-
-# 3. Nudge them with context
-midtown coworker nudge <name> -m "Work on task #X: <brief description>"
-
-# 4. Monitor progress
+# 2. Monitor progress
 midtown status
 midtown channel read
 ```
@@ -68,26 +62,20 @@ midtown channel read
 midtown status               # Check daemon and coworker status
 midtown coworker spawn       # Spawn a new coworker
 midtown coworker shutdown <name>  # Shutdown a coworker
-midtown coworker nudge <name>     # Send message to coworker
 midtown channel post "msg"   # Post to team channel
 midtown channel read         # Read recent channel messages
 ```
 
 ## Spawning Coworkers
-**Prefer reusing idle coworkers over spawning new ones.** Check `midtown status` first - if a coworker is idle (no current task), nudge them with the new work instead of spawning.
+The daemon automatically assigns tasks to idle coworkers or spawns new ones as needed. You generally don't need to manually spawn coworkers - just create tasks and the daemon handles assignment.
 
 ```bash
-# First, check for idle coworkers
-midtown status
+# Create a task - the daemon assigns it automatically
+TaskCreate with subject and description
 
-# If idle coworker exists, reuse them:
-midtown coworker nudge <idle-name> -m "Work on task #X: <brief description>"
-
-# Only spawn if all coworkers are busy:
+# If you need to manually spawn (rare):
 midtown coworker spawn
-midtown coworker nudge <name> -m "Work on task #X: <brief description>"
 ```
-Coworkers start with no context - they need a nudge to know what to do.
 
 ## Coordination
 - Review work from coworkers
@@ -97,11 +85,11 @@ Coworkers start with no context - they need a nudge to know what to do.
 - Check channel for updates: `midtown channel read`
 
 ## Forwarding User Suggestions
-When the human makes a suggestion or provides feedback related to an in-progress task, **nudge it to the coworker working on that task**:
+When the human makes a suggestion or provides feedback related to an in-progress task, post it to the channel using @mentions so the relevant coworker sees it:
 
 ```bash
 # User suggests something about task #3 that park is working on:
-midtown coworker nudge park -m "User feedback: <their suggestion>"
+midtown channel post "@park User feedback: <their suggestion>"
 ```
 
 This ensures coworkers get real-time input without the Lead needing to context-switch into the implementation details.


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Removed all `midtown coworker nudge` references from `agents/lead.md` and `agents/coworker.md`
- The daemon now handles all task assignment and communication routing automatically
- Lead workflow simplified: create tasks and the daemon assigns them
- "Forwarding User Suggestions" now uses channel @mentions instead of nudge
- Coworker PR review references updated from "nudged" to "assigned"

## Test plan
- [x] No remaining "nudge" references in agents/ directory
- [x] Clippy and fmt pass
- [x] Prompts still correctly describe workflow without nudge commands

🤖 Generated with [Claude Code](https://claude.ai/code)