### PR TITLE
feat: Add github_user config option for gh CLI authentication

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,7 @@
 //! - `MIDTOWN_WEBHOOK_RESTART_INTERVAL`
 //! - `MIDTOWN_PR_POLL_INTERVAL`
 //! - `MIDTOWN_CHAT_MONITOR` (set to 0 to disable)
+//! - `MIDTOWN_GITHUB_USER`
 
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -332,6 +333,11 @@ pub struct DaemonSection {
     /// Enable chat monitor for @mention routing (default: true)
     #[serde(default)]
     pub chat_monitor_enabled: Option<bool>,
+
+    /// GitHub username for `gh` CLI authentication.
+    /// When set, runs `gh auth switch --user <github_user>` at daemon startup.
+    #[serde(default)]
+    pub github_user: Option<String>,
 }
 
 impl DaemonSection {
@@ -348,6 +354,10 @@ impl DaemonSection {
                 .or(self.webhook_restart_interval_secs),
             pr_poll_interval_secs: other.pr_poll_interval_secs.or(self.pr_poll_interval_secs),
             chat_monitor_enabled: other.chat_monitor_enabled.or(self.chat_monitor_enabled),
+            github_user: other
+                .github_user
+                .clone()
+                .or_else(|| self.github_user.clone()),
         }
     }
 }
@@ -436,6 +446,10 @@ impl GlobalConfig {
 
 # Enable chat monitor for @mention routing
 # chat_monitor_enabled = true
+
+# GitHub username for gh CLI authentication
+# When set, runs `gh auth switch --user <value>` at daemon startup
+# github_user = ""
 "#
         .to_string()
     }
@@ -469,6 +483,7 @@ fn load_project_config(project_name: &str) -> Option<ProjectConfig> {
             || full.default.max_coworkers.is_some()
             || full.default.personality.is_some()
             || full.project.name.is_some()
+            || full.daemon.github_user.is_some()
         {
             return Some(full.default);
         }
@@ -897,6 +912,7 @@ max_coworkers = 4
         assert!(config.daemon.webhook_restart_interval_secs.is_none());
         assert!(config.daemon.pr_poll_interval_secs.is_none());
         assert!(config.daemon.chat_monitor_enabled.is_none());
+        assert!(config.daemon.github_user.is_none());
     }
 
     #[test]
@@ -942,6 +958,41 @@ webhook_port = 0
 "#;
         let config: GlobalConfig = toml::from_str(toml).unwrap();
         assert_eq!(config.daemon.webhook_port, Some(0));
+    }
+
+    #[test]
+    fn test_daemon_github_user_parse() {
+        let toml = r#"
+[daemon]
+github_user = "midtown-sh"
+"#;
+        let config: GlobalConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.daemon.github_user, Some("midtown-sh".to_string()));
+    }
+
+    #[test]
+    fn test_daemon_github_user_merge_override() {
+        let global = DaemonSection {
+            github_user: Some("global-user".to_string()),
+            ..DaemonSection::default()
+        };
+        let project = DaemonSection {
+            github_user: Some("project-user".to_string()),
+            ..DaemonSection::default()
+        };
+        let merged = global.merge(&project);
+        assert_eq!(merged.github_user, Some("project-user".to_string()));
+    }
+
+    #[test]
+    fn test_daemon_github_user_merge_fallback() {
+        let global = DaemonSection {
+            github_user: Some("global-user".to_string()),
+            ..DaemonSection::default()
+        };
+        let project = DaemonSection::default();
+        let merged = global.merge(&project);
+        assert_eq!(merged.github_user, Some("global-user".to_string()));
     }
 
     #[test]
@@ -1158,6 +1209,7 @@ name = "solo"
             webhook_restart_interval_secs: Some(300),
             pr_poll_interval_secs: Some(60),
             chat_monitor_enabled: Some(true),
+            github_user: Some("global-user".to_string()),
         };
 
         let project = DaemonSection {
@@ -1166,6 +1218,7 @@ name = "solo"
             webhook_restart_interval_secs: None,
             pr_poll_interval_secs: Some(120),
             chat_monitor_enabled: None,
+            github_user: None,
         };
 
         let merged = global.merge(&project);
