### PR TITLE
fix: Replace blocking_lock() with async lock().await in idle shutdown path

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -964,16 +964,19 @@ async fn check_and_shutdown_idle_coworkers(state: &DaemonState) {
         // For isolated coworkers (reviewers), verify the review was actually posted
         let (should_shutdown, shutdown_msg) = if is_isolated {
             // Look up the PR this reviewer was assigned to
+            // Try in-memory tracker first
             let pr_number = {
-                // Try in-memory tracker first
                 let tracker = state.pr_review_tracker.lock().await;
                 tracker.pr_for_coworker(&name)
-            }
-            .or_else(|| {
-                // Fall back to persistent state
-                let github_state = state.github_state.blocking_lock();
-                github_state.pr_for_reviewer(&name)
-            });
+            };
+            let pr_number = match pr_number {
+                Some(pr) => Some(pr),
+                None => {
+                    // Fall back to persistent state
+                    let github_state = state.github_state.lock().await;
+                    github_state.pr_for_reviewer(&name)
+                }
+            };
 
             match pr_number {
                 Some(pr) => {


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Fixed daemon crash when auto-shutting down idle reviewer coworkers
- Replaced `state.github_state.blocking_lock()` with `state.github_state.lock().await` at daemon.rs:974
- Restructured `.or_else()` into a `match` pattern to support the async `.await` call

## Problem
The daemon panicked with "Cannot block the current thread from within a runtime" when the idle shutdown check tried to look up a reviewer's PR in persistent state using `blocking_lock()` inside the async idle check loop.

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] No remaining `blocking_lock` usages in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)