### PR TITLE
feat: Add @user mention bell notification

### DIFF
--- a/agents/lead.md
+++ b/agents/lead.md
@@ -84,6 +84,26 @@ midtown coworker spawn
 - Monitor overall progress via `midtown status`
 - Check channel for updates: `midtown channel read`
 
+## Requesting Human Input with @user
+When you need human guidance or a decision that you can't make on your own, use `@user` in a channel message. This triggers a bell notification on the human's terminal to get their attention.
+
+```bash
+midtown channel post "@user Should I prioritize the multi-repo kanban or the personality feature?"
+midtown channel post "@user PR #301 has a conflict I can't resolve, need your input"
+midtown channel post "@user The test suite is failing on CI - should I block the release?"
+```
+
+**Only use @user for things that genuinely require human input:**
+- Prioritization decisions between competing tasks
+- Ambiguous requirements that need clarification
+- Merge conflicts or CI failures you can't resolve
+- Architecture decisions with significant trade-offs
+
+**Don't use @user for:**
+- Status updates (just post to the channel normally)
+- Things you can decide yourself based on context
+- Routine progress reports
+
 ## Forwarding User Suggestions
 When the human makes a suggestion or provides feedback related to an in-progress task, post it to the channel using @mentions so the relevant coworker sees it:
 

--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -504,6 +504,26 @@ impl CoworkerManager {
         tmux::send_keys(&self.session_name, "lead.0", message)
     }
 
+    /// Send a bell notification to the human's terminal.
+    ///
+    /// This is triggered when someone posts an @user mention in the channel.
+    /// The bell is sent to the lead's chat pane (.1) since that's the pane
+    /// the human interacts with directly.
+    pub fn notify_user(&self) -> crate::Result<()> {
+        // Check if lead window exists (the human operates through the lead session)
+        if !tmux::window_exists(&self.session_name, "lead")? {
+            return Err(crate::Error::Rpc {
+                code: -32602,
+                message: "Lead session not found".to_string(),
+            });
+        }
+
+        // Send bell to the lead's chat pane (.1) where the human types.
+        // Also send to pane .0 (Claude Code) to cover both panes.
+        let _ = tmux::send_bell(&self.session_name, "lead.1");
+        tmux::send_bell(&self.session_name, "lead.0")
+    }
+
     /// Spawn a coworker with a specific name.
     ///
     /// Unlike `spawn()` which picks a random available name, this takes an explicit

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2657,6 +2657,14 @@ fn handle_channel_post(id: RequestId, from: &str, message: &str, state: &DaemonS
                 }
             }
 
+            // Send bell notification to human when @user is mentioned
+            if content.to_lowercase().contains("@user") && from != "user" {
+                info!("Bell notification: @user mentioned by {}", from);
+                if let Err(e) = state.coworkers.notify_user() {
+                    warn!("Failed to send bell notification for @user mention: {}", e);
+                }
+            }
+
             Response::success(
                 id,
                 serde_json::json!({

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -558,6 +558,30 @@ fn find_window_target(session: &str, base_name: &str) -> Option<String> {
     None
 }
 
+/// Send a bell character (\a) to a tmux pane to trigger a terminal notification.
+///
+/// Uses `tmux send-keys` with the BEL control character (ASCII 7). This triggers
+/// the terminal's bell/notification mechanism (audible beep, visual flash, or
+/// macOS notification depending on terminal settings).
+pub fn send_bell(session: &str, name: &str) -> crate::Result<()> {
+    let target = format!("{}:{}", session, name);
+
+    // Send BEL character (ASCII 7) using octal escape
+    let status = Command::new("tmux")
+        .args(["send-keys", "-t", &target, "-l", "\x07"])
+        .status()
+        .map_err(Error::Io)?;
+
+    if !status.success() {
+        return Err(Error::Rpc {
+            code: -32603,
+            message: format!("Failed to send bell to tmux window: {}", target),
+        });
+    }
+
+    Ok(())
+}
+
 /// Send raw keys without appending Enter.
 pub fn send_keys_raw(session: &str, name: &str, keys: &str) -> crate::Result<()> {
     let target = format!("{}:{}", session, name);


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Daemon detects `@user` mentions in channel messages and sends a terminal bell (BEL/\x07) to the lead's tmux panes to notify the human
- Added `tmux::send_bell()` for sending bell characters to tmux panes
- Added `CoworkerManager::notify_user()` that sends bell to both lead panes (.0 and .1)
- Updated lead system prompt with `@user` usage guidance — when to use it (decisions, blockers, ambiguity) and when not to (status updates, routine reports)

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` — all tests pass (2 pre-existing failures in channel lock tests unrelated to this change)
- [ ] Manual: Post `@user test` via channel, verify bell fires in lead's terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)