### PR TITLE
feat: Add TUI chat input and rename mobile sender to user

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -115,6 +115,12 @@ pub struct App {
     repo_status_receiver: Option<Receiver<RepoStatus>>,
     /// Selection mode - when true, mouse capture is disabled for text selection
     pub selection_mode: bool,
+    /// Input mode - when true, keyboard input goes to the text input
+    pub input_mode: bool,
+    /// Current text in the input field
+    pub input_text: String,
+    /// Cursor position within input_text
+    pub input_cursor: usize,
 }
 
 /// Interval between kanban data refreshes (30 seconds)
@@ -153,6 +159,9 @@ impl App {
             repo_status_last_refresh: Instant::now() - REPO_STATUS_REFRESH_INTERVAL, // Force initial refresh
             repo_status_receiver: None,
             selection_mode: false,
+            input_mode: false,
+            input_text: String::new(),
+            input_cursor: 0,
         };
 
         // Initial load
@@ -349,6 +358,24 @@ impl App {
     /// Toggle selection mode (disables mouse capture for text selection)
     pub fn toggle_selection_mode(&mut self) {
         self.selection_mode = !self.selection_mode;
+    }
+
+    /// Send the current input text as a message to the channel
+    pub fn send_input(&mut self) {
+        let text = self.input_text.trim().to_string();
+        if text.is_empty() {
+            return;
+        }
+        if let Some(ref channel) = self.channel {
+            let message = Message::text("user", &text);
+            if channel.send(&message).is_ok() {
+                self.input_text.clear();
+                self.input_cursor = 0;
+                // Refresh to pick up the new message
+                self.refresh();
+                self.scroll_to_bottom();
+            }
+        }
     }
 
     /// Maximum scroll offset
@@ -882,6 +909,9 @@ mod tests {
             repo_status_last_refresh: Instant::now(),
             repo_status_receiver: None,
             selection_mode: false,
+            input_mode: false,
+            input_text: String::new(),
+            input_cursor: 0,
         };
 
         let (pending, in_progress, completed) = app.tasks_by_status();
@@ -925,6 +955,9 @@ mod tests {
             repo_status_last_refresh: Instant::now(),
             repo_status_receiver: None,
             selection_mode: false,
+            input_mode: false,
+            input_text: String::new(),
+            input_cursor: 0,
         };
 
         let visible = app.visible_messages();

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -240,9 +240,63 @@ enum EventResult {
 
 /// Handle a terminal event, returns the result
 fn handle_event(app: &mut App, event: Event) -> EventResult {
+    // Input mode: route all key events to the text input
+    if app.input_mode {
+        if let Event::Key(key) = event
+            && key.kind == KeyEventKind::Press
+        {
+            match key.code {
+                KeyCode::Esc => {
+                    app.input_mode = false;
+                }
+                KeyCode::Enter => {
+                    app.send_input();
+                    app.input_mode = false;
+                }
+                KeyCode::Backspace => {
+                    if app.input_cursor > 0 {
+                        app.input_cursor -= 1;
+                        app.input_text.remove(app.input_cursor);
+                    }
+                }
+                KeyCode::Delete => {
+                    if app.input_cursor < app.input_text.len() {
+                        app.input_text.remove(app.input_cursor);
+                    }
+                }
+                KeyCode::Left => {
+                    if app.input_cursor > 0 {
+                        app.input_cursor -= 1;
+                    }
+                }
+                KeyCode::Right => {
+                    if app.input_cursor < app.input_text.len() {
+                        app.input_cursor += 1;
+                    }
+                }
+                KeyCode::Home => {
+                    app.input_cursor = 0;
+                }
+                KeyCode::End => {
+                    app.input_cursor = app.input_text.len();
+                }
+                KeyCode::Char(c) => {
+                    app.input_text.insert(app.input_cursor, c);
+                    app.input_cursor += 1;
+                }
+                _ => {}
+            }
+        }
+        return EventResult::Continue;
+    }
+
+    // Normal mode
     match event {
         Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
             KeyCode::Char('q') | KeyCode::Esc => return EventResult::Exit,
+            KeyCode::Char('i') => {
+                app.input_mode = true;
+            }
             KeyCode::Char('s') => {
                 app.toggle_selection_mode();
                 return EventResult::ToggleSelectionMode;

--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -147,19 +147,21 @@ pub fn draw(f: &mut Frame, app: &mut App) -> Vec<Hyperlink> {
     let (_pending, in_progress, _completed) = app.tasks_by_status();
     let kanban_height = calculate_kanban_height(in_progress.len(), app.prs.len());
 
-    // Split into repo status (top), kanban (middle), and chat (bottom) panels
+    // Split into repo status (top), kanban, chat, and input (bottom) panels
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(REPO_STATUS_HEIGHT),
             Constraint::Length(kanban_height),
             Constraint::Min(10),
+            Constraint::Length(3),
         ])
         .split(f.area());
 
     draw_repo_status_line(f, app, chunks[0]);
     let hyperlinks = draw_kanban_panel(f, app, chunks[1]);
     draw_chat_panel(f, app, chunks[2]);
+    draw_input_box(f, app, chunks[3]);
 
     hyperlinks
 }
@@ -693,6 +695,43 @@ fn draw_chat_panel(f: &mut Frame, app: &mut App, area: Rect) {
 
     f.render_widget(block, area);
     f.render_widget(paragraph, inner);
+}
+
+/// Draw the input box for typing messages
+fn draw_input_box(f: &mut Frame, app: &App, area: Rect) {
+    let border_color = if app.input_mode {
+        Color::Cyan
+    } else {
+        Color::DarkGray
+    };
+    let title = if app.input_mode {
+        " Message (Enter to send, Esc to cancel) "
+    } else {
+        " Press 'i' to type "
+    };
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color));
+
+    let inner = block.inner(area);
+
+    let display_text = if app.input_mode || !app.input_text.is_empty() {
+        app.input_text.as_str()
+    } else {
+        ""
+    };
+
+    let paragraph = Paragraph::new(Line::from(display_text.to_string()))
+        .style(Style::default().fg(Color::White));
+
+    f.render_widget(block, area);
+    f.render_widget(paragraph, inner);
+
+    // Show cursor when in input mode
+    if app.input_mode {
+        f.set_cursor_position((inner.x + app.input_cursor as u16, inner.y));
+    }
 }
 
 /// Render a single message into one or more Lines

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2371,12 +2371,12 @@ fn handle_channel_post(id: RequestId, from: &str, message: &str, state: &DaemonS
                 }
             }
 
