### PR TITLE
fix: Add review completion tracking and increase throughput

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -290,11 +290,11 @@ pub struct PrReviewTracker {
 /// This gives CI time to start and allows the author to add context.
 pub const PR_REVIEW_DELAY_SECS: u64 = 120;
 
-/// How long a review assignment is valid before it can be reassigned (30 minutes)
-pub const PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS: u64 = 1800;
+/// How long a review assignment is valid before it can be reassigned (10 minutes)
+pub const PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS: u64 = 600;
 
 /// Maximum number of concurrent review assignments (rate limiting)
-pub const MAX_CONCURRENT_REVIEWS: usize = 2;
+pub const MAX_CONCURRENT_REVIEWS: usize = 4;
 
 impl PrReviewTracker {
     pub fn new() -> Self {
@@ -1376,6 +1376,15 @@ async fn spawn_reviewers_for_prs(
         // Check if PR already has a Claude review (expensive, do last)
         if pr_has_claude_review(pr_number) {
             debug!("PR #{} already has a Claude review", pr_number);
+            // Free the tracker slot if this PR was assigned — the review completed
+            // but mark_reviewed() was never called (it only fires on nudge failure)
+            {
+                let mut tracker = state.pr_review_tracker.lock().await;
+                if tracker.is_assigned(pr_number) {
+                    debug!("PR #{} review completed, freeing tracker slot", pr_number);
+                    tracker.mark_reviewed(pr_number);
+                }
+            }
             continue;
         }
 


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- **Free tracker slots on review completion**: When `pr_has_claude_review()` detects a completed review for a tracked PR, immediately call `mark_reviewed()` to free the slot. Previously `mark_reviewed()` was only called on nudge failure, so successful reviews occupied slots for the full timeout.
- **Increase MAX_CONCURRENT_REVIEWS from 2 to 4**: With 6+ idle coworkers regularly available, 2 concurrent reviews was a bottleneck.
- **Reduce timeout from 30 min to 10 min**: Most reviews complete in under 5 minutes; 30 minutes was excessive as a safety net.

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` — all 171 unit tests + integration tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)