### PR TITLE
feat: Nudge lead when mobile messages arrive in channel

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2371,6 +2371,15 @@ fn handle_channel_post(id: RequestId, from: &str, message: &str, state: &DaemonS
                 }
             }
 
+            // Nudge lead when mobile messages arrive (from web UI)
+            if from == "mobile" {
+                let nudge_msg = format!("user: {}", content);
+                info!("Nudging Lead about mobile message");
+                if let Err(e) = state.coworkers.nudge_lead(&nudge_msg) {
+                    warn!("Failed to nudge Lead about mobile message: {}", e);
+                }
+            }
+
             // Nudge the Lead when a coworker explicitly mentions @lead
             if is_coworker_sender(from) && content.to_lowercase().contains("@lead") {
                 // Use message ID to avoid duplicate nudges


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- When a message is posted to the channel from the `"mobile"` sender (web UI), the daemon now calls `nudge_lead()` with the message content prefixed by `"user: "`.
- This ensures the lead is immediately notified of user messages sent from the mobile app, matching the existing pattern for `@lead` mentions and feedback requests.

## Changes
- `src/daemon.rs`: Added a check in `handle_channel_post()` — if `from == "mobile"`, nudge the lead with `"user: {content}"`.

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` — all 187 unit tests pass
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)