### PR TITLE
feat: Add Haiku-based scoring and filtering for PR issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +504,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +528,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -537,10 +567,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -684,6 +735,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +852,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -791,6 +862,39 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -799,14 +903,24 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -834,10 +948,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -869,6 +1085,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -935,6 +1167,12 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "litrs"
@@ -1006,6 +1244,7 @@ dependencies = [
  "ntest",
  "once_cell",
  "ratatui",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -1046,6 +1285,23 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1112,6 +1368,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1463,21 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1304,6 +1619,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +1708,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,10 +1753,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1528,6 +1962,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,6 +2034,41 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "tailf"
@@ -1648,6 +2123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,6 +2158,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1782,12 +2287,14 @@ dependencies = [
  "http-body-util",
  "http-range-header",
  "httpdate",
+ "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1868,6 +2375,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1932,10 +2445,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1961,10 +2498,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1992,6 +2544,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2024,6 +2590,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2090,6 +2666,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,6 +2692,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2279,6 +2875,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2292,6 +2917,66 @@ name = "zerocopy-derive"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ crossterm = { version = "0.29", features = ["event-stream"] }
 tailf = "0.1"
 futures = "0.3"
 
+# HTTP client for LLM API calls
+reqwest = { version = "0.12", features = ["json"] }
+
 [dev-dependencies]
 tempfile = "3.0"
 ntest = "0.9"  # Test utilities including timeout attribute

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -22,6 +22,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::channel::Channel;
 use crate::coworker::CoworkerManager;
+use crate::haiku::{SCORE_THRESHOLD, filter_by_threshold, score_issues};
 use crate::message::{Message, MessageType};
 use crate::rpc::{Request, RequestId, Response, RpcError};
 use crate::webhook::{WebhookConfig, start_webhook_server};
@@ -1337,8 +1338,24 @@ async fn poll_prs_for_issues(
 
         // Check for actionable issues
         let issues = detect_pr_issues(pr);
+        let issue_count = issues.len();
 
-        for issue_type in issues {
+        // Score issues using Haiku and filter by threshold
+        let scored_issues = score_issues(pr_number, title, issues, pr).await;
+        let high_priority_issues = filter_by_threshold(scored_issues);
+
+        if high_priority_issues.len() < issue_count {
+            debug!(
+                "PR #{}: filtered {} issues to {} high-priority (threshold {})",
+                pr_number,
+                issue_count,
+                high_priority_issues.len(),
+                SCORE_THRESHOLD
+            );
+        }
+
+        for scored in high_priority_issues {
+            let issue_type = scored.issue_type;
             // Check if we should nudge for this issue
             let should_nudge = {
                 let tracker = state.pr_issue_tracker.lock().await;

--- a/src/haiku.rs
+++ b/src/haiku.rs
@@ -1,0 +1,376 @@
+//! Haiku LLM scoring for PR issue prioritization.
+//!
+//! This module provides functions to score PR issues using Claude Haiku,
+//! filtering out low-priority issues before escalation.
+
+use serde::{Deserialize, Serialize};
+use std::env;
+use tracing::{debug, warn};
+
+use crate::daemon::PrIssueType;
+
+/// Minimum score threshold for issues to be actioned (0-100).
+pub const SCORE_THRESHOLD: u8 = 80;
+
+/// Anthropic API base URL.
+const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
+
+/// Haiku model identifier.
+const HAIKU_MODEL: &str = "claude-3-5-haiku-latest";
+
+/// A scored PR issue with its priority score.
+#[derive(Debug, Clone)]
+pub struct ScoredIssue {
+    pub issue_type: PrIssueType,
+    pub score: u8,
+    pub reasoning: String,
+}
+
+impl ScoredIssue {
+    /// Check if this issue passes the score threshold.
+    pub fn passes_threshold(&self) -> bool {
+        self.score >= SCORE_THRESHOLD
+    }
+}
+
+/// Request body for Anthropic messages API.
+#[derive(Debug, Serialize)]
+struct AnthropicRequest {
+    model: String,
+    max_tokens: u32,
+    messages: Vec<AnthropicMessage>,
+}
+
+#[derive(Debug, Serialize)]
+struct AnthropicMessage {
+    role: String,
+    content: String,
+}
+
+/// Response from Anthropic messages API.
+#[derive(Debug, Deserialize)]
+struct AnthropicResponse {
+    content: Vec<ContentBlock>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ContentBlock {
+    text: String,
+}
+
+/// Score a PR issue using Claude Haiku.
+///
+/// Returns a score from 0-100 indicating priority:
+/// - 0-39: Low priority, probably noise
+/// - 40-79: Medium priority, monitor but don't escalate
+/// - 80-100: High priority, requires immediate action
+pub async fn score_issue(
+    pr_number: u64,
+    pr_title: &str,
+    issue_type: PrIssueType,
+    pr_context: &serde_json::Value,
+) -> Option<ScoredIssue> {
+    let api_key = match env::var("ANTHROPIC_API_KEY") {
+        Ok(key) => key,
+        Err(_) => {
+            debug!("ANTHROPIC_API_KEY not set, skipping issue scoring");
+            // Return issue with max score when API key not available
+            // This ensures issues are processed without scoring
+            return Some(ScoredIssue {
+                issue_type,
+                score: 100,
+                reasoning: "Scoring skipped (no API key)".to_string(),
+            });
+        }
+    };
+
+    let prompt = build_scoring_prompt(pr_number, pr_title, issue_type, pr_context);
+
+    match call_haiku(&api_key, &prompt).await {
+        Ok(response) => parse_score_response(&response, issue_type),
+        Err(e) => {
+            warn!("Failed to score issue via Haiku: {}", e);
+            // Return issue with max score on API failure to ensure processing
+            Some(ScoredIssue {
+                issue_type,
+                score: 100,
+                reasoning: format!("Scoring failed: {}", e),
+            })
+        }
+    }
+}
+
+/// Score multiple issues in parallel.
+pub async fn score_issues(
+    pr_number: u64,
+    pr_title: &str,
+    issues: Vec<PrIssueType>,
+    pr_context: &serde_json::Value,
+) -> Vec<ScoredIssue> {
+    let pr_context = pr_context.clone();
+    let futures: Vec<_> = issues
+        .into_iter()
+        .map(|issue_type| {
+            let ctx = pr_context.clone();
+            async move { score_issue(pr_number, pr_title, issue_type, &ctx).await }
+        })
+        .collect();
+
+    let results = futures::future::join_all(futures).await;
+    results.into_iter().flatten().collect()
+}
+
+/// Filter issues to only those passing the score threshold.
+pub fn filter_by_threshold(scored_issues: Vec<ScoredIssue>) -> Vec<ScoredIssue> {
+    scored_issues
+        .into_iter()
+        .filter(|issue| issue.passes_threshold())
+        .collect()
+}
+
+/// Build the scoring prompt for a PR issue.
+fn build_scoring_prompt(
+    pr_number: u64,
+    pr_title: &str,
+    issue_type: PrIssueType,
+    pr_context: &serde_json::Value,
+) -> String {
+    let context_summary = summarize_pr_context(pr_context, issue_type);
+
+    format!(
+        r#"You are scoring the priority of a PR issue to determine if it needs immediate attention.
+
+PR #{}: "{}"
+Issue Type: {}
+
+Context:
+{}
+
+Score this issue from 0-100 based on urgency and impact:
+- 0-39: Low priority (noise, transient, or self-resolving)
+- 40-79: Medium priority (should be addressed but not urgent)
+- 80-100: High priority (requires immediate attention)
+
+Consider:
+1. Is this a blocking issue or just informational?
+2. How long has this state persisted?
+3. Is human intervention actually needed?
+4. Could this resolve on its own (e.g., temporary CI flakiness)?
+
+Respond with ONLY a JSON object in this format:
+{{"score": <number>, "reasoning": "<brief explanation>"}}
+"#,
+        pr_number, pr_title, issue_type, context_summary
+    )
+}
+
+/// Summarize PR context relevant to the issue type.
+fn summarize_pr_context(pr: &serde_json::Value, issue_type: PrIssueType) -> String {
+    let mut summary = String::new();
+
+    match issue_type {
+        PrIssueType::MergeConflict => {
+            let mergeable = pr
+                .get("mergeable")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown");
+            summary.push_str(&format!("Mergeable status: {}\n", mergeable));
+        }
+        PrIssueType::CiFailed => {
+            if let Some(checks) = pr.get("statusCheckRollup").and_then(|c| c.as_array()) {
+                summary.push_str("CI Check Results:\n");
+                for check in checks {
+                    let name = check
+                        .get("name")
+                        .and_then(|n| n.as_str())
+                        .unwrap_or("unknown");
+                    let conclusion = check
+                        .get("conclusion")
+                        .and_then(|c| c.as_str())
+                        .unwrap_or("pending");
+                    summary.push_str(&format!("  - {}: {}\n", name, conclusion));
+                }
+            }
+        }
+        PrIssueType::ChangesRequested | PrIssueType::Approved => {
+            let decision = pr
+                .get("reviewDecision")
+                .and_then(|r| r.as_str())
+                .unwrap_or("none");
+            summary.push_str(&format!("Review decision: {}\n", decision));
+        }
+        PrIssueType::NeedsReview | PrIssueType::ReviewComment => {
+            let decision = pr
+                .get("reviewDecision")
+                .and_then(|r| r.as_str())
+                .unwrap_or("none");
+            let is_draft = pr.get("isDraft").and_then(|d| d.as_bool()).unwrap_or(false);
+            summary.push_str(&format!("Review decision: {}\n", decision));
+            summary.push_str(&format!("Is draft: {}\n", is_draft));
+        }
+    }
+
+    // Add creation time if available
+    if let Some(created) = pr.get("createdAt").and_then(|c| c.as_str()) {
+        summary.push_str(&format!("Created: {}\n", created));
+    }
+
+    summary
+}
+
+/// Call Haiku API with a prompt.
+async fn call_haiku(api_key: &str, prompt: &str) -> Result<String, String> {
+    let client = reqwest::Client::new();
+
+    let request = AnthropicRequest {
+        model: HAIKU_MODEL.to_string(),
+        max_tokens: 150,
+        messages: vec![AnthropicMessage {
+            role: "user".to_string(),
+            content: prompt.to_string(),
+        }],
+    };
+
+    let response = client
+        .post(ANTHROPIC_API_URL)
+        .header("x-api-key", api_key)
+        .header("anthropic-version", "2023-06-01")
+        .header("content-type", "application/json")
+        .json(&request)
+        .send()
+        .await
+        .map_err(|e| format!("HTTP request failed: {}", e))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!("API error {}: {}", status, body));
+    }
+
+    let api_response: AnthropicResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+    api_response
+        .content
+        .first()
+        .map(|block| block.text.clone())
+        .ok_or_else(|| "Empty response from API".to_string())
+}
+
+/// Parse the score response from Haiku.
+fn parse_score_response(response: &str, issue_type: PrIssueType) -> Option<ScoredIssue> {
+    // Try to parse as JSON
+    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(response) {
+        let score = parsed.get("score").and_then(|s| s.as_u64()).unwrap_or(100) as u8;
+        let reasoning = parsed
+            .get("reasoning")
+            .and_then(|r| r.as_str())
+            .unwrap_or("No reasoning provided")
+            .to_string();
+
+        return Some(ScoredIssue {
+            issue_type,
+            score,
+            reasoning,
+        });
+    }
+
+    // Fallback: try to extract a number from the response
+    let score = response
+        .chars()
+        .filter(|c| c.is_ascii_digit())
+        .take(3)
+        .collect::<String>()
+        .parse::<u8>()
+        .unwrap_or(100);
+
+    Some(ScoredIssue {
+        issue_type,
+        score,
+        reasoning: "Could not parse structured response".to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_score_threshold() {
+        let high_score = ScoredIssue {
+            issue_type: PrIssueType::CiFailed,
+            score: 85,
+            reasoning: "Critical failure".to_string(),
+        };
+        assert!(high_score.passes_threshold());
+
+        let low_score = ScoredIssue {
+            issue_type: PrIssueType::CiFailed,
+            score: 50,
+            reasoning: "Flaky test".to_string(),
+        };
+        assert!(!low_score.passes_threshold());
+
+        let boundary_score = ScoredIssue {
+            issue_type: PrIssueType::MergeConflict,
+            score: 80,
+            reasoning: "At threshold".to_string(),
+        };
+        assert!(boundary_score.passes_threshold());
+    }
+
+    #[test]
+    fn test_filter_by_threshold() {
+        let issues = vec![
+            ScoredIssue {
+                issue_type: PrIssueType::CiFailed,
+                score: 90,
+                reasoning: "High".to_string(),
+            },
+            ScoredIssue {
+                issue_type: PrIssueType::MergeConflict,
+                score: 60,
+                reasoning: "Medium".to_string(),
+            },
+            ScoredIssue {
+                issue_type: PrIssueType::Approved,
+                score: 85,
+                reasoning: "High".to_string(),
+            },
+        ];
+
+        let filtered = filter_by_threshold(issues);
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.iter().all(|i| i.score >= 80));
+    }
+
+    #[test]
+    fn test_parse_score_response_json() {
+        let response = r#"{"score": 75, "reasoning": "Test failure looks flaky"}"#;
+        let result = parse_score_response(response, PrIssueType::CiFailed).unwrap();
+        assert_eq!(result.score, 75);
+        assert_eq!(result.reasoning, "Test failure looks flaky");
+    }
+
+    #[test]
+    fn test_parse_score_response_fallback() {
+        let response = "The score is 85 because this is critical";
+        let result = parse_score_response(response, PrIssueType::CiFailed).unwrap();
+        assert_eq!(result.score, 85);
+    }
+
+    #[test]
+    fn test_build_scoring_prompt() {
+        let pr = serde_json::json!({
+            "mergeable": "CONFLICTING",
+            "createdAt": "2024-01-15T10:00:00Z"
+        });
+        let prompt = build_scoring_prompt(42, "Fix auth bug", PrIssueType::MergeConflict, &pr);
+        assert!(prompt.contains("PR #42"));
+        assert!(prompt.contains("Fix auth bug"));
+        assert!(prompt.contains("merge conflict"));
+        assert!(prompt.contains("CONFLICTING"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,9 @@ pub mod agents;
 // Claude Code task storage integration
 pub mod tasks;
 
+// Haiku LLM scoring for issue prioritization
+pub mod haiku;
+
 // Path utilities (socket paths, repo detection)
 pub mod paths;
 


### PR DESCRIPTION
<!-- midtown: mercer -->

## Summary
- Add new `haiku` module that uses Claude Haiku to score PR issues (0-100)
- Filter out issues below score threshold (80) before escalation
- Reduce noise from low-priority or transient issues like flaky CI

## Changes
- **src/haiku.rs**: New module with Haiku API integration, scoring prompts, and filtering logic
- **src/daemon.rs**: Integrate scoring into the issue processing loop
- **Cargo.toml**: Add `reqwest` dependency for HTTP API calls

## How it works
When ANTHROPIC_API_KEY is set, issues are scored by Haiku considering:
- Whether the issue is blocking or informational
- How long the state has persisted  
- Whether human intervention is needed
- Whether the issue might self-resolve

Issues scoring below 80 are filtered out. When ANTHROPIC_API_KEY is not set, issues pass through with max score to maintain backward compatibility.

## Test plan
- [x] All haiku module unit tests pass
- [x] Cargo clippy passes
- [x] Cargo fmt passes
- [ ] Integration test with ANTHROPIC_API_KEY set

🤖 Generated with [Claude Code](https://claude.com/claude-code)