### PR TITLE
fix: Recognize active PR reviewers as not idle in daemon

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4255,8 +4255,8 @@ mod tests {
         tracker.assign(44, "lexington"); // duplicate reviewer
 
         let reviewers = tracker.active_reviewers();
-        assert!(reviewers.contains(&"lexington".to_string()));
-        assert!(reviewers.contains(&"park".to_string()));
+        assert!(reviewers.contains("lexington"));
+        assert!(reviewers.contains("park"));
         // Should deduplicate
         assert_eq!(reviewers.len(), 2);
     }
@@ -4271,8 +4271,8 @@ mod tests {
         tracker.mark_reviewed(42);
 
         let reviewers = tracker.active_reviewers();
-        assert!(!reviewers.contains(&"lexington".to_string()));
-        assert!(reviewers.contains(&"park".to_string()));
+        assert!(!reviewers.contains("lexington"));
+        assert!(reviewers.contains("park"));
         assert_eq!(reviewers.len(), 1);
     }
 


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Fixed bug where daemon incorrectly marked active PR reviewers as idle because reviewers use isolated task lists that don't appear in the shared task list
- Added `active_reviewers()` method to `PrReviewTracker` that returns the set of coworkers with active review assignments (within the 10-minute timeout window)
- Updated `check_and_shutdown_idle_coworkers` to check the review tracker alongside task list and open PR checks

## Test plan
- [x] Added unit test for `active_reviewers()` with duplicate reviewer deduplication
- [x] Added unit test for `active_reviewers()` after `mark_reviewed()` removes assignment
- [x] All 214 existing lib tests pass
- [x] Build clean, clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)