### PR TITLE
feat: daemon waits for empty lead input before nudging

### DIFF
--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -4,13 +4,18 @@
 //! within the project session.
 
 use std::collections::HashMap;
+use std::sync::mpsc;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::tmux;
 use crate::worktree::{WorktreeError, WorktreeManager};
+
+/// Timeout for waiting for the lead's input to be empty before nudging.
+const LEAD_INPUT_WAIT_TIMEOUT: Duration = Duration::from_secs(90);
 
 /// Primary Manhattan avenue names used for coworker naming.
 const AVENUE_NAMES: &[&str] = &[
@@ -96,6 +101,9 @@ pub struct CoworkerManager {
     /// Names of coworkers discovered from tmux on startup (before daemon was managing them).
     /// Used to nudge them to continue their tasks after daemon restart.
     discovered_on_startup: Arc<RwLock<Vec<String>>>,
+    /// Queue for lead nudges. A background thread waits for the lead's input to
+    /// be empty before delivering each nudge, so the daemon loop is never blocked.
+    lead_nudge_tx: mpsc::Sender<String>,
 }
 
 impl CoworkerManager {
@@ -120,6 +128,19 @@ impl CoworkerManager {
         additional_worktree_managers: Vec<WorktreeManager>,
     ) -> Self {
         let session = session_name.into();
+
+        // Spawn a background thread to process lead nudges with input-empty waiting.
+        // The thread waits for the lead's input to be clear before delivering each nudge,
+        // ensuring the daemon loop is never blocked and nudges arrive in FIFO order.
+        let (lead_nudge_tx, lead_nudge_rx) = mpsc::channel::<String>();
+        let nudge_session = session.clone();
+        std::thread::Builder::new()
+            .name("lead-nudge-queue".into())
+            .spawn(move || {
+                Self::lead_nudge_worker(&nudge_session, lead_nudge_rx);
+            })
+            .expect("Failed to spawn lead nudge worker thread");
+
         let manager = Self {
             coworkers: Arc::new(RwLock::new(HashMap::new())),
             worktree_manager: Arc::new(worktree_manager),
@@ -129,6 +150,7 @@ impl CoworkerManager {
                 .collect(),
             session_name: session,
             discovered_on_startup: Arc::new(RwLock::new(Vec::new())),
+            lead_nudge_tx,
         };
 
         // Discover existing coworkers from tmux on startup
@@ -644,9 +666,14 @@ impl CoworkerManager {
 
     /// Send a nudge (input) to the Lead session.
     ///
-    /// This is used to notify the Lead about coworker feedback requests.
+    /// The nudge is queued and delivered by a background thread that waits for
+    /// the lead's input prompt to be empty before sending. This prevents nudges
+    /// from corrupting text the human is currently typing. If the input isn't
+    /// empty after 90 seconds, the nudge is sent anyway.
+    ///
+    /// Returns immediately — the actual delivery happens asynchronously.
     pub fn nudge_lead(&self, message: &str) -> crate::Result<()> {
-        // Check if lead window exists
+        // Check if lead window exists before queuing
         if !tmux::window_exists(&self.session_name, "lead")? {
             return Err(crate::Error::Rpc {
                 code: -32602,
@@ -654,11 +681,38 @@ impl CoworkerManager {
             });
         }
 
-        // Send keys to the lead's Claude Code pane (pane .0), NOT the chat pane (.1).
-        // Without the pane qualifier, tmux targets the active pane which is often
-        // the chat TUI — causing nudge text to be sent as a user message, which
-        // triggers more @lead nudges in an infinite feedback loop.
-        tmux::send_keys(&self.session_name, "lead.0", message)
+        self.lead_nudge_tx
+            .send(message.to_string())
+            .map_err(|e| crate::Error::Rpc {
+                code: -32603,
+                message: format!("Lead nudge queue closed: {}", e),
+            })
+    }
+
+    /// Background worker that processes queued lead nudges.
+    ///
+    /// For each nudge, waits until the lead's input prompt is empty (or 90s
+    /// timeout expires), then delivers the nudge via tmux send-keys.
+    fn lead_nudge_worker(session: &str, rx: mpsc::Receiver<String>) {
+        let target = format!("{}:lead.0", session);
+
+        for message in rx {
+            // Wait for the lead's input to be empty before sending
+            let cleared = tmux::wait_for_empty_input(&target, LEAD_INPUT_WAIT_TIMEOUT);
+            if !cleared {
+                tracing::info!(
+                    "Lead input still has text after {}s timeout, nudging anyway",
+                    LEAD_INPUT_WAIT_TIMEOUT.as_secs()
+                );
+            }
+
+            // Send keys to the lead's Claude Code pane (pane .0), NOT the chat pane (.1).
+            if let Err(e) = tmux::send_keys(session, "lead.0", &message) {
+                tracing::error!("Failed to deliver lead nudge: {}", e);
+            }
+        }
+
+        tracing::debug!("Lead nudge worker shutting down (channel closed)");
     }
 
     /// Send a bell notification to the human's terminal.

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -357,6 +357,67 @@ pub fn capture_pane(target: &str) -> Option<String> {
     Some(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+/// Check whether the human has typed text into the Claude Code input prompt.
+///
+/// Inspects the last few lines of pane content for the `❯` prompt symbol.
+/// Returns `true` if there is non-whitespace text after the prompt, meaning
+/// the human is currently typing. Returns `false` if the prompt is empty
+/// or no prompt is visible (e.g., Claude is processing).
+///
+/// Used by the daemon to avoid nudging the lead while they're mid-sentence.
+pub fn has_input_text(pane_content: &str) -> bool {
+    // Skip trailing blank lines (tmux pads the pane with empty lines),
+    // then find the MOST RECENT line containing the ❯ prompt.
+    // Only check that line — older prompt lines in scrollback are irrelevant.
+    let prompt_line = pane_content
+        .lines()
+        .rev()
+        .filter(|l| !l.trim().is_empty())
+        .find(|l| l.contains('❯'));
+
+    if let Some(line) = prompt_line
+        && let Some(pos) = line.find('❯')
+    {
+        let after_prompt = &line[pos + '❯'.len_utf8()..];
+        return !after_prompt.trim().is_empty();
+    }
+
+    false
+}
+
+/// Wait until the lead's input prompt is empty, polling periodically.
+///
+/// Returns `true` if the input cleared within the timeout, `false` if
+/// the timeout expired with text still present. Either way, the caller
+/// should proceed with the nudge — this is a courtesy delay, not a gate.
+pub fn wait_for_empty_input(target: &str, timeout: std::time::Duration) -> bool {
+    use std::time::{Duration, Instant};
+
+    let start = Instant::now();
+    let poll_interval = Duration::from_secs(3);
+
+    loop {
+        if let Some(content) = capture_pane(target) {
+            if !has_input_text(&content) {
+                return true;
+            }
+        } else {
+            // Can't read pane — don't block, just proceed
+            return true;
+        }
+
+        if start.elapsed() >= timeout {
+            tracing::info!(
+                "Lead input not empty after {}s, nudging anyway",
+                timeout.as_secs()
+            );
+            return false;
+        }
+
+        std::thread::sleep(poll_interval);
+    }
+}
+
 /// Check if the nudge text is still sitting in the input line (not submitted).
 ///
 /// Returns true if the nudge appears to be stuck (Enter didn't work).
@@ -1305,5 +1366,64 @@ Claude is now processing the request
         let pane_content = "❯ You've been assigned";
         let nudge_text = "You've been assigned task #36: Chat TUI still showing old messages";
         assert!(is_nudge_stuck(pane_content, nudge_text));
+    }
+
+    #[test]
+    fn test_has_input_text_empty_prompt() {
+        // Just a prompt with nothing after it — input is empty
+        let pane = "Some previous output\n❯ ";
+        assert!(!has_input_text(pane));
+    }
+
+    #[test]
+    fn test_has_input_text_prompt_no_space() {
+        // Prompt with no trailing space — still empty
+        let pane = "Some output\n❯";
+        assert!(!has_input_text(pane));
+    }
+
+    #[test]
+    fn test_has_input_text_with_typed_text() {
+        // User has typed something after the prompt
+        let pane = "Some output\n❯ please add a feature that";
+        assert!(has_input_text(pane));
+    }
+
+    #[test]
+    fn test_has_input_text_no_prompt_at_all() {
+        // No prompt visible — treat as not having input text (safe to nudge)
+        let pane = "Claude is working on your request...\nProcessing...";
+        assert!(!has_input_text(pane));
+    }
+
+    #[test]
+    fn test_has_input_text_prompt_on_earlier_line() {
+        // Most recent non-blank line without ❯ means the prompt with text
+        // is from a PREVIOUS interaction. Only the most recent prompt matters.
+        // Here "Output line 2" is the most recent non-blank line (no prompt),
+        // so we look for the nearest prompt line — it has text.
+        let pane = "Output line 1\n❯ some typed text\nOutput line 2";
+        assert!(has_input_text(pane));
+    }
+
+    #[test]
+    fn test_has_input_text_old_prompt_text_new_prompt_empty() {
+        // Old prompt had text, new prompt is empty — should be false
+        // (the human already submitted, now on a fresh prompt)
+        let pane = "❯ old command that was submitted\nSome output\n❯ ";
+        assert!(!has_input_text(pane));
+    }
+
+    #[test]
+    fn test_has_input_text_blank_lines_after_prompt() {
+        // Prompt followed by blank lines — still empty input
+        let pane = "Output\n❯ \n\n";
+        assert!(!has_input_text(pane));
+    }
+
+    #[test]
+    fn test_has_input_text_only_whitespace_after_prompt() {
+        let pane = "Output\n❯    ";
+        assert!(!has_input_text(pane));
     }
 }

--- a/tests/nudge_delivery_e2e.rs
+++ b/tests/nudge_delivery_e2e.rs
@@ -376,12 +376,13 @@ fn test_nudge_reaches_lead() {
     let session = test_session_name();
     let _cleanup = Cleanup(&session);
 
-    // Setup: Create session with a "Lead" window (matching the real layout)
+    // Setup: Create session with a "lead" window (matching the real layout).
+    // The daemon targets lowercase "lead" for nudge delivery.
     assert!(
         create_test_session(&session),
         "Failed to create test session"
     );
-    create_test_window(&session, "Lead");
+    create_test_window(&session, "lead");
 
     // Also create a coworker window to simulate the real session layout
     create_test_window(&session, "lexington");
@@ -418,8 +419,11 @@ fn test_nudge_reaches_lead() {
         result.err()
     );
 
-    // Verify the message appears in the Lead pane
-    let content = capture_pane(&session, "Lead");
+    // Wait for the background nudge worker to deliver the message
+    thread::sleep(Duration::from_millis(2000));
+
+    // Verify the message appears in the lead pane
+    let content = capture_pane(&session, "lead");
     assert!(
         content
             .as_ref()
@@ -533,6 +537,277 @@ fn test_send_keys_vs_send_nudge() {
         "send_nudge message not found. Content: {}",
         content2
     );
+}
+
+/// Test that nudge goes through immediately when the lead's input is empty.
+///
+/// Verifies the happy path: no text in the input prompt → no waiting.
+#[test]
+#[ignore] // Requires tmux to be running
+fn test_lead_nudge_immediate_when_input_empty() {
+    if !tmux_available() {
+        eprintln!("Skipping test: tmux not available");
+        return;
+    }
+
+    let session = test_session_name();
+    let _cleanup = Cleanup(&session);
+
+    assert!(
+        create_test_session(&session),
+        "Failed to create test session"
+    );
+    create_test_window(&session, "lead");
+    thread::sleep(Duration::from_millis(500));
+
+    // Input is empty — wait_for_empty_input should return true immediately
+    let target = format!("{}:lead", session);
+    let start = std::time::Instant::now();
+    let result = midtown::tmux::wait_for_empty_input(&target, Duration::from_secs(10));
+    let elapsed = start.elapsed();
+
+    assert!(result, "Should return true when input is empty");
+    // Should complete well under the poll interval (3s)
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "Should return immediately, took {:?}",
+        elapsed
+    );
+}
+
+/// Test that nudge is delayed when the lead's input has text.
+///
+/// Puts text in the input, then clears it from a background thread.
+/// The wait function should block until the text is cleared.
+#[test]
+#[ignore] // Requires tmux to be running
+fn test_lead_nudge_delayed_when_input_has_text() {
+    if !tmux_available() {
+        eprintln!("Skipping test: tmux not available");
+        return;
+    }
+
+    let session = test_session_name();
+    let _cleanup = Cleanup(&session);
+
+    assert!(
+        create_test_session(&session),
+        "Failed to create test session"
+    );
+
+    // Run a shell that shows a prompt with ❯
+    let target = format!("{}:", session);
+    let status = Command::new("tmux")
+        .args([
+            "new-window",
+            "-t",
+            &target,
+            "-n",
+            "lead",
+            "bash",
+            "-c",
+            // Show prompt, read input (simulates Claude Code prompt)
+            r#"printf '❯ '; read line; printf '❯ '; cat"#,
+        ])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    assert!(status, "Failed to create lead window with prompt");
+    thread::sleep(Duration::from_millis(500));
+
+    // Type some text (without Enter) to simulate user typing
+    let tmux_target = format!("{}:lead", session);
+    let _ = Command::new("tmux")
+        .args([
+            "send-keys",
+            "-t",
+            &tmux_target,
+            "-l",
+            "I am typing something",
+        ])
+        .status();
+    thread::sleep(Duration::from_millis(200));
+
+    // Verify text is there
+    let content = capture_pane(&session, "lead").unwrap_or_default();
+    assert!(
+        midtown::tmux::has_input_text(&content),
+        "Should detect text in input. Content: {:?}",
+        content
+    );
+
+    // Clear the text after 4 seconds from a background thread
+    let session_clone = session.clone();
+    std::thread::spawn(move || {
+        thread::sleep(Duration::from_secs(4));
+        let target = format!("{}:lead", session_clone);
+        // Send Enter to submit the text (clears the input line)
+        let _ = Command::new("tmux")
+            .args(["send-keys", "-t", &target, "Enter"])
+            .status();
+    });
+
+    // Wait for empty input — should block until the text is cleared
+    let start = std::time::Instant::now();
+    let result = midtown::tmux::wait_for_empty_input(&tmux_target, Duration::from_secs(30));
+    let elapsed = start.elapsed();
+
+    assert!(result, "Should return true after input clears");
+    // Should take roughly 4-7 seconds (4s for clear + poll interval)
+    assert!(
+        elapsed >= Duration::from_secs(3),
+        "Should have waited for text to clear, only waited {:?}",
+        elapsed
+    );
+    assert!(
+        elapsed < Duration::from_secs(15),
+        "Should not wait too long, waited {:?}",
+        elapsed
+    );
+}
+
+/// Test that nudge goes through after timeout even if input still has text.
+///
+/// Uses a short timeout (5s) and never clears the input.
+#[test]
+#[ignore] // Requires tmux to be running
+fn test_lead_nudge_timeout_with_text() {
+    if !tmux_available() {
+        eprintln!("Skipping test: tmux not available");
+        return;
+    }
+
+    let session = test_session_name();
+    let _cleanup = Cleanup(&session);
+
+    assert!(
+        create_test_session(&session),
+        "Failed to create test session"
+    );
+
+    // Run a shell that shows ❯ prompt
+    let target = format!("{}:", session);
+    let status = Command::new("tmux")
+        .args([
+            "new-window",
+            "-t",
+            &target,
+            "-n",
+            "lead",
+            "bash",
+            "-c",
+            r#"printf '❯ '; read line"#,
+        ])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    assert!(status, "Failed to create lead window with prompt");
+    thread::sleep(Duration::from_millis(500));
+
+    // Type some text that we never clear
+    let tmux_target = format!("{}:lead", session);
+    let _ = Command::new("tmux")
+        .args([
+            "send-keys",
+            "-t",
+            &tmux_target,
+            "-l",
+            "still typing forever",
+        ])
+        .status();
+    thread::sleep(Duration::from_millis(200));
+
+    // Wait with a short timeout (5s)
+    let start = std::time::Instant::now();
+    let result = midtown::tmux::wait_for_empty_input(&tmux_target, Duration::from_secs(5));
+    let elapsed = start.elapsed();
+
+    assert!(!result, "Should return false on timeout");
+    // Should take roughly 5 seconds
+    assert!(
+        elapsed >= Duration::from_secs(4),
+        "Should wait until timeout, only waited {:?}",
+        elapsed
+    );
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "Should not wait much longer than timeout, waited {:?}",
+        elapsed
+    );
+}
+
+/// Test that queued nudges arrive in FIFO order after input clears.
+///
+/// Sends multiple nudges while input has text, clears the input,
+/// and verifies all nudges were delivered in order.
+#[test]
+#[ignore] // Requires tmux to be running
+fn test_lead_nudge_queue_ordering() {
+    if !tmux_available() {
+        eprintln!("Skipping test: tmux not available");
+        return;
+    }
+
+    let session = test_session_name();
+    let _cleanup = Cleanup(&session);
+
+    assert!(
+        create_test_session(&session),
+        "Failed to create test session"
+    );
+    create_test_window(&session, "lead");
+    thread::sleep(Duration::from_millis(500));
+
+    // Create a CoworkerManager pointing at this test session
+    let temp_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
+    Command::new("git")
+        .args(["init"])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("Failed to init git repo");
+    Command::new("git")
+        .args(["commit", "--allow-empty", "-m", "Initial commit"])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("Failed to create initial commit");
+
+    let worktree_manager = midtown::worktree::WorktreeManager::new(temp_dir.path().to_path_buf())
+        .expect("Failed to create worktree manager");
+    let manager = midtown::coworker::CoworkerManager::new(session.clone(), worktree_manager);
+
+    // Queue several nudges to the lead (input is empty so they go through immediately)
+    let messages: Vec<String> = (0..3)
+        .map(|i| format!("queued-nudge-{}-{}", std::process::id(), i))
+        .collect();
+
+    for msg in &messages {
+        let result = manager.nudge_lead(msg);
+        assert!(
+            result.is_ok(),
+            "nudge_lead should succeed: {:?}",
+            result.err()
+        );
+    }
+
+    // Wait for delivery — nudges are queued and delivered sequentially by
+    // the background worker. Each send_keys call takes ~600ms, so 3 nudges
+    // need roughly 2s. Give extra margin.
+    thread::sleep(Duration::from_millis(5000));
+
+    // Verify all messages appeared in order
+    let content = capture_pane(&session, "lead").unwrap_or_default();
+    let mut last_pos = 0;
+    for msg in &messages {
+        let pos = content[last_pos..].find(msg.as_str()).map(|p| p + last_pos);
+        assert!(
+            pos.is_some(),
+            "Message '{}' should appear in pane after position {}. Content: {}",
+            msg,
+            last_pos,
+            content
+        );
+        last_pos = pos.unwrap();
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Daemon now checks if the human is typing in the lead's Claude Code input (❯ prompt) before sending nudges
- Nudges are queued on a background thread (FIFO) so the daemon loop is never blocked
- If input isn't clear after 90 seconds, nudge is sent anyway to avoid missing critical notifications
- Adds 8 unit tests for input detection and 4 e2e tests covering immediate delivery, delayed delivery, timeout, and queue ordering

## Test plan
- [x] 451 unit tests pass (`cargo test --lib`)
- [x] 12 e2e tests pass (`cargo test --test nudge_delivery_e2e -- --ignored`)
- [x] Clippy clean, `cargo fmt` clean
- [x] Test: nudge goes through immediately when input is empty
- [x] Test: nudge is delayed when input has text, delivered after text clears
- [x] Test: nudge goes through after timeout even if input still has text
- [x] Test: queued nudges are sent in FIFO order

🤖 Generated with [Claude Code](https://claude.com/claude-code)