### PR TITLE
refactor: central event dispatch with DaemonEvent enum

### DIFF
--- a/src/daemon/events.rs
+++ b/src/daemon/events.rs
@@ -1,0 +1,65 @@
+//! Daemon event dispatch — the central coordination point for the state machine.
+//!
+//! Each event source (timer tick, webhook, RPC, signal) maps to a `DaemonEvent`
+//! variant. The `evaluate_tick` function dispatches the event to the appropriate
+//! set of check functions, collecting all effects into a single `Vec<Effect>`.
+//!
+//! ```text
+//! Timer/Webhook/RPC → DaemonEvent
+//!                   → collect WorldSnapshot (immutable)
+//!                   → evaluate_tick(event, snapshot, state) → Vec<Effect>
+//!                   → execute_effects(effects)
+//! ```
+
+use super::DaemonState;
+use super::effects::Effect;
+use super::snapshot::WorldSnapshot;
+
+/// Events that drive the daemon's state machine.
+///
+/// Currently covers the two periodic tick groups. Future phases will add
+/// variants for webhook events, RPC requests, and signals — converting
+/// the remaining inline side effects to the evaluate/execute pattern.
+#[derive(Debug)]
+pub enum DaemonEvent {
+    /// Periodic idle-check tick: idle shutdown, interrupt/prompt nudge, usage limits.
+    IdleCheckTick,
+    /// Periodic orphan-check tick: duplicate detection, orphan recovery, task spawning,
+    /// worktree cleanup, reminders.
+    OrphanCheckTick,
+}
+
+/// Evaluate a daemon event against the current world snapshot, returning effects.
+///
+/// This is the central dispatch point. Each event variant maps to a batch of
+/// pure (or near-pure) check functions that read from the snapshot and return
+/// effects. The caller executes all returned effects via `execute_effects`.
+///
+/// Some check functions still take `&DaemonState` for mutable tracker state
+/// (idle_since, interrupted_since, etc.) and inline spawns. These will become
+/// fully pure in Phase 6 when TrackerState is consolidated.
+pub async fn evaluate_tick(
+    event: &DaemonEvent,
+    snap: &WorldSnapshot,
+    state: &DaemonState,
+) -> Vec<Effect> {
+    match event {
+        DaemonEvent::IdleCheckTick => {
+            let mut effects = Vec::new();
+            effects.extend(super::check_and_shutdown_idle_coworkers(snap, state).await);
+            effects.extend(super::check_and_nudge_interrupted_coworkers(snap, state).await);
+            effects.extend(super::check_and_nudge_prompted_coworkers(snap, state).await);
+            effects.extend(super::check_for_usage_limits(snap));
+            effects.extend(super::maybe_nudge_usage_limit_expiry(snap));
+            effects
+        }
+        DaemonEvent::OrphanCheckTick => {
+            let mut effects = Vec::new();
+            effects.extend(super::check_for_duplicate_task_workers(snap));
+            effects.extend(super::check_and_recover_orphans(snap, state));
+            effects.extend(super::spawn_for_pending_tasks(snap, state));
+            effects.extend(super::check_and_fire_reminders(snap, state));
+            effects
+        }
+    }
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -7,6 +7,7 @@
 
 mod constants;
 pub(crate) mod effects;
+pub(crate) mod events;
 mod helpers;
 pub(crate) mod snapshot;
 mod trackers;
@@ -914,18 +915,14 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                 if let Err(e) = state.coworkers.sync_with_tmux() {
                     warn!("Failed to sync coworker state with tmux: {}", e);
                 }
-                // Collect all data once for this tick group
+                // event → snapshot → evaluate → execute
                 let snap = snapshot::collect_world_snapshot(&state).await;
-                let idle_effects = check_and_shutdown_idle_coworkers(&snap, &state).await;
-                effects::execute_effects(idle_effects, &state).await;
-                let interrupt_effects = check_and_nudge_interrupted_coworkers(&snap, &state).await;
-                effects::execute_effects(interrupt_effects, &state).await;
-                let prompt_effects = check_and_nudge_prompted_coworkers(&snap, &state).await;
-                effects::execute_effects(prompt_effects, &state).await;
-                let usage_effects = check_for_usage_limits(&snap);
-                effects::execute_effects(usage_effects, &state).await;
-                let expiry_effects = maybe_nudge_usage_limit_expiry(&snap);
-                effects::execute_effects(expiry_effects, &state).await;
+                let tick_effects = events::evaluate_tick(
+                    &events::DaemonEvent::IdleCheckTick,
+                    &snap,
+                    &state,
+                ).await;
+                effects::execute_effects(tick_effects, &state).await;
             }
 
             // Check lead pane activity for typing indicator
