### PR TITLE
fix: detect review comments posted as PR comments, not just formal reviews

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -2102,22 +2102,18 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
         }
 
         // Check if already assigned for review (check both in-memory and persistent state)
-        {
+        let is_assigned = {
             let tracker = state.pr_review_tracker.lock().await;
-            if tracker.is_assigned(pr_number) {
-                debug!("PR #{} already assigned for review (in-memory)", pr_number);
-                continue;
-            }
-        }
-        {
+            tracker.is_assigned(pr_number)
+        } || {
             let github_state = state.github_state.lock().await;
-            if github_state.is_assigned(pr_number) {
-                debug!("PR #{} already assigned for review (persistent)", pr_number);
-                continue;
-            }
-        }
+            github_state.is_assigned(pr_number)
+        };
 
-        // Check if PR already has a Claude review (expensive, do last)
+        // Check if PR already has a Claude review (expensive, do last).
+        // We check this even for assigned PRs so that reviews posted as PR
+        // comments (not formal GitHub reviews) are detected promptly, rather
+        // than waiting for the reviewer to go idle.
         if pr_has_claude_review(pr_number) {
             debug!("PR #{} already has a Claude review", pr_number);
 
@@ -2295,6 +2291,15 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
                 }
             }
 
+            continue;
+        }
+
+        // If already assigned, the reviewer is still working — don't spawn another
+        if is_assigned {
+            debug!(
+                "PR #{} already assigned for review, reviewer still working",
+                pr_number
+            );
             continue;
         }
 


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Restructured `spawn_reviewers_for_prs()` so that assigned PRs are no longer skipped before `pr_has_claude_review()` runs
- Reviews posted as PR comments (via `gh pr comment`) are now detected during the polling cycle, not just when the reviewer goes idle
- The `is_assigned` flag is stored and checked after the review detection, preventing duplicate reviewer spawns while still enabling comment-based review detection

## Context

Coworker reviews are posted as regular PR comments (not formal GitHub reviews, since all coworkers share one GitHub user and can't approve their own PRs). Previously, the daemon's `spawn_reviewers_for_prs()` function would `continue` past assigned PRs before reaching the `pr_has_claude_review()` check. This meant review completion was only detected when:
1. The reviewer went idle and the idle-shutdown path ran `pr_has_claude_review()`
2. The reviewer was fully shut down and the next poll found no assignment

Now, every polling cycle checks assigned PRs for review completion, detecting comment-based reviews within ~30 seconds of being posted.

## Test plan
- [x] All 471 library tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] Verified the restructured control flow: assigned PRs flow through review check, then skip spawning if still assigned

🤖 Generated with [Claude Code](https://claude.ai/code)