### PR TITLE
fix: Call sync_with_tmux periodically in daemon idle check loop

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -615,6 +615,10 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
 
             // Periodically check for idle coworkers and shut them down
             _ = idle_check_interval.tick() => {
+                // Sync internal state with actual tmux windows first
+                if let Err(e) = state.coworkers.sync_with_tmux() {
+                    warn!("Failed to sync coworker state with tmux: {}", e);
+                }
                 check_and_shutdown_idle_coworkers(&state).await;
             }
 


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Calls `CoworkerManager::sync_with_tmux()` at the start of each idle check interval tick in the daemon's main loop
- This prunes coworkers whose tmux windows have died (crash, auto-shutdown) so the daemon doesn't think they're still active
- Without this, stale state causes "no available coworker slots", silent nudge failures, and pending tasks never getting worked on

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] All 175 unit tests pass
- [x] All integration tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)