### PR TITLE
feat: add structured logging for daemon decisions

### DIFF
--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -442,6 +442,13 @@ impl CoworkerManager {
             coworkers.insert(name.clone(), coworker);
         }
 
+        tracing::info!(
+            "Spawned coworker {} (isolated={}, resume={})",
+            name,
+            isolated_tasks,
+            resume,
+        );
+
         // If a prompt was provided, wait for initialization and send it
         if let Some(prompt_text) = prompt {
             self.send_initial_prompt(&name, prompt_text);
@@ -521,6 +528,7 @@ impl CoworkerManager {
             let mut coworkers = self.coworkers.write().unwrap();
             if let Some(cw) = coworkers.get_mut(name) {
                 cw.status = CoworkerStatus::Stopping;
+                tracing::debug!("Coworker {} status: Running -> Stopping", name);
             } else {
                 return Err(crate::Error::Rpc {
                     code: -32602,
@@ -540,6 +548,10 @@ impl CoworkerManager {
         {
             let mut coworkers = self.coworkers.write().unwrap();
             coworkers.remove(name);
+        }
+
+        if kill_result.is_ok() {
+            tracing::info!("Shut down coworker {}", name);
         }
 
         kill_result
@@ -881,7 +893,12 @@ impl CoworkerManager {
             coworkers.insert(name.to_string(), coworker);
         }
 
-        tracing::info!("Spawned coworker {} with resume={}", name, resume);
+        tracing::info!(
+            "Spawned coworker {} (isolated={}, resume={})",
+            name,
+            isolated_tasks,
+            resume,
+        );
 
         // If a prompt was provided, wait for initialization and send it
         if let Some(prompt_text) = prompt {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1019,6 +1019,26 @@ async fn check_and_shutdown_idle_coworkers(state: &DaemonState) {
         reviewers
     };
 
+    debug!(
+        "Idle shutdown check: active={}, busy=[{}], open_prs=[{}], reviewers=[{}]",
+        active_coworkers.len(),
+        busy_coworkers
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", "),
+        coworkers_with_open_prs
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", "),
+        active_reviewers
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
+
     // Build coworker snapshots for the pure decision function
     let snapshots: Vec<crate::rules::CoworkerSnapshot> = active_coworkers
         .iter()
@@ -4331,6 +4351,17 @@ fn spawn_for_pending_tasks(state: &DaemonState) {
         .map(|cw| cw.name.clone())
         .collect();
 
+    debug!(
+        "Task assignment state: active={}, busy=[{}], idle=[{}]",
+        active_coworkers.len(),
+        busy_coworkers
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", "),
+        idle_coworkers.join(", "),
+    );
+
     // Case 1: Pending tasks with owners assigned but coworker not running
     let pending_with_owners = crate::tasks::get_pending_tasks_with_owners();
     for (task_id, task_subject, owner) in pending_with_owners {
@@ -4491,6 +4522,17 @@ fn spawn_for_pending_tasks(state: &DaemonState) {
             })
             .cloned()
         {
+            debug!(
+                "Task #{}: selected idle coworker {} (idle=[{}], already_assigned=[{}])",
+                task.id,
+                idle_name,
+                idle_coworkers.join(", "),
+                task_coworker_map
+                    .values()
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            );
             idle_name
         } else {
             // No idle coworkers available - allocate a new coworker name
@@ -4498,6 +4540,10 @@ fn spawn_for_pending_tasks(state: &DaemonState) {
                 debug!("No available coworker slots for unowned task #{}", task.id);
                 break;
             };
+            debug!(
+                "Task #{}: no idle coworkers available, allocated new name {}",
+                task.id, name,
+            );
             name
         };
 


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Added `debug!`-level logging at daemon decision points: task assignment state (active/busy/idle coworker sets), idle coworker selection reasoning, and idle shutdown state collection
- Added `info!`-level logging for coworker lifecycle events: successful spawn (with isolated/resume flags) and shutdown completion
- Unified `spawn()` and `spawn_with_name()` log format for consistency
- These logs enable diagnosing "why didn't the daemon assign task X to coworker Y?" from log output instead of reading tmux panes

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes
- [x] `cargo clippy` passes (pre-commit hook)
- [x] `cargo fmt --check` passes (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.ai/code)