### PR TITLE
fix: route user @mentions directly to coworkers as nudges

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1574,7 +1574,7 @@ async fn pr_poll_task(
 // ============================================================================
 
 /// Senders to skip when routing mentions (loop protection).
-const SKIP_SENDERS: &[&str] = &["midtown", "system", "github"];
+const SKIP_SENDERS: &[&str] = &["midtown", "system", "github", "user"];
 
 /// Background task that monitors the channel for @mentions and routes them.
 ///
@@ -4940,10 +4940,13 @@ mod tests {
 
     #[test]
     fn test_skip_senders() {
-        // Verify SKIP_SENDERS contains expected values
+        // Verify SKIP_SENDERS contains expected values.
+        // "user" is skipped because handle_channel_post routes user @mentions
+        // directly, similar to how the webhook handler routes "github" mentions.
         assert!(SKIP_SENDERS.contains(&"midtown"));
         assert!(SKIP_SENDERS.contains(&"system"));
         assert!(SKIP_SENDERS.contains(&"github"));
+        assert!(SKIP_SENDERS.contains(&"user"));
     }
 
     #[test]


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Fixed bug where user @mentions of coworkers were only nudging the lead instead of the mentioned coworker
- Moved `route_mentions` call into `handle_channel_post` for user messages, so both the RPC and mobile message paths route mentions correctly
- Removed the now-redundant external `route_mentions` call from the mobile_rx handler
- Added test for user @mention extraction behavior

## Test plan
- [x] New unit test `test_user_mentions_coworker_should_be_extracted` passes
- [x] All 314 unit tests pass
- [x] Clippy clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)