### PR TITLE
fix: Sanitize task owner to prevent empty-name coworker spawns

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2973,7 +2973,8 @@ async fn check_and_recover_orphans(state: &DaemonState) {
     // Find orphaned tasks (in_progress with owner not in active list)
     // Rate limit: only recover ONE coworker per tick to prevent spawn storms
     for (task_id, task_subject, owner) in in_progress {
-        // Skip if owner is Lead or empty
+        // Skip if owner is Lead, empty, or just whitespace/quotes
+        let owner = owner.trim().trim_matches('"').to_string();
         if owner.is_empty() || owner.eq_ignore_ascii_case("lead") {
             continue;
         }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -124,6 +124,7 @@ fn parse_task_json(content: &str) -> Result<Task, serde_json::Error> {
     let owner = value
         .get("owner")
         .and_then(|v| v.as_str())
+        .map(|s| s.trim().trim_matches('"'))
         .filter(|s| !s.is_empty())
         .map(String::from);
 
@@ -404,6 +405,31 @@ mod tests {
         assert_eq!(pending_without_owners.len(), 2);
         assert_eq!(pending_without_owners[0].id, "1");
         assert_eq!(pending_without_owners[1].id, "3");
+    }
+
+    #[test]
+    fn test_parse_quoted_empty_owner_as_none() {
+        // Bug: Claude Code sometimes sets owner to literal '""' (two quote chars)
+        // which passes is_empty() check (length 2) and causes the daemon to
+        // spawn a coworker with an empty name.
+        let json = r#"{"id": "367", "subject": "Score and filter issues", "status": "in_progress", "owner": "\"\""}"#;
+        let task = parse_task_json(json).unwrap();
+        assert!(
+            task.owner.is_none(),
+            "owner '\"\"' (literal quotes) should be parsed as None, got {:?}",
+            task.owner
+        );
+    }
+
+    #[test]
+    fn test_parse_whitespace_only_owner_as_none() {
+        let json = r#"{"id": "1", "subject": "Test", "status": "pending", "owner": "  "}"#;
+        let task = parse_task_json(json).unwrap();
+        assert!(
+            task.owner.is_none(),
+            "whitespace-only owner should be parsed as None, got {:?}",
+            task.owner
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Fix bug where daemon spawned coworker with empty name `""` for orphaned tasks
- Root cause: task owner field contained literal quote characters `""` (length 2) which passed `is_empty()` check
- Added `trim().trim_matches('"')` sanitization in `parse_task_json` to normalize bogus owner values to `None`
- Added defensive trim in `check_and_recover_orphans` as belt-and-suspenders

## Test plan
- [x] Added `test_parse_quoted_empty_owner_as_none` - verifies literal `""` owner becomes `None`
- [x] Added `test_parse_whitespace_only_owner_as_none` - verifies whitespace owner becomes `None`
- [x] Both tests confirmed failing before fix, passing after
- [x] Full test suite passes (`cargo test -p midtown`)

🤖 Generated with [Claude Code](https://claude.ai/code)