### PR TITLE
fix: Prevent idle coworkers from claiming code-review sub-tasks

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -87,6 +87,8 @@ Don't hoard tasks - claim one, finish it, then claim another.
 
 **Exception:** Do NOT claim "Code review PR #X" tasks from the task list. PR reviews are assigned directly by the daemon to prevent duplicate reviews. Only review PRs when specifically assigned to do so.
 
+Also do NOT claim code-review sub-tasks (e.g., "Run 5 parallel code review agents", "Score and filter issues", "Post review comment on PR #X", "Find relevant CLAUDE.md files", "Check PR #X eligibility", "Get PR #X summary"). These are internal workflow steps owned by the coworker running the review.
+
 ## Git Workflow
 - You're in an isolated worktree (detached HEAD at the Lead's current commit)
 - First thing: create a feature branch for your task: `git checkout -b {name}/<task-description>`
@@ -155,6 +157,13 @@ When you are assigned a PR review:
 ```
 /code-review:code-review <PR number>
 ```
+
+**IMPORTANT: Own your sub-tasks.** The code-review skill creates a todo list of sub-tasks (eligibility check, find CLAUDE.md files, run review agents, score issues, post comment, etc.). After creating each sub-task, **immediately set yourself as owner** so other coworkers don't claim them:
+```
+TaskCreate with subject: "...", description: "..."
+TaskUpdate with taskId: <new task id>, owner: "{name}"
+```
+Review sub-tasks are internal workflow steps — they should not appear as claimable work for other coworkers.
 
 2. **Post your review as a GitHub comment** on the PR. The skill will guide you through this, but you MUST ensure your review is posted to GitHub (not just the channel).
 


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Reviewers now set themselves as owner on code-review sub-tasks immediately after creating them, preventing other coworkers from claiming internal review workflow steps
- Added explicit exception in task claiming rules: coworkers should not claim tasks matching review sub-task patterns (e.g., "Run 5 parallel code review agents", "Score and filter issues")

## Context
The code-review skill creates a todo list of sub-tasks via TaskCreate. These appeared as unclaimed in the shared task list, causing idle coworkers to pile onto the same PR review. This addresses the problem from both sides: producer (reviewer owns sub-tasks) and consumer (coworkers skip review sub-tasks).

## Test plan
- [x] Verify coworker.md changes are syntactically correct
- [ ] Next code review should have owned sub-tasks that idle coworkers skip

🤖 Generated with [Claude Code](https://claude.ai/code)