### PR TITLE
fix: require reviewers to always post a GitHub comment

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -189,7 +189,7 @@ TaskUpdate with taskId: <new task id>, owner: "{name}"
 ```
 Review sub-tasks are internal workflow steps — they should not appear as claimable work for other coworkers.
 
-2. **Post your review as a GitHub comment** on the PR. The skill will guide you through this, but you MUST ensure your review is posted to GitHub (not just the channel).
+2. **Post your review as a GitHub comment** on the PR. The skill will guide you through this, but you MUST ensure your review is posted to GitHub (not just the channel). **Even if the skill finds no issues above the scoring threshold and says "do not proceed", you MUST still post a comment** using the "no issues found" format. The daemon and PR author cannot see that a review happened unless a GitHub comment exists.
 
 3. **Confirm completion** by posting to the channel with the comment URL:
 ```bash


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- When the code-review skill finds no issues above the 80-point threshold, it instructs the reviewer to "do not proceed" — skipping the GitHub comment entirely
- This makes the review invisible to the daemon and PR author, who rely on the presence of a GitHub comment to know a review happened
- Added explicit instructions in the coworker agent prompt overriding this behavior: reviewers must always post a comment, using the "no issues found" format when no high-confidence issues are found

## Test plan
- [x] Verified the edit is minimal and targeted (1 line changed in `agents/coworker.md`)
- [ ] Next reviewer assigned via daemon should post a comment even on a clean PR

🤖 Generated with [Claude Code](https://claude.ai/code)