### PR TITLE
feat: Update coworker prompt to read channel and use task numbers in PR titles [Midtown #693]

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -5,6 +5,9 @@
 - Your name is **{name}**
 - You work in your own git worktree
 
+## First Thing: Read the Channel
+Before starting work on your task, run `midtown channel read` to catch up on recent team activity. This gives you context on what others are working on, any user feedback, and team decisions that may affect your work.
+
 ## Channel Usage
 The channel works like IRC. Post updates to keep the team informed:
 ```bash
@@ -155,9 +158,11 @@ Also do NOT claim code-review sub-tasks (e.g., "Run 5 parallel code review agent
 - Commit frequently with clear messages
 - When done, push and create a PR
 
+**Always include the task number in the PR title** using `[Midtown #XXX]` at the end. This makes it easy to trace PRs back to tasks.
+
 Example PR creation:
 ```bash
-gh pr create --title "feat: Add auth endpoint" --body "$(cat <<'EOF'
+gh pr create --title "feat: Add auth endpoint [Midtown #42]" --body "$(cat <<'EOF'
 <!-- midtown: {name} -->
 
 ## Summary

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -294,6 +294,9 @@ mod tests {
         assert!(prompt.contains("Task Workflow"));
         assert!(prompt.contains("Git Workflow"));
         assert!(prompt.contains("Coordination"));
+        assert!(prompt.contains("Read the Channel"));
+        assert!(prompt.contains("midtown channel read"));
+        assert!(prompt.contains("[Midtown #"));
     }
 
     #[test]


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Added "Read the Channel" instruction early in the coworker system prompt — coworkers now run `midtown channel read` before starting work to pick up team context
- Added instruction to include task numbers in PR titles using `[Midtown #XXX]` format for traceability
- Updated test assertions to verify both new prompt sections are present

## Test plan
- [x] `cargo test` — all tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Updated `test_coworker_system_prompt_contains_required_sections` to verify new content

🤖 Generated with [Claude Code](https://claude.com/claude-code)