### PR TITLE
fix(web-ui): show coworker name instead of GitHub username for reviews

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -259,7 +259,7 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
                 "pr",
                 "list",
                 "--json",
-                "number,title,author,state,isDraft,reviewDecision",
+                "number,title,author,state,isDraft,reviewDecision,createdAt",
             ])
             .output();
         match output {
@@ -293,14 +293,18 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
                     _ => "open",
                 }
             };
-            // Look up reviewer from persistent state
-            let reviewer = github_state.get_reviewer(pr_number);
+            // Look up reviewer assignment from persistent state
+            let assignment = github_state.pr_reviewers.get(&pr_number);
+            let reviewer = assignment.map(|a| a.reviewer.as_str());
+            let reviewer_assigned_at = assignment.map(|a| a.assigned_at.to_rfc3339());
             serde_json::json!({
                 "number": pr_number,
                 "title": pr.get("title").and_then(|t| t.as_str()).unwrap_or(""),
                 "author": pr.get("author").and_then(|a| a.get("login")).and_then(|l| l.as_str()).unwrap_or("unknown"),
                 "status": status,
                 "reviewer": reviewer,
+                "reviewer_assigned_at": reviewer_assigned_at,
+                "created_at": pr.get("createdAt").and_then(|c| c.as_str()),
             })
         })
         .collect();

--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -46,6 +46,9 @@ function updateKanbanData(data) {
       title: pr.title,
       author: pr.author,
       status: pr.status,
+      reviewer: pr.reviewer,
+      reviewer_assigned_at: pr.reviewer_assigned_at,
+      created_at: pr.created_at,
     })),
     done: mergedPrs.slice(0, 10).map((pr) => ({
       number: pr.number,


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Fix web UI not displaying reviewer names for PRs in the Review column
- Add timestamp fields (created_at, reviewer_assigned_at) for better context

## Changes

**Backend (src/web.rs):**
- Add `createdAt` to GitHub API request for PR creation timestamps
- Extract full `PrReviewerAssignment` to include the `assigned_at` timestamp
- Include `reviewer_assigned_at` and `created_at` in API response

**Frontend (web-app/src/lib/api.js):**
- Pass `reviewer`, `reviewer_assigned_at`, and `created_at` fields through to the kanban store

## Root Cause
The `updateKanbanData` function was mapping PR data but not including the `reviewer` field. The backend was correctly sending coworker names from `GitHubState`, but the frontend was dropping them during the mapping.

## Test plan
- [x] All Rust tests pass (212 tests)
- [x] Code compiles without warnings (clippy)
- [x] Pre-commit hooks pass (fmt)
- [ ] Manual verification: view web UI and confirm reviewer names appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)