### PR TITLE
test: add regression tests for recent bugs

### DIFF
--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -136,12 +136,11 @@ fn newest_file_mtime(dir: &std::path::Path) -> Option<std::time::SystemTime> {
                         continue;
                     }
                     walk(&path, newest);
-                } else if let Ok(meta) = path.metadata() {
-                    if let Ok(mtime) = meta.modified() {
-                        if newest.is_none() || Some(mtime) > *newest {
-                            *newest = Some(mtime);
-                        }
-                    }
+                } else if let Ok(meta) = path.metadata()
+                    && let Ok(mtime) = meta.modified()
+                    && (newest.is_none() || Some(mtime) > *newest)
+                {
+                    *newest = Some(mtime);
                 }
             }
         }


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Add `tests/regression_tests.rs` with 4 regression tests for bugs caught this session:
  - **CLI argument conflict (#644)**: Verify `midtown start --help` and `midtown --help` exit cleanly (catches clap panics from arg name collisions), and that `--add-repo` appears in help
  - **Stale web assets**: Compare `web-app/src/` source timestamps against `web/` build output to catch forgotten rebuilds
  - **Global config template (#653)**: Verify auto-generated template is valid TOML with all config sections
- Note: `list_running` filtering (#659) already has `test_list_running_excludes_stopping_coworkers` in `coworker.rs`, and review signature detection (#658) has 6 existing tests in `daemon/mod.rs`

## Test plan
- [x] `cargo test --all-features` — all 4 new tests pass
- [x] Full test suite passes (476+ unit tests, 4 regression tests)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)