### PR TITLE
feat: Move kanban above tabs and add repo status bar

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -228,6 +228,103 @@ async fn api_channel_history(
     Ok(axum::Json(response))
 }
 
+/// CI status for the repository
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CiStatus {
+    Passed,
+    Failed,
+    Running,
+    Unknown,
+}
+
+/// Repository status information (commit, CI, release)
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct RepoStatus {
+    pub commit_hash: String,
+    pub commit_time: Option<String>,
+    pub ci_status: Option<CiStatus>,
+    pub release_tag: Option<String>,
+    pub release_time: Option<String>,
+}
+
+/// Fetch repository status via gh CLI
+fn fetch_repo_status() -> RepoStatus {
+    let mut status = RepoStatus::default();
+
+    // Fetch latest commit on default branch
+    if let Ok(output) = std::process::Command::new("gh")
+        .args([
+            "api",
+            "repos/{owner}/{repo}/commits/{branch}",
+            "--jq",
+            r#"{sha: .sha[0:7], date: .commit.author.date}"#,
+        ])
+        .output()
+        && output.status.success()
+    {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if let Ok(data) = serde_json::from_str::<serde_json::Value>(&stdout) {
+            if let Some(sha) = data.get("sha").and_then(|v| v.as_str()) {
+                status.commit_hash = sha.to_string();
+            }
+            if let Some(date_str) = data.get("date").and_then(|v| v.as_str()) {
+                status.commit_time = Some(date_str.to_string());
+            }
+        }
+    }
+
+    // Fetch CI status from latest workflow run on main branch
+    if let Ok(output) = std::process::Command::new("gh")
+        .args([
+            "api",
+            "repos/{owner}/{repo}/actions/runs?branch=main&per_page=1",
+            "--jq",
+            ".workflow_runs[0] | {status: .status, conclusion: .conclusion}",
+        ])
+        .output()
+        && output.status.success()
+    {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if let Ok(data) = serde_json::from_str::<serde_json::Value>(&stdout) {
+            let run_status = data.get("status").and_then(|v| v.as_str()).unwrap_or("");
+            let conclusion = data.get("conclusion").and_then(|v| v.as_str());
+
+            status.ci_status = Some(match (run_status, conclusion) {
+                ("completed", Some("success")) => CiStatus::Passed,
+                ("completed", Some("failure")) => CiStatus::Failed,
+                ("completed", Some("cancelled")) => CiStatus::Failed,
+                ("in_progress", _) | ("queued", _) | ("waiting", _) => CiStatus::Running,
+                _ => CiStatus::Unknown,
+            });
+        }
+    }
+
+    // Fetch latest release
+    if let Ok(output) = std::process::Command::new("gh")
+        .args([
+            "api",
+            "repos/{owner}/{repo}/releases/latest",
+            "--jq",
+            "{tag: .tag_name, published_at: .published_at}",
+        ])
+        .output()
+        && output.status.success()
+    {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if let Ok(data) = serde_json::from_str::<serde_json::Value>(&stdout) {
+            if let Some(tag) = data.get("tag").and_then(|v| v.as_str()) {
+                status.release_tag = Some(tag.to_string());
+            }
+            if let Some(date_str) = data.get("published_at").and_then(|v| v.as_str()) {
+                status.release_time = Some(date_str.to_string());
+            }
+        }
+    }
+
+    status
+}
+
 /// Get daemon/coworker status including tasks and PRs for kanban board
 async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoResponse, StatusCode> {
     // Read tasks directly from Claude Code task storage
@@ -348,12 +445,19 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
         })
         .unwrap_or_default();
 
+    // Fetch repo status (blocking I/O)
+    let repo_status = tokio::task::spawn_blocking(fetch_repo_status)
+        .await
+        .unwrap_or_default();
+
     let status = serde_json::json!({
         "daemon": "running",
         "coworkers": coworkers_data,
         "tasks": tasks,
         "pull_requests": pull_requests,
         "merged_prs": merged_prs,
+        "repo_name": state.config.repo,
+        "repo_status": repo_status,
     });
 
     Ok(axum::Json(status))

--- a/web-app/src/App.svelte
+++ b/web-app/src/App.svelte
@@ -28,6 +28,8 @@
     </span>
   </header>
 
+  <Kanban />
+
   <nav>
     <button
       class:active={activeTab === 'channel'}
@@ -48,8 +50,6 @@
       Tmux
     </button>
   </nav>
