### PR TITLE
feat: distribute tasks across idle coworkers via shuffling

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -4324,12 +4324,14 @@ fn spawn_for_pending_tasks(state: &DaemonState) {
             .collect();
 
     // Build set of idle coworkers: active, non-busy, non-isolated (not reviewers)
-    let idle_coworkers: Vec<String> = active_coworkers
+    // Shuffle to distribute tasks across idle coworkers instead of always picking the first.
+    let mut idle_coworkers: Vec<String> = active_coworkers
         .iter()
         .filter(|cw| !cw.isolated_tasks) // Skip reviewers
         .filter(|cw| !busy_coworkers.contains(&cw.name.to_lowercase()))
         .map(|cw| cw.name.clone())
         .collect();
+    fastrand::shuffle(&mut idle_coworkers);
 
     // Case 1: Pending tasks with owners assigned but coworker not running
     let pending_with_owners = crate::tasks::get_pending_tasks_with_owners();


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- The idle coworker selection in `spawn_for_pending_tasks` used `.find()` which always returned the first match in the vector, causing the same coworker to receive all tasks in a single tick while others sat idle
- Added `fastrand::shuffle()` on the `idle_coworkers` vec before iteration, so tasks are distributed randomly across available idle coworkers
- Matches the existing `fastrand` randomization pattern already used in `next_available_name()` for new coworker allocation

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes
- [x] `cargo clippy` passes (pre-commit hook)
- [x] `cargo fmt --check` passes (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.ai/code)