### PR TITLE
fix: Strip status suffix from tmux window names in list_windows

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -489,8 +489,6 @@ pub fn send_keys(session: &str, name: &str, keys: &str) -> crate::Result<()> {
 ///
 /// Status is truncated to keep the tab readable (max 20 chars).
 pub fn rename_window(session: &str, name: &str, status: Option<&str>) -> crate::Result<()> {
-    let target = format!("{}:{}", session, name);
-
     // Build the new window name with parsed/abbreviated status
     let new_name = match status {
         Some(s) if !s.is_empty() => {
@@ -499,6 +497,16 @@ pub fn rename_window(session: &str, name: &str, status: Option<&str>) -> crate::
             format!("{}:{}", name, parsed)
         }
         _ => name.to_string(),
+    };
+
+    // Find the window by base name, since it may already have a status suffix
+    // (e.g., "york:dev#3" instead of "york")
+    let target = match find_window_target(session, name) {
+        Some(t) => t,
+        None => {
+            tracing::debug!("Window {} not found in session {}", name, session);
+            return Ok(());
+        }
     };
 
     let status = Command::new("tmux")
@@ -512,6 +520,42 @@ pub fn rename_window(session: &str, name: &str, status: Option<&str>) -> crate::
     }
 
     Ok(())
+}
+
+/// Find a tmux window target by base name (stripping any status suffix).
+///
+/// Returns `Some("session:index")` if found, `None` otherwise.
+/// Uses window index for targeting since the window name may contain colons
+/// that conflict with tmux's `session:window` target syntax.
+fn find_window_target(session: &str, base_name: &str) -> Option<String> {
+    let output = Command::new("tmux")
+        .args([
+            "list-windows",
+            "-t",
+            session,
+            "-F",
+            "#{window_index}:#{window_name}",
+        ])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let base_lower = base_name.to_lowercase();
+
+    for line in stdout.lines() {
+        // Format: "index:window_name" (e.g., "2:york:done#204")
+        let (index, window_name) = line.split_once(':')?;
+        let window_base = window_name.split(':').next().unwrap_or(window_name);
+        if window_base.to_lowercase() == base_lower {
+            return Some(format!("{}:{}", session, index));
+        }
+    }
+
+    None
 }
 
 /// Send raw keys without appending Enter.
