### PR TITLE
feat: use friendlier break language for auto-shutdown messages

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1210,7 +1210,7 @@ async fn check_and_shutdown_idle_coworkers(state: &DaemonState) {
                         (
                             true,
                             format!(
-                                "🔍 Sending {} on a break (review complete for PR #{})",
+                                "☕ Letting {} take a break (review complete for PR #{})",
                                 name, pr
                             ),
                         )
@@ -1242,7 +1242,7 @@ async fn check_and_shutdown_idle_coworkers(state: &DaemonState) {
                     );
                     (
                         true,
-                        format!("⚠️ Sending {} on a break (no PR assignment found)", name),
+                        format!("☕ Letting {} take a break (no PR assignment found)", name),
                     )
                 }
             }
@@ -1251,10 +1251,7 @@ async fn check_and_shutdown_idle_coworkers(state: &DaemonState) {
                 "Sending idle coworker {} on a break (idle for 5+ minutes)",
                 name
             );
-            (
-                true,
-                format!("⏱️ Sending {} on a break (idle for 5+ minutes)", name),
-            )
+            (true, format!("☕ Letting {} take a break", name))
         };
 
         if !should_shutdown {


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Replaced "⚠️ Auto-shutting down idle coworker: X" with "☕ Letting X take a break"
- Replaced "🔍 Auto-shutting down reviewer: X" with "☕ Letting X take a break (review complete for PR #N)"
- Replaced "⚠️ Auto-shutting down reviewer: X (no PR assignment found)" with "☕ Letting X take a break (no PR assignment found)"
- Internal log messages (`info!`, `warn!`) left unchanged

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` — all 15 tests pass
- [x] `cargo clippy` and `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)