@@ -935,17 +932,16 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
 
             // Periodic orphan check, duplicate detection, and worktree cleanup
             _ = orphan_check_interval.tick() => {
-                // Collect all data once for this tick group
+                // event → snapshot → evaluate → execute
                 let snap = snapshot::collect_world_snapshot(&state).await;
-                let dup_effects = check_for_duplicate_task_workers(&snap);
-                effects::execute_effects(dup_effects, &state).await;
-                let orphan_effects = check_and_recover_orphans(&snap, &state);
-                effects::execute_effects(orphan_effects, &state).await;
-                let spawn_effects = spawn_for_pending_tasks(&snap, &state);
-                effects::execute_effects(spawn_effects, &state).await;
+                let tick_effects = events::evaluate_tick(
+                    &events::DaemonEvent::OrphanCheckTick,
+                    &snap,
+                    &state,
+                ).await;
+                effects::execute_effects(tick_effects, &state).await;
+                // cleanup_orphaned_worktrees is not yet effect-based
                 cleanup_orphaned_worktrees(&state);
-                let reminder_effects = check_and_fire_reminders(&snap, &state);
-                effects::execute_effects(reminder_effects, &state).await;
             }
 
             // Periodic channel log rotation
@@ -3098,7 +3094,7 @@ async fn handle_connection(
                         break;
                     }
                     Ok(_) => {
-                        let response = handle_request(&line, &state);
+                        let response = handle_request(&line, &state).await;
                         let response_json = match serde_json::to_string(&response) {
                             Ok(json) => json,
                             Err(e) => {
@@ -3133,7 +3129,7 @@ async fn handle_connection(
 }
 
 /// Process a JSON-RPC request and return a response.
-fn handle_request(line: &str, state: &DaemonState) -> Response {
+async fn handle_request(line: &str, state: &DaemonState) -> Response {
     // Parse the request
     let request: Request = match serde_json::from_str(line) {
         Ok(req) => req,
@@ -3288,7 +3284,9 @@ fn handle_request(line: &str, state: &DaemonState) -> Response {
 
         "daemon.check-pending" => {
             info!("Check-pending triggered via RPC");
-            spawn_for_pending_tasks(state);
+            let snap = snapshot::collect_world_snapshot(state).await;
+            let pending_effects = spawn_for_pending_tasks(&snap, state);
+            effects::execute_effects(pending_effects, state).await;
             Response::success(request.id, serde_json::json!({"status": "ok"}))
         }
 


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- **Phase 5** of the daemon state machine refactor: introduces `DaemonEvent` enum and central `evaluate_tick()` dispatch function
- Created `src/daemon/events.rs` with `DaemonEvent` enum (two variants: `IdleCheckTick`, `OrphanCheckTick`) and `evaluate_tick()` function that dispatches to the appropriate batch of check functions
- Restructured main loop to follow the `event → snapshot → evaluate → execute` pipeline:
  ```rust
  let snap = collect_world_snapshot(&state).await;
  let effects = evaluate_tick(&event, &snap, &state).await;
  execute_effects(effects, &state).await;
  ```
- Each tick handler now collects effects from all its check functions in a single `Vec<Effect>` and executes them in one pass
- `cleanup_orphaned_worktrees` remains outside the effect system (called separately)
- Net change: +81 lines (new dispatch module), -20 lines (simplified main loop handlers)

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all tests pass
- [x] `cargo fmt` — properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)