### PR TITLE
feat: auto-route user @mentions to coworkers, skip lead

### DIFF
--- a/agents/lead.md
+++ b/agents/lead.md
@@ -111,8 +111,13 @@ midtown channel post "@user The test suite is failing on CI - should I block the
 - Things you can decide yourself based on context
 - Routine progress reports
 
+## Auto-Routed User @mentions
+When the user @mentions a coworker directly (e.g., "@riverside continue"), the daemon automatically routes the message to that coworker as a nudge. **You do not need to forward these messages.** The daemon skips nudging you entirely for user messages that @mention specific coworkers, so you won't even see them unless the user also @mentions you with `@lead`.
+
+If the user sends a general message without @mentions, you'll still receive it as usual and can decide how to handle it.
+
 ## Forwarding User Suggestions
-When the human makes a suggestion or provides feedback related to an in-progress task, post it to the channel using @mentions so the relevant coworker sees it:
+When the human makes a suggestion or provides feedback related to an in-progress task but does NOT @mention the coworker directly, post it to the channel using @mentions so the relevant coworker sees it:
 
 ```bash
 # User suggests something about task #3 that park is working on:

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3055,14 +3055,29 @@ fn handle_channel_post(id: RequestId, from: &str, message: &str, state: &DaemonS
 
             // Nudge lead when user messages arrive (from web UI or TUI input)
             if from == "user" {
-                let nudge_msg = format!("user: {}", content);
-                info!("Nudging Lead about user message");
-                if let Err(e) = state.coworkers.nudge_lead(&nudge_msg) {
-                    warn!("Failed to nudge Lead about user message: {}", e);
-                }
+                // Check if user is @mentioning specific coworkers or @all
+                let has_coworker_mentions =
+                    !extract_mentions(&content).is_empty() || contains_at_all(&content);
+                let has_lead_mention = content.to_lowercase().contains("@lead");
 
                 // Route @mentions in user messages directly to coworkers
                 route_mentions(state, &msg);
+
+                // Only nudge lead if there are no coworker @mentions (regular
+                // message for the lead) or if the user also @mentioned the lead.
+                // This lets users talk directly to coworkers without the lead
+                // acting as a middleman.
+                if !has_coworker_mentions || has_lead_mention {
+                    let nudge_msg = format!("user: {}", content);
+                    info!("Nudging Lead about user message");
+                    if let Err(e) = state.coworkers.nudge_lead(&nudge_msg) {
+                        warn!("Failed to nudge Lead about user message: {}", e);
+                    }
+                } else {
+                    info!(
+                        "Skipping Lead nudge — user message routed directly to mentioned coworker(s)"
+                    );
+                }
             }
 
             // Nudge the Lead when a coworker explicitly mentions @lead
@@ -5136,6 +5151,46 @@ mod tests {
         let lead_msg = "@lead what do you think?";
         let mentions = extract_mentions(lead_msg);
         assert!(mentions.is_empty() || !mentions.contains(&"lead".to_string()));
+    }
+
+    #[test]
+    fn test_user_mention_routing_skips_lead() {
+        // When a user message @mentions a coworker, the lead should NOT be
+        // nudged — the daemon routes directly to the coworker. This test
+        // validates the detection logic used in handle_channel_post.
+
+        // User @mentions a coworker → has_coworker_mentions = true, skip lead
+        let content = "@riverside continue";
+        let has_coworker_mentions =
+            !extract_mentions(content).is_empty() || contains_at_all(content);
+        let has_lead_mention = content.to_lowercase().contains("@lead");
+        assert!(has_coworker_mentions);
+        assert!(!has_lead_mention);
+        // Should skip lead: has_coworker_mentions && !has_lead_mention
+        assert!(has_coworker_mentions && !has_lead_mention);
+
+        // User sends a regular message → no mentions, nudge lead
+        let content = "how is task 5 going?";
+        let has_coworker_mentions =
+            !extract_mentions(content).is_empty() || contains_at_all(content);
+        assert!(!has_coworker_mentions);
+
+        // User @mentions coworker AND @lead → nudge lead too
+        let content = "@riverside @lead please coordinate on this";
+        let has_coworker_mentions =
+            !extract_mentions(content).is_empty() || contains_at_all(content);
+        let has_lead_mention = content.to_lowercase().contains("@lead");
+        assert!(has_coworker_mentions);
+        assert!(has_lead_mention);
+
+        // User uses @all → coworker mentions detected, skip lead
+        // (route_at_all already broadcasts to lead)
+        let content = "@all stand up time";
+        let has_coworker_mentions =
+            !extract_mentions(content).is_empty() || contains_at_all(content);
+        let has_lead_mention = content.to_lowercase().contains("@lead");
+        assert!(has_coworker_mentions);
+        assert!(!has_lead_mention);
     }
 
     // Duplicate task worker detection tests


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- When a user message @mentions a coworker (e.g., `@riverside continue`), the daemon now routes it directly to the coworker **without nudging the lead**
- Lead is still nudged for regular user messages (no @mentions) and when user also @mentions `@lead`
- Updated lead system prompt to document the auto-routing behavior
- Added unit test covering all routing scenarios (coworker mention, no mention, @lead + coworker, @all)

## Motivation
Previously, `@riverside continue` would nudge the lead AND route to riverside. The lead would then manually forward the message — redundant work since `route_mentions()` already handled direct routing. This change eliminates the lead as a middleman for direct coworker communication.

## Test plan
- [x] New test `test_user_mention_routing_skips_lead` passes
- [x] All 324 unit tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)