### PR TITLE
feat: Add pending task data to WorldSnapshot [Midtown #700]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -4946,8 +4946,8 @@ fn spawn_for_pending_tasks(
     let mut effects = Vec::new();
 
     // Case 1: Pending tasks with owners assigned but coworker not running
-    let pending_with_owners = crate::tasks::get_pending_tasks_with_owners();
-    for (task_id, task_subject, owner) in pending_with_owners {
+    let pending_with_owners = &snap.pending_tasks_with_owners;
+    for (task_id, task_subject, owner) in pending_with_owners.iter() {
         // Check nudge cooldown for this task
         let task_key = format!("pending-{}", task_id);
         let on_nudge_cooldown = {
@@ -4957,9 +4957,9 @@ fn spawn_for_pending_tasks(
 
         // Decide action using pure decision function
         let action = crate::rules::decide_pending_task_action(
-            &task_id.to_string(),
-            &task_subject,
-            &owner,
+            task_id,
+            task_subject,
+            owner,
             &snap.active_names,
             snap.is_at_dev_limit,
             on_nudge_cooldown,
@@ -5024,9 +5024,9 @@ fn spawn_for_pending_tasks(
     }
 
     // Case 2: Pending tasks without owners - assign ownership atomically, then spawn
-    let pending_unowned = crate::tasks::get_pending_tasks_without_owners();
-    // Read all tasks once for relationship lookups (blockedBy, PR owner search)
-    let all_tasks = crate::tasks::read_tasks();
+    let pending_unowned = &snap.pending_tasks_without_owners;
+    // All tasks from snapshot for relationship lookups (blockedBy, PR owner search)
+    let all_tasks = &snap.all_tasks;
     // Track PR# → coworker and task_id → coworker assignments made during this loop iteration.
     // This prevents assigning different coworkers to sub-tasks of the same PR review
     // when multiple sub-tasks are processed in the same tick.
@@ -5034,7 +5034,7 @@ fn spawn_for_pending_tasks(
         std::collections::HashMap::new();
     let mut task_coworker_map: std::collections::HashMap<String, String> =
         std::collections::HashMap::new();
-    for task in pending_unowned {
+    for task in pending_unowned.iter() {
         // Check dev coworkers limit before spawning (reserve slots for reviewers)
         if snap.is_at_dev_limit {
             debug!(
@@ -5049,7 +5049,7 @@ fn spawn_for_pending_tasks(
         //           blockedBy relationship → new coworker name
         let grouped_name: Option<String> = 'resolve: {
             // Strategy A: Extract PR number from subject or description
-            if let Some(pr_num) = crate::tasks::extract_pr_number_from_task(&task) {
+            if let Some(pr_num) = crate::tasks::extract_pr_number_from_task(task) {
                 // Check in-memory map first (handles same-tick assignments)
                 if let Some(name) = pr_coworker_map.get(&pr_num) {
                     info!(
@@ -5060,7 +5060,7 @@ fn spawn_for_pending_tasks(
                 }
                 // Check disk for previously assigned PR tasks
                 if let Some(existing_owner) =
-                    crate::tasks::find_pr_owner_in_tasks(&pr_num, &all_tasks)
+                    crate::tasks::find_pr_owner_in_tasks(&pr_num, all_tasks)
                 {
                     info!(
                         "Task #{} references PR #{} - assigning to existing owner {}",
@@ -5082,7 +5082,7 @@ fn spawn_for_pending_tasks(
                 }
             }
             // Check disk for blockedBy owners
-            if let Some(owner) = crate::tasks::find_owner_via_blocked_by(&task, &all_tasks) {
+            if let Some(owner) = crate::tasks::find_owner_via_blocked_by(task, all_tasks) {
                 info!(
                     "Task #{} blocked by owned task - assigning to {}",
                     task.id, owner
@@ -5128,7 +5128,7 @@ fn spawn_for_pending_tasks(
 
         // Record this assignment in in-memory maps for same-tick grouping
         task_coworker_map.insert(task.id.clone(), coworker_name.clone());
-        if let Some(pr_num) = crate::tasks::extract_pr_number_from_task(&task) {
+        if let Some(pr_num) = crate::tasks::extract_pr_number_from_task(task) {
             pr_coworker_map.insert(pr_num, coworker_name.clone());
         }
 

--- a/src/daemon/snapshot.rs
+++ b/src/daemon/snapshot.rs
@@ -12,6 +12,7 @@ use chrono::{DateTime, Utc};
 
 use crate::coworker::Coworker;
 use crate::rules::CoworkerSnapshot;
+use crate::tasks::Task;
 
 use super::DaemonState;
 
@@ -45,6 +46,12 @@ pub struct WorldSnapshot {
     pub in_progress_tasks: Vec<(String, String, String)>,
     /// Names of coworkers who are busy (have in-progress tasks), lowercase.
     pub busy_coworkers: HashSet<String>,
+    /// All tasks from disk (for relationship lookups).
+    pub all_tasks: Vec<Task>,
+    /// Pending tasks that have an owner: `(task_id, subject, owner)`.
+    pub pending_tasks_with_owners: Vec<(String, String, String)>,
+    /// Pending tasks with no owner (unclaimed, past grace period, unblocked).
+    pub pending_tasks_without_owners: Vec<Task>,
 
     // ── PR / GitHub state ───────────────────────────────────────────────
     /// Coworkers who have at least one open PR.
@@ -123,6 +130,9 @@ pub async fn collect_world_snapshot(state: &DaemonState) -> WorldSnapshot {
             .into_iter()
             .map(|n| n.to_lowercase())
             .collect();
+    let all_tasks = crate::tasks::read_tasks();
+    let pending_tasks_with_owners = crate::tasks::get_pending_tasks_with_owners();
+    let pending_tasks_without_owners = crate::tasks::get_pending_tasks_without_owners();
 
     // ── PR / GitHub state ───────────────────────────────────────────────
     let coworkers_with_open_prs: HashSet<String> = super::get_coworkers_with_open_prs(state)
@@ -166,6 +176,9 @@ pub async fn collect_world_snapshot(state: &DaemonState) -> WorldSnapshot {
         pane_contents,
         in_progress_tasks,
         busy_coworkers,
+        all_tasks,
+        pending_tasks_with_owners,
+        pending_tasks_without_owners,
         coworkers_with_open_prs,
         coworkers_with_merged_prs,
         active_reviewers,


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Adds `pending_tasks_with_owners`, `pending_tasks_unowned`, and `all_tasks` fields to `WorldSnapshot`
- Populates them in `collect_world_snapshot()` alongside existing task state collection
- Updates `spawn_for_pending_tasks()` to read from snapshot instead of making direct disk calls
- Fixes 3 clippy needless-borrow warnings introduced by the iteration change

## Why
`spawn_for_pending_tasks()` previously called `get_pending_tasks_with_owners()`, `get_pending_tasks_without_owners()`, and `read_tasks()` separately from disk, meaning it could see task state that differed from the snapshot collected at tick start. This completes the snapshot pattern so all evaluation functions see consistent task data within a single tick.

## Test plan
- [x] All 638 tests pass
- [x] Clippy clean (0 warnings)
- [x] Cargo fmt clean
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)