### PR TITLE
feat: add lead reminder feature with all-work-merged trigger

### DIFF
--- a/agents/lead.md
+++ b/agents/lead.md
@@ -148,6 +148,24 @@ midtown channel post "Replied to user: Gave status update on auth feature - 2 ta
 midtown channel post "Replied to user: Created task #12 for dashboard export feature"
 ```
 
+## Reminders
+You can ask the daemon to remind you when a condition is met. This is useful for planning
+follow-up work that depends on current work being fully landed.
+
+```bash
+# Set a reminder for when all tasks are done and all PRs are merged
+midtown lead remind all-work-merged "Cut v0.4.0 release"
+
+# List active reminders
+midtown lead remind list
+
+# Cancel a reminder
+midtown lead remind cancel <id>
+```
+
+The daemon checks the condition every 30 seconds. When it fires, you'll see a message
+in the channel. Reminders are one-shot — they fire once and are done.
+
 ## Assigning Tasks
 When assigning a task to a specific coworker, use `TaskUpdate` to set the `owner` field:
 ```

--- a/src/bin/midtown/cli/lead.rs
+++ b/src/bin/midtown/cli/lead.rs
@@ -1,0 +1,13 @@
+use super::Response;
+use crate::RemindCommand;
+use crate::client::DaemonClient;
+
+pub fn handle_remind(cmd: &RemindCommand, client: &DaemonClient) -> Result<Response, String> {
+    match cmd {
+        RemindCommand::AllWorkMerged { message } => {
+            client.reminder_create("all-work-merged", message)
+        }
+        RemindCommand::List => client.reminder_list(),
+        RemindCommand::Cancel { id } => client.reminder_cancel(id),
+    }
+}

--- a/src/bin/midtown/cli/mod.rs
+++ b/src/bin/midtown/cli/mod.rs
@@ -3,6 +3,7 @@ mod chat;
 mod coworker;
 mod daemon;
 mod hooks;
+mod lead;
 mod pr;
 mod response;
 mod task;
