### PR TITLE
feat: trigger immediate coworker spawn via hook on task creation

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,4 +1,26 @@
 {
+  "PostToolUse": [
+    {
+      "matcher": "TaskCreate",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "midtown hook task",
+          "timeout": 10
+        }
+      ]
+    },
+    {
+      "matcher": "TaskUpdate",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "midtown hook task",
+          "timeout": 10
+        }
+      ]
+    }
+  ],
   "Stop": [
     {
       "matcher": "*",

--- a/src/bin/midtown/cli/hooks.rs
+++ b/src/bin/midtown/cli/hooks.rs
@@ -458,6 +458,13 @@ fn handle_task_hook() -> Result<Response, String> {
         .send(&message)
         .map_err(|e| format!("Failed to post to channel: {}", e))?;
 
+    // On TaskCreate, notify daemon to immediately check for pending tasks
+    if tool_name == "TaskCreate"
+        && let Ok(client) = crate::client::DaemonClient::connect()
+    {
+        let _ = client.check_pending();
+    }
+
     Ok(Response::Message {
         message: format!("Posted: * {} {}", agent, action_message),
     })

--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -256,6 +256,12 @@ impl DaemonClient {
         self.send("pr.list", None)
     }
 
+    // Daemon commands
+
+    pub fn check_pending(&self) -> Result<Response, String> {
+        self.send("daemon.check-pending", None)
+    }
+
     // Kanban commands
 
     pub fn kanban_data(&self) -> Result<Value, String> {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3118,6 +3118,12 @@ fn handle_request(line: &str, state: &DaemonState) -> Response {
             }
         }
 
+        "daemon.check-pending" => {
+            info!("Check-pending triggered via RPC");
+            spawn_for_pending_tasks(state);
+            Response::success(request.id, serde_json::json!({"status": "ok"}))
+        }
+
         _ => {
             warn!("Unknown method: {}", request.method);
             Response::error(request.id, RpcError::method_not_found())


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Add `daemon.check-pending` RPC endpoint that calls `spawn_for_pending_tasks` immediately
- Extend existing PostToolUse task hook to send RPC on TaskCreate, so newly created tasks get picked up without waiting for the next poll cycle (~2s)
- Add PostToolUse hooks to lead's plugin `hooks.json` for TaskCreate and TaskUpdate, ensuring the lead's session also triggers immediate spawning and channel posting

This replaces the channel-detection approach from PR #391 with a direct hook-to-RPC path, as requested in the review feedback.

## Test plan
- [x] All tests pass (`cargo test`)
- [x] Clippy clean
- [x] Manual verification: task hook fires on TaskCreate → RPC sent → daemon spawns coworker immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)