### PR TITLE
fix: Instruct review coworkers to post /me status before starting review

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2007,10 +2007,8 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
 
                 // Nudge the new reviewer to run /code-review:code-review
                 let nudge_msg = format!(
-                    "Please review PR #{}: {}. Run: /code-review:code-review {}",
-                    pr_number,
-                    truncate_str(title, 50),
-                    pr_number
+                    "First, post a /me status update: `midtown channel post \"/me reviewing PR #{}\"` — then run: /code-review:code-review {}",
+                    pr_number, pr_number
                 );
 
                 match state.coworkers.nudge(&new_coworker, &nudge_msg) {


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Modified the daemon's reviewer nudge message to instruct coworkers to post a `/me reviewing PR #X` status update before running the code review skill
- This prevents false idle detection from killing reviewers before they start processing

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes
- [x] Verified nudge message format is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)