### PR TITLE
feat: Add LEAD.md & COWORKER.md support for custom system prompts

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -163,14 +163,14 @@ fn load_custom_prompt_files(filename: &str) -> String {
 /// `~/.midtown/projects/<repo>/LEAD.md` is appended if present.
 pub fn lead_system_prompt() -> String {
     let lead = load_prompt_file("lead.md").unwrap_or_else(|| DEFAULT_LEAD_PROMPT.to_string());
-    let common = common_prompt().replace("{name}", "Lead");
+    let common = common_prompt();
     let custom = load_custom_prompt_files("LEAD.md");
 
     let mut prompt = format!("{lead}\n{common}");
     if !custom.is_empty() {
         prompt = format!("{prompt}\n\n{custom}");
     }
-    prompt
+    prompt.replace("{name}", "Lead")
 }
 
 /// Load the coworker agent's system prompt with name substitution.


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Add support for LEAD.md and COWORKER.md files that get appended to the respective system prompts
- Global files: `~/.midtown/LEAD.md` and `~/.midtown/COWORKER.md`
- Project files: `~/.midtown/projects/<repo>/LEAD.md` and `~/.midtown/projects/<repo>/COWORKER.md`
- Both locations are checked in order; content from both is concatenated if present

## How it works
The `load_custom_prompt_files()` function loads and concatenates content from global and project-level locations. This content is then appended to the base prompts in `lead_system_prompt()` and `coworker_system_prompt()`.

## Test plan
- [x] All existing tests pass (215 tests)
- [x] New tests verify behavior when custom files don't exist
- [x] New tests verify the load function returns empty string for nonexistent files
- [x] Manual testing: prompts work correctly without custom files (no regressions)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)