### PR TITLE
fix: Handle Unicode display width in TUI chat input cursor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,6 +1017,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "unicode-width 0.2.0",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ crossterm = { version = "0.29", features = ["event-stream"] }
 # Async file tailing for instant message updates
 tailf = "0.1"
 futures = "0.3"
+unicode-width = "0.2.0"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -256,12 +256,15 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                 KeyCode::Backspace => {
                     if app.input_cursor > 0 {
                         app.input_cursor -= 1;
-                        app.input_text.remove(app.input_cursor);
+                        let byte_idx = char_index_to_byte_index(&app.input_text, app.input_cursor);
+                        app.input_text.remove(byte_idx);
                     }
                 }
                 KeyCode::Delete => {
-                    if app.input_cursor < app.input_text.len() {
-                        app.input_text.remove(app.input_cursor);
+                    let char_count = app.input_text.chars().count();
+                    if app.input_cursor < char_count {
+                        let byte_idx = char_index_to_byte_index(&app.input_text, app.input_cursor);
+                        app.input_text.remove(byte_idx);
                     }
                 }
                 KeyCode::Left => {
@@ -270,7 +273,8 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                     }
                 }
                 KeyCode::Right => {
-                    if app.input_cursor < app.input_text.len() {
+                    let char_count = app.input_text.chars().count();
+                    if app.input_cursor < char_count {
                         app.input_cursor += 1;
                     }
                 }
@@ -278,10 +282,11 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                     app.input_cursor = 0;
                 }
                 KeyCode::End => {
-                    app.input_cursor = app.input_text.len();
+                    app.input_cursor = app.input_text.chars().count();
                 }
                 KeyCode::Char(c) => {
-                    app.input_text.insert(app.input_cursor, c);
+                    let byte_idx = char_index_to_byte_index(&app.input_text, app.input_cursor);
+                    app.input_text.insert(byte_idx, c);
                     app.input_cursor += 1;
                 }
                 _ => {}
@@ -317,4 +322,92 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
         _ => {}
     }
     EventResult::Continue
+}
+
+/// Convert a character index to a byte index within a string.
+///
+/// Returns the byte offset of the `n`th character. If `n` equals the character
+/// count, returns `s.len()` (the end of the string).
+fn char_index_to_byte_index(s: &str, char_idx: usize) -> usize {
+    s.char_indices()
+        .nth(char_idx)
+        .map(|(byte_idx, _)| byte_idx)
+        .unwrap_or(s.len())
+}
+
+/// Compute the display width of the first `char_count` characters in a string.
+///
+/// Uses Unicode display widths so that wide characters (emoji, CJK) count as
+/// 2 columns and combining marks count as 0.
+pub(crate) fn display_width_up_to(s: &str, char_count: usize) -> u16 {
+    use unicode_width::UnicodeWidthChar;
+    s.chars()
+        .take(char_count)
+        .map(|c| UnicodeWidthChar::width(c).unwrap_or(0))
+        .sum::<usize>() as u16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_char_index_to_byte_index_ascii() {
+        assert_eq!(char_index_to_byte_index("hello", 0), 0);
+        assert_eq!(char_index_to_byte_index("hello", 3), 3);
+        assert_eq!(char_index_to_byte_index("hello", 5), 5);
+    }
+
+    #[test]
+    fn test_char_index_to_byte_index_multibyte() {
+        // '界' is 3 bytes in UTF-8
+        let s = "界hello";
+        assert_eq!(char_index_to_byte_index(s, 0), 0); // start of '界'
+        assert_eq!(char_index_to_byte_index(s, 1), 3); // start of 'h'
+        assert_eq!(char_index_to_byte_index(s, 2), 4); // start of 'e'
+    }
+
+    #[test]
+    fn test_char_index_to_byte_index_emoji() {
+        // '🎉' is 4 bytes in UTF-8
+        let s = "a🎉b";
+        assert_eq!(char_index_to_byte_index(s, 0), 0); // 'a'
+        assert_eq!(char_index_to_byte_index(s, 1), 1); // '🎉'
+        assert_eq!(char_index_to_byte_index(s, 2), 5); // 'b'
+        assert_eq!(char_index_to_byte_index(s, 3), 6); // end
+    }
+
+    #[test]
+    fn test_display_width_ascii() {
+        assert_eq!(display_width_up_to("hello", 5), 5);
+        assert_eq!(display_width_up_to("hello", 3), 3);
+    }
+
+    #[test]
+    fn test_display_width_wide_chars() {
+        // CJK characters are 2 columns wide
+        assert_eq!(display_width_up_to("界", 1), 2);
+        assert_eq!(display_width_up_to("界hello", 1), 2);
+        assert_eq!(display_width_up_to("界hello", 2), 3); // 2 + 1
+    }
+
+    #[test]
+    fn test_display_width_emoji() {
+        // Emoji are typically 2 columns wide
+        assert_eq!(display_width_up_to("🎉", 1), 2);
+        assert_eq!(display_width_up_to("a🎉b", 1), 1); // just 'a'
+        assert_eq!(display_width_up_to("a🎉b", 2), 3); // 'a' + '🎉'
+        assert_eq!(display_width_up_to("a🎉b", 3), 4); // 'a' + '🎉' + 'b'
+    }
+
+    #[test]
+    fn test_display_width_mixed() {
+        // Mix of ASCII, CJK, and emoji
+        let s = "hi界🎉";
+        assert_eq!(display_width_up_to(s, 0), 0);
+        assert_eq!(display_width_up_to(s, 1), 1); // 'h'
+        assert_eq!(display_width_up_to(s, 2), 2); // 'h' + 'i'
+        assert_eq!(display_width_up_to(s, 3), 4); // 'h' + 'i' + '界'
+        assert_eq!(display_width_up_to(s, 4), 6); // 'h' + 'i' + '界' + '🎉'
+    }
 }

--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -730,7 +730,8 @@ fn draw_input_box(f: &mut Frame, app: &App, area: Rect) {
 
     // Show cursor when in input mode
     if app.input_mode {
-        f.set_cursor_position((inner.x + app.input_cursor as u16, inner.y));
+        let cursor_col = super::display_width_up_to(&app.input_text, app.input_cursor);
+        f.set_cursor_position((inner.x + cursor_col, inner.y));
     }
 }
 


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Fixes chat input cursor panicking on multi-byte characters (emoji, CJK) and rendering at wrong position for wide characters
- Tracks `input_cursor` as a character index instead of byte index
- Converts char index to byte index for `String::insert`/`String::remove` operations
- Uses `unicode-width` crate to compute correct display column width for cursor rendering

## Root cause
`input_cursor` was incremented by 1 per character but used as a byte index for `String::insert()`/`String::remove()`. For multi-byte characters (e.g. '界' = 3 bytes, '🎉' = 4 bytes), cursor position 1 would point inside a multi-byte sequence, causing a panic. The cursor rendering also assumed 1 char = 1 column, which is wrong for wide characters.

## Test plan
- [x] 7 unit tests for `char_index_to_byte_index` and `display_width_up_to` covering ASCII, multi-byte, emoji, CJK, and mixed text
- [x] All 278 tests pass (204 lib + 74 bin)
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.ai/code)