### PR TITLE
test: add pure decision functions and tests for daemon lifecycle rules

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6333,6 +6333,16 @@ mod tests {
     }
 
     #[test]
+    fn test_idle_shutdown_isolated_but_reviewing_protected() {
+        // Regression test for PR #344: isolated coworkers (reviewers) must NOT be
+        // shut down while they still have an active review assignment.
+        let cw = test_isolated_coworker("broadway");
+        let now = Instant::now();
+        let decision = decide_idle_shutdown(&cw, false, false, true, None, now, Utc::now());
+        assert_eq!(decision, IdleDecision::Protected);
+    }
+
+    #[test]
     fn test_idle_shutdown_starts_tracking_new_idle() {
         let cw = test_coworker("park");
         let now = Instant::now();


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Adds `decisions` module (behind `#[cfg(test)]`) with pure decision functions extracted from `check_and_shutdown_idle_coworkers`, `check_and_nudge_interrupted_coworkers`, and `check_and_nudge_prompted_coworkers`
- Adds 16 new test cases covering all lifecycle decision scenarios (idle shutdown, interrupt nudge, prompt detection)
- Test count goes from 78 to 94 — all existing tests continue to pass
- This is PR 1 of the daemon rules engine refactor (Phase 1a from the plan)

## Test plan
- [x] `cargo test --lib daemon::tests` — all 94 tests pass
- [x] `cargo test` — full suite passes
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)