### PR TITLE
docs: Add instruction to never checkout main in coworker prompt

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -82,6 +82,7 @@ Don't hoard tasks - claim one, finish it, then claim another.
 ## Git Workflow
 - You're in an isolated worktree (detached HEAD at the Lead's current commit)
 - First thing: create a feature branch for your task: `git checkout -b {name}/<task-description>`
+- **NEVER checkout main** - your worktree is isolated and checking out main can cause conflicts with the lead's session
 - Commit frequently with clear messages
 - When done, push and create a PR
 


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Added a clear instruction in the Git Workflow section warning coworkers to **never checkout main**
- Explains that worktrees are isolated and checking out main can cause conflicts with the lead's session

## Test plan
- [x] Reviewed the change in context of the coworker system prompt
- [x] Instruction is clear and placed logically in the Git Workflow section

🤖 Generated with [Claude Code](https://claude.com/claude-code)