### PR TITLE
fix: Fetch recent chat history on websocket reconnect

### DIFF
--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -73,6 +73,8 @@ export function connectWebSocket() {
     if (reconnectTimeout) {
       clearTimeout(reconnectTimeout)
       reconnectTimeout = null
+      // Fetch recent history to get messages sent during disconnection
+      fetchHistory()
     }
   }
 


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Fixes the web UI to fetch recent chat history when the websocket reconnects
- Messages sent during disconnection are now visible after reconnect
- Uses the existing `reconnectTimeout` variable to detect reconnection vs initial connection

## Test plan
- [x] Cargo tests pass
- [x] Clippy passes
- [x] Format check passes
- [ ] Manual test: Open web UI, disconnect server briefly, reconnect - chat history should repopulate

🤖 Generated with [Claude Code](https://claude.com/claude-code)