### PR TITLE
fix: prevent coworker worktrees from being registered as projects

### DIFF
--- a/src/bin/midtown/cli/coworker.rs
+++ b/src/bin/midtown/cli/coworker.rs
@@ -273,21 +273,10 @@ fn post_question_to_channel(agent: &str, question: &str) -> Result<(), String> {
 }
 
 /// Try to detect the current git repository name.
+/// Uses the worktree-aware detect_repo_name() to avoid returning coworker
+/// worktree names instead of the actual repository name.
 fn detect_git_repo() -> Option<String> {
-    std::process::Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .ok()
-        .and_then(|output| {
-            if output.status.success() {
-                let path = String::from_utf8_lossy(&output.stdout);
-                std::path::Path::new(path.trim())
-                    .file_name()
-                    .map(|s| s.to_string_lossy().to_string())
-            } else {
-                None
-            }
-        })
+    midtown::paths::detect_repo_name()
 }
 
 fn handle_nudge_config(

--- a/src/bin/midtown/cli/task.rs
+++ b/src/bin/midtown/cli/task.rs
@@ -182,23 +182,11 @@ fn post_to_channel(repo: &str, from: &str, content: &str) -> Result<(), String> 
     Ok(())
 }
 
-/// Try to detect the current git repository name
+/// Try to detect the current git repository name.
+/// Uses the worktree-aware detect_repo_name() to avoid returning coworker
+/// worktree names instead of the actual repository name.
 fn detect_git_repo() -> Option<String> {
-    // Try to get repo name from git remote or directory name
-    std::process::Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .ok()
-        .and_then(|output| {
-            if output.status.success() {
-                let path = String::from_utf8_lossy(&output.stdout);
-                std::path::Path::new(path.trim())
-                    .file_name()
-                    .map(|s| s.to_string_lossy().to_string())
-            } else {
-                None
-            }
-        })
+    midtown::paths::detect_repo_name()
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -459,6 +459,18 @@ pub fn get_project_config(project_name: &str) -> ProjectConfig {
 /// If it doesn't exist, a minimal config is created with the project name
 /// and repo path inferred from the working directory.
 pub fn ensure_project_config(project_name: &str, workdir: &Path) -> std::io::Result<()> {
+    // Reject coworker names to prevent worktree directories from being
+    // registered as projects (e.g., "broadway" instead of "midtown").
+    if crate::coworker::is_coworker_name(project_name) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "Refusing to create project config for '{}': this is a coworker name, not a project",
+                project_name
+            ),
+        ));
+    }
+
     let path = project_config_path(project_name);
     if path.exists() {
         return Ok(());
@@ -1136,6 +1148,23 @@ name = "solo"
         let loaded = FullProjectConfig::load_from(&config_path).unwrap();
         assert_eq!(loaded.project.name(), Some("testproj"));
         assert_eq!(loaded.project.primary_repo(), Some("/tmp/repo"));
+    }
+
+    #[test]
+    fn test_ensure_project_config_rejects_coworker_names() {
+        let workdir = Path::new("/tmp/fake-repo");
+
+        // Coworker avenue names should be rejected
+        let result = ensure_project_config("broadway", workdir);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidInput);
+
+        let result = ensure_project_config("amsterdam", workdir);
+        assert!(result.is_err());
+
+        // Overflow names should also be rejected
+        let result = ensure_project_config("bleecker", workdir);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -29,6 +29,13 @@ const AVENUE_NAMES: &[&str] = &[
 /// Overflow street names for when primary avenues are exhausted.
 const OVERFLOW_NAMES: &[&str] = &["bleecker", "houston", "canal", "spring", "prince", "mercer"];
 
+/// Check if a name is a known coworker name (avenue or overflow).
+///
+/// Used to prevent coworker worktree names from being registered as projects.
+pub fn is_coworker_name(name: &str) -> bool {
+    AVENUE_NAMES.contains(&name) || OVERFLOW_NAMES.contains(&name)
+}
+
 /// Status of a coworker.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -1098,6 +1105,27 @@ mod tests {
 
         // Should return None when all names exhausted
         assert_eq!(manager.next_available_name(), None);
+    }
+
+    #[test]
+    fn test_is_coworker_name() {
+        // Avenue names should be recognized
+        assert!(is_coworker_name("broadway"));
+        assert!(is_coworker_name("amsterdam"));
+        assert!(is_coworker_name("columbus"));
+        assert!(is_coworker_name("vernon"));
+        assert!(is_coworker_name("park"));
+
+        // Overflow names should be recognized
+        assert!(is_coworker_name("bleecker"));
+        assert!(is_coworker_name("houston"));
+        assert!(is_coworker_name("canal"));
+
+        // Real project names should not match
+        assert!(!is_coworker_name("midtown"));
+        assert!(!is_coworker_name("my-project"));
+        assert!(!is_coworker_name("distiller"));
+        assert!(!is_coworker_name("default"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub mod github_state;
 pub mod push;
 
 pub use channel::Channel;
-pub use coworker::{Coworker, CoworkerManager, CoworkerStatus};
+pub use coworker::{Coworker, CoworkerManager, CoworkerStatus, is_coworker_name};
 pub use cursor::Cursor;
 pub use message::{Message, MessageType};
 pub use worktree::{WorktreeError, WorktreeInfo, WorktreeManager};

--- a/src/webserver.rs
+++ b/src/webserver.rs
@@ -121,6 +121,14 @@ fn discover_projects() -> Vec<ProjectInfo> {
         }
 
         let name = entry.file_name().to_string_lossy().to_string();
+
+        // Skip entries that are coworker names, not real projects.
+        // These get created when a coworker process in a worktree incorrectly
+        // registers itself as a project using the worktree directory name.
+        if crate::coworker::is_coworker_name(&name) {
+            continue;
+        }
+
         let pid_file = entry.path().join("daemon.pid");
         let socket_path = crate::paths::daemon_socket_for_repo(&name);
 
@@ -375,6 +383,32 @@ mod tests {
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains("\"status\":\"running\""));
         assert!(json.contains("\"name\":\"test\""));
+    }
+
+    #[test]
+    fn test_discover_projects_filters_coworker_names() {
+        // Create a temp dir to act as ~/.midtown/projects/
+        let temp_dir = tempfile::tempdir().unwrap();
+        let projects_dir = temp_dir.path();
+
+        // Create directories: some real projects, some coworker names
+        std::fs::create_dir(projects_dir.join("midtown")).unwrap();
+        std::fs::create_dir(projects_dir.join("broadway")).unwrap();
+        std::fs::create_dir(projects_dir.join("amsterdam")).unwrap();
+        std::fs::create_dir(projects_dir.join("my-app")).unwrap();
+        std::fs::create_dir(projects_dir.join("bleecker")).unwrap();
+
+        // Read entries and filter like discover_projects does
+        let entries = std::fs::read_dir(projects_dir).unwrap();
+        let mut names: Vec<String> = entries
+            .flatten()
+            .filter(|e| e.path().is_dir())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .filter(|name| !crate::coworker::is_coworker_name(name))
+            .collect();
+        names.sort();
+
+        assert_eq!(names, vec!["midtown", "my-app"]);
     }
 
     #[test]


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- **Root cause**: `detect_git_repo()` in `task.rs` and `coworker.rs` used `git rev-parse --show-toplevel` which returns the worktree directory name (e.g., "broadway") instead of the actual repo name from a git worktree. This caused `Channel::for_repo()` to create bogus project entries under `~/.midtown/projects/<coworker-name>/`
- **Fix**: Replace duplicate broken implementations with the worktree-aware `paths::detect_repo_name()` that uses `--git-common-dir`
- **Defense in depth**: Added `is_coworker_name()` guard in `ensure_project_config()` and `discover_projects()` to prevent and filter coworker names even if detection regresses

## Test plan
- [x] Added `test_is_coworker_name` — verifies avenue and overflow names are recognized, real project names are not
- [x] Added `test_ensure_project_config_rejects_coworker_names` — verifies coworker names are rejected with InvalidInput error
- [x] Added `test_discover_projects_filters_coworker_names` — verifies coworker-named directories are filtered from project list
- [x] All 323 unit tests + 15 doc tests pass
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)