### PR TITLE
feat: Speed up reviewer spawning for PRs

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -64,8 +64,8 @@ pub const DEFAULT_WEBHOOK_RESTART_INTERVAL_SECS: u64 = 300;
 /// Default port for the webhook server (obscure to avoid conflicts)
 pub const DEFAULT_WEBHOOK_PORT: u16 = 47022;
 
-/// Default interval for polling PRs (1 minute)
-pub const DEFAULT_PR_POLL_INTERVAL_SECS: u64 = 60;
+/// Default interval for polling PRs (30 seconds)
+pub const DEFAULT_PR_POLL_INTERVAL_SECS: u64 = 30;
 
 /// Minimum time between nudging the same PR issue (10 minutes)
 pub const PR_NUDGE_COOLDOWN_SECS: u64 = 600;
@@ -342,9 +342,9 @@ pub struct PrReviewTracker {
     assigned: HashMap<u64, (String, Instant)>,
 }
 
-/// How long to wait after PR is opened before auto-reviewing (2 minutes)
+/// How long to wait after PR is opened before auto-reviewing (1 minute)
 /// This gives CI time to start and allows the author to add context.
-pub const PR_REVIEW_DELAY_SECS: u64 = 120;
+pub const PR_REVIEW_DELAY_SECS: u64 = 60;
 
 /// How long a review assignment is valid before it can be reassigned (10 minutes)
 /// Re-exported from github_state for use by the in-memory tracker.
@@ -736,6 +736,14 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                     let state = Arc::clone(&state);
                     tokio::spawn(async move {
                         handle_pr_comment_nudge(&state, activity).await;
+                    });
+                }
+
+                // Schedule immediate (after delay) reviewer spawn for new PRs
+                if let Some(pr_number) = webhook_event.needs_review {
+                    let state = Arc::clone(&state);
+                    tokio::spawn(async move {
+                        handle_webhook_review_spawn(&state, pr_number).await;
                     });
                 }
 
@@ -2067,6 +2075,68 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
             reviews_spawned
         );
     }
+}
+
+/// Handle webhook-triggered reviewer spawning for a newly opened or ready-for-review PR.
+///
+/// Waits the review delay, then fetches the PR data and spawns a reviewer if eligible.
+/// This bypasses the polling interval so reviewers start sooner after a PR is opened.
+async fn handle_webhook_review_spawn(state: &DaemonState, pr_number: u64) {
+    info!(
+        "Webhook: PR #{} needs review, waiting {}s before spawning reviewer",
+        pr_number, PR_REVIEW_DELAY_SECS
+    );
+    tokio::time::sleep(Duration::from_secs(PR_REVIEW_DELAY_SECS)).await;
+
+    // Fetch this specific PR's data
+    let output = match tokio::process::Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &pr_number.to_string(),
+            "--json",
+            "number,mergeable,statusCheckRollup,headRefName,reviewDecision,title,isDraft,createdAt,state",
+        ])
+        .output()
+        .await
+    {
+        Ok(output) => output,
+        Err(e) => {
+            warn!(
+                "Webhook: Failed to fetch PR #{} for review spawn: {}",
+                pr_number, e
+            );
+            return;
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        warn!("Webhook: gh pr view #{} failed: {}", pr_number, stderr);
+        return;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let pr: serde_json::Value = match serde_json::from_str(&stdout) {
+        Ok(pr) => pr,
+        Err(e) => {
+            warn!("Webhook: Failed to parse PR #{} JSON: {}", pr_number, e);
+            return;
+        }
+    };
+
+    // Check the PR is still open
+    let pr_state = pr.get("state").and_then(|s| s.as_str()).unwrap_or("");
+    if pr_state != "OPEN" {
+        debug!(
+            "Webhook: PR #{} is no longer open (state={}), skipping review",
+            pr_number, pr_state
+        );
+        return;
+    }
+
+    // Reuse the existing spawn logic (handles draft check, assignment dedup, etc.)
+    spawn_reviewers_for_prs(state, &[pr]).await;
 }
 
 /// Detect actionable issues for a PR.

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -47,6 +47,8 @@ pub struct WebhookEvent {
     pub message: Message,
     /// Structured PR activity data (if this event relates to a PR)
     pub pr_activity: Option<PrActivity>,
+    /// PR number that needs a reviewer spawned (set on "opened" / "ready_for_review")
+    pub needs_review: Option<u64>,
 }
 
 /// Structured data about PR-related webhook activity.
@@ -280,6 +282,8 @@ struct PullRequest {
     merged: Option<bool>,
     head: Option<PullRequestHead>,
     body: Option<String>,
+    #[serde(default)]
+    draft: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -526,10 +530,19 @@ fn handle_pull_request(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json::
         _ => return Ok(None),
     };
 
+    // Trigger immediate reviewer spawn for non-draft PRs that are opened or
+    // marked ready for review. Draft PRs and other actions don't need review.
+    let needs_review = match event.action.as_str() {
+        "opened" if !event.pull_request.draft => Some(event.number),
+        "ready_for_review" => Some(event.number),
+        _ => None,
+    };
+
     let content = format!("{}{}", mention, action_text);
     Ok(Some(WebhookEvent {
         message: Message::new("github", content, MessageType::Text),
         pr_activity: None,
+        needs_review,
     }))
 }
 
@@ -570,6 +583,7 @@ fn handle_pull_request_review(body: &[u8]) -> Result<Option<WebhookEvent>, serde
             owner_coworker: coworker.map(|s| s.to_string()),
             actor: event.review.user.login,
         }),