-            // Nudge lead when mobile messages arrive (from web UI)
-            if from == "mobile" {
+            // Nudge lead when user messages arrive (from web UI or TUI input)
+            if from == "user" {
                 let nudge_msg = format!("user: {}", content);
-                info!("Nudging Lead about mobile message");
+                info!("Nudging Lead about user message");
                 if let Err(e) = state.coworkers.nudge_lead(&nudge_msg) {
-                    warn!("Failed to nudge Lead about mobile message: {}", e);
+                    warn!("Failed to nudge Lead about user message: {}", e);
                 }
             }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -408,20 +408,20 @@ async fn handle_client_message(text: &str, state: &Arc<WebState>) -> Result<(), 
 
     match msg {
         ClientMessage::SendMessage { content } => {
-            // Post message to channel as "mobile" user
+            // Post message to channel as "user"
             let channel = Channel::for_repo(&state.config.repo)
                 .map_err(|e| format!("Failed to open channel: {}", e))?;
 
-            let message = Message::text("mobile", &content);
+            let message = Message::text("user", &content);
             channel
                 .send(&message)
                 .map_err(|e| format!("Failed to send message: {}", e))?;
 
-            info!("Mobile user sent: {}", content);
+            info!("User sent: {}", content);
 
             // Broadcast the message to all connected clients
             let update = WebUpdate::ChannelMessage(ChannelMessageData {
-                from: "mobile".to_string(),
+                from: "user".to_string(),
                 content,
                 timestamp: message.timestamp.to_rfc3339(),
                 msg_type: "text".to_string(),


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Added a text input box at the bottom of the chat TUI — press `i` to type, Enter to send, Esc to cancel (vim-like UX)
- Renamed "mobile" sender to "user" in web.rs and daemon.rs since messages can now come from either the web app or the TUI
- Input box shows cursor position and visual focus state (cyan border when active)

## Test plan
- [ ] `cargo test` passes (67 bin tests + 15 doc tests)
- [ ] `cargo clippy` and `cargo fmt` pass
- [ ] Open the chat TUI — input box appears at bottom with "Press 'i' to type"
- [ ] Press `i` — border turns cyan, cursor appears, title shows key hints
- [ ] Type a message and press Enter — message posts to channel as "user"
- [ ] Press Esc — exits input mode without sending
- [ ] Arrow keys, Home, End, Backspace, Delete work for cursor movement
- [ ] Web app messages now show as "user" instead of "mobile"
- [ ] Daemon nudges Lead when "user" messages arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)