### PR TITLE
fix: Show PR# prefix consistently, conditional repo badge for single-repo

### DIFF
--- a/src/bin/midtown/cli/response.rs
+++ b/src/bin/midtown/cli/response.rs
@@ -163,7 +163,7 @@ impl Response {
                     out.push_str(&format!("\nPRs: {} open\n", full.pull_requests.len()));
                     for pr in &full.pull_requests {
                         out.push_str(&format!(
-                            "  #{} {} ({}) - {}\n",
+                            "  PR#{} {} ({}) - {}\n",
                             pr.number, pr.title, pr.author, pr.status
                         ));
                     }
@@ -261,7 +261,7 @@ impl Response {
                 let mut out = String::from("Pull Requests\n─────────────────────────────\n");
                 for pr in pull_requests {
                     out.push_str(&format!(
-                        "#{:<5} {:10} {:12} {}\n",
+                        "PR#{:<5} {:10} {:12} {}\n",
                         pr.number, pr.status, pr.author, pr.title
                     ));
                 }
@@ -411,6 +411,6 @@ mod tests {
         assert!(pretty.contains("Tasks: 1 open"));
         assert!(pretty.contains("[in_progress] implement auth endpoint (lex)"));
         assert!(pretty.contains("PRs: 1 open"));
-        assert!(pretty.contains("#42 Add auth (lex) - awaiting review"));
+        assert!(pretty.contains("PR#42 Add auth (lex) - awaiting review"));
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3251,13 +3251,16 @@ fn handle_kanban_data(id: RequestId, state: &DaemonState) -> Response {
         .unwrap_or_default();
 
     // Fetch PRs from all repos in the project
+    let is_multi_repo = state.all_repo_paths.len() > 1;
     let mut prs = Vec::new();
     let mut merged_prs = Vec::new();
     for repo_path in &state.all_repo_paths {
-        let repo_label = repo_path
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or("unknown");
+        // Only include repo label when the project has multiple repos
+        let repo_label = if is_multi_repo {
+            repo_path.file_name().and_then(|s| s.to_str())
+        } else {
+            None
+        };
         prs.extend(fetch_kanban_prs(
             &reviewer_assignments,
             repo_path,
@@ -3311,12 +3314,12 @@ fn handle_kanban_data(id: RequestId, state: &DaemonState) -> Response {
 
 /// Fetch open PRs with rich data for the kanban board.
 ///
-/// For multi-repo projects, this is called once per repo with the repo's path
-/// and a short label (directory name) to include in the response.
+/// Called once per repo with the repo's path. The `repo_label` is `Some(name)`
+/// only for multi-repo projects (to display a repo badge on kanban cards).
 fn fetch_kanban_prs(
     reviewer_assignments: &HashMap<u64, (String, Instant)>,
     repo_path: &std::path::Path,
-    repo_label: &str,
+    repo_label: Option<&str>,
 ) -> Vec<serde_json::Value> {
     let output = std::process::Command::new("gh")
         .current_dir(repo_path)
@@ -3410,10 +3413,10 @@ fn fetch_kanban_prs(
 
 /// Fetch recently merged PRs for the kanban Done column.
 ///
-/// For multi-repo projects, called once per repo with its path and label.
+/// Called once per repo. The `repo_label` is `Some(name)` only for multi-repo projects.
 fn fetch_kanban_merged_prs(
     repo_path: &std::path::Path,
-    repo_label: &str,
+    repo_label: Option<&str>,
 ) -> Vec<serde_json::Value> {
     let output = std::process::Command::new("gh")
         .current_dir(repo_path)


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Use `PR#` prefix (instead of bare `#`) when displaying PR numbers in `midtown status` output, making PRs visually distinct from task IDs
- Only include repo label on kanban PR/merged-PR data when the project has multiple repos — single-repo projects no longer get unnecessary `[midtown]` badges on every card

## Changes
- `daemon.rs`: `handle_kanban_data()` now checks `state.all_repo_paths.len() > 1` before passing repo labels to `fetch_kanban_prs()` and `fetch_kanban_merged_prs()` (signatures changed from `&str` to `Option<&str>`)
- `response.rs`: Changed `#{number}` → `PR#{number}` in both the full status output and the standalone PR list display

## Test plan
- [x] All existing tests pass (`cargo test`)
- [x] Clippy and fmt pass (verified by pre-commit hook)
- [x] Single-repo projects: kanban cards won't show repo badge
- [x] Multi-repo projects: kanban cards will still show `[repo-name]` badge
- [x] `midtown status` output now shows `PR#42` instead of `#42`

🤖 Generated with [Claude Code](https://claude.com/claude-code)