### PR TITLE
fix: Preserve daemon logs across restarts with append mode and panic hook

### DIFF
--- a/src/bin/midtown/main.rs
+++ b/src/bin/midtown/main.rs
@@ -201,20 +201,38 @@ fn main() {
             let stdout_path = log_dir.join("daemon.out");
             let stderr_path = log_dir.join("daemon.err");
 
-            let stdout = match std::fs::File::create(&stdout_path) {
+            let stdout = match std::fs::File::options()
+                .append(true)
+                .create(true)
+                .open(&stdout_path)
+            {
                 Ok(f) => f,
                 Err(e) => {
-                    eprintln!("Failed to create stdout log: {}", e);
+                    eprintln!("Failed to open stdout log: {}", e);
                     std::process::exit(1);
                 }
             };
-            let stderr = match std::fs::File::create(&stderr_path) {
+            let stderr = match std::fs::File::options()
+                .append(true)
+                .create(true)
+                .open(&stderr_path)
+            {
                 Ok(f) => f,
                 Err(e) => {
-                    eprintln!("Failed to create stderr log: {}", e);
+                    eprintln!("Failed to open stderr log: {}", e);
                     std::process::exit(1);
                 }
             };
+
+            // Write startup separator to both logs so runs are distinguishable
+            use std::io::Write;
+            let separator = format!(
+                "\n=== Daemon started at {} ===\n",
+                chrono::Local::now().format("%Y-%m-%d %H:%M:%S")
+            );
+            // Best-effort writes; if these fail, the daemon will still start
+            let _ = (&stdout).write_all(separator.as_bytes());
+            let _ = (&stderr).write_all(separator.as_bytes());
 
             // Note: We don't use daemonize's pid_file feature because we have
             // our own PID file with flock-based locking for singleton enforcement.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -559,6 +559,16 @@ fn acquire_pid_lock(pid_path: &PathBuf) -> crate::Result<File> {
 /// This function will block until the daemon receives a shutdown signal
 /// (SIGTERM or SIGINT) or the socket is removed.
 pub async fn run(config: DaemonConfig) -> crate::Result<()> {
+    // Install panic hook so unhandled panics are logged to stderr before aborting
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        eprintln!(
+            "=== DAEMON PANIC at {} ===",
+            chrono::Local::now().format("%Y-%m-%d %H:%M:%S")
+        );
+        default_hook(info);
+    }));
+
     // Initialize logging
     let filter = if config.verbose { "debug" } else { "info" };
     tracing_subscriber::fmt()


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Changed `File::create` to `File::options().append(true).create(true).open()` for daemon stdout/stderr logs so crash evidence is preserved across restarts
- Added timestamped startup separator (`=== Daemon started at {time} ===`) to both log files so runs are distinguishable
- Installed a `panic::set_hook` in `daemon::run()` that timestamps and logs unhandled panics to stderr before the default hook runs

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes  
- [x] All 236 unit tests pass
- [ ] Manual: restart daemon and verify `daemon.err` contains previous run's output plus new separator

🤖 Generated with [Claude Code](https://claude.com/claude-code)