### PR TITLE
refactor: quick cleanups from state machine refactor review [Midtown #701]

### DIFF
--- a/src/daemon/events.rs
+++ b/src/daemon/events.rs
@@ -46,6 +46,9 @@ pub async fn evaluate_tick(
     match event {
         DaemonEvent::IdleCheckTick => {
             let mut effects = Vec::new();
+            // Order matters: later calls can override phase transitions from earlier
+            // calls. For example, a prompt nudge can supersede an idle shutdown
+            // decision for the same coworker.
             effects.extend(super::check_and_shutdown_idle_coworkers(snap, state).await);
             effects.extend(super::check_and_nudge_interrupted_coworkers(snap, state).await);
             effects.extend(super::check_and_nudge_prompted_coworkers(snap, state).await);

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -18,6 +18,7 @@ pub use constants::{
     DEFAULT_WEBHOOK_RESTART_INTERVAL_SECS, MAX_CONCURRENT_REVIEWS, PR_NUDGE_COOLDOWN_SECS,
     PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS, PR_REVIEW_DELAY_SECS,
 };
+use effects::Effect;
 use helpers::*;
 pub use trackers::{
     PrIssueTracker, PrIssueType, PrReviewTracker, StuckConditionTracker, StuckConditionType,
@@ -1105,8 +1106,6 @@ async fn check_and_shutdown_idle_coworkers(
     snap: &snapshot::WorldSnapshot,
     state: &DaemonState,
 ) -> Vec<effects::Effect> {
-    use effects::Effect;
-
     if snap.active_coworkers.is_empty() {
         return vec![];
     }
@@ -1281,8 +1280,6 @@ async fn check_and_nudge_interrupted_coworkers(
     snap: &snapshot::WorldSnapshot,
     state: &DaemonState,
 ) -> Vec<effects::Effect> {
-    use effects::Effect;
-
     if snap.active_coworkers.is_empty() {
         return vec![];
     }
@@ -1331,8 +1328,6 @@ async fn check_and_nudge_prompted_coworkers(
     snap: &snapshot::WorldSnapshot,
     state: &DaemonState,
 ) -> Vec<effects::Effect> {
-    use effects::Effect;
-
     if snap.active_coworkers.is_empty() {
         return vec![];
     }
@@ -1379,8 +1374,6 @@ async fn check_and_nudge_prompted_coworkers(
 /// will be stuck. We detect it from any coworker, parse the expiry, and
 /// schedule a single nudge time for everyone.
 fn check_for_usage_limits(snap: &snapshot::WorldSnapshot) -> Vec<effects::Effect> {
-    use effects::Effect;
-
     // If we already have a nudge scheduled, don't re-detect
     if snap.usage_limit_nudge_scheduled {
         return vec![];
@@ -1390,18 +1383,8 @@ fn check_for_usage_limits(snap: &snapshot::WorldSnapshot) -> Vec<effects::Effect
         return vec![];
     }
 
-    // Convert snapshot pane contents to the Vec<(String, String)> format expected by rules
-    let pane_contents: Vec<(String, String)> = snap
-        .pane_contents
-        .iter()
-        .map(|(name, content)| (name.clone(), content.clone()))
-        .collect();
-
     // Pure decision: detect usage limit
-    let decision = crate::rules::decide_usage_limit_detection(
-        &pane_contents,
-        snap.usage_limit_nudge_scheduled,
-    );
+    let decision = crate::rules::decide_usage_limit_detection(&snap.pane_contents);
 
     let detected_coworker = match decision {
         crate::rules::UsageLimitDecision::Detected { coworker } => coworker,
@@ -1447,8 +1430,6 @@ fn check_for_usage_limits(snap: &snapshot::WorldSnapshot) -> Vec<effects::Effect
 
 /// Check if a scheduled usage limit nudge is due, and if so, nudge all active coworkers.
 fn maybe_nudge_usage_limit_expiry(snap: &snapshot::WorldSnapshot) -> Vec<effects::Effect> {
-    use effects::Effect;
-
     // Pure decision: should we nudge?
     let decision = crate::rules::decide_usage_limit_expiry(
         snap.usage_limit_nudge_at,
@@ -1487,14 +1468,6 @@ fn maybe_nudge_usage_limit_expiry(snap: &snapshot::WorldSnapshot) -> Vec<effects
     }
 
     effects
-}
-
-/// Get list of coworker names who have in_progress tasks.
-///
-/// Takes the repo name explicitly to avoid relying on git detection,
-/// which may fail in daemon background processes.
-fn get_busy_coworkers(repo_name: &str) -> Vec<String> {
-    crate::tasks::get_busy_coworkers_for_repo(repo_name)
 }
 
 /// Get list of coworker names who have open PRs.
@@ -3729,8 +3702,6 @@ fn check_and_fire_reminders(
     snap: &snapshot::WorldSnapshot,
     state: &DaemonState,
 ) -> Vec<effects::Effect> {
-    use effects::Effect;
-
     // Convert snapshot HashSet to Vec for evaluate_trigger compatibility
     let open_pr_coworkers: Vec<String> = snap.coworkers_with_open_prs.iter().cloned().collect();
 
@@ -4596,8 +4567,6 @@ fn check_and_recover_orphans(
     snap: &snapshot::WorldSnapshot,
     state: &DaemonState,
 ) -> Vec<effects::Effect> {
-    use effects::Effect;
-
     // Check cooldown - skip if we spawned too recently
     {
         let cooldowns = state.cooldowns.lock().unwrap();
@@ -4705,7 +4674,7 @@ async fn nudge_discovered_coworkers(state: &DaemonState) {
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
     // Get in_progress tasks with owners
-    let in_progress = get_in_progress_tasks_with_owners();
+    let in_progress = crate::tasks::get_in_progress_tasks_with_subjects();
 
     // Build a map of owner -> (task_id, task_subject)
     let mut owner_tasks: std::collections::HashMap<String, (String, String)> =
@@ -4813,8 +4782,6 @@ async fn nudge_discovered_coworkers(state: &DaemonState) {
 /// 3. For tasks with multiple workers, keeps the one that started earliest
 /// 4. Shuts down the duplicate workers with an explanatory message
 fn check_for_duplicate_task_workers(snap: &snapshot::WorldSnapshot) -> Vec<effects::Effect> {
-    use effects::Effect;
-
     if snap.in_progress_tasks.is_empty() {
         return vec![];
     }
@@ -4910,11 +4877,6 @@ fn check_for_duplicate_task_workers(snap: &snapshot::WorldSnapshot) -> Vec<effec
     effects
 }
 
-/// Get list of in_progress tasks with their owners and subjects.
-fn get_in_progress_tasks_with_owners() -> Vec<(String, String, String)> {
-    crate::tasks::get_in_progress_tasks_with_subjects()
-}
-
 // ============================================================================
 // Pending task auto-spawn
 // ============================================================================
@@ -4976,8 +4938,6 @@ fn spawn_for_pending_tasks(
     snap: &snapshot::WorldSnapshot,
     state: &DaemonState,
 ) -> Vec<effects::Effect> {
-    use effects::Effect;
-
     debug!(
         "Task assignment state: active={}",
         snap.running_coworkers.len()

--- a/src/daemon/snapshot.rs
+++ b/src/daemon/snapshot.rs
@@ -117,11 +117,12 @@ pub async fn collect_world_snapshot(state: &DaemonState) -> WorldSnapshot {
     }
 
     // ── Task state ──────────────────────────────────────────────────────
-    let in_progress_tasks = super::get_in_progress_tasks_with_owners();
-    let busy_coworkers: HashSet<String> = super::get_busy_coworkers(&state.repo_name)
-        .into_iter()
-        .map(|n| n.to_lowercase())
-        .collect();
+    let in_progress_tasks = crate::tasks::get_in_progress_tasks_with_subjects();
+    let busy_coworkers: HashSet<String> =
+        crate::tasks::get_busy_coworkers_for_repo(&state.repo_name)
+            .into_iter()
+            .map(|n| n.to_lowercase())
+            .collect();
 
     // ── PR / GitHub state ───────────────────────────────────────────────
     let coworkers_with_open_prs: HashSet<String> = super::get_coworkers_with_open_prs(state)

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -363,24 +363,17 @@ const USAGE_LIMIT_PATTERNS: &[&str] = &[
 pub(crate) enum UsageLimitDecision {
     /// Usage limit detected in pane — schedule a nudge.
     Detected { coworker: String },
-    /// Nudge is already scheduled — skip re-detection.
-    AlreadyScheduled,
     /// No usage limit found in any pane.
     NoneDetected,
 }
 
 /// Decide whether pane contents indicate a usage limit.
 ///
-/// Scans pane contents for known usage/rate limit patterns. If a nudge is
-/// already scheduled (`nudge_already_scheduled`), skips re-detection.
+/// Scans pane contents for known usage/rate limit patterns.
+/// The caller is responsible for skipping this call when a nudge is already scheduled.
 pub(crate) fn decide_usage_limit_detection(
-    pane_contents: &[(String, String)], // (coworker_name, pane_content)
-    nudge_already_scheduled: bool,
+    pane_contents: &HashMap<String, String>,
 ) -> UsageLimitDecision {
-    if nudge_already_scheduled {
-        return UsageLimitDecision::AlreadyScheduled;
-    }
-
     for (name, content) in pane_contents {
         let has_limit = USAGE_LIMIT_PATTERNS
             .iter()


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- **Hoist `use effects::Effect`** to module-level imports — removes 9 identical local imports scattered across `daemon/mod.rs`
- **Inline two trivial wrappers** (`get_in_progress_tasks_with_owners`, `get_busy_coworkers`) that were single-line pass-throughs to `crate::tasks`
- **Remove redundant `nudge_already_scheduled` parameter** from `decide_usage_limit_detection` in `rules.rs` — the caller already early-returns when true, so the parameter was always false at the call site
- **Eliminate pane content cloning** by changing `decide_usage_limit_detection` to accept `&HashMap<String, String>` directly instead of `&[(String, String)]`
- **Add call-order comment** in `evaluate_tick` explaining why the order of check function calls matters

Net result: -43 lines, cleaner interfaces, one fewer allocation per tick.

## Test plan
- [x] `cargo test` — all 638 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)