### PR TITLE
fix: resolve standalone webserver static_dir relative to executable

### DIFF
--- a/src/webserver.rs
+++ b/src/webserver.rs
@@ -43,9 +43,16 @@ pub struct WebserverConfig {
 
 impl Default for WebserverConfig {
     fn default() -> Self {
+        // Resolve web directory relative to the executable, not the working directory.
+        // This matches how the daemon's WebConfig resolves its static_dir.
+        let static_dir = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+            .map(|exe_dir| exe_dir.join("web"));
+
         Self {
             port: DEFAULT_WEBSERVER_PORT,
-            static_dir: None,
+            static_dir,
         }
     }
 }
@@ -335,7 +342,17 @@ mod tests {
     fn test_webserver_config_default() {
         let config = WebserverConfig::default();
         assert_eq!(config.port, 47022);
-        assert!(config.static_dir.is_none());
+        // static_dir should auto-resolve to exe_dir/web, not None
+        assert!(
+            config.static_dir.is_some(),
+            "static_dir should default to exe_dir/web, not None"
+        );
+        let dir = config.static_dir.unwrap();
+        assert!(
+            dir.ends_with("web"),
+            "static_dir should end with 'web', got: {:?}",
+            dir
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Fixed standalone webserver (`midtown webserver run`) returning 404 for all static file requests
- `WebserverConfig::default()` now resolves `web/` relative to the executable path via `current_exe()`, matching how the daemon's `WebConfig` does it
- Previously `static_dir` defaulted to `None`, meaning no static files were served unless `--static_dir` was explicitly passed (which `launch_webserver()` never did)

## Test plan
- [x] Updated `test_webserver_config_default` to assert `static_dir` is `Some` and ends with `"web"`
- [x] Confirmed test fails before fix (red), passes after (green)
- [x] Full test suite: 313/313 pass
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)