### PR TITLE
chore: Bump version to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "midtown"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "axum",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midtown"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 description = "Midtown - a multi-Claude Code workspace manager, inspired by Gastown"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Bumps version from 0.3.1 to 0.3.2 for the next patch release

## Changes since v0.3.1
- feat: detect coworker interactive prompts and nudge lead (#324)
- fix: route user @mentions directly to coworkers as nudges (#321)
- fix: resolve web static assets via compile-time source path fallback (#323)
- fix: update web interface logo to new transparent version (#322)
- fix: optimize web logo from 419K to 12K (#326)
- refactor: remove static file serving from per-project daemons (#325)

🤖 Generated with [Claude Code](https://claude.com/claude-code)