### PR TITLE
feat: Spawn PR owners for CI failures and merge conflicts

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1400,9 +1400,9 @@ async fn poll_prs_for_issues(
                             "Failed to spawn {} for PR #{} {}: {}",
                             owner, pr_number, issue_type, e
                         );
-                        // Fall back to posting to channel
+                        // Fall back to posting to channel (indicate spawn was attempted)
                         let channel_message = format!(
-                            "PR #{} ({}) owned by {} - {}: {}",
+                            "PR #{} ({}) owned by {} - {}: {} (spawn failed)",
                             pr_number,
                             truncate_str(title, 40),
                             owner,


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Daemon now spawns inactive PR owners when CI fails or merge conflicts occur
- Matches the existing pattern in `handle_pr_comment_nudge` (line 2667)
- Falls back to channel post if spawn fails

## Changes
In `poll_prs_for_issues`, when a PR has issues and the owner is not active:
- **Before:** Only posted to channel: "PR #X owned by Y - CI failed: please investigate"
- **After:** Spawns the owner with a prompt about the issue, posts "🚀 Spawned Y to address CI failed on PR #X"

## Test plan
- [x] All 179 unit tests pass
- [x] Clippy and fmt checks pass
- [ ] Manual test: Stop a PR owner, let CI fail, verify daemon spawns them

🤖 Generated with [Claude Code](https://claude.com/claude-code)