### PR TITLE
fix: Add retry wrappers to all flaky channel tests

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -612,6 +612,14 @@ mod tests {
         })
     }
 
+    fn read_since_cursor_with_retry(
+        channel: &Channel,
+        agent: &str,
+        max_attempts: u32,
+    ) -> Result<Vec<Message>> {
+        retry_with_backoff(max_attempts, || channel.read_since_cursor(agent))
+    }
+
     #[test]
     fn test_channel_creation() {
         let temp_dir = TempDir::new().unwrap();
@@ -619,7 +627,7 @@ mod tests {
         assert!(temp_dir.path().join("cursors").exists());
         // Channel file should exist (for tailf) but be empty (no messages)
         assert!(channel.exists());
-        assert_eq!(channel.message_count().unwrap(), 0);
+        assert_eq!(message_count_with_retry(&channel, 5).unwrap(), 0);
     }
 
     #[test]
@@ -663,20 +671,20 @@ mod tests {
         channel.send(&Message::text("agent1", "Message 1")).unwrap();
         channel.send(&Message::text("agent1", "Message 2")).unwrap();
 
-        // Agent reads all messages
-        let messages = channel.read_since_cursor("reader").unwrap();
+        // Agent reads all messages (retry to handle transient lock contention in CI)
+        let messages = read_since_cursor_with_retry(&channel, "reader", 5).unwrap();
         assert_eq!(messages.len(), 2);
 
         // Send more messages
         channel.send(&Message::text("agent1", "Message 3")).unwrap();
 
         // Agent should only see new message
-        let new_messages = channel.read_since_cursor("reader").unwrap();
+        let new_messages = read_since_cursor_with_retry(&channel, "reader", 5).unwrap();
         assert_eq!(new_messages.len(), 1);
         assert_eq!(new_messages[0].content, "Message 3");
 
         // Another agent sees all messages
-        let all_messages = channel.read_since_cursor("other_reader").unwrap();
+        let all_messages = read_since_cursor_with_retry(&channel, "other_reader", 5).unwrap();
         assert_eq!(all_messages.len(), 3);
     }
 
@@ -687,14 +695,14 @@ mod tests {
 
         channel.send(&Message::text("agent1", "Message")).unwrap();
 
-        // Read once
-        let _ = channel.read_since_cursor("reader").unwrap();
+        // Read once (retry to handle transient lock contention in CI)
+        let _ = read_since_cursor_with_retry(&channel, "reader", 5).unwrap();
 
         // Reset cursor
         channel.reset_cursor("reader").unwrap();
 
         // Should see message again
-        let messages = channel.read_since_cursor("reader").unwrap();
+        let messages = read_since_cursor_with_retry(&channel, "reader", 5).unwrap();
         assert_eq!(messages.len(), 1);
     }
 
@@ -750,7 +758,8 @@ mod tests {
         channel.send(&Message::status("agent1", "working")).unwrap();
         channel.send(&Message::error("agent1", "failed")).unwrap();
 
-        let messages = channel.read_all().unwrap();
+        // Use retry helper to handle transient lock contention in CI
+        let messages = read_all_with_retry(&channel, 5).unwrap();
         assert_eq!(messages.len(), 5);
         assert_eq!(messages[0].message_type, MessageType::Text);
         assert_eq!(messages[1].message_type, MessageType::System);
@@ -764,11 +773,11 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let channel = Channel::new(temp_dir.path()).unwrap();
 
-        // Reading from non-existent channel should return empty vec
-        let messages = channel.read_all().unwrap();
+        // Reading from empty channel should return empty vec
+        let messages = read_all_with_retry(&channel, 5).unwrap();
         assert!(messages.is_empty());
 
-        let messages = channel.read_since_cursor("reader").unwrap();
+        let messages = read_since_cursor_with_retry(&channel, "reader", 5).unwrap();
         assert!(messages.is_empty());
     }
 
@@ -816,7 +825,7 @@ mod tests {
         drop(file);
 
         // Read messages - they should be sorted by timestamp (oldest first)
-        let messages = channel.read_all().unwrap();
+        let messages = read_all_with_retry(&channel, 5).unwrap();
         assert_eq!(messages.len(), 2);
         assert_eq!(
             messages[0].content, "Old message (delayed)",
@@ -949,7 +958,7 @@ mod tests {
         assert_eq!(archived, 0, "No messages should be archived");
 
         // All messages still present
-        let messages = channel.read_all().unwrap();
+        let messages = read_all_with_retry(&channel, 5).unwrap();
         assert_eq!(messages.len(), 2);
     }
 
@@ -1003,7 +1012,7 @@ mod tests {
         assert_eq!(archived, 3, "3 old messages should be archived");
 
         // Only recent messages remain in channel
-        let remaining = channel.read_all().unwrap();
+        let remaining = read_all_with_retry(&channel, 5).unwrap();
         assert_eq!(remaining.len(), 2);
         assert!(remaining[0].content.starts_with("Recent"));
         assert!(remaining[1].content.starts_with("Recent"));
@@ -1058,7 +1067,7 @@ mod tests {
         channel.send(&Message::text("agent1", "Recent")).unwrap();
 
         // Agent reads to establish a cursor at some byte offset
-        let _ = channel.read_since_cursor("reader").unwrap();
+        let _ = read_since_cursor_with_retry(&channel, "reader", 5).unwrap();
         let cursor_before = channel.get_cursor("reader").unwrap();
         assert!(cursor_before.position > 0, "Cursor should be past 0");
 
@@ -1107,6 +1116,18 @@ mod tests {
             file.write_all(existing.as_bytes()).unwrap();
         }
 
-        assert!(channel.needs_rotation(24));
+        // Retry: needs_rotation uses try_lock_shared internally and returns false on WouldBlock
+        let mut rotation_needed = false;
+        for _ in 0..5 {
+            if channel.needs_rotation(24) {
+                rotation_needed = true;
+                break;
+            }
+            thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(
+            rotation_needed,
+            "Channel with old messages should need rotation"
+        );
     }
 }


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Added `read_since_cursor_with_retry` helper to match existing `read_all_with_retry` pattern
- Applied retry wrappers to all channel tests that called read methods directly without retry
- Fixed `test_needs_rotation` with manual retry loop since `needs_rotation()` silently returns `false` on `WouldBlock`

## Root cause
Channel read methods use `try_lock_shared()` (non-blocking) which returns `WouldBlock` if an exclusive lock is held. On CI runners, brief timing windows between `flock` release (from `send()`) and acquisition (from read methods) cause intermittent failures. The `test_different_message_types` test was the most frequent offender on CI (confirmed in two separate main branch failures).

## Tests affected
- `test_channel_creation` - `message_count()` → `message_count_with_retry()`
- `test_cursor_based_reading` - `read_since_cursor()` → `read_since_cursor_with_retry()`
- `test_cursor_reset` - `read_since_cursor()` → `read_since_cursor_with_retry()`
- `test_different_message_types` - `read_all()` → `read_all_with_retry()`
- `test_empty_channel_read` - both `read_all()` and `read_since_cursor()` → retry versions
- `test_messages_sorted_by_timestamp` - `read_all()` → `read_all_with_retry()`
- `test_rotate_all_recent_messages` - `read_all()` → `read_all_with_retry()`
- `test_rotate_archives_old_messages` - `read_all()` → `read_all_with_retry()`
- `test_rotate_resets_cursors` - `read_since_cursor()` → `read_since_cursor_with_retry()`
- `test_needs_rotation` - added manual retry for `needs_rotation()` which returns `false` on lock failure

## Test plan
- [x] All 300 lib tests pass locally
- [x] All 113 binary tests pass locally
- [x] Clippy clean, formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)