### PR TITLE
chore: state machine refactor cleanup (Phase 7)

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -10,7 +10,7 @@ use crate::message::Message;
 /// effects are carried out. This separation makes the decision logic testable
 /// without mocking async infrastructure.
 #[derive(Debug)]
-#[allow(dead_code)] // Variants defined for upcoming phases of the state machine refactor
+#[allow(dead_code)] // SpawnCoworker defined for when inline spawns are fully extracted
 pub enum Effect {
     /// Spawn a coworker (or respawn an existing one).
     SpawnCoworker {

--- a/src/daemon/events.rs
+++ b/src/daemon/events.rs
@@ -36,8 +36,8 @@ pub enum DaemonEvent {
 /// effects. The caller executes all returned effects via `execute_effects`.
 ///
 /// Some check functions still take `&DaemonState` for mutable tracker state
-/// (idle_since, interrupted_since, etc.) and inline spawns. These will become
-/// fully pure in Phase 6 when TrackerState is consolidated.
+/// (coworker_phases, cooldowns, etc.) and inline spawns that cannot yet be
+/// expressed as pure effects (spawn success/failure determines follow-up effects).
 pub async fn evaluate_tick(
     event: &DaemonEvent,
     snap: &WorldSnapshot,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3734,7 +3734,6 @@ fn check_and_fire_reminders(
     // Convert snapshot HashSet to Vec for evaluate_trigger compatibility
     let open_pr_coworkers: Vec<String> = snap.coworkers_with_open_prs.iter().cloned().collect();
 
-    // reminder_state is mutable tracker state — stays on DaemonState until Phase 6
     let mut reminder_state = state.reminder_state.lock().unwrap();
     let mut fired_any = false;
     let mut effects = Vec::new();
@@ -4600,7 +4599,6 @@ fn check_and_recover_orphans(
     use effects::Effect;
 
     // Check cooldown - skip if we spawned too recently
-    // (cooldowns is mutable tracker state — stays on DaemonState until Phase 6)
     {
         let cooldowns = state.cooldowns.lock().unwrap();
         if !cooldowns.check("orphan_spawn", "global", ORPHAN_SPAWN_COOLDOWN) {
@@ -5250,10 +5248,9 @@ fn spawn_for_pending_tasks(
 
 // ─── Pure Decision Functions ───────────────────────────────────────────────
 //
-// These functions extract the decision logic from the async check-and-act
-// functions so it can be tested without mocking tmux, `gh`, or async state.
-// Phase 3 (PRs 5-8) will refactor the async functions to call these,
-// at which point the #[cfg(test)] gates can be removed.
+// Per-coworker decision helpers for unit tests. The batch `decide_*` functions
+// in `rules.rs` handle the full coworker set; these single-coworker variants
+// make individual test cases easier to write.
 #[cfg(test)]
 mod decisions {
     use std::time::Instant;
@@ -5263,7 +5260,7 @@ mod decisions {
 
     /// Snapshot of a coworker's state for decision-making (no async, no side effects).
     #[derive(Debug, Clone)]
-    #[allow(dead_code)] // name used in tests and will be used by async callers in Phase 3
+    #[allow(dead_code)]
     pub struct CoworkerSnapshot {
         pub name: String,
         pub started_at: chrono::DateTime<chrono::Utc>,

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -3,8 +3,8 @@
 //! Each `decide_*` function takes pre-collected state snapshots and returns
 //! a decision enum or struct — no side effects, no async, fully testable.
 //!
-//! The [`CooldownTracker`] provides a unified cooldown mechanism that will
-//! replace the six separate cooldown fields in `DaemonState` (Phase 6).
+//! The [`CooldownTracker`] provides a unified cooldown mechanism.
+//! The [`CoworkerPhase`] enum tracks per-coworker lifecycle state.
 
 use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
@@ -33,7 +33,7 @@ pub(crate) struct CoworkerSnapshot {
 /// were last recorded. Call [`check`](CooldownTracker::check) before firing
 /// and [`record`](CooldownTracker::record) after a successful fire.
 ///
-/// Currently used only in tests; will be wired into DaemonState in Phase 6.
+/// Currently used in DaemonState's `cooldowns` field.
 #[allow(dead_code)]
 #[derive(Debug, Default)]
 pub(crate) struct CooldownTracker {


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- **Phase 7** (final) of the daemon state machine refactor: cleanup pass
- Removed stale "stays on DaemonState until Phase 6" comments (Phase 6 is now complete)
- Updated module-level doc comments in `rules.rs` and `events.rs` to reflect current architecture
- Clarified `#[allow(dead_code)]` annotation on `Effect` enum — `SpawnCoworker` variant defined for when inline spawns are fully extracted
- Updated test module comment in `mod.rs` to describe current purpose
- All 491 tests pass, clippy clean

This completes the 7-phase daemon state machine refactor:
1. Effect enum + executor
2. Idle shutdown path migration
3. Remaining check function migrations (3a, 3b, 3c)
4. WorldSnapshot for once-per-tick data collection
5. Central event dispatch (DaemonEvent enum)
6. CoworkerPhase enum replacing separate tracker maps
7. Cleanup (this PR)

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 491 tests pass
- [x] `cargo fmt` — properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)