-
-  <Kanban />
 
   <div class="content">
     {#if activeTab === 'channel'}

--- a/web-app/src/lib/Kanban.svelte
+++ b/web-app/src/lib/Kanban.svelte
@@ -1,9 +1,48 @@
 <script>
-  import { kanbanData } from './store.js'
+  import { kanbanData, repoStatus } from './store.js'
 
   const repoUrl = 'https://github.com/btucker/midtown'
 
   let expanded = $state(false)
+
+  // Format relative time for display (e.g., "3m", "2h", "1d")
+  function formatRelativeTime(timestamp) {
+    if (!timestamp) return ''
+    try {
+      const date = new Date(timestamp)
+      const now = new Date()
+      const diffMs = now - date
+      const diffMins = Math.floor(diffMs / 60000)
+
+      if (diffMins < 1) return '<1m'
+      if (diffMins < 60) return `${diffMins}m`
+      const diffHours = Math.floor(diffMins / 60)
+      if (diffHours < 24) return `${diffHours}h`
+      const diffDays = Math.floor(diffHours / 24)
+      return `${diffDays}d`
+    } catch {
+      return ''
+    }
+  }
+
+  // CI status dot color
+  function ciStatusColor(status) {
+    switch (status) {
+      case 'passed':
+        return '#4ade80'
+      case 'failed':
+        return '#ef4444'
+      case 'running':
+        return '#fbbf24'
+      default:
+        return '#666'
+    }
+  }
+
+  // CI status dot character
+  function ciStatusDot(status) {
+    return status && status !== 'unknown' ? '●' : '○'
+  }
   let selectedItem = $state(null)
 
   function toggleExpand() {
@@ -67,7 +106,23 @@
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div class="kanban-header" onclick={toggleExpand}>
-    <span class="kanban-title">Kanban</span>
+    <div class="repo-status">
+      <span class="repo-name">{$repoStatus.repoName || 'midtown'}</span>
+      {#if $repoStatus.commitHash}
+        <span class="commit-hash">{$repoStatus.commitHash}</span>
+        {#if $repoStatus.commitTime}
+          <span class="commit-time">{formatRelativeTime($repoStatus.commitTime)}</span>
+        {/if}
+      {/if}
+      <span class="ci-status" style="color: {ciStatusColor($repoStatus.ciStatus)}">{ciStatusDot($repoStatus.ciStatus)}</span>
+      {#if $repoStatus.releaseTag}
+        <span class="release-label">Releases:</span>
+        <span class="release-tag">{$repoStatus.releaseTag}</span>
+        {#if $repoStatus.releaseTime}
+          <span class="release-time">{formatRelativeTime($repoStatus.releaseTime)}</span>
+        {/if}
+      {/if}
+    </div>
     <span class="chevron" class:expanded>▲</span>
   </div>
 
@@ -243,11 +298,47 @@
     background: #1a2744;
   }
 
-  .kanban-title {
+  .repo-status {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     font-size: 0.7rem;
+    overflow: hidden;
+  }
+
+  .repo-name {
+    color: #666;
+    flex-shrink: 0;
+  }
+
+  .commit-hash {
+    color: #fbbf24;
+    font-family: ui-monospace, monospace;
+    flex-shrink: 0;
+  }
+
+  .commit-time {
+    color: #666;
+    flex-shrink: 0;
+  }
+
+  .ci-status {
+    flex-shrink: 0;
+  }
+
+  .release-label {
+    color: #666;
+    flex-shrink: 0;
+  }
+
+  .release-tag {
     color: #00d9ff;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+    flex-shrink: 0;
+  }
+
+  .release-time {
+    color: #666;
+    flex-shrink: 0;
   }
 
   .chevron {

--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -1,4 +1,11 @@
-import { messages, connected, coworkers, daemonStatus, kanbanData } from './store.js'
+import {
+  messages,
+  connected,
+  coworkers,
+  daemonStatus,
+  kanbanData,
+  repoStatus,
+} from './store.js'
 
 let ws = null
 let reconnectTimeout = null
@@ -27,6 +34,7 @@ export async function fetchStatus() {
       daemonStatus.set(data)
       coworkers.set(data.coworkers || [])
       updateKanbanData(data)
+      updateRepoStatus(data)
     }
   } catch (err) {
     console.error('Failed to fetch status:', err)
@@ -52,6 +60,18 @@ function updateKanbanData(data) {
       title: pr.title,
       mergedAt: pr.mergedAt,
     })),
+  })
+}
+
+function updateRepoStatus(data) {
+  const rs = data.repo_status || {}
+  repoStatus.set({
+    repoName: data.repo_name || '',
+    commitHash: rs.commit_hash || '',
+    commitTime: rs.commit_time || null,
+    ciStatus: rs.ci_status || null,
+    releaseTag: rs.release_tag || null,
+    releaseTime: rs.release_time || null,
   })
 }
 

--- a/web-app/src/lib/store.js
+++ b/web-app/src/lib/store.js
@@ -19,3 +19,13 @@ export const kanbanData = writable({
   review: [],
   done: [],
 })
+
+// Repository status (commit, CI, release)
+export const repoStatus = writable({
+  repoName: '',
+  commitHash: '',
+  commitTime: null,
+  ciStatus: null,
+  releaseTag: null,
+  releaseTime: null,
+})


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Moves the kanban board above the tab navigation in the web UI (flips the order)
- Replaces the "Kanban" header text with a repo status bar showing:
  - Repository name (dim)
  - Latest commit hash (yellow) with relative time
  - CI status dot (green/yellow/red based on status)
  - Latest release tag (cyan) with relative time
- Adds `repo_name` and `repo_status` fields to the `/api/status` endpoint
- Backend fetches repo status via `gh api` calls (same as TUI)

This brings the web UI layout closer to the TUI experience.

## Test plan
- [x] Cargo tests pass
- [x] Clippy passes
- [x] Format check passes
- [ ] Manual test: Verify kanban appears above tabs
- [ ] Manual test: Verify repo status bar shows commit hash, CI dot, release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)