### PR TITLE
docs: Add note to skip insights for PR Review Workflow

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -136,6 +136,8 @@ The daemon automatically detects new PRs and assigns reviewers - you don't need 
 
 ### Reviewing PRs
 
+> **Note:** Do not generate insights about PR Review Workflow - follow the documented procedures.
+
 **IMPORTANT:** Only review PRs that are specifically assigned to you via a task. Do NOT proactively look for PRs to review or claim review tasks from the task list. The daemon assigns reviews directly to coworkers to prevent duplicate reviews.
 
 When you are assigned a PR review:


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Adds a note to the coworker system prompt instructing coworkers not to generate educational insight blocks for the PR Review Workflow section
- These are procedural steps that should simply be followed, not explained

## Test plan
- [x] Verify note appears in the correct location in `agents/coworker.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)