@@ -84,6 +85,14 @@ pub fn handle_chat() -> Result<(), String> {
 /// Handle hook commands (insight, idle) - no daemon required
 pub fn handle_hook(cmd: &HookCommand) -> Result<Response, String> {
     hooks::handle(cmd)
+}
+
+/// Handle `midtown lead remind` subcommands
+pub fn handle_remind(
+    cmd: &crate::RemindCommand,
+    client: &DaemonClient,
+) -> Result<Response, String> {
+    lead::handle_remind(cmd, client)
 }
 
 /// Handle `midtown webserver stop` command

--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -145,6 +145,23 @@ impl DaemonClient {
         self.send("channel.read", Some(serde_json::json!({ "all": all })))
     }
 
+    // Reminder commands
+
+    pub fn reminder_create(&self, trigger: &str, message: &str) -> Result<Response, String> {
+        self.send(
+            "reminder.create",
+            Some(serde_json::json!({ "trigger": trigger, "message": message })),
+        )
+    }
+
+    pub fn reminder_list(&self) -> Result<Response, String> {
+        self.send("reminder.list", None)
+    }
+
+    pub fn reminder_cancel(&self, id: &str) -> Result<Response, String> {
+        self.send("reminder.cancel", Some(serde_json::json!({ "id": id })))
+    }
+
     // Coworker commands
 
     pub fn coworker_spawn(&self, resume: bool, prompt: Option<&str>) -> Result<Response, String> {

--- a/src/bin/midtown/main.rs
+++ b/src/bin/midtown/main.rs
@@ -161,6 +161,27 @@ enum WebserverCommand {
 enum LeadCommand {
     /// Register this session for task sharing with coworkers
     RegisterSession,
+    /// Manage reminders (condition-based notifications)
+    Remind {
+        #[command(subcommand)]
+        command: RemindCommand,
+    },
+}
+
+#[derive(Subcommand, Clone)]
+enum RemindCommand {
+    /// Set a reminder for when all tasks are done and all PRs are merged
+    AllWorkMerged {
+        /// Message to display when the reminder fires
+        message: String,
+    },
+    /// List active reminders
+    List,
+    /// Cancel a reminder by ID
+    Cancel {
+        /// Reminder ID to cancel
+        id: String,
+    },
 }
 
 #[derive(Subcommand, Clone)]
@@ -364,10 +385,19 @@ fn main() {
         return;
     }
 
-    // Lead commands (no daemon required)
+    // Lead commands
     if let Commands::Lead { command } = &command {
         let result = match command {
             LeadCommand::RegisterSession => cli::handle_register_session(),
+            LeadCommand::Remind {
+                command: remind_cmd,
+            } => match DaemonClient::connect() {
+                Ok(client) => cli::handle_remind(remind_cmd, &client),
+                Err(e) => Err(format!(
+                    "Failed to connect to daemon: {}. Is it running?",
+                    e
+                )),
+            },
         };
         handle_result(format, result);
         return;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -300,6 +300,8 @@ pub(crate) struct DaemonState {
     /// When a coworker hits an API usage/rate limit, we parse the expiry and store it here.
     /// The main loop checks this and nudges everyone when the time arrives.
     usage_limit_nudge_at: Mutex<Option<tokio::time::Instant>>,
+    /// Persistent reminder state (one-shot condition-based notifications)
+    reminder_state: std::sync::Mutex<crate::reminders::ReminderState>,
 }
 
 impl DaemonState {
@@ -333,6 +335,14 @@ impl DaemonState {
                 crate::github_state::GitHubState::default()
             });
 
+        // Load persistent reminder state
+        let reminder_path = crate::paths::reminders_file_for_repo(&repo_name);
+        let reminder_state =
+            crate::reminders::ReminderState::load(&reminder_path).unwrap_or_else(|e| {
+                warn!("Failed to load reminders.json: {}, using defaults", e);
+                crate::reminders::ReminderState::default()
+            });
+
         Ok(Self {
             coworkers,
             channel,
@@ -355,6 +365,7 @@ impl DaemonState {
             last_lead_pane_hash: std::sync::Mutex::new(0),
             lead_working: std::sync::Mutex::new(false),
             last_lead_activity: std::sync::Mutex::new(None),
+            reminder_state: std::sync::Mutex::new(reminder_state),
         })
     }
 
@@ -812,6 +823,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                 check_and_recover_orphans(&state).await;
                 spawn_for_pending_tasks(&state);
                 cleanup_orphaned_worktrees(&state);
+                check_and_fire_reminders(&state);
             }
 
             // Periodic channel log rotation
@@ -2650,6 +2662,38 @@ fn handle_request(line: &str, state: &DaemonState) -> Response {
             handle_channel_read(request.id, all, state)
         }
 
+        "reminder.create" => {
+            let params = request.params.as_ref();
+            let trigger = params
+                .and_then(|p| p.get("trigger"))
+                .and_then(|v| v.as_str());
+            let message = params
+                .and_then(|p| p.get("message"))
+                .and_then(|v| v.as_str());
+
+            match (trigger, message) {
+                (Some("all-work-merged"), Some(msg)) => {
+                    handle_reminder_create(request.id, msg, state)
+                }
+                _ => Response::error(request.id, RpcError::invalid_params()),
+            }
+        }
+
+        "reminder.list" => handle_reminder_list(request.id, state),
+
+        "reminder.cancel" => {
+            let id = request
+                .params
+                .as_ref()
+                .and_then(|p| p.get("id"))
+                .and_then(|v| v.as_str());
+
+            match id {
+                Some(id) => handle_reminder_cancel(request.id, id, state),
+                None => Response::error(request.id, RpcError::invalid_params()),
+            }
+        }
+
         _ => {
             warn!("Unknown method: {}", request.method);
             Response::error(request.id, RpcError::method_not_found())
@@ -3017,6 +3061,108 @@ fn handle_channel_read(id: RequestId, all: bool, state: &DaemonState) -> Respons
             "messages": messages_json,
         }),
     )
+}
+
+/// Handle reminder.create RPC method.
+fn handle_reminder_create(id: RequestId, message: &str, state: &DaemonState) -> Response {
+    let mut reminder_state = state.reminder_state.lock().unwrap();
+    let reminder_id = reminder_state.add(
+        crate::reminders::ReminderTrigger::AllWorkMerged,
+        message.to_string(),
+    );
+
+    let path = crate::paths::reminders_file_for_repo(&state.repo_name);
+    if let Err(e) = reminder_state.save(&path) {
+        error!("Failed to save reminders: {}", e);
+    }
+
+    let confirmation = format!(
+        "Reminder set (id: {}): I'll notify you when all tasks are completed and all PRs are merged. Message: \"{}\"",
+        reminder_id, message
+    );
+    info!("{}", confirmation);
+    Response::success(id, serde_json::json!({ "message": confirmation }))
+}
+
+/// Handle reminder.list RPC method.
+fn handle_reminder_list(id: RequestId, state: &DaemonState) -> Response {
+    let reminder_state = state.reminder_state.lock().unwrap();
+    let active = reminder_state.active();
+
+    if active.is_empty() {
+        return Response::success(id, serde_json::json!({ "message": "No active reminders." }));
+    }
+
+    let lines: Vec<String> = active
+        .iter()
+        .map(|r| {
+            format!(
+                "  {} [{}] \"{}\" (created {})",
+                r.id,
+                r.trigger,
+                r.message,
+                r.created_at.format("%Y-%m-%d %H:%M UTC")
+            )
+        })
+        .collect();
+
+    let output = format!("Active reminders:\n{}", lines.join("\n"));
+    Response::success(id, serde_json::json!({ "message": output }))
+}
+
+/// Handle reminder.cancel RPC method.
+fn handle_reminder_cancel(id: RequestId, reminder_id: &str, state: &DaemonState) -> Response {
+    let mut reminder_state = state.reminder_state.lock().unwrap();
+    if reminder_state.cancel(reminder_id) {
+        let path = crate::paths::reminders_file_for_repo(&state.repo_name);
+        if let Err(e) = reminder_state.save(&path) {
+            error!("Failed to save reminders: {}", e);
+        }
+        let msg = format!("Reminder {} cancelled.", reminder_id);
+        info!("{}", msg);
+        Response::success(id, serde_json::json!({ "message": msg }))
+    } else {
+        Response::error(
+            id,
+            RpcError::new(-32602, format!("Reminder '{}' not found", reminder_id)),
+        )
+    }
+}
+
+/// Check all active reminders and fire any whose conditions are met.
+fn check_and_fire_reminders(state: &DaemonState) {
+    let open_pr_coworkers = get_coworkers_with_open_prs();
+
+    let mut reminder_state = state.reminder_state.lock().unwrap();
+    let mut fired_any = false;
+
+    for reminder in &mut reminder_state.reminders {
+        if reminder.fired {
+            continue;
+        }
+        if crate::reminders::evaluate_trigger(&reminder.trigger, &open_pr_coworkers) {
+            info!(
+                "Reminder {} fired (trigger: {}): {}",
+                reminder.id, reminder.trigger, reminder.message
+            );
+            let msg = Message::system(format!(
+                "\u{23f0} Reminder ({}): {}",
+                reminder.trigger, reminder.message
+            ));
+            if let Err(e) = state.send_and_broadcast(&msg) {
+                error!("Failed to post reminder to channel: {}", e);
+            }
+            reminder.fired = true;
+            fired_any = true;
+        }
+    }
+
+    if fired_any {
+        let path = crate::paths::reminders_file_for_repo(&state.repo_name);
+        if let Err(e) = reminder_state.save(&path) {
+            error!("Failed to save reminders after firing: {}", e);
+        }
+    }
 }
 
 /// Handle status RPC method.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,9 @@ pub mod paths;
 // Persistent GitHub state (PR reviewer assignments)
 pub mod github_state;
 
