### PR TITLE
fix: Reduce task check interval from 10s to 5s

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -242,8 +242,8 @@ const CHANNEL_ROTATION_MAX_AGE_HOURS: u64 = 24;
 /// How many minutes of recent messages to retain after rotation (60 minutes)
 const CHANNEL_ROTATION_RETAIN_MINUTES: i64 = 60;
 
-/// Interval for checking orphaned tasks (10 seconds)
-const ORPHAN_CHECK_INTERVAL_SECS: u64 = 10;
+/// Interval for checking orphaned tasks (5 seconds)
+const ORPHAN_CHECK_INTERVAL_SECS: u64 = 5;
 
 /// Minimum time a coworker must be alive before auto-shutdown (5 minutes)
 /// This prevents spawn storms where coworkers are rapidly spawned and killed.


### PR DESCRIPTION
## Summary
- Reduces `ORPHAN_CHECK_INTERVAL_SECS` from 10s to 5s for faster coworker spawning when pending tasks appear.

## Test plan
- [ ] `cargo test` passes
- [ ] Restart daemon, create a task, verify coworker spawns within ~5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)