### PR TITLE
chore: Add docs/plans/ and web-app/node_modules/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ target
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+# Coworker plan files (should go to ~/.claude/plans/)
+docs/plans/
+
+# Node.js dependencies
+web-app/node_modules/


### PR DESCRIPTION
## Summary
- Add `docs/plans/` to .gitignore — coworker plan files belong in `~/.claude/plans/`, not the repo
- Add `web-app/node_modules/` preemptively for the Svelte web app

🤖 Generated with [Claude Code](https://claude.com/claude-code)