### PR TITLE
ci: run daemon e2e tests in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,35 @@ jobs:
       - name: Run tests
         run: cargo test --all-features
 
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Run e2e tests
+        run: cargo test --all-features --test daemon_e2e -- --ignored
+        env:
+          MIDTOWN_WEBHOOK_PORT: "0"
+          MIDTOWN_CHAT_MONITOR: "0"
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/tests/daemon_e2e.rs
+++ b/tests/daemon_e2e.rs
@@ -101,6 +101,7 @@ impl DaemonFixture {
         let midtown_dir = dirs::home_dir()
             .unwrap_or_else(|| PathBuf::from("."))
             .join(".midtown")
+            .join("projects")
             .join(&repo_name);
         let pid_path = midtown_dir.join("daemon.pid");
 


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Add a dedicated **E2E Tests** CI job that builds the release binary and runs `cargo test --test daemon_e2e -- --ignored`
- Fix PID file path in `DaemonFixture` to match the current `~/.midtown/projects/<repo>/` directory layout (was missing `projects/` segment)

## Test plan
- [x] All 10 daemon e2e tests pass locally after the PID path fix
- [x] Regular unit tests still pass (`cargo test --all-features`)
- [ ] CI E2E job runs successfully on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)