### PR TITLE
fix: Remove duplicate kanban board from status tab

### DIFF
--- a/web-app/src/App.svelte
+++ b/web-app/src/App.svelte
@@ -49,11 +49,12 @@
     </button>
   </nav>
 
+  <Kanban />
+
   <div class="content">
     {#if activeTab === 'channel'}
       <Channel />
     {:else if activeTab === 'status'}
-      <Kanban />
       <Status />
     {:else if activeTab === 'lead'}
       <Lead />


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Moved `<Kanban />` from inside the status tab conditional back to the nav level in `App.svelte`
- The kanban board is now always visible (below nav, above tab content), eliminating the duplication with the Status component's own task list

Fixes task #437.

## Test plan
- [x] `vite build` succeeds
- [ ] Verify kanban board appears once (below nav) on all tabs
- [ ] Verify status tab no longer shows a duplicate kanban

🤖 Generated with [Claude Code](https://claude.com/claude-code)