### PR TITLE
ci: speed up e2e with rust-cache and single release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo registry and build
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run tests
         run: cargo test --all-features
@@ -43,31 +34,19 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo registry and build
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install tmux
         run: sudo apt-get update && sudo apt-get install -y tmux
 
-      - name: Build release binary
-        run: cargo build --release
-
       - name: Run daemon e2e tests
-        run: cargo test --all-features --test daemon_e2e -- --ignored --test-threads=1
+        run: cargo test --release --all-features --test daemon_e2e -- --ignored --test-threads=1
         env:
           MIDTOWN_WEBHOOK_PORT: "0"
           MIDTOWN_CHAT_MONITOR: "0"
 
       - name: Run tmux e2e tests
-        run: cargo test --all-features --test tmux_rename_e2e -- --ignored
+        run: cargo test --release --all-features --test tmux_rename_e2e -- --ignored
 
   clippy:
     name: Clippy
@@ -80,16 +59,7 @@ jobs:
         with:
           components: clippy
 
-      - name: Cache cargo registry and build
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,15 +17,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-publish-
+      - uses: Swatinem/rust-cache@v2
 
       - name: Verify version matches release tag
         run: |


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Replace manual `actions/cache@v4` with `Swatinem/rust-cache@v2` across all CI and publish jobs for profile-aware, automatic cache management
- Eliminate double compilation in e2e job by running tests with `--release` flag (daemon e2e already expects `target/release/midtown`), removing the separate `cargo build --release` step
- Net reduction of 38 lines of YAML boilerplate

## Test plan
- [ ] All four CI jobs (Test, E2E, Clippy, Format) pass
- [ ] E2E job no longer builds both debug and release profiles
- [ ] Subsequent CI runs show cache hits from `rust-cache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)