+        needs_review: None,
     }))
 }
 
@@ -606,6 +620,7 @@ fn handle_issue_comment(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json:
             owner_coworker: None,
             actor: commenter,
         }),
+        needs_review: None,
     }))
 }
 
@@ -642,6 +657,7 @@ fn handle_review_comment(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json
             owner_coworker: coworker.map(|s| s.to_string()),
             actor: commenter,
         }),
+        needs_review: None,
     }))
 }
 
@@ -681,6 +697,7 @@ fn handle_status(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json::Error>
     Ok(Some(WebhookEvent {
         message: Message::new("github", content, MessageType::Text),
         pr_activity: None,
+        needs_review: None,
     }))
 }
 
@@ -724,6 +741,7 @@ fn handle_check_run(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json::Err
     Ok(Some(WebhookEvent {
         message: Message::new("github", content, MessageType::Text),
         pr_activity: None,
+        needs_review: None,
     }))
 }
 
@@ -808,6 +826,32 @@ mod tests {
         );
         // Sender is always "github"
         assert_eq!(event.message.from, "github");
+        // Non-draft opened PR triggers review spawn
+        assert_eq!(event.needs_review, Some(42));
+    }
+
+    #[test]
+    fn test_handle_pull_request_opened_draft_no_review() {
+        let payload = r#"{
+            "action": "opened",
+            "number": 42,
+            "pull_request": {
+                "title": "WIP: Add auth endpoint",
+                "user": {"login": "btucker"},
+                "merged": false,
+                "draft": true,
+                "head": {"ref": "lexington/add-auth"}
+            },
+            "repository": {"full_name": "org/repo"}
+        }"#;
+
+        let event = handle_pull_request(payload.as_bytes()).unwrap().unwrap();
+        assert_eq!(
+            event.message.content,
+            "@lexington opened PR #42: WIP: Add auth endpoint"
+        );
+        // Draft PRs should NOT trigger review spawn
+        assert_eq!(event.needs_review, None);
     }
 
     #[test]
@@ -855,6 +899,8 @@ mod tests {
             "@lexington merged PR #42: Add auth endpoint"
         );
         assert_eq!(event.message.from, "github");
+        // Merged PRs should NOT trigger review spawn
+        assert_eq!(event.needs_review, None);
     }
 
     #[test]
@@ -876,6 +922,8 @@ mod tests {
         // No @mention when no coworker is identified
         assert_eq!(event.message.content, "opened PR #42: Add auth endpoint");
         assert_eq!(event.message.from, "github");
+        // Non-draft opened PR still triggers review even without coworker match
+        assert_eq!(event.needs_review, Some(42));
     }
 
     #[test]


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Reduce `PR_REVIEW_DELAY_SECS` from 120s to 60s (1 min is enough for CI to start)
- Reduce `DEFAULT_PR_POLL_INTERVAL_SECS` from 60s to 30s
- Add webhook-triggered reviewer spawning: when a PR is opened or marked ready-for-review, immediately schedule a delayed reviewer spawn instead of waiting for the next poll cycle

This reduces worst-case reviewer spawn time from ~3 minutes (60s poll + 120s delay) to ~60s (webhook fires immediately + 60s delay). The polling path still works as a fallback.

## Changes
- **daemon.rs**: Reduced constants, added `handle_webhook_review_spawn()` that sleeps for the review delay then fetches and spawns for a specific PR, wired into the main event loop
- **webhook.rs**: Added `needs_review` field to `WebhookEvent`, set on `opened` (non-draft) and `ready_for_review` actions. Added `draft` field to `PullRequest` struct.

## Test plan
- [x] All 237 unit tests pass (including new `test_handle_pull_request_opened_draft_no_review`)
- [x] Clippy clean, formatting clean
- [x] Draft PRs correctly excluded from webhook-triggered review
- [x] Merged/closed PR actions don't set `needs_review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)