### PR TITLE
fix: include repo_statuses in web API for multi-repo PR links

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -785,13 +785,34 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
     let mut shared_push_manager: Option<std::sync::Arc<crate::push::PushManager>> = None;
     let (forwarder_shutdown_tx, forwarder_shutdown_rx) = watch::channel(false);
 
+    // Build list of all repo paths for multi-repo PR fetching
+    // (needed by both the web server and daemon state)
+    let all_repo_paths = {
+        let mut paths = vec![config.workdir.clone()];
+        if let Some(full_config) = crate::config::load_full_project_config(&project_name) {
+            for repo in full_config.project.repos() {
+                let path = PathBuf::from(repo);
+                if path != config.workdir {
+                    paths.push(path);
+                }
+            }
+        }
+        paths
+    };
+
     if let Some(port) = config.webhook_port {
         let webhook_config = WebhookConfig {
             port,
             secret: config.webhook_secret.clone(),
             repo: repo_name.clone(),
         };
-        match start_webhook_server(webhook_config, Some(coworker_manager.clone())).await {
+        match start_webhook_server(
+            webhook_config,
+            Some(coworker_manager.clone()),
+            all_repo_paths.clone(),
+        )
+        .await
+        {
             Ok((rx, updates_tx, mob_rx, push_mgr)) => {
                 info!("Webhook server started on port {}", port);
                 webhook_rx = Some(rx);
@@ -817,20 +838,6 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
 
     // Create daemon state (pass channel and web updates sender so messages
     // are broadcast to WebSocket clients in real-time)
-    // Build list of all repo paths for multi-repo PR fetching
-    let all_repo_paths = {
-        let mut paths = vec![config.workdir.clone()];
-        if let Some(full_config) = crate::config::load_full_project_config(&project_name) {
-            for repo in full_config.project.repos() {
-                let path = PathBuf::from(repo);
-                if path != config.workdir {
-                    paths.push(path);
-                }
-            }
-        }
-        paths
-    };
-
     let state = Arc::new(DaemonState::new(
         config.socket_path.clone(),
         coworker_manager,

--- a/src/web.rs
+++ b/src/web.rs
@@ -57,6 +57,8 @@ pub struct WebState {
     pub channel_post_tx: mpsc::Sender<MobileChannelPost>,
     /// Web Push notification manager (shared with daemon)
     pub push_manager: Option<Arc<PushManager>>,
+    /// Paths to all repos in the project (for multi-repo PR URL resolution)
+    pub all_repo_paths: Vec<std::path::PathBuf>,
 }
 
 /// Types of real-time updates sent to clients
@@ -396,6 +398,46 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
         .await
         .unwrap_or_default();
 
+    // Build repo metadata for multi-repo PR URL resolution
+    let repo_paths = state.all_repo_paths.clone();
+    let repo_statuses: Vec<serde_json::Value> = if repo_paths.len() > 1 {
+        tokio::task::spawn_blocking(move || {
+            repo_paths
+                .iter()
+                .map(|repo_path| {
+                    let label = repo_path
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("unknown")
+                        .to_string();
+                    let full_name = std::process::Command::new("gh")
+                        .current_dir(repo_path)
+                        .args([
+                            "repo",
+                            "view",
+                            "--json",
+                            "nameWithOwner",
+                            "--jq",
+                            ".nameWithOwner",
+                        ])
+                        .output()
+                        .ok()
+                        .filter(|o| o.status.success())
+                        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+                        .unwrap_or_default();
+                    serde_json::json!({
+                        "label": label,
+                        "fullName": full_name,
+                    })
+                })
+                .collect()
+        })
+        .await
+        .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
     let status = serde_json::json!({
         "daemon": "running",
         "coworkers": coworkers_data,
@@ -404,6 +446,7 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
         "merged_prs": merged_prs,
         "repo_name": state.config.repo,
         "repo_status": repo_status,
+        "repo_statuses": repo_statuses,
     });
 
     Ok(axum::Json(status))
@@ -716,6 +759,7 @@ mod tests {
             coworkers: None,
             channel_post_tx,
             push_manager: None,
+            all_repo_paths: Vec::new(),
         });
 
         let json = r#"{"type": "send_message", "content": "hello from mobile"}"#;

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -102,6 +102,7 @@ const GITHUB_SIGNATURE_HEADER: &str = "X-Hub-Signature-256";
 pub async fn start_webhook_server(
     config: WebhookConfig,
     coworker_manager: Option<CoworkerManager>,
+    all_repo_paths: Vec<std::path::PathBuf>,
 ) -> crate::Result<(
     mpsc::Receiver<WebhookEvent>,
     broadcast::Sender<WebUpdate>,
@@ -140,6 +141,7 @@ pub async fn start_webhook_server(
         coworkers: coworker_manager,
         channel_post_tx: mobile_tx,
         push_manager: push_manager.clone(),
+        all_repo_paths,
     });
 
     // CORS layer for development (allows requests from Vite dev server)


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Fixed kanban board PR links always pointing to hardcoded default repo instead of the correct repo in multi-repo projects
- Added `all_repo_paths` to `WebState` and threaded it from daemon startup through `start_webhook_server`
- The `/api/status` endpoint now returns `repo_statuses` array with `{label, fullName}` for each repo, matching what `Kanban.svelte`'s `prRepoUrl()` expects
- Moved `all_repo_paths` computation earlier in `daemon.rs` so it's available for both the web server and daemon state

## Test plan
- [x] `cargo check` — clean compile
- [x] `cargo test` — all 474 tests pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)