### PR TITLE
fix: resolve webserver port mismatch and standalone webserver not starting

### DIFF
--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -698,11 +698,16 @@ pub fn handle_start(
     if !webserver_is_running() {
         match launch_webserver() {
             Ok(()) => messages.push(format!(
-                "Started webserver on http://0.0.0.0:{}",
+                "Started webserver on http://localhost:{}",
                 midtown::webserver::DEFAULT_WEBSERVER_PORT
             )),
             Err(e) => messages.push(format!("Warning: Failed to start webserver: {}", e)),
         }
+    } else {
+        messages.push(format!(
+            "Webserver running at http://localhost:{}",
+            midtown::webserver::DEFAULT_WEBSERVER_PORT
+        ));
     }
 
     // Build response message
@@ -734,7 +739,7 @@ fn launch_webserver() -> Result<(), String> {
         std::env::current_exe().map_err(|e| format!("Failed to get current executable: {}", e))?;
 
     let mut cmd = Command::new(&exe);
-    cmd.arg("webserver");
+    cmd.args(["webserver", "run"]);
     // Don't pass --foreground so it daemonizes itself
     cmd.stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -808,12 +813,12 @@ pub fn handle_webserver_restart() -> Result<Response, String> {
     launch_webserver()?;
     if was_running {
         Ok(Response::message(format!(
-            "Restarted webserver on http://0.0.0.0:{}",
+            "Restarted webserver on http://localhost:{}",
             midtown::webserver::DEFAULT_WEBSERVER_PORT
         )))
     } else {
         Ok(Response::message(format!(
-            "Started webserver on http://0.0.0.0:{}",
+            "Started webserver on http://localhost:{}",
             midtown::webserver::DEFAULT_WEBSERVER_PORT
         )))
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@
 //!    ]
 //!
 //!    [daemon]
-//!    webhook_port = 47022
+//!    webhook_port = 47023
 //!    webhook_secret = "your-secret"
 //!    webhook_restart_interval_secs = 300
 //!    pr_poll_interval_secs = 60
@@ -310,7 +310,7 @@ pub struct PluginsConfig {
 /// - `MIDTOWN_CHAT_MONITOR` (set to 0 to disable)
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DaemonSection {
-    /// Port for the webhook server (default: 47022, set to 0 to disable)
+    /// Port for the webhook server (default: 47023, set to 0 to disable)
     #[serde(default)]
     pub webhook_port: Option<u16>,
 
@@ -483,7 +483,7 @@ pub fn project_config_path(project_name: &str) -> PathBuf {
 }
 
 /// Starting port for auto-assigned per-project webhook ports.
-/// Port 47022 is reserved for the shared webserver (Phase 2).
+/// Port 47022 is reserved for the shared multi-project webserver.
 const AUTO_PORT_START: u16 = 47023;
 
 /// Scan all project configs and collect the webhook ports that are in use.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -63,8 +63,10 @@ pub struct DaemonConfig {
 /// Default interval for restarting the webhook forwarder (5 minutes)
 pub const DEFAULT_WEBHOOK_RESTART_INTERVAL_SECS: u64 = 300;
 
-/// Default port for the webhook server (obscure to avoid conflicts)
-pub const DEFAULT_WEBHOOK_PORT: u16 = 47022;
+/// Default port for the per-project webhook server.
+/// Port 47022 is reserved for the shared multi-project webserver.
+/// Per-project daemons use 47023+.
+pub const DEFAULT_WEBHOOK_PORT: u16 = 47023;
 
 /// Default interval for polling PRs (30 seconds)
 pub const DEFAULT_PR_POLL_INTERVAL_SECS: u64 = 30;


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Fixed `DEFAULT_WEBHOOK_PORT` from 47022 to 47023 — port 47022 is reserved for the shared multi-project webserver, per-project daemons should start at 47023+
- Fixed `launch_webserver()` to invoke `midtown webserver run` instead of `midtown webserver` (missing `run` subcommand caused clap to print help and exit)
- Web URL now always shown in `midtown start` output (whether freshly started or already running)
- Changed user-facing URLs from `0.0.0.0` to `localhost`
- Updated doc comments in config.rs to reflect correct port assignments

## Test plan
- [x] All 300+ unit tests pass
- [x] Clippy clean
- [x] Fmt check passes
- [ ] Manual: `midtown start` should show webserver URL and `localhost:47022` should serve the multi-project UI
- [ ] Manual: Per-project daemon webhook port should be 47023+, not 47022

🤖 Generated with [Claude Code](https://claude.com/claude-code)