### PR TITLE
fix: nudge lead for @lead mentions in system/daemon messages

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1695,7 +1695,11 @@ async fn chat_monitor_loop(
                                     // System/daemon messages may contain @lead that still
                                     // needs to trigger a nudge (e.g., orphaned worktree
                                     // warnings). Route @lead before skipping.
-                                    if msg.content.to_lowercase().contains("@lead") {
+                                    // Exclude "user" — user messages with @lead are already
+                                    // handled in handle_channel_post to avoid double-nudging.
+                                    if !msg.from.eq_ignore_ascii_case("user")
+                                        && msg.content.to_lowercase().contains("@lead")
+                                    {
                                         let nudge_text = format!("{}: {}", msg.from, msg.content);
                                         if let Err(e) = state.coworkers.nudge_lead(&nudge_text) {
                                             warn!("Failed to nudge lead for @lead in {} message: {}", msg.from, e);
@@ -5268,9 +5272,13 @@ mod tests {
         // System messages containing @lead should be detected as needing a lead
         // nudge. The chat_monitor_loop checks for @lead in SKIP_SENDERS messages
         // before skipping them. This test validates the detection logic.
+        // Mirrors the chat_monitor_loop logic: skip-sender messages nudge lead
+        // for @lead, EXCEPT "user" messages (already handled in handle_channel_post).
         let should_nudge = |from: &str, content: &str| -> bool {
             let is_skip_sender = SKIP_SENDERS.iter().any(|&s| s.eq_ignore_ascii_case(from));
-            is_skip_sender && content.to_lowercase().contains("@lead")
+            is_skip_sender
+                && !from.eq_ignore_ascii_case("user")
+                && content.to_lowercase().contains("@lead")
         };
 
         // System messages with @lead should trigger nudge
@@ -5290,6 +5298,9 @@ mod tests {
             "system",
             "Channel log rotated: 50 old messages archived"
         ));
+
+        // User messages with @lead should NOT trigger here (handled in handle_channel_post)
+        assert!(!should_nudge("user", "@lead what do you think?"));
 
         // Coworker messages should NOT be in SKIP_SENDERS at all
         assert!(!should_nudge("lexington", "@lead can you review this?"));


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Fixed bug where `@lead` mentions in system/daemon channel messages (e.g., orphaned worktree warnings) were silently ignored because the `chat_monitor_loop` skipped all `SKIP_SENDERS` messages before routing mentions
- Added `@lead` detection in the skip-sender path so the lead gets a tmux nudge + push notification even from system messages
- Added regression test validating that system-sender messages with `@lead` are properly detected

## Root Cause
The `chat_monitor_loop` in `src/daemon/mod.rs` checks `SKIP_SENDERS` (which includes "system", "midtown", "github", "user") and `continue`s before ever calling `route_mentions()`. System messages like orphaned worktree warnings used `Message::system(...)` with `from: "system"`, so the `@lead` text appeared in the channel log but never triggered a nudge.

## Fix
Before the `continue` in the skip-sender branch, we now check if the message content contains `@lead`. If so, we call `nudge_lead()` and `send_push_notification()` directly, matching the same behavior that `handle_channel_post` provides for coworker `@lead` mentions.

## Test plan
- [x] New unit test `test_system_message_with_at_lead_should_trigger_nudge` validates detection logic
- [x] Full test suite passes (477 unit tests + integration tests)
- [x] `cargo clippy` and `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)