### PR TITLE
fix: prevent reviewers from being sent on break due to expired PR assignment tracking

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -418,6 +418,29 @@ impl PrReviewTracker {
         self.assigned.retain(|_, (_, t)| t.elapsed() < timeout);
     }
 
+    /// Clean up stale assignments, but preserve assignments for active coworkers.
+    ///
+    /// This prevents reviewers from losing their PR assignment tracking while
+    /// they are still actively running (e.g., a review taking longer than the
+    /// timeout). Assignments for inactive coworkers are cleaned up normally.
+    /// Active coworkers' assignments are refreshed so timeout-based lookups
+    /// (active_reviewers, pr_for_coworker) continue to work.
+    pub fn cleanup_preserving(&mut self, active_coworkers: &HashSet<String>) {
+        let timeout = Duration::from_secs(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS);
+        let now = Instant::now();
+        self.assigned.retain(|_, (name, t)| {
+            if t.elapsed() < timeout {
+                return true;
+            }
+            // Expired, but coworker is still active — refresh the timestamp
+            if active_coworkers.contains(name) {
+                *t = now;
+                return true;
+            }
+            false
+        });
+    }
+
     /// Mark a PR as reviewed (remove from tracking)
     pub fn mark_reviewed(&mut self, pr_number: u64) {
         self.assigned.remove(&pr_number);
@@ -1075,10 +1098,18 @@ async fn check_and_shutdown_idle_coworkers(state: &DaemonState) {
     // Get coworkers with open PRs - they should NEVER be sent on a break
     let coworkers_with_open_prs = get_coworkers_with_open_prs();
 
-    // Get coworkers actively assigned to review PRs - they should not be considered idle
+    // Get coworkers actively assigned to review PRs - they should not be considered idle.
+    // Check BOTH in-memory and persistent state. The in-memory tracker can be empty after
+    // a daemon restart, and the persistent state survives restarts.
     let active_reviewers = {
         let tracker = state.pr_review_tracker.lock().await;
-        tracker.active_reviewers()
+        let mut reviewers = tracker.active_reviewers();
+        // Also include reviewers from persistent state (survives daemon restarts)
+        let github_state = state.github_state.lock().await;
+        for reviewer_name in github_state.assigned_reviewers() {
+            reviewers.insert(reviewer_name.to_string());
+        }
+        reviewers
     };
 
     let now = Instant::now();
@@ -1979,14 +2010,21 @@ async fn poll_prs_for_issues(
     let stdout = String::from_utf8_lossy(&output.stdout);
     let prs: Vec<serde_json::Value> = serde_json::from_str(&stdout)?;
 
-    // Cleanup old tracking entries
+    // Cleanup old tracking entries, but preserve assignments for active coworkers
+    // so reviewers don't lose their PR tracking while still running
+    let active_coworker_names: HashSet<String> = state
+        .coworkers
+        .list()
+        .iter()
+        .map(|cw| cw.name.clone())
+        .collect();
     {
         let mut tracker = state.pr_issue_tracker.lock().await;
         tracker.cleanup();
     }
     {
         let mut review_tracker = state.pr_review_tracker.lock().await;
-        review_tracker.cleanup();
+        review_tracker.cleanup_preserving(&active_coworker_names);
     }
 
     // Filter to only open PRs (defense-in-depth: gh pr list --state open should only return
@@ -2007,7 +2045,7 @@ async fn poll_prs_for_issues(
             .collect();
         let mut github_state = state.github_state.lock().await;
         github_state.cleanup_closed_prs(&open_pr_numbers);
-        github_state.cleanup_expired_assignments();
+        github_state.cleanup_expired_preserving(&active_coworker_names);
         if let Err(e) = crate::github_state::save_state_for_repo(&state.repo_name, &github_state) {
             warn!("Failed to save github-state.json after cleanup: {}", e);
         }
@@ -4968,6 +5006,57 @@ mod tests {
         assert!(!reviewers.contains("lexington"));
         assert!(reviewers.contains("park"));
         assert_eq!(reviewers.len(), 1);
+    }
+
+    #[test]
+    fn test_cleanup_preserves_active_coworkers() {
+        let mut tracker = PrReviewTracker::new();
+
+        // Simulate an expired assignment (> 10 minutes old) for an active coworker
+        tracker.assigned.insert(
+            42,
+            (
+                "broadway".to_string(),
+                Instant::now() - Duration::from_secs(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS + 60),
+            ),
+        );
+        // And a fresh assignment for another coworker
+        tracker.assign(43, "park");
+
+        // broadway is still active (running as a coworker)
+        let active: HashSet<String> = ["broadway".to_string()].into_iter().collect();
+
+        // cleanup_preserving should keep broadway's assignment alive
+        tracker.cleanup_preserving(&active);
+
+        // broadway's assignment should be preserved because they're still active
+        assert_eq!(tracker.pr_for_coworker("broadway"), Some(42));
+        assert!(tracker.active_reviewers().contains("broadway"));
+
+        // park's fresh assignment should also still be there
+        assert_eq!(tracker.pr_for_coworker("park"), Some(43));
+    }
+
+    #[test]
+    fn test_cleanup_removes_expired_inactive_coworkers() {
+        let mut tracker = PrReviewTracker::new();
+
+        // Simulate an expired assignment for an inactive coworker
+        tracker.assigned.insert(
+            42,
+            (
+                "broadway".to_string(),
+                Instant::now() - Duration::from_secs(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS + 60),
+            ),
+        );
+
+        // broadway is NOT active
+        let active: HashSet<String> = HashSet::new();
+
+        tracker.cleanup_preserving(&active);
+
+        // broadway's assignment should be removed
+        assert_eq!(tracker.pr_for_coworker("broadway"), None);
     }
 
     // Chat monitor @mention tests

--- a/src/github_state.rs
+++ b/src/github_state.rs
@@ -139,6 +139,46 @@ impl GitHubState {
         }
     }
 
+    /// Clean up expired assignments, but preserve those for active coworkers.
+    ///
+    /// Same as `cleanup_expired_assignments` but skips removal of assignments
+    /// where the reviewer coworker is still running. This prevents losing track
+    /// of a reviewer just because the review is taking longer than the timeout.
+    /// Active coworkers' assignments are refreshed to the current time.
+    pub fn cleanup_expired_preserving(
+        &mut self,
+        active_coworkers: &std::collections::HashSet<String>,
+    ) {
+        let now = Utc::now();
+        let timeout = chrono::Duration::seconds(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS as i64);
+        let to_remove: Vec<_> = self
+            .pr_reviewers
+            .iter()
+            .filter(|(_, a)| {
+                now.signed_duration_since(a.assigned_at) > timeout
+                    && !active_coworkers.contains(&a.reviewer)
+            })
+            .map(|(pr, _)| *pr)
+            .collect();
+
+        for pr in to_remove {
+            debug!(
+                "Cleaning up expired reviewer assignment for PR #{} (timed out, coworker inactive)",
+                pr
+            );
+            self.pr_reviewers.remove(&pr);
+        }
+
+        // Refresh timestamps for active coworkers whose assignments would have expired
+        for assignment in self.pr_reviewers.values_mut() {
+            if now.signed_duration_since(assignment.assigned_at) > timeout
+                && active_coworkers.contains(&assignment.reviewer)
+            {
+                assignment.assigned_at = now;
+            }
+        }
+    }
+
     /// Clean up assignments for PRs that are no longer open.
     ///
     /// Takes a list of open PR numbers and removes assignments for any PRs not in the list.
@@ -320,5 +360,49 @@ mod tests {
         // PR 42 should be removed (expired), PR 43 should remain (fresh)
         assert!(!state.pr_reviewers.contains_key(&42));
         assert!(state.pr_reviewers.contains_key(&43));
+    }
+
+    #[test]
+    fn test_cleanup_expired_preserves_active_coworkers() {
+        let mut state = GitHubState::default();
+        state.assign_reviewer(42, "broadway");
+        state.assign_reviewer(43, "park");
+
+        // Backdate broadway's assignment past the timeout
+        if let Some(assignment) = state.pr_reviewers.get_mut(&42) {
+            assignment.assigned_at = Utc::now()
+                - chrono::Duration::seconds(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS as i64 + 1);
+        }
+
+        // broadway is still active
+        let active: std::collections::HashSet<String> =
+            ["broadway".to_string()].into_iter().collect();
+
+        state.cleanup_expired_preserving(&active);
+
+        // broadway's expired assignment should be preserved (still active coworker)
+        assert!(state.pr_reviewers.contains_key(&42));
+        // park's fresh assignment should also be there
+        assert!(state.pr_reviewers.contains_key(&43));
+    }
+
+    #[test]
+    fn test_cleanup_expired_removes_inactive_expired() {
+        let mut state = GitHubState::default();
+        state.assign_reviewer(42, "broadway");
+
+        // Backdate assignment past timeout
+        if let Some(assignment) = state.pr_reviewers.get_mut(&42) {
+            assignment.assigned_at = Utc::now()
+                - chrono::Duration::seconds(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS as i64 + 1);
+        }
+
+        // broadway is NOT active
+        let active: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        state.cleanup_expired_preserving(&active);
+
+        // Should be removed (expired + inactive)
+        assert!(!state.pr_reviewers.contains_key(&42));
     }
 }


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Reviewers were being sent on break with "no PR assignment found" because PR assignment tracking expired after 10 minutes even when the reviewer coworker was still actively running
- Added `cleanup_preserving()` methods to both `PrReviewTracker` and `GitHubState` that skip removal of assignments for active coworkers and refresh their timestamps
- Updated idle checker to consult both in-memory and persistent state for reviewer assignments, surviving daemon restarts

## Root cause
Two issues combined to cause the bug:
1. **Assignment timeout expiry**: Both in-memory and persistent trackers clean up assignments older than `PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS` (10 min). Code reviews often take longer. Once expired, the reviewer lost idle-check protection AND the shutdown path couldn't find their PR assignment.
2. **Missing persistent state check**: The idle checker only checked in-memory `active_reviewers()`. After a daemon restart, the in-memory tracker is empty, so all surviving reviewers immediately lost protection — even though the persistent `github_state.json` still had their assignments.

## Changes
- `PrReviewTracker::cleanup_preserving(active_coworkers)` — retains + refreshes expired assignments for still-running coworkers
- `GitHubState::cleanup_expired_preserving(active_coworkers)` — same for persistent state
- `poll_prs_for_issues` — passes active coworker names to both cleanup methods
- `check_and_shutdown_idle_coworkers` — merges persistent state reviewers into `active_reviewers` set

## Test plan
- [x] 4 new unit tests covering preserving and removal behavior for both trackers
- [x] All 327 existing tests pass
- [x] Clippy + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)