### PR TITLE
feat: Nudge discovered orphaned coworkers to continue their tasks

### DIFF
--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -84,6 +84,9 @@ pub struct CoworkerManager {
     worktree_manager: Arc<WorktreeManager>,
     /// The tmux session name for the project (e.g., "midtown-projectname")
     session_name: String,
+    /// Names of coworkers discovered from tmux on startup (before daemon was managing them).
+    /// Used to nudge them to continue their tasks after daemon restart.
+    discovered_on_startup: Arc<RwLock<Vec<String>>>,
 }
 
 impl CoworkerManager {
@@ -98,11 +101,17 @@ impl CoworkerManager {
             coworkers: Arc::new(RwLock::new(HashMap::new())),
             worktree_manager: Arc::new(worktree_manager),
             session_name: session,
+            discovered_on_startup: Arc::new(RwLock::new(Vec::new())),
         };
 
         // Discover existing coworkers from tmux on startup
-        if let Err(e) = manager.discover_existing() {
-            tracing::warn!("Failed to discover existing coworkers: {}", e);
+        match manager.discover_existing() {
+            Ok(names) => {
+                *manager.discovered_on_startup.write().unwrap() = names;
+            }
+            Err(e) => {
+                tracing::warn!("Failed to discover existing coworkers: {}", e);
+            }
         }
 
         manager
@@ -113,11 +122,23 @@ impl CoworkerManager {
         &self.session_name
     }
 
+    /// Take the list of coworker names discovered from tmux on startup.
+    ///
+    /// This drains the list so it can only be consumed once. The daemon uses
+    /// this to nudge discovered coworkers to continue their assigned tasks
+    /// after a daemon restart.
+    pub fn take_discovered_on_startup(&self) -> Vec<String> {
+        std::mem::take(&mut *self.discovered_on_startup.write().unwrap())
+    }
+
     /// Discover existing coworker windows from tmux and add them to tracking.
     ///
     /// This is called on startup to recover coworkers that were running before
     /// the daemon was restarted. The coworkers continue running uninterrupted.
-    fn discover_existing(&self) -> crate::Result<()> {
+    ///
+    /// Returns the names of discovered coworkers so the daemon can nudge them
+    /// to continue their assigned tasks.
+    fn discover_existing(&self) -> crate::Result<Vec<String>> {
         // Get all known coworker names
         let all_names: std::collections::HashSet<&str> = AVENUE_NAMES
             .iter()
@@ -130,11 +151,11 @@ impl CoworkerManager {
             Ok(w) => w,
             Err(_) => {
                 // Session might not exist yet, that's OK
-                return Ok(());
+                return Ok(Vec::new());
             }
         };
 
-        let mut discovered = 0;
+        let mut discovered_names = Vec::new();
         let mut coworkers = self.coworkers.write().unwrap();
 
         for window_name in windows {
@@ -169,18 +190,18 @@ impl CoworkerManager {
             };
 
             coworkers.insert(window_name.clone(), coworker);
-            discovered += 1;
+            discovered_names.push(window_name.clone());
             tracing::info!("Discovered existing coworker: {}", window_name);
         }
 
-        if discovered > 0 {
+        if !discovered_names.is_empty() {
             tracing::info!(
                 "Discovered {} existing coworker(s) from tmux session",
-                discovered
+                discovered_names.len()
             );
         }
 
-        Ok(())
+        Ok(discovered_names)
     }
 
     /// Get a randomly selected available avenue name.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -724,6 +724,15 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
     // Skip the first tick (which fires immediately)
     channel_rotation_interval.tick().await;
 
+    // Nudge any coworkers discovered from tmux to continue their tasks.
+    // This runs once at startup after the daemon has fully initialized.
+    {
+        let state = Arc::clone(&state);
+        tokio::spawn(async move {
+            nudge_discovered_coworkers(&state).await;
+        });
+    }
+
     // Main accept loop
     loop {
         let shutdown_rx = shutdown_tx.subscribe();
@@ -3677,6 +3686,122 @@ async fn check_and_recover_orphans(state: &DaemonState) {
                 }
             }
         }
+    }
+}
+
+/// Nudge coworkers that were discovered from tmux on daemon startup.
+///
+/// After a daemon restart, existing coworkers are found in tmux but they may
+/// be stuck waiting for input or idle. This function checks if each discovered
+/// coworker has an assigned task (in_progress with them as owner) or a reviewer
+/// assignment (in github-state.json), and nudges them to continue.
+///
+/// This runs once at startup, with a short delay to let coworkers settle.
+async fn nudge_discovered_coworkers(state: &DaemonState) {
+    let discovered = state.coworkers.take_discovered_on_startup();
+    if discovered.is_empty() {
+        return;
+    }
+
+    info!(
+        "Checking {} discovered coworker(s) for tasks to resume",
+        discovered.len()
+    );
+
+    // Small delay to let things settle after daemon startup
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    // Get in_progress tasks with owners
+    let in_progress = get_in_progress_tasks_with_owners();
+
+    // Build a map of owner -> (task_id, task_subject)
+    let mut owner_tasks: std::collections::HashMap<String, (String, String)> =
+        std::collections::HashMap::new();
+    for (task_id, task_subject, owner) in &in_progress {
+        let owner_lower = owner.trim().trim_matches('"').to_lowercase();
+        if !owner_lower.is_empty() {
+            owner_tasks.insert(owner_lower, (task_id.clone(), task_subject.clone()));
+        }
+    }
+
+    // Check reviewer assignments from github-state.json
+    let reviewer_prs: std::collections::HashMap<String, u64> = {
+        let github_state = state.github_state.lock().await;
+        discovered
+            .iter()
+            .filter_map(|name| {
+                github_state
+                    .pr_for_reviewer(name)
+                    .map(|pr| (name.to_lowercase(), pr))
+            })
+            .collect()
+    };
+
+    for name in &discovered {
+        let name_lower = name.to_lowercase();
+
+        // Check for an in_progress task owned by this coworker
+        if let Some((task_id, task_subject)) = owner_tasks.get(&name_lower) {
+            let prompt = format!(
+                "Resume task #{}: {}. The daemon was restarted and discovered you still running. Check your git status and continue where you left off.",
+                task_id, task_subject
+            );
+
+            info!(
+                "Nudging discovered coworker {} to resume task #{}",
+                name, task_id
+            );
+
+            if let Err(e) = state.coworkers.nudge(name, &prompt) {
+                warn!("Failed to nudge discovered coworker {}: {}", name, e);
+            }
+
+            // Post recovery message to channel
+            let msg = Message::text(
+                "midtown",
+                format!(
+                    "♻️ Nudged discovered coworker {} to resume task #{}",
+                    name, task_id
+                ),
+            );
+            if let Err(e) = state.send_and_broadcast(&msg) {
+                warn!("Failed to post discovery nudge message: {}", e);
+            }
+        } else if let Some(pr_number) = reviewer_prs.get(&name_lower) {
+            // Coworker was assigned to review a PR
+            let prompt = format!(
+                "Resume reviewing PR #{}. The daemon was restarted and discovered you still running. Continue your code review where you left off.",
+                pr_number
+            );
+
+            info!(
+                "Nudging discovered coworker {} to resume review of PR #{}",
+                name, pr_number
+            );
+
+            if let Err(e) = state.coworkers.nudge(name, &prompt) {
+                warn!("Failed to nudge discovered reviewer {}: {}", name, e);
+            }
+
+            let msg = Message::text(
+                "midtown",
+                format!(
+                    "♻️ Nudged discovered reviewer {} to resume PR #{} review",
+                    name, pr_number
+                ),
+            );
+            if let Err(e) = state.send_and_broadcast(&msg) {
+                warn!("Failed to post discovery nudge message: {}", e);
+            }
+        } else {
+            debug!(
+                "Discovered coworker {} has no assigned task or review - skipping nudge",
+                name
+            );
+        }
+
+        // Small delay between nudges to avoid overwhelming tmux
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     }
 }
 


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- After daemon restart, coworkers discovered from tmux are now nudged to continue their assigned tasks
- Checks both in_progress task ownership and github-state.json reviewer assignments
- Runs once at startup with a 5-second settling delay, with 500ms between nudges

## Problem
When the daemon restarts, `discover_existing()` finds coworkers still running in tmux and adds them to the active list. However, `check_and_recover_orphans()` only handles coworkers NOT in the active list (it respawns them). Since discovered coworkers ARE active, they fell through both code paths — nobody nudged them to resume their work.

## Changes
- **coworker.rs**: `discover_existing()` now returns discovered coworker names; new `take_discovered_on_startup()` method for one-time consumption
- **daemon.rs**: New `nudge_discovered_coworkers()` function that checks task assignments and reviewer state, then nudges each discovered coworker

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` clean
- [x] `cargo test` — 15/15 pass
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)