### PR TITLE
docs: Add task grouping guidance to reduce PR sprawl

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -100,6 +100,16 @@ This prevents wasted effort from duplicate work.
 
 Don't hoard tasks - claim one, finish it, then claim another.
 
+### Claiming Follow-Up Tasks
+When you complete a task, check if any newly unblocked tasks are closely related to your work. If the next task is a natural continuation and should be part of the same PR (e.g., it builds directly on your changes), claim it and continue working on the same branch rather than waiting for the daemon to assign it to a new coworker.
+
+```bash
+# After completing task 5, you see task 6 was unblocked and is closely related:
+midtown channel post "@lead claiming task 6 as continuation of task 5, will include in same PR"
+```
+
+This avoids unnecessary PR sprawl when sequential tasks are tightly coupled. Only do this when the follow-up task genuinely belongs in the same changeset — if it can be reviewed independently, let the daemon assign it normally.
+
 ### Blocked Tasks
 **Never work on a task that has unresolved `blockedBy` dependencies.** Before claiming a task, check its `blockedBy` list using `TaskGet`. If any blocking task is not yet `Completed`, do NOT claim or start work on it. Instead:
 1. Post to channel: `/me idle - pending tasks are blocked`

--- a/agents/lead.md
+++ b/agents/lead.md
@@ -131,6 +131,21 @@ TaskUpdate with taskId, owner: "<coworker-name>"
 
 This ensures `midtown status` shows the assignment before the coworker claims it.
 
+## Grouping Related Tasks
+When creating tasks, prefer combining tightly coupled work into a single task rather than splitting it across multiple tasks that each produce a separate PR.
+
+**Guidelines:**
+- If task B can't be meaningfully reviewed without task A's changes, they should be **one task**
+- Only split into separate tasks when work is truly independent and can be reviewed/merged independently
+- Use `blockedBy` dependencies when tasks must be sequential but are independent enough for separate PRs
+- Rule of thumb: fewer, well-scoped PRs are better than many tiny PRs that must be merged in order
+
+**Example - combine into one task:**
+- "Add user model" + "Add user API endpoint" → these are tightly coupled and should be one task: "Add user model and API endpoint"
+
+**Example - keep separate:**
+- "Add auth middleware" + "Update README with API docs" → these can be reviewed independently
+
 ## Plans
 - Always save plans to `~/.claude/plans/`
 - Use descriptive filenames: `YYYY-MM-DD-<topic>.md`


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Added "Grouping Related Tasks" section to the lead prompt (`agents/lead.md`) with guidelines on combining tightly-coupled tasks instead of splitting them into separate PRs
- Added "Claiming Follow-Up Tasks" section to the coworker prompt (`agents/coworker.md`) guiding coworkers to claim related follow-up tasks and include them in the same PR

## Test plan
- [x] Markdown files render correctly
- [x] Pre-existing tests unaffected (only markdown changes)
- [x] Clippy and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)