+// Reminder system (one-shot condition-based reminders)
+pub mod reminders;
+
 // Web Push notification support
 pub mod push;
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -240,6 +240,13 @@ pub fn github_state_file() -> PathBuf {
     github_state_file_for_repo(&repo)
 }
 
+/// Get the reminders file path for a specific repository.
+///
+/// Returns `~/.midtown/projects/<repo>/reminders.json`.
+pub fn reminders_file_for_repo(repo: &str) -> PathBuf {
+    projects_dir_for_repo(repo).join("reminders.json")
+}
+
 /// Get the daemon socket path for a specific repository.
 ///
 /// Returns `~/.local/state/midtown/<repo>/daemon.sock`.

--- a/src/reminders.rs
+++ b/src/reminders.rs
@@ -1,0 +1,228 @@
+//! Reminder system for the midtown daemon.
+//!
+//! Supports one-shot reminders that fire when a trigger condition is met.
+//! Currently supports the `AllWorkMerged` trigger, which fires when there are
+//! no pending/in_progress tasks and no coworkers with open PRs.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{self, ErrorKind};
+use std::path::Path;
+use tracing::{debug, warn};
+
+/// Conditions that can trigger a reminder.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ReminderTrigger {
+    /// Fire when all tasks are completed and all coworker PRs are merged.
+    AllWorkMerged,
+}
+
+impl std::fmt::Display for ReminderTrigger {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReminderTrigger::AllWorkMerged => write!(f, "all-work-merged"),
+        }
+    }
+}
+
+/// A one-shot reminder that fires when its trigger condition is met.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Reminder {
+    /// Unique identifier (short hex string)
+    pub id: String,
+    /// What condition triggers this reminder
+    pub trigger: ReminderTrigger,
+    /// Message to display when the reminder fires
+    pub message: String,
+    /// When the reminder was created
+    pub created_at: DateTime<Utc>,
+    /// Whether the reminder has already fired
+    pub fired: bool,
+}
+
+/// Persistent state for reminders.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ReminderState {
+    #[serde(default)]
+    pub reminders: Vec<Reminder>,
+}
+
+impl ReminderState {
+    /// Load state from a file, returning default if file doesn't exist.
+    pub fn load(path: &Path) -> io::Result<Self> {
+        match fs::read_to_string(path) {
+            Ok(contents) => {
+                let state: Self = serde_json::from_str(&contents).map_err(|e| {
+                    warn!("Failed to parse reminders.json: {}", e);
+                    io::Error::new(ErrorKind::InvalidData, e)
+                })?;
+                debug!("Loaded {} reminders", state.reminders.len());
+                Ok(state)
+            }
+            Err(e) if e.kind() == ErrorKind::NotFound => {
+                debug!("reminders.json not found, using defaults");
+                Ok(Self::default())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Save state to a file.
+    pub fn save(&self, path: &Path) -> io::Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let contents = serde_json::to_string_pretty(self)?;
+        fs::write(path, contents)?;
+        debug!("Saved {} reminders", self.reminders.len());
+        Ok(())
+    }
+
+    /// Add a new reminder and return its ID.
+    pub fn add(&mut self, trigger: ReminderTrigger, message: String) -> String {
+        let id = generate_short_id();
+        self.reminders.push(Reminder {
+            id: id.clone(),
+            trigger,
+            message,
+            created_at: Utc::now(),
+            fired: false,
+        });
+        id
+    }
+
+    /// Cancel a reminder by ID. Returns true if found and removed.
+    pub fn cancel(&mut self, id: &str) -> bool {
+        let before = self.reminders.len();
+        self.reminders.retain(|r| r.id != id);
+        self.reminders.len() < before
+    }
+
+    /// Get all active (unfired) reminders.
+    pub fn active(&self) -> Vec<&Reminder> {
+        self.reminders.iter().filter(|r| !r.fired).collect()
+    }
+}
+
+/// Evaluate whether a trigger condition is met.
+///
+/// For `AllWorkMerged`: checks that there are no pending/in_progress tasks
+/// AND no coworkers with open PRs.
+pub fn evaluate_trigger(trigger: &ReminderTrigger, open_pr_coworkers: &[String]) -> bool {
+    match trigger {
+        ReminderTrigger::AllWorkMerged => {
+            let pending = crate::tasks::get_pending_tasks();
+            let in_progress = crate::tasks::get_in_progress_tasks();
+            let has_work = !pending.is_empty() || !in_progress.is_empty();
+            let has_prs = !open_pr_coworkers.is_empty();
+            !has_work && !has_prs
+        }
+    }
+}
+
+/// Generate a short hex ID for reminders.
+fn generate_short_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos();
+    format!("{:08x}", nanos)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_state_default() {
+        let state = ReminderState::default();
+        assert!(state.reminders.is_empty());
+        assert!(state.active().is_empty());
+    }
+
+    #[test]
+    fn test_add_reminder() {
+        let mut state = ReminderState::default();
+        let id = state.add(ReminderTrigger::AllWorkMerged, "Cut release".to_string());
+        assert!(!id.is_empty());
+        assert_eq!(state.reminders.len(), 1);
+        assert_eq!(state.active().len(), 1);
+        assert_eq!(state.reminders[0].message, "Cut release");
+        assert_eq!(state.reminders[0].trigger, ReminderTrigger::AllWorkMerged);
+        assert!(!state.reminders[0].fired);
+    }
+
+    #[test]
+    fn test_cancel_reminder() {
+        let mut state = ReminderState::default();
+        let id = state.add(ReminderTrigger::AllWorkMerged, "Test".to_string());
+        assert_eq!(state.reminders.len(), 1);
+
+        assert!(state.cancel(&id));
+        assert!(state.reminders.is_empty());
+
+        // Cancel non-existent ID returns false
+        assert!(!state.cancel("nonexistent"));
+    }
+
+    #[test]
+    fn test_active_excludes_fired() {
+        let mut state = ReminderState::default();
+        state.add(ReminderTrigger::AllWorkMerged, "Active".to_string());
+        state.add(ReminderTrigger::AllWorkMerged, "Fired".to_string());
+        state.reminders[1].fired = true;
+
+        let active = state.active();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].message, "Active");
+    }
+
+    #[test]
+    fn test_save_and_load_roundtrip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("reminders.json");
+
+        let mut state = ReminderState::default();
+        state.add(ReminderTrigger::AllWorkMerged, "Release v1".to_string());
+        state.add(ReminderTrigger::AllWorkMerged, "Deploy".to_string());
+        state.reminders[1].fired = true;
+
+        state.save(&path).unwrap();
+
+        let loaded = ReminderState::load(&path).unwrap();
+        assert_eq!(loaded.reminders.len(), 2);
+        assert_eq!(loaded.reminders[0].message, "Release v1");
+        assert!(!loaded.reminders[0].fired);
+        assert_eq!(loaded.reminders[1].message, "Deploy");
+        assert!(loaded.reminders[1].fired);
+    }
+
+    #[test]
+    fn test_load_nonexistent_returns_default() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nonexistent.json");
+
+        let state = ReminderState::load(&path).unwrap();
+        assert!(state.reminders.is_empty());
+    }
+
+    #[test]
+    fn test_trigger_display() {
+        assert_eq!(
+            format!("{}", ReminderTrigger::AllWorkMerged),
+            "all-work-merged"
+        );
+    }
+
+    #[test]
+    fn test_evaluate_trigger_all_work_merged_with_prs() {
+        // If there are open PRs, trigger should NOT fire
+        let coworkers = vec!["park".to_string()];
+        let result = evaluate_trigger(&ReminderTrigger::AllWorkMerged, &coworkers);
+        assert!(!result, "Should not fire when coworkers have open PRs");
+    }
+}


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Adds `midtown lead remind` subcommand for one-shot condition-based reminders
- Supports `all-work-merged` trigger: fires when all tasks are completed and all coworker PRs are merged
- Daemon evaluates reminders every 30s (piggybacks on orphan-check cadence) and posts a system message to the channel when conditions are met
- Reminders are persisted to `reminders.json` and survive daemon restarts

### New files
- `src/reminders.rs` — Core types (`ReminderTrigger`, `Reminder`, `ReminderState`), JSON persistence, trigger evaluation, 8 unit tests
- `src/bin/midtown/cli/lead.rs` — CLI handler for remind subcommands

### Modified files
- `src/daemon/mod.rs` — RPC handlers (create/list/cancel), `DaemonState` field, main loop evaluation
- `src/bin/midtown/main.rs` — `LeadCommand::Remind` variant with `RemindCommand` subcommands
- `src/bin/midtown/cli/mod.rs` — `mod lead` + `handle_remind` export
- `src/bin/midtown/client/mod.rs` — Three RPC client methods
- `src/lib.rs` — `pub mod reminders`
- `src/paths.rs` — `reminders_file_for_repo` helper
- `agents/lead.md` — Reminders documentation section

## Test plan
- [x] 8 unit tests for ReminderState (add, cancel, active filtering, save/load roundtrip, trigger evaluation)
- [x] All 463 lib tests pass
- [x] Clippy + fmt clean
- [ ] Manual: `midtown lead remind all-work-merged "test"` creates reminder
- [ ] Manual: `midtown lead remind list` shows it
- [ ] Manual: `midtown lead remind cancel <id>` removes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)