@@ -1174,6 +1227,7 @@ name = "solo"
         assert_eq!(merged.webhook_restart_interval_secs, Some(300)); // Falls back to global
         assert_eq!(merged.pr_poll_interval_secs, Some(120)); // Project overrides
         assert_eq!(merged.chat_monitor_enabled, Some(true)); // Falls back to global
+        assert_eq!(merged.github_user, Some("global-user".to_string())); // Falls back to global
     }
 
     #[test]
@@ -1184,6 +1238,7 @@ name = "solo"
             webhook_restart_interval_secs: None,
             pr_poll_interval_secs: None,
             chat_monitor_enabled: None,
+            github_user: None,
         };
 
         let empty = DaemonSection::default();
@@ -1363,5 +1418,6 @@ name = "solo"
         assert!(template.contains("personality"));
         assert!(template.contains("webhook_port"));
         assert!(template.contains("chat_layout"));
+        assert!(template.contains("github_user"));
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -69,6 +69,9 @@ pub struct DaemonConfig {
     pub max_coworkers: usize,
     /// Explicit project name (from --project flag). Overrides auto-detection.
     pub project_name: Option<String>,
+    /// GitHub username for `gh` CLI authentication.
+    /// When set, runs `gh auth switch --user <github_user>` at daemon startup.
+    pub github_user: Option<String>,
 }
 
 impl Default for DaemonConfig {
@@ -130,6 +133,11 @@ impl Default for DaemonConfig {
             None => daemon_section.chat_monitor_enabled.unwrap_or(true),
         };
 
+        // GitHub user: env var -> config.toml -> None
+        let github_user = std::env::var("MIDTOWN_GITHUB_USER")
+            .ok()
+            .or_else(|| daemon_section.github_user.clone());
+
         // Max concurrent coworkers: env var > project config > global config > default (16)
         let max_coworkers = std::env::var("MIDTOWN_MAX_COWORKERS")
             .ok()
@@ -164,6 +172,7 @@ impl Default for DaemonConfig {
             chat_monitor_enabled,
             max_coworkers,
             project_name: None,
+            github_user,
         }
     }
 }
@@ -540,6 +549,32 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
 
     // Ensure required plugins are installed (non-blocking, logs warnings on failure)
     ensure_plugins_installed().await;
+
+    // Switch gh CLI to the configured GitHub user (fail loudly if switch fails)
+    if let Some(ref github_user) = config.github_user {
+        info!("Switching gh CLI auth to user: {}", github_user);
+        let status = std::process::Command::new("gh")
+            .args(["auth", "switch", "--user", github_user])
+            .status()
+            .map_err(|e| crate::Error::Rpc {
+                code: -32603,
+                message: format!(
+                    "Failed to run `gh auth switch --user {}`: {}",
+                    github_user, e
+                ),
+            })?;
+        if !status.success() {
+            return Err(crate::Error::Rpc {
+                code: -32603,
+                message: format!(
+                    "gh auth switch --user {} failed (exit code: {}). Is the user logged in? Run `gh auth login` first.",
+                    github_user,
+                    status.code().unwrap_or(-1)
+                ),
+            });
+        }
+        info!("Successfully switched gh auth to user: {}", github_user);
+    }
 
     // Acquire exclusive lock on PID file to enforce singleton behavior
     let pid_file = acquire_pid_lock(&config.pid_file_path)?;


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Adds `github_user` config option to `[daemon]` section for specifying which `gh` CLI account to authenticate as
- Runs `gh auth switch --user <github_user>` at daemon startup, failing loudly if the switch fails (user not logged in)
- Supports `MIDTOWN_GITHUB_USER` env var override, following the same precedence pattern as other daemon settings
- Includes 3 new tests for parsing, merge override, and merge fallback behavior

## Config example
```toml
[daemon]
github_user = "midtown-sh"
```

## Test plan
- [x] `cargo test` — all 493 lib tests + integration tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] New tests: `test_daemon_github_user_parse`, `test_daemon_github_user_merge_override`, `test_daemon_github_user_merge_fallback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)