### PR TITLE
chore: Bump version to 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "midtown"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "axum",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midtown"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 description = "Midtown - a multi-Claude Code workspace manager, inspired by Gastown"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Bump version from 0.3.2 to 0.3.3 in preparation for patch release

## Test plan
- [x] `cargo check` succeeds with new version
- [x] Clippy and fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)