### PR TITLE
fix: use appropriate shutdown message when coworker's PR already merged

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1011,6 +1011,9 @@ async fn check_and_shutdown_idle_coworkers(state: &DaemonState) {
     let coworkers_with_open_prs: HashSet<String> =
         get_coworkers_with_open_prs().into_iter().collect();
 
+    // Get coworkers with recently merged PRs - used for better shutdown messages
+    let coworkers_with_merged_prs: HashSet<String> = get_coworkers_with_merged_prs();
+
     // Get coworkers actively assigned to review PRs - they should not be considered idle.
     // Check BOTH in-memory and persistent state. The in-memory tracker can be empty after
     // a daemon restart, and the persistent state survives restarts.
@@ -1129,17 +1132,34 @@ async fn check_and_shutdown_idle_coworkers(state: &DaemonState) {
                     }
                 }
                 None => {
-                    // Can't find PR assignment - shut down with warning
-                    warn!(
-                        "Isolated coworker {} has no PR assignment found, sending on a break",
-                        name
-                    );
-                    (
-                        true,
-                        daemon_messages::break_no_pr(name, config::get_personality()),
-                    )
+                    // Can't find PR assignment — check if their work already merged
+                    if coworkers_with_merged_prs.contains(name) {
+                        info!(
+                            "Isolated coworker {} has no PR assignment but has merged PR, sending on a break",
+                            name
+                        );
+                        (
+                            true,
+                            daemon_messages::break_work_merged(name, config::get_personality()),
+                        )
+                    } else {
+                        warn!(
+                            "Isolated coworker {} has no PR assignment found, sending on a break",
+                            name
+                        );
+                        (
+                            true,
+                            daemon_messages::break_no_pr(name, config::get_personality()),
+                        )
+                    }
                 }
             }
+        } else if coworkers_with_merged_prs.contains(name) {
+            info!("Sending idle coworker {} on a break (PR merged)", name);
+            (
+                true,
+                daemon_messages::break_work_merged(name, config::get_personality()),
+            )
         } else {
             info!(
                 "Sending idle coworker {} on a break (idle for 30+ seconds)",
@@ -1472,6 +1492,43 @@ fn get_coworkers_with_open_prs() -> Vec<String> {
         _ => {
             debug!("Failed to get PRs from gh CLI for idle check");
             Vec::new()
+        }
+    }
+}
+
+/// Get coworker names that have recently merged PRs (branch name starts with coworker name).
+fn get_coworkers_with_merged_prs() -> HashSet<String> {
+    let output = std::process::Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--state",
+            "merged",
+            "--limit",
+            "20",
+            "--json",
+            "headRefName",
+        ])
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if let Ok(prs) = serde_json::from_str::<Vec<serde_json::Value>>(&stdout) {
+                return prs
+                    .iter()
+                    .filter_map(|pr| {
+                        pr.get("headRefName")
+                            .and_then(|r| r.as_str())
+                            .and_then(coworker_from_branch)
+                    })
+                    .collect();
+            }
+            HashSet::new()
+        }
+        _ => {
+            debug!("Failed to get merged PRs from gh CLI for idle check");
+            HashSet::new()
         }
     }
 }

--- a/src/daemon_messages.rs
+++ b/src/daemon_messages.rs
@@ -155,6 +155,18 @@ pub fn break_no_pr(name: &str, personality: Personality) -> String {
     pick(templates, personality).replace("{name}", name)
 }
 
+/// Letting {name} take a break (work merged).
+pub fn break_work_merged(name: &str, personality: Personality) -> String {
+    let templates: &[&str] = &[
+        "☕ Letting {name} take a break (work's all merged)",
+        "🎉 {name}'s PR landed — heading out on a high note",
+        "✅ {name}'s work is merged, taking a well-earned break",
+        "🚀 {name} shipped it! Stepping out now",
+        "🏁 {name} crossed the finish line — PR merged, signing off",
+    ];
+    pick(templates, personality).replace("{name}", name)
+}
+
 /// Letting {name} take a break (generic idle).
 pub fn break_idle(name: &str, personality: Personality) -> String {
     let templates: &[&str] = &[
@@ -182,6 +194,10 @@ mod tests {
             assert_eq!(
                 break_review_complete("carol", 42, Personality::Normal),
                 "☕ Letting carol take a break (review complete for PR #42)"
+            );
+            assert_eq!(
+                break_work_merged("alice", Personality::Normal),
+                "☕ Letting alice take a break (work's all merged)"
             );
             assert_eq!(
                 called_in_reviewer("dave", 99, Personality::Normal),
@@ -219,6 +235,9 @@ mod tests {
 
         let msg = break_review_complete(name, 40, Personality::Fun);
         assert!(msg.contains(name) && msg.contains("40"), "{msg}");
+
+        let msg = break_work_merged(name, Personality::Fun);
+        assert!(msg.contains(name), "{msg}");
 
         let msg = break_no_pr(name, Personality::Fun);
         assert!(msg.contains(name), "{msg}");


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Added `break_work_merged` message template for coworkers whose PRs have been merged (e.g., "work's all merged", "shipped it!", "crossed the finish line")
- Added `get_coworkers_with_merged_prs()` to check recently merged PRs via `gh pr list --state merged`
- Updated idle shutdown logic for both regular and isolated coworkers to use the merged message when their branch has a merged PR
- Previously, a coworker who completed their task and got their PR merged would get misleading messages like "no PR in sight" or a generic "taking a break"

## Test plan
- [x] All existing daemon_messages tests pass (Normal, Fun, Wild personalities)
- [x] New `break_work_merged` tests for Normal personality (canonical message) and Fun personality (name inclusion)
- [x] Full test suite passes (484 lib + 105 bin + 15 doc tests)
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)