### PR TITLE
fix: prevent idle coworkers from being invisible to task assignment

### DIFF
--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -529,8 +529,9 @@ impl CoworkerManager {
             }
         }
 
-        // Kill the tmux window
-        tmux::kill_window(&self.session_name, name)?;
+        // Kill the tmux window — if this fails, we still clean up tracking
+        // to avoid leaving the coworker permanently stuck in Stopping state.
+        let kill_result = tmux::kill_window(&self.session_name, name);
 
         // Clean up additional repo worktrees (multi-repo projects)
         self.cleanup_additional_worktrees(name);
@@ -541,7 +542,7 @@ impl CoworkerManager {
             coworkers.remove(name);
         }
 
-        Ok(())
+        kill_result
     }
 
     /// Send all coworkers on a break.
@@ -601,6 +602,20 @@ impl CoworkerManager {
     pub fn list(&self) -> Vec<Coworker> {
         let coworkers = self.coworkers.read().unwrap();
         coworkers.values().cloned().collect()
+    }
+
+    /// List only coworkers with `Running` status.
+    ///
+    /// Use this instead of `list()` when building active-name sets for task
+    /// assignment, so that coworkers stuck in `Stopping` or other non-running
+    /// states are excluded.
+    pub fn list_running(&self) -> Vec<Coworker> {
+        let coworkers = self.coworkers.read().unwrap();
+        coworkers
+            .values()
+            .filter(|cw| cw.status == CoworkerStatus::Running)
+            .cloned()
+            .collect()
     }
 
     /// Get a coworker by name.
@@ -1487,5 +1502,92 @@ mod tests {
         // Cleanup
         manager.cleanup_additional_worktrees("testworker");
         assert!(!extra_wt_path.exists());
+    }
+
+    #[test]
+    fn test_list_running_excludes_stopping_coworkers() {
+        let (manager, _temp_dir) = test_manager();
+
+        {
+            let mut coworkers = manager.coworkers.write().unwrap();
+            coworkers.insert(
+                "lexington".to_string(),
+                Coworker {
+                    name: "lexington".to_string(),
+                    status: CoworkerStatus::Running,
+                    working_dir: "/tmp".to_string(),
+                    started_at: Utc::now(),
+                    current_task: None,
+                    session_id: None,
+                    isolated_tasks: false,
+                },
+            );
+            coworkers.insert(
+                "park".to_string(),
+                Coworker {
+                    name: "park".to_string(),
+                    status: CoworkerStatus::Stopping,
+                    working_dir: "/tmp".to_string(),
+                    started_at: Utc::now(),
+                    current_task: None,
+                    session_id: None,
+                    isolated_tasks: false,
+                },
+            );
+            coworkers.insert(
+                "madison".to_string(),
+                Coworker {
+                    name: "madison".to_string(),
+                    status: CoworkerStatus::Running,
+                    working_dir: "/tmp".to_string(),
+                    started_at: Utc::now(),
+                    current_task: None,
+                    session_id: None,
+                    isolated_tasks: false,
+                },
+            );
+        }
+
+        // list() returns all 3 coworkers
+        assert_eq!(manager.list().len(), 3);
+
+        // list_running() should only return the 2 Running coworkers
+        let running = manager.list_running();
+        assert_eq!(running.len(), 2);
+        let names: Vec<&str> = running.iter().map(|cw| cw.name.as_str()).collect();
+        assert!(names.contains(&"lexington"));
+        assert!(names.contains(&"madison"));
+        assert!(!names.contains(&"park"));
+    }
+
+    #[test]
+    fn test_shutdown_cleans_up_even_on_tmux_failure() {
+        let (manager, _temp_dir) = test_manager();
+
+        // Insert a coworker into the HashMap
+        {
+            let mut coworkers = manager.coworkers.write().unwrap();
+            coworkers.insert(
+                "lexington".to_string(),
+                Coworker {
+                    name: "lexington".to_string(),
+                    status: CoworkerStatus::Running,
+                    working_dir: "/tmp".to_string(),
+                    started_at: Utc::now(),
+                    current_task: None,
+                    session_id: None,
+                    isolated_tasks: false,
+                },
+            );
+        }
+
+        assert_eq!(manager.count(), 1);
+
+        // shutdown() will fail because there's no real tmux session,
+        // but it should still remove the coworker from the HashMap
+        let _ = manager.shutdown("lexington");
+
+        // The coworker should be removed from tracking regardless of tmux failure
+        assert_eq!(manager.count(), 0);
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3922,10 +3922,10 @@ async fn check_and_recover_orphans(state: &DaemonState) {
         return;
     }
 
-    // Get list of currently active coworkers
+    // Get list of currently running coworkers (excludes Stopping/Stopped)
     let active_names: std::collections::HashSet<String> = state
         .coworkers
-        .list()
+        .list_running()
         .iter()
         .map(|cw| cw.name.to_lowercase())
         .collect();
@@ -4303,8 +4303,8 @@ fn cleanup_orphaned_worktrees(state: &DaemonState) {
 /// 1. Pending tasks with owners - spawn/nudge the assigned coworker if not running
 /// 2. Pending tasks without owners - spawn a new coworker, assign the task, and nudge
 fn spawn_for_pending_tasks(state: &DaemonState) {
-    // Get list of currently active coworkers
-    let active_coworkers = state.coworkers.list();
+    // Get list of currently running coworkers (excludes Stopping/Stopped)
+    let active_coworkers = state.coworkers.list_running();
     let active_names: std::collections::HashSet<String> = active_coworkers
         .iter()
         .map(|cw| cw.name.to_lowercase())


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- `shutdown()` used `?` on `tmux::kill_window()`, leaving coworkers permanently stuck in `Stopping` state when the kill failed — now always cleans up the HashMap regardless
- `spawn_for_pending_tasks()` and orphan recovery built `active_names` from `list()` which includes all coworkers regardless of status — now uses `list_running()` to filter to `Running` only
- Added `list_running()` method to `CoworkerManager` and two regression tests

## Test plan
- [x] `test_shutdown_cleans_up_even_on_tmux_failure` — wrote failing test, confirmed failure, then fixed
- [x] `test_list_running_excludes_stopping_coworkers` — verifies `Stopping` coworkers are excluded
- [x] Full test suite passes
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.ai/code)