### PR TITLE
fix: render kanban board only on status tab

### DIFF
--- a/web-app/src/App.svelte
+++ b/web-app/src/App.svelte
@@ -49,12 +49,11 @@
     </button>
   </nav>
 
-  <Kanban />
-
   <div class="content">
     {#if activeTab === 'channel'}
       <Channel />
     {:else if activeTab === 'status'}
+      <Kanban />
       <Status />
     {:else if activeTab === 'lead'}
       <Lead />


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Fixed the kanban board appearing on every tab by moving `<Kanban />` inside the status tab conditional in `App.svelte`
- Previously, the Kanban component was rendered unconditionally outside the tab content area, causing it to appear duplicated when viewing the status tab

## Test plan
- [x] Vite build passes
- [x] Pre-commit hooks (clippy, fmt) pass
- [ ] Verify kanban board only appears on the Status tab
- [ ] Verify Channel and Lead tabs no longer show the kanban board

🤖 Generated with [Claude Code](https://claude.com/claude-code)