### PR TITLE
fix: ensure reviewers always post a comment even when no issues found

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -209,7 +209,7 @@ midtown channel post "Posted review on PR #42: https://github.com/org/repo/pull/
 ```
 
 A code review is **not complete** until you have:
-- Posted actionable feedback as a GitHub PR comment
+- Posted a GitHub PR comment (either with issues found or a "no issues found" message)
 - Shared the comment URL in the channel
 
 ### Responding to PR Review Feedback

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -2329,8 +2329,11 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
         // which could fail if the Enter key didn't register.
         // Isolated review coworkers are sent on a break when they go idle (no 5-minute wait).
         let review_prompt = format!(
-            "First, post a /me status update: `midtown channel post \"/me reviewing PR #{}\"` — then run: /code-review:code-review {}",
-            pr_number, pr_number
+            "First, post a /me status update: `midtown channel post \"/me reviewing PR #{}\"` — then run: /code-review:code-review {}\n\n\
+             IMPORTANT: You MUST always post a GitHub comment on the PR, even if no issues are found. \
+             If the code-review skill finishes without posting a comment (e.g. because no issues scored above the threshold), \
+             post a comment yourself using `gh pr comment {} --body` with the \"no issues found\" format from the skill.",
+            pr_number, pr_number, pr_number
         );
 
         match state.coworkers.spawn(false, Some(&review_prompt), true) {
@@ -4094,8 +4097,11 @@ async fn nudge_discovered_coworkers(state: &DaemonState) {
         } else if let Some(pr_number) = reviewer_prs.get(&name_lower) {
             // Coworker was assigned to review a PR
             let prompt = format!(
-                "Resume reviewing PR #{}. The daemon was restarted and discovered you still running. Continue your code review where you left off.",
-                pr_number
+                "Resume reviewing PR #{}. The daemon was restarted and discovered you still running. Continue your code review where you left off.\n\n\
+                 IMPORTANT: You MUST always post a GitHub comment on the PR, even if no issues are found. \
+                 If the code-review skill finishes without posting a comment, \
+                 post a comment yourself using `gh pr comment {} --body` with the \"no issues found\" format from the skill.",
+                pr_number, pr_number
             );
 
             info!(


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Updated the reviewer spawn prompt and resume prompt in the daemon to explicitly instruct reviewers to always post a GitHub comment, even when no issues score above the confidence threshold
- Updated coworker.md review completion criteria to accept "no issues found" comments as valid review completions
- Previously, the code-review skill's step 6 ("do not proceed" when no issues pass) would cause reviewers to silently finish without posting any comment, making it impossible for the daemon and teammates to know the review was completed

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] All 35 review-related tests pass (`cargo test -- review`)
- [ ] Deploy and verify that a reviewer assigned to a clean PR posts a "no issues found" comment

🤖 Generated with [Claude Code](https://claude.ai/code)