### PR TITLE
feat: keep coworker alive when they unblock dependent tasks

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1057,8 +1057,13 @@ async fn check_and_shutdown_idle_coworkers(state: &DaemonState) {
         reviewers
     };
 
+    // Get coworkers that completed tasks which unblocked pending follow-ups.
+    // These coworkers should be kept alive so the daemon can assign the
+    // follow-up to them (preserving context for tightly coupled task chains).
+    let coworkers_with_unblocked_deps = crate::tasks::get_coworkers_with_unblocked_dependents();
+
     debug!(
-        "Idle shutdown check: active={}, busy=[{}], open_prs=[{}], reviewers=[{}]",
+        "Idle shutdown check: active={}, busy=[{}], open_prs=[{}], reviewers=[{}], unblocked_deps=[{}]",
         active_coworkers.len(),
         busy_coworkers
             .iter()
@@ -1071,6 +1076,11 @@ async fn check_and_shutdown_idle_coworkers(state: &DaemonState) {
             .collect::<Vec<_>>()
             .join(", "),
         active_reviewers
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", "),
+        coworkers_with_unblocked_deps
             .iter()
             .cloned()
             .collect::<Vec<_>>()
@@ -1095,6 +1105,7 @@ async fn check_and_shutdown_idle_coworkers(state: &DaemonState) {
             &busy_coworkers,
             &coworkers_with_open_prs,
             &active_reviewers,
+            &coworkers_with_unblocked_deps,
             &mut idle_since,
             Instant::now(),
             chrono::Utc::now(),

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -115,6 +115,7 @@ pub(crate) fn decide_idle_shutdowns(
     busy_coworkers: &HashSet<String>,
     coworkers_with_open_prs: &HashSet<String>,
     active_reviewers: &HashSet<String>,
+    coworkers_with_unblocked_deps: &HashSet<String>,
     idle_since: &mut HashMap<String, Instant>,
     now: Instant,
     now_utc: DateTime<Utc>,
@@ -142,8 +143,11 @@ pub(crate) fn decide_idle_shutdowns(
         let is_reviewing = active_reviewers
             .iter()
             .any(|r| r.eq_ignore_ascii_case(coworker));
+        let has_unblocked_deps = coworkers_with_unblocked_deps
+            .iter()
+            .any(|d| d.eq_ignore_ascii_case(coworker));
 
-        if is_busy || has_open_pr || is_reviewing {
+        if is_busy || has_open_pr || is_reviewing || has_unblocked_deps {
             idle_since.remove(coworker);
         } else if cw.isolated_tasks {
             // Isolated coworkers (reviewers) go on break immediately when idle
@@ -882,6 +886,7 @@ mod tests {
             &set(&[]),
             &set(&[]),
             &set(&[]),
+            &set(&[]),
             &mut idle_since,
             Instant::now(),
             Utc::now(),
@@ -904,6 +909,7 @@ mod tests {
         let decisions = decide_idle_shutdowns(
             &coworkers,
             &set(&["york"]),
+            &set(&[]),
             &set(&[]),
             &set(&[]),
             &mut idle_since,
@@ -929,6 +935,7 @@ mod tests {
             &set(&[]),
             &set(&["york"]),
             &set(&[]),
+            &set(&[]),
             &mut idle_since,
             Instant::now(),
             Utc::now(),
@@ -950,6 +957,7 @@ mod tests {
             &set(&[]),
             &set(&[]),
             &set(&["york"]),
+            &set(&[]),
             &mut idle_since,
             Instant::now(),
             Utc::now(),
@@ -961,6 +969,30 @@ mod tests {
     }
 
     #[test]
+    fn idle_shutdown_skips_coworker_with_unblocked_deps() {
+        let coworkers = vec![cw("york", 10)];
+        let mut idle_since = HashMap::new();
+        idle_since.insert("york".to_string(), Instant::now() - Duration::from_secs(60));
+
+        let decisions = decide_idle_shutdowns(
+            &coworkers,
+            &set(&[]),
+            &set(&[]),
+            &set(&[]),
+            &set(&["york"]),
+            &mut idle_since,
+            Instant::now(),
+            Utc::now(),
+            Duration::from_secs(30),
+            Duration::from_secs(300),
+        );
+
+        assert!(decisions.is_empty());
+        // Coworker with unblocked deps removed from idle tracking
+        assert!(!idle_since.contains_key("york"));
+    }
+
+    #[test]
     fn idle_shutdown_skips_young_coworker() {
         let coworkers = vec![cw("york", 2)]; // Only 2 minutes old
         let mut idle_since = HashMap::new();
@@ -968,6 +1000,7 @@ mod tests {
 
         let decisions = decide_idle_shutdowns(
             &coworkers,
+            &set(&[]),
             &set(&[]),
             &set(&[]),
             &set(&[]),
@@ -993,6 +1026,7 @@ mod tests {
             &set(&[]),
             &set(&[]),
             &set(&[]),
+            &set(&[]),
             &mut idle_since,
             Instant::now(),
             Utc::now(),
@@ -1012,6 +1046,7 @@ mod tests {
 
         let decisions = decide_idle_shutdowns(
             &coworkers,
+            &set(&[]),
             &set(&[]),
             &set(&[]),
             &set(&[]),

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -339,6 +339,47 @@ pub fn get_pending_tasks_without_owners_with_grace(grace_secs: u64) -> Vec<Task>
         .collect()
 }
 
+/// Get coworkers that have newly-unblocked dependent tasks.
+///
+/// A coworker has unblocked dependents when:
+/// 1. They own a completed task
+/// 2. A pending task's `blockedBy` includes that completed task
+/// 3. The pending task is now fully unblocked (all its blockers are completed)
+/// 4. The pending task has no owner yet (hasn't been assigned)
+///
+/// This is used to protect coworkers from idle shutdown when their follow-up
+/// tasks are about to become assignable.
+pub fn get_coworkers_with_unblocked_dependents() -> std::collections::HashSet<String> {
+    let all_tasks = read_tasks();
+    let mut result = std::collections::HashSet::new();
+
+    // Find pending, unowned tasks that are fully unblocked
+    let unblocked_pending: Vec<&Task> = all_tasks
+        .iter()
+        .filter(|t| {
+            t.status == TaskStatus::Pending
+                && t.owner.is_none()
+                && !t.blocked_by.is_empty()
+                && !has_unresolved_blockers(t, &all_tasks)
+        })
+        .collect();
+
+    // For each unblocked pending task, find the owner of its blocking tasks
+    for task in &unblocked_pending {
+        for blocker_id in &task.blocked_by {
+            if let Some(blocker) = all_tasks.iter().find(|t| t.id == *blocker_id)
+                && blocker.status == TaskStatus::Completed
+                && let Some(ref owner) = blocker.owner
+                && !owner.is_empty()
+            {
+                result.insert(owner.to_lowercase());
+            }
+        }
+    }
+
+    result
+}
+
 /// Check whether a task has unresolved `blockedBy` dependencies.
 ///
 /// Returns `true` if any task ID in `blocked_by` refers to a task that is not


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Prevents idle shutdown of coworkers that just completed a task which unblocked pending follow-up tasks
- Adds `get_coworkers_with_unblocked_dependents()` in `tasks.rs` — finds coworkers whose completed tasks unblocked pending, unowned tasks
- Extends `decide_idle_shutdowns()` with a `coworkers_with_unblocked_deps` parameter, treating these coworkers as protected from shutdown
- Protection is transient: clears once the follow-up is assigned (becomes in_progress with an owner)
- Works with the existing `find_owner_via_blocked_by` chain in `spawn_for_pending_tasks` to assign follow-ups to the same coworker

Depends on PR #393 (always spawn fresh model) being merged first.

## Test plan
- [x] New test: `idle_shutdown_skips_coworker_with_unblocked_deps`
- [x] All 630 tests pass
- [x] `cargo clippy` and `cargo fmt` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)