### PR TITLE
feat: default max_coworkers to 8 and include in generated config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -201,7 +201,10 @@ impl FullProjectConfig {
                 repos: vec![repo_path.to_string()],
                 primary_repo: Some(repo_path.to_string()),
             },
-            default: ProjectConfig::default(),
+            default: ProjectConfig {
+                max_coworkers: Some(8),
+                ..ProjectConfig::default()
+            },
             daemon: DaemonSection::default(),
         }
     }
@@ -240,7 +243,7 @@ pub struct ProjectConfig {
     #[serde(default)]
     pub chat_min_width: Option<u16>,
 
-    /// Maximum number of concurrent coworkers (default: 16)
+    /// Maximum number of concurrent coworkers (default: 8)
     #[serde(default)]
     pub max_coworkers: Option<usize>,
 
@@ -693,7 +696,7 @@ bin_command = "custom-command"
             bin_command: Some("midtown".to_string()),
             chat_layout: None,
             chat_min_width: None,
-            max_coworkers: Some(16),
+            max_coworkers: Some(8),
             personality: None,
         };
 
@@ -1036,7 +1039,7 @@ webhook_port = 47023
         assert_eq!(config.project.name(), Some("myapp"));
         assert_eq!(config.project.primary_repo(), Some("/home/user/myapp"));
         assert_eq!(config.project.repos(), vec!["/home/user/myapp"]);
-        assert!(config.default.max_coworkers().is_none());
+        assert_eq!(config.default.max_coworkers(), Some(8));
         assert!(config.daemon.webhook_port.is_none());
     }
 

--- a/src/daemon/constants.rs
+++ b/src/daemon/constants.rs
@@ -7,9 +7,7 @@ use std::time::Duration;
 // ---------------------------------------------------------------------------
 
 /// Default maximum number of concurrent coworkers.
-///
-/// This matches the total number of available name slots (10 avenues + 6 overflow).
-pub const DEFAULT_MAX_COWORKERS: usize = 16;
+pub const DEFAULT_MAX_COWORKERS: usize = 8;
 
 /// Default interval for restarting the webhook forwarder (5 minutes)
 pub const DEFAULT_WEBHOOK_RESTART_INTERVAL_SECS: u64 = 300;


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Lower `DEFAULT_MAX_COWORKERS` from 16 to 8 for a more conservative default
- Include `max_coworkers = 8` in `FullProjectConfig::minimal()` so auto-generated project configs expose the setting
- Update doc comments and tests to reflect the new default

## Test plan
- [x] `cargo build` compiles
- [x] `cargo test --all-features` passes (including updated assertions)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)