### PR TITLE
fix: Add grace period to prevent daemon from claiming newly created tasks

### DIFF
--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -864,7 +864,7 @@ mod tests {
 
         let now = SystemTime::now();
 
-        let tasks = vec![
+        let tasks = [
             // Sub-task just created by reviewing coworker (5 seconds ago)
             Task {
                 id: "471".to_string(),


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Fixes a race condition where the daemon's 30s polling tick claims newly-created review sub-tasks before the creating coworker sets ownership via TaskUpdate
- Adds a 45-second grace period using filesystem creation timestamps, so recently-created unowned tasks are skipped by `get_pending_tasks_without_owners()`
- Adds `created_at: Option<SystemTime>` field to `Task` struct, populated from file metadata in `read_tasks_from_dir`

## Root cause
When a coworker creates sub-tasks with `TaskCreate` (no owner), then calls `TaskUpdate` to set ownership, the daemon can poll between those two operations. It sees unowned tasks and assigns them to different coworkers, splitting the review pipeline across multiple coworkers (e.g., tasks #471→canal, #472→prince, #475→vernon for PR #246).

## Test plan
- [x] Added `test_grace_period_filters_recently_created_tasks` — verifies tasks within grace window are filtered, older tasks pass through
- [x] Added `test_grace_period_reproduces_split_bug` — simulates the exact scenario: recently-created sub-tasks are skipped, only older legitimately-unowned tasks are returned
- [x] All 203 lib tests pass
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.ai/code)