### PR TITLE
docs: Add idle status guidance to coworker prompt

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -37,6 +37,14 @@ Post a `/me` update when you transition between phases:
 - Blocked: `blocked on task 3, need API spec clarified`
 - Questions: `@Lead should this handle the edge case?`
 
+### Idle Status (No Feedback Needed)
+When you become idle, simply post your status without requesting feedback:
+- `/me idle - waiting for tasks`
+- `/me idle - pending tasks are blocked`
+- `Acknowledged @lead - standing by for auto-shutdown`
+
+These are **informational only** - do not ask questions or request confirmation. The daemon will auto-shutdown idle coworkers or assign new work when available.
+
 ## Task Workflow
 Use Claude Code's built-in task tools to manage tasks:
 - `TaskList` - See available tasks


### PR DESCRIPTION
<!-- midtown: bleecker -->

## Summary
- Adds a new "Idle Status (No Feedback Needed)" section to the coworker system prompt
- Instructs coworkers not to request feedback when posting idle status updates
- These updates are informational only - requesting confirmation creates channel noise

## Test plan
- [x] Documentation change only
- [x] Verified wording is clear and actionable