### PR TITLE
feat: extract PR/review + task assignment decision functions (Phase 3c+3d)

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1913,74 +1913,70 @@ fn route_mentions(state: &DaemonState, msg: &Message) {
     );
 
     for name in mentions {
-        // Skip if mentioned coworker is the sender (don't nudge yourself)
-        if name.eq_ignore_ascii_case(&msg.from) {
-            continue;
-        }
-
-        // Check if coworker is already running
         let is_running = state.coworkers.get(&name).is_some();
-
-        // Build the message to send to the coworker
         let nudge_text = format!("{} said: {}", msg.from, msg.content);
 
-        if !is_running {
-            // Check dev coworkers limit before spawning (reserve slots for reviewers)
-            if state.is_at_dev_limit() {
-                debug!(
-                    "Dev coworkers limit reached, cannot spawn {} for @mention",
-                    name
-                );
-                let err_msg = Message::text(
-                    "midtown",
-                    format!(
-                        "⚠️ Cannot call in {} for @mention: dev coworkers limit reached",
-                        name
-                    ),
-                );
-                let _ = state.send_and_broadcast(&err_msg);
-                continue;
-            }
+        // Decide action using pure decision function
+        let action = crate::rules::decide_mention_action(
+            &name,
+            &msg.from,
+            is_running,
+            state.is_at_dev_limit(),
+            &nudge_text,
+        );
 
-            // Spawn the coworker with resume flag and the @mention message as prompt
-            info!(
-                "Spawning mentioned coworker {} (not currently running)",
-                name
-            );
-            // spawn_with_name handles waiting and sending the prompt internally
-            // Use shared task list (not isolated) for @mention spawns
-            match state
-                .coworkers
-                .spawn_with_name(&name, true, Some(&nudge_text), false)
-            {
-                Ok(_) => {
-                    info!("Spawned coworker {} via @mention", name);
-                    // Post to channel about the call-in
-                    let spawn_msg = Message::text(
-                        "midtown",
-                        format!("🚀 Called in {} in response to @mention", name),
-                    );
-                    if let Err(e) = state.send_and_broadcast(&spawn_msg) {
-                        warn!("Failed to post call-in message: {}", e);
+        match action {
+            crate::rules::MentionAction::Nudge {
+                name: ref n,
+                message: ref m,
+            } => {
+                if let Err(e) = state.coworkers.nudge(n, m) {
+                    warn!("Failed to nudge {} about @mention: {}", n, e);
+                } else {
+                    info!("Nudged {} about @mention from {}", n, msg.from);
+                }
+            }
+            crate::rules::MentionAction::Spawn {
+                name: ref n,
+                message: ref m,
+            } => {
+                info!("Spawning mentioned coworker {} (not currently running)", n);
+                match state
+                    .coworkers
+                    .spawn_with_name(n, true, Some(m.as_str()), false)
+                {
+                    Ok(_) => {
+                        info!("Spawned coworker {} via @mention", n);
+                        let spawn_msg = Message::text(
+                            "midtown",
+                            format!("🚀 Called in {} in response to @mention", n),
+                        );
+                        if let Err(e) = state.send_and_broadcast(&spawn_msg) {
+                            warn!("Failed to post call-in message: {}", e);
+                        }
+                    }
+                    Err(e) => {
+                        warn!("Failed to spawn coworker {}: {}", n, e);
+                        let err_msg = Message::text(
+                            "midtown",
+                            format!("⚠️ Failed to call in {} for @mention: {}", n, e),
+                        );
+                        let _ = state.send_and_broadcast(&err_msg);
                     }
                 }
-                Err(e) => {
-                    warn!("Failed to spawn coworker {}: {}", name, e);
-                    // Post error to channel
+            }
+            crate::rules::MentionAction::Skip { ref reason } => {
+                debug!("{}", reason);
+                if reason.contains("dev limit") {
                     let err_msg = Message::text(
                         "midtown",
-                        format!("⚠️ Failed to call in {} for @mention: {}", name, e),
+                        format!(
+                            "⚠️ Cannot call in {} for @mention: dev coworkers limit reached",
+                            name
+                        ),
                     );
                     let _ = state.send_and_broadcast(&err_msg);
-                    continue;
                 }
-            }
-        } else {
-            // Coworker is already running - just nudge them
-            if let Err(e) = state.coworkers.nudge(&name, &nudge_text) {
-                warn!("Failed to nudge {} about @mention: {}", name, e);
-            } else {
-                info!("Nudged {} about @mention from {}", name, msg.from);
             }
         }
     }
@@ -4169,102 +4165,77 @@ async fn check_and_recover_orphans(state: &DaemonState) {
         .map(|cw| cw.name.to_lowercase())
         .collect();
 
-    // Check dev coworkers limit before attempting recovery (reserve slots for reviewers)
-    if state.is_at_dev_limit() {
-        debug!("Dev coworkers limit reached, deferring orphan recovery");
+    // Decide which orphan (if any) to recover using pure decision function
+    let recovery =
+        crate::rules::decide_orphan_recovery(&in_progress, &active_names, state.is_at_dev_limit());
+
+    let Some(recovery) = recovery else {
         return;
-    }
+    };
 
-    // Find orphaned tasks (in_progress with owner not in active list)
-    // Rate limit: only recover ONE coworker per tick to prevent spawn storms
-    for (task_id, task_subject, owner) in in_progress {
-        // Skip if owner is Lead, empty, or just whitespace/quotes
-        let owner = owner.trim().trim_matches('"').to_string();
-        if owner.is_empty() || owner.eq_ignore_ascii_case("lead") {
-            continue;
+    info!(
+        "Detected orphaned task #{} owned by {} - attempting recovery",
+        recovery.task_id, recovery.owner
+    );
+
+    let prompt = format!(
+        "Resume task #{}: {}. You were working on this task before your session was interrupted. Check your git status and continue where you left off.",
+        recovery.task_id, recovery.task_subject
+    );
+
+    match state
+        .coworkers
+        .spawn_with_name(&recovery.owner, true, Some(&prompt), false)
+    {
+        Ok(_) => {
+            info!("Respawned coworker {} successfully", recovery.owner);
+            state.broadcast_coworker_update(&recovery.owner, "running", None);
+
+            // Update last spawn time for rate limiting
+            {
+                let mut last_spawn = state.last_orphan_spawn.lock().await;
+                *last_spawn = Some(Instant::now());
+            }
+
+            let recovery_msg = Message::text(
+                "midtown",
+                format!(
+                    "♻️ Recovered coworker {} for orphaned task #{}",
+                    recovery.owner, recovery.task_id
+                ),
+            );
+            if let Err(e) = state.send_and_broadcast(&recovery_msg) {
+                warn!("Failed to post recovery message: {}", e);
+            }
         }
+        Err(e) => {
+            warn!(
+                "Could not respawn {} for orphaned task #{}: {} - resetting task to pending",
+                recovery.owner, recovery.task_id, e
+            );
 
-        // Skip if coworker is already active
-        if active_names.contains(&owner.to_lowercase()) {
-            continue;
-        }
+            if let Err(reset_err) =
+                crate::tasks::reset_task_to_pending_for_repo(&recovery.task_id, &state.repo_name)
+            {
+                warn!(
+                    "Failed to reset orphaned task #{} to pending: {}",
+                    recovery.task_id, reset_err
+                );
+            } else {
+                info!(
+                    "Reset orphaned task #{} to pending (original owner {} could not be respawned)",
+                    recovery.task_id, recovery.owner
+                );
 
-        // This is an orphaned task - try to recover the coworker
-        info!(
-            "Detected orphaned task #{} owned by {} - attempting recovery",
-            task_id, owner
-        );
-
-        // Build the prompt message to send during spawn
-        let prompt = format!(
-            "Resume task #{}: {}. You were working on this task before your session was interrupted. Check your git status and continue where you left off.",
-            task_id, task_subject
-        );
-
-        // spawn_with_name handles waiting and sending the prompt internally
-        // Use shared task list (not isolated) for orphan recovery spawns
-        match state
-            .coworkers
-            .spawn_with_name(&owner, true, Some(&prompt), false)
-        {
-            Ok(_) => {
-                info!("Respawned coworker {} successfully", owner);
-                state.broadcast_coworker_update(&owner, "running", None);
-
-                // Update last spawn time for rate limiting
-                {
-                    let mut last_spawn = state.last_orphan_spawn.lock().await;
-                    *last_spawn = Some(Instant::now());
-                }
-
-                // Post to channel about the recovery
-                let recovery_msg = Message::text(
+                let msg = Message::text(
                     "midtown",
                     format!(
-                        "♻️ Recovered coworker {} for orphaned task #{}",
-                        owner, task_id
+                        "🔄 Task #{} reset to pending - {} could not be called back in",
+                        recovery.task_id, recovery.owner
                     ),
                 );
-                if let Err(e) = state.send_and_broadcast(&recovery_msg) {
-                    warn!("Failed to post recovery message: {}", e);
-                }
-
-                // Rate limit: only spawn ONE coworker per tick
-                break;
-            }
-            Err(e) => {
-                // Could not respawn - reset task to pending so another coworker can claim it
-                // This might happen if the worktree doesn't exist after restart
-                warn!(
-                    "Could not respawn {} for orphaned task #{}: {} - resetting task to pending",
-                    owner, task_id, e
-                );
-
-                // Reset the task so it can be picked up by another coworker
-                if let Err(reset_err) =
-                    crate::tasks::reset_task_to_pending_for_repo(&task_id, &state.repo_name)
-                {
-                    warn!(
-                        "Failed to reset orphaned task #{} to pending: {}",
-                        task_id, reset_err
-                    );
-                } else {
-                    info!(
-                        "Reset orphaned task #{} to pending (original owner {} could not be respawned)",
-                        task_id, owner
-                    );
-
-                    // Post to channel so team knows the task is available
-                    let msg = Message::text(
-                        "midtown",
-                        format!(
-                            "🔄 Task #{} reset to pending - {} could not be called back in",
-                            task_id, owner
-                        ),
-                    );
-                    if let Err(e) = state.send_and_broadcast(&msg) {
-                        warn!("Failed to post task reset message: {}", e);
-                    }
+                if let Err(e) = state.send_and_broadcast(&msg) {
+                    warn!("Failed to post task reset message: {}", e);
                 }
             }
         }
@@ -4577,89 +4548,77 @@ fn spawn_for_pending_tasks(state: &DaemonState) {
     // Case 1: Pending tasks with owners assigned but coworker not running
     let pending_with_owners = crate::tasks::get_pending_tasks_with_owners();
     for (task_id, task_subject, owner) in pending_with_owners {
-        // Skip if owner is Lead or empty
-        if owner.is_empty() || owner.eq_ignore_ascii_case("lead") {
-            continue;
-        }
+        // Check nudge cooldown for this task
+        let task_key = format!("pending-{}", task_id);
+        let on_nudge_cooldown = {
+            let cooldowns = state.pending_task_nudge_cooldowns.lock().unwrap();
+            match cooldowns.get(&task_key) {
+                Some(last_nudge) => last_nudge.elapsed() < Duration::from_secs(300),
+                None => false,
+            }
+        };
 
-        // If coworker is already active, nudge them about the pending task (with cooldown)
-        if active_names.contains(&owner.to_lowercase()) {
-            let task_key = format!("pending-{}", task_id);
-            let should_nudge = {
-                let cooldowns = state.pending_task_nudge_cooldowns.lock().unwrap();
-                match cooldowns.get(&task_key) {
-                    Some(last_nudge) => last_nudge.elapsed() >= Duration::from_secs(300),
-                    None => true,
-                }
-            };
-            if should_nudge {
-                let nudge_msg = format!(
-                    "You have pending task #{}: {}. Get started!",
-                    task_id, task_subject
-                );
-                if let Err(e) = state.coworkers.nudge(&owner, &nudge_msg) {
-                    debug!(
-                        "Failed to nudge {} about pending task #{}: {}",
-                        owner, task_id, e
-                    );
+        // Decide action using pure decision function
+        let action = crate::rules::decide_pending_task_action(
+            &task_id.to_string(),
+            &task_subject,
+            &owner,
+            &active_names,
+            state.is_at_dev_limit(),
+            on_nudge_cooldown,
+        );
+
+        match action {
+            crate::rules::PendingTaskAction::NudgeOwner {
+                owner: ref o,
+                task_id: ref tid,
+                task_subject: ref subj,
+            } => {
+                let nudge_msg = format!("You have pending task #{}: {}. Get started!", tid, subj);
+                if let Err(e) = state.coworkers.nudge(o, &nudge_msg) {
+                    debug!("Failed to nudge {} about pending task #{}: {}", o, tid, e);
                 } else {
-                    info!("Nudged {} about pending task #{}", owner, task_id);
+                    info!("Nudged {} about pending task #{}", o, tid);
                     let mut cooldowns = state.pending_task_nudge_cooldowns.lock().unwrap();
                     cooldowns.insert(task_key, Instant::now());
                 }
             }
-            continue;
-        }
-
-        // Check dev coworkers limit before spawning (reserve slots for reviewers)
-        if state.is_at_dev_limit() {
-            debug!(
-                "Dev coworkers limit reached, deferring spawn for task #{} owned by {}",
-                task_id, owner
-            );
-            continue;
-        }
-
-        // Coworker is assigned but not running - spawn with prompt
-        info!(
-            "Pending task #{} is assigned to {} but coworker not running - spawning",
-            task_id, owner
-        );
-
-        // Build the prompt message to send during spawn
-        let prompt = format!(
-            "You've been assigned task #{}: {}. Get started!",
-            task_id, task_subject
-        );
-
-        // spawn_with_name handles waiting and sending the prompt internally
-        // Use shared task list (not isolated) for assigned task spawns
-        match state
-            .coworkers
-            .spawn_with_name(&owner, true, Some(&prompt), false)
-        {
-            Ok(_) => {
-                info!("Spawned coworker {} for pending task #{}", owner, task_id);
-                state.broadcast_coworker_update(&owner, "running", None);
-
-                // Post to channel
-                let msg = Message::text(
-                    "midtown",
-                    daemon_messages::called_in_pending_task(
-                        &owner,
-                        &task_id.to_string(),
-                        config::get_personality(),
-                    ),
+            crate::rules::PendingTaskAction::SpawnOwner {
+                owner: ref o,
+                task_id: ref tid,
+                task_subject: ref subj,
+            } => {
+                info!(
+                    "Pending task #{} is assigned to {} but coworker not running - spawning",
+                    tid, o
                 );
-                if let Err(e) = state.send_and_broadcast(&msg) {
-                    warn!("Failed to post call-in message: {}", e);
+                let prompt = format!("You've been assigned task #{}: {}. Get started!", tid, subj);
+                match state
+                    .coworkers
+                    .spawn_with_name(o, true, Some(&prompt), false)
+                {
+                    Ok(_) => {
+                        info!("Spawned coworker {} for pending task #{}", o, tid);
+                        state.broadcast_coworker_update(o, "running", None);
+                        let msg = Message::text(
+                            "midtown",
+                            daemon_messages::called_in_pending_task(
+                                o,
+                                &tid.to_string(),
+                                config::get_personality(),
+                            ),
+                        );
+                        if let Err(e) = state.send_and_broadcast(&msg) {
+                            warn!("Failed to post call-in message: {}", e);
+                        }
+                    }
+                    Err(e) => {
+                        debug!("Could not spawn {} for pending task #{}: {}", o, tid, e);
+                    }
                 }
             }
-            Err(e) => {
-                debug!(
-                    "Could not spawn {} for pending task #{}: {}",
-                    owner, task_id, e
-                );
+            crate::rules::PendingTaskAction::Skip { ref reason } => {
+                debug!("{}", reason);
             }
         }
     }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -647,6 +647,165 @@ pub(crate) fn decide_review_complete_action(
 }
 
 // ---------------------------------------------------------------------------
+// Task assignment decision types and functions
+// ---------------------------------------------------------------------------
+
+/// Action to take for a pending task with an assigned owner.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PendingTaskAction {
+    /// Owner is active — nudge them about the pending task.
+    NudgeOwner {
+        owner: String,
+        task_id: String,
+        task_subject: String,
+    },
+    /// Owner is inactive — spawn them for the pending task.
+    SpawnOwner {
+        owner: String,
+        task_id: String,
+        task_subject: String,
+    },
+    /// Skip — owner is lead/empty, at dev limit, or nudge on cooldown.
+    Skip { reason: String },
+}
+
+/// Decide what action to take for a pending task with an assigned owner.
+///
+/// Pure function: determines whether to nudge an active owner, spawn an
+/// inactive one, or skip.
+pub(crate) fn decide_pending_task_action(
+    task_id: &str,
+    task_subject: &str,
+    owner: &str,
+    active_names: &HashSet<String>,
+    at_dev_limit: bool,
+    on_nudge_cooldown: bool,
+) -> PendingTaskAction {
+    // Skip empty or lead-owned tasks
+    if owner.is_empty() || owner.eq_ignore_ascii_case("lead") {
+        return PendingTaskAction::Skip {
+            reason: format!("task #{} owner is lead or empty", task_id),
+        };
+    }
+
+    // Owner is active → nudge (unless on cooldown)
+    if active_names.contains(&owner.to_lowercase()) {
+        if on_nudge_cooldown {
+            return PendingTaskAction::Skip {
+                reason: format!("task #{} nudge on cooldown for {}", task_id, owner),
+            };
+        }
+        return PendingTaskAction::NudgeOwner {
+            owner: owner.to_string(),
+            task_id: task_id.to_string(),
+            task_subject: task_subject.to_string(),
+        };
+    }
+
+    // Owner is inactive → check dev limit
+    if at_dev_limit {
+        return PendingTaskAction::Skip {
+            reason: format!(
+                "dev limit reached, deferring spawn for task #{} owned by {}",
+                task_id, owner
+            ),
+        };
+    }
+
+    PendingTaskAction::SpawnOwner {
+        owner: owner.to_string(),
+        task_id: task_id.to_string(),
+        task_subject: task_subject.to_string(),
+    }
+}
+
+/// Result of orphan recovery decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OrphanRecovery {
+    pub task_id: String,
+    pub task_subject: String,
+    pub owner: String,
+}
+
+/// Decide which orphaned task (if any) to recover.
+///
+/// An orphaned task is `in_progress` but its owner is not active.
+/// Returns at most ONE recovery action (rate-limited to one per tick).
+pub(crate) fn decide_orphan_recovery(
+    in_progress: &[(String, String, String)], // (task_id, task_subject, owner)
+    active_names: &HashSet<String>,
+    at_dev_limit: bool,
+) -> Option<OrphanRecovery> {
+    if at_dev_limit {
+        return None;
+    }
+
+    for (task_id, task_subject, owner) in in_progress {
+        let owner_clean = owner.trim().trim_matches('"').to_string();
+        if owner_clean.is_empty() || owner_clean.eq_ignore_ascii_case("lead") {
+            continue;
+        }
+        if active_names.contains(&owner_clean.to_lowercase()) {
+            continue;
+        }
+        // Found an orphan — return the first one (rate-limited)
+        return Some(OrphanRecovery {
+            task_id: task_id.clone(),
+            task_subject: task_subject.clone(),
+            owner: owner_clean,
+        });
+    }
+
+    None
+}
+
+/// Action to take for an @mention of a coworker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MentionAction {
+    /// Coworker is active — nudge them.
+    Nudge { name: String, message: String },
+    /// Coworker is inactive — spawn them.
+    Spawn { name: String, message: String },
+    /// Skip — self-mention or at dev limit.
+    Skip { reason: String },
+}
+
+/// Decide what action to take for an @mention of a coworker.
+pub(crate) fn decide_mention_action(
+    mentioned_name: &str,
+    sender: &str,
+    is_running: bool,
+    at_dev_limit: bool,
+    nudge_text: &str,
+) -> MentionAction {
+    // Skip self-mentions
+    if mentioned_name.eq_ignore_ascii_case(sender) {
+        return MentionAction::Skip {
+            reason: format!("{} mentioned themselves, skipping", mentioned_name),
+        };
+    }
+
+    if is_running {
+        MentionAction::Nudge {
+            name: mentioned_name.to_string(),
+            message: nudge_text.to_string(),
+        }
+    } else if at_dev_limit {
+        MentionAction::Skip {
+            reason: format!(
+                "dev limit reached, cannot spawn {} for @mention",
+                mentioned_name
+            ),
+        }
+    } else {
+        MentionAction::Spawn {
+            name: mentioned_name.to_string(),
+            message: nudge_text.to_string(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -1239,5 +1398,156 @@ mod tests {
         let action =
             decide_review_complete_action("york", &active(&["amsterdam"]), true, "review complete");
         assert!(matches!(action, PrAction::Skip { .. }));
+    }
+
+    // -----------------------------------------------------------------------
+    // decide_pending_task_action tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pending_task_nudges_active_owner() {
+        let names = set(&["york"]);
+        let action = decide_pending_task_action("42", "Fix bug", "york", &names, false, false);
+        assert!(matches!(action, PendingTaskAction::NudgeOwner { .. }));
+    }
+
+    #[test]
+    fn pending_task_skips_nudge_on_cooldown() {
+        let names = set(&["york"]);
+        let action = decide_pending_task_action("42", "Fix bug", "york", &names, false, true);
+        assert!(matches!(action, PendingTaskAction::Skip { .. }));
+    }
+
+    #[test]
+    fn pending_task_spawns_inactive_owner() {
+        let names = set(&["amsterdam"]);
+        let action = decide_pending_task_action("42", "Fix bug", "york", &names, false, false);
+        assert_eq!(
+            action,
+            PendingTaskAction::SpawnOwner {
+                owner: "york".to_string(),
+                task_id: "42".to_string(),
+                task_subject: "Fix bug".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn pending_task_skips_at_dev_limit() {
+        let names = set(&["amsterdam"]);
+        let action = decide_pending_task_action("42", "Fix bug", "york", &names, true, false);
+        assert!(matches!(action, PendingTaskAction::Skip { .. }));
+    }
+
+    #[test]
+    fn pending_task_skips_lead_owner() {
+        let names = set(&["york"]);
+        let action = decide_pending_task_action("42", "Fix bug", "lead", &names, false, false);
+        assert!(matches!(action, PendingTaskAction::Skip { .. }));
+    }
+
+    #[test]
+    fn pending_task_skips_empty_owner() {
+        let names = set(&["york"]);
+        let action = decide_pending_task_action("42", "Fix bug", "", &names, false, false);
+        assert!(matches!(action, PendingTaskAction::Skip { .. }));
+    }
+
+    // -----------------------------------------------------------------------
+    // decide_orphan_recovery tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn orphan_recovery_finds_orphan() {
+        let tasks = vec![("1".to_string(), "Fix bug".to_string(), "york".to_string())];
+        let active = set(&["amsterdam"]);
+        let result = decide_orphan_recovery(&tasks, &active, false);
+        assert_eq!(
+            result,
+            Some(OrphanRecovery {
+                task_id: "1".to_string(),
+                task_subject: "Fix bug".to_string(),
+                owner: "york".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn orphan_recovery_skips_active_owner() {
+        let tasks = vec![("1".to_string(), "Fix bug".to_string(), "york".to_string())];
+        let active = set(&["york"]);
+        let result = decide_orphan_recovery(&tasks, &active, false);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn orphan_recovery_skips_at_dev_limit() {
+        let tasks = vec![("1".to_string(), "Fix bug".to_string(), "york".to_string())];
+        let active = set(&["amsterdam"]);
+        let result = decide_orphan_recovery(&tasks, &active, true);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn orphan_recovery_skips_lead_owner() {
+        let tasks = vec![("1".to_string(), "Fix bug".to_string(), "lead".to_string())];
+        let active = set(&["amsterdam"]);
+        let result = decide_orphan_recovery(&tasks, &active, false);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn orphan_recovery_returns_first_only() {
+        let tasks = vec![
+            ("1".to_string(), "Fix bug".to_string(), "york".to_string()),
+            (
+                "2".to_string(),
+                "Add test".to_string(),
+                "broadway".to_string(),
+            ),
+        ];
+        let active = set(&["amsterdam"]);
+        let result = decide_orphan_recovery(&tasks, &active, false);
+        assert_eq!(result.unwrap().task_id, "1");
+    }
+
+    // -----------------------------------------------------------------------
+    // decide_mention_action tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn mention_nudges_running_coworker() {
+        let action = decide_mention_action("york", "amsterdam", true, false, "hey york");
+        assert_eq!(
+            action,
+            MentionAction::Nudge {
+                name: "york".to_string(),
+                message: "hey york".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn mention_spawns_inactive_coworker() {
+        let action = decide_mention_action("york", "amsterdam", false, false, "hey york");
+        assert_eq!(
+            action,
+            MentionAction::Spawn {
+                name: "york".to_string(),
+                message: "hey york".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn mention_skips_self_mention() {
+        let action = decide_mention_action("york", "york", true, false, "hey @york");
+        assert!(matches!(action, MentionAction::Skip { .. }));
+    }
+
+    #[test]
+    fn mention_skips_at_dev_limit() {
+        let action = decide_mention_action("york", "amsterdam", false, true, "hey york");
+        assert!(matches!(action, MentionAction::Skip { .. }));
     }
 }


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
Extracts decision logic from daemon.rs into pure functions in rules.rs, completing Phase 3 of the rules engine refactor.

### Phase 3c: PR/review decision functions
- `PrAction` enum (`NudgeOwner`, `SpawnOwner`, `PostToChannel`, `Skip`)
- `decide_pr_issue_action()` — for PR issues detected during polling
- `decide_pr_comment_action()` — for webhook-driven PR comment nudges
- `decide_review_complete_action()` — for completed review feedback
- Refactored: `poll_prs_for_issues`, `handle_pr_comment_nudge`, `spawn_reviewers_for_prs`

### Phase 3d: Task assignment + mention routing decision functions
- `PendingTaskAction` enum (`NudgeOwner`, `SpawnOwner`, `Skip`)
- `decide_pending_task_action()` — for owned pending task decisions
- `OrphanRecovery` struct + `decide_orphan_recovery()` — orphan detection
- `MentionAction` enum (`Nudge`, `Spawn`, `Skip`)
- `decide_mention_action()` — for @mention routing
- Refactored: `spawn_for_pending_tasks`, `check_and_recover_orphans`, `route_mentions`

This completes Phase 3 — all four "spawn vs nudge" locations identified in the plan now use centralized pure decision functions.

## Test plan
- [x] All 443 unit tests pass (27 new decision tests)
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)