@@ -561,7 +605,11 @@ pub fn list_windows(session: &str) -> crate::Result<Vec<String>> {
     let windows: Vec<String> = stdout
         .lines()
         .filter(|name| *name != "lead") // Exclude the lead window
-        .map(|s| s.to_string())
+        .map(|s| {
+            // Strip status suffix (e.g., "york:done#204" -> "york")
+            // Windows get renamed via rename_window() with status info after a colon
+            s.split(':').next().unwrap_or(s).to_string()
+        })
         .collect();
 
     Ok(windows)

--- a/tests/tmux_rename_e2e.rs
+++ b/tests/tmux_rename_e2e.rs
@@ -1,0 +1,210 @@
+//! End-to-end tests for tmux window rename handling.
+//!
+//! Verifies that `list_windows()` strips status suffixes from renamed windows
+//! so that `sync_with_tmux()` and `discover_existing()` can match coworkers
+//! by their base name after the window has been renamed.
+//!
+//! Run with `cargo test -- --ignored tmux_rename` as these require tmux.
+
+use ntest::timeout;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::Duration;
+
+/// Counter for unique session names across tests.
+static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Generate a unique test session name to avoid conflicts.
+fn test_session_name() -> String {
+    let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+    format!("midtown-rename-test-{}-{}", std::process::id(), counter)
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .args(["list-sessions"])
+        .output()
+        .map(|o| o.status.success() || o.status.code() == Some(1))
+        .unwrap_or(false)
+}
+
+fn create_test_session(session: &str) -> bool {
+    Command::new("tmux")
+        .args(["new-session", "-d", "-s", session])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn create_test_window(session: &str, window: &str) -> bool {
+    Command::new("tmux")
+        .args(["new-window", "-t", session, "-n", window])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn rename_tmux_window(session: &str, old_name: &str, new_name: &str) -> bool {
+    let target = format!("{}:{}", session, old_name);
+    Command::new("tmux")
+        .args(["rename-window", "-t", &target, new_name])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn kill_test_session(session: &str) {
+    let _ = Command::new("tmux")
+        .args(["kill-session", "-t", session])
+        .status();
+}
+
+#[test]
+#[timeout(30000)]
+#[ignore] // Requires tmux to be running
+fn test_list_windows_strips_status_suffix() {
+    if !tmux_available() {
+        eprintln!("Skipping test: tmux not available");
+        return;
+    }
+
+    let session = test_session_name();
+    assert!(
+        create_test_session(&session),
+        "Failed to create tmux session"
+    );
+
+    // Create a coworker window named "york"
+    assert!(
+        create_test_window(&session, "york"),
+        "Failed to create window"
+    );
+    thread::sleep(Duration::from_millis(100));
+
+    // Rename the window to simulate a status suffix: "york" -> "york:done#204"
+    assert!(
+        rename_tmux_window(&session, "york", "york:done#204"),
+        "Failed to rename window"
+    );
+    thread::sleep(Duration::from_millis(100));
+
+    // list_windows should return the base name "york", not "york:done#204"
+    let windows = midtown::tmux::list_windows(&session).expect("list_windows failed");
+
+    kill_test_session(&session);
+
+    assert!(
+        windows.contains(&"york".to_string()),
+        "Expected list_windows to return base name 'york', got: {:?}",
+        windows
+    );
+    assert!(
+        !windows.contains(&"york:done#204".to_string()),
+        "list_windows should NOT return the suffixed name, got: {:?}",
+        windows
+    );
+}
+
+#[test]
+#[timeout(30000)]
+#[ignore] // Requires tmux to be running
+fn test_list_windows_deduplicates_after_stripping() {
+    if !tmux_available() {
+        eprintln!("Skipping test: tmux not available");
+        return;
+    }
+
+    let session = test_session_name();
+    assert!(
+        create_test_session(&session),
+        "Failed to create tmux session"
+    );
+
+    // Create a window and rename it with suffix
+    assert!(
+        create_test_window(&session, "amsterdam"),
+        "Failed to create window"
+    );
+    thread::sleep(Duration::from_millis(100));
+
+    rename_tmux_window(&session, "amsterdam", "amsterdam:dev#5");
+    thread::sleep(Duration::from_millis(100));
+
+    // list_windows should return just "amsterdam" (no suffix, no duplicates)
+    let windows = midtown::tmux::list_windows(&session).expect("list_windows failed");
+
+    kill_test_session(&session);
+
+    let amsterdam_count = windows.iter().filter(|w| w.as_str() == "amsterdam").count();
+    assert_eq!(
+        amsterdam_count, 1,
+        "Expected exactly one 'amsterdam', got {} in {:?}",
+        amsterdam_count, windows
+    );
+}
+
+#[test]
+#[timeout(30000)]
+#[ignore] // Requires tmux to be running
+fn test_rename_window_works_after_previous_rename() {
+    if !tmux_available() {
+        eprintln!("Skipping test: tmux not available");
+        return;
+    }
+
+    let session = test_session_name();
+    assert!(
+        create_test_session(&session),
+        "Failed to create tmux session"
+    );
+    assert!(
+        create_test_window(&session, "york"),
+        "Failed to create window"
+    );
+    thread::sleep(Duration::from_millis(100));
+
+    // First rename: york -> york:dev#5
+    midtown::tmux::rename_window(&session, "york", Some("developing task 5"))
+        .expect("First rename failed");
+    thread::sleep(Duration::from_millis(100));
+
+    // Verify the window was renamed
+    let raw_output = Command::new("tmux")
+        .args(["list-windows", "-t", &session, "-F", "#{window_name}"])
+        .output()
+        .expect("list-windows failed");
+    let raw_names: Vec<String> = String::from_utf8_lossy(&raw_output.stdout)
+        .lines()
+        .map(|s| s.to_string())
+        .collect();
+    assert!(
+        raw_names.iter().any(|n| n.starts_with("york:")),
+        "Expected a renamed window starting with 'york:', got: {:?}",
+        raw_names
+    );
+
+    // Second rename: should still find the window and rename it
+    midtown::tmux::rename_window(&session, "york", Some("testing task 5"))
+        .expect("Second rename failed");
+    thread::sleep(Duration::from_millis(100));
+
+    // Verify the second rename took effect
+    let raw_output2 = Command::new("tmux")
+        .args(["list-windows", "-t", &session, "-F", "#{window_name}"])
+        .output()
+        .expect("list-windows failed");
+    let raw_names2: Vec<String> = String::from_utf8_lossy(&raw_output2.stdout)
+        .lines()
+        .map(|s| s.to_string())
+        .collect();
+
+    kill_test_session(&session);
+
+    // The window should have the new status suffix
+    assert!(
+        raw_names2.iter().any(|n| n.contains("test")),
+        "Expected window with 'test' status after second rename, got: {:?}",
+        raw_names2
+    );
+}


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- `list_windows()` now strips status suffixes (e.g., `york:done#204` → `york`) so `sync_with_tmux()` and `discover_existing()` correctly match coworkers by base name
- `rename_window()` now finds windows by base name using window index, so subsequent renames work after the window has already been renamed with a status suffix
- Added `find_window_target()` helper that looks up windows by base name and returns `session:index` for reliable targeting

## Test plan
- [x] Added e2e test `test_list_windows_strips_status_suffix` — creates window, renames with suffix, asserts `list_windows` returns base name
- [x] Added e2e test `test_list_windows_deduplicates_after_stripping` — verifies no duplicates after stripping
- [x] Added e2e test `test_rename_window_works_after_previous_rename` — verifies two sequential renames work correctly
- [x] All 3 new tests confirmed failing before fix, passing after
- [x] All 175 unit tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)