### PR TITLE
fix: Use configured binary for chat pane restart

### DIFF
--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -620,15 +620,11 @@ pub fn handle_restart() -> Result<Response, String> {
         // Brief pause for the process to terminate
         std::thread::sleep(std::time::Duration::from_millis(100));
 
-        // Restart the chat with cargo run --release
+        // Restart the chat using the configured binary
+        let bin_command = midtown::config::get_bin_command();
+        let chat_cmd = format!("{} chat", bin_command);
         let _ = Command::new("tmux")
-            .args([
-                "send-keys",
-                "-t",
-                &chat_pane,
-                "cargo run --release -- chat",
-                "Enter",
-            ])
+            .args(["send-keys", "-t", &chat_pane, &chat_cmd, "Enter"])
             .status();
     }
 


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Fixed `handle_restart()` to use `get_bin_command()` instead of hardcoded `cargo run --release -- chat`
- Aligns chat restart behavior with initial chat pane creation, which already used the configured binary

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` passes  
- [x] `cargo fmt` passes
- [ ] Manual: run `midtown restart` and verify chat pane restarts with `midtown chat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)