### PR TITLE
feat: Replace hardcoded 'main' branch name with dynamic default branch detection [Midtown #698]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -1028,6 +1028,27 @@ fn fetch_kanban_data_via_rpc() -> Option<(Vec<KanbanPr>, Vec<MergedPr>, Vec<(Str
     Some((prs, merged_prs, repos))
 }
 
+/// Detect the default branch for a repository.
+///
+/// Uses `gh api` to query the default branch from GitHub. Falls back to "main".
+fn detect_default_branch_for_repo(repo_full_name: Option<&str>) -> String {
+    let api_path = match repo_full_name {
+        Some(name) => format!("repos/{}", name),
+        None => "repos/{owner}/{repo}".to_string(),
+    };
+    if let Ok(output) = std::process::Command::new("gh")
+        .args(["api", &api_path, "--jq", ".default_branch"])
+        .output()
+        && output.status.success()
+    {
+        let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !branch.is_empty() {
+            return branch;
+        }
+    }
+    "main".to_string()
+}
+
 /// Fetch repository status (commit, CI status, release) from GitHub using gh CLI.
 ///
 /// If `repo_full_name` is provided (e.g., "btucker/midtown"), uses explicit API paths.
@@ -1035,16 +1056,25 @@ fn fetch_kanban_data_via_rpc() -> Option<(Vec<KanbanPr>, Vec<MergedPr>, Vec<(Str
 fn fetch_repo_status(repo_full_name: Option<&str>) -> RepoStatus {
     let mut status = RepoStatus::default();
 
+    // Detect the default branch for CI status queries
+    let default_branch = detect_default_branch_for_repo(repo_full_name);
+
     // Build API path prefix: explicit repo or gh template variable
     let (commits_path, actions_path, releases_path) = match repo_full_name {
         Some(name) => (
             format!("repos/{}/commits/HEAD", name),
-            format!("repos/{}/actions/runs?branch=main&per_page=1", name),
+            format!(
+                "repos/{}/actions/runs?branch={}&per_page=1",
+                name, default_branch
+            ),
             format!("repos/{}/releases/latest", name),
         ),
         None => (
             "repos/{owner}/{repo}/commits/{branch}".to_string(),
-            "repos/{owner}/{repo}/actions/runs?branch=main&per_page=1".to_string(),
+            format!(
+                "repos/{{owner}}/{{repo}}/actions/runs?branch={}&per_page=1",
+                default_branch
+            ),
             "repos/{owner}/{repo}/releases/latest".to_string(),
         ),
     };

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -286,6 +286,8 @@ pub(crate) struct DaemonState {
     pr_review_tracker: Mutex<PrReviewTracker>,
     /// Repository name (primary repo)
     repo_name: String,
+    /// Default branch name (detected at startup, e.g. "main" or "master")
+    default_branch: String,
     /// Paths to all repos in the project (primary + additional)
     all_repo_paths: Vec<PathBuf>,
     /// Unified cooldown tracker for orphan spawning and task nudge rate limiting.
@@ -358,6 +360,7 @@ impl DaemonState {
         web_updates_tx: Option<tokio::sync::broadcast::Sender<WebUpdate>>,
         max_coworkers: usize,
         push_manager: Option<std::sync::Arc<crate::push::PushManager>>,
+        default_branch: String,
     ) -> crate::Result<Self> {
         // Load persistent GitHub state
         let github_state =
@@ -386,6 +389,7 @@ impl DaemonState {
             pr_issue_tracker: Mutex::new(PrIssueTracker::new()),
             pr_review_tracker: Mutex::new(PrReviewTracker::new()),
             repo_name,
+            default_branch,
             all_repo_paths,
             cooldowns: std::sync::Mutex::new(crate::rules::CooldownTracker::new()),
             warned_orphans: std::sync::RwLock::new(HashSet::new()),
@@ -683,6 +687,13 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
         paths
     };
 
+    // Detect the default branch early so it's available for both the webhook server and daemon state
+    let default_branch = all_repo_paths
+        .first()
+        .and_then(|path| crate::worktree::detect_default_branch(path))
+        .unwrap_or_else(|| "main".to_string());
+    info!("Detected default branch: {}", default_branch);
+
     if let Some(port) = config.webhook_port {
         let webhook_config = WebhookConfig {
             port,
@@ -693,6 +704,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
             webhook_config,
             Some(coworker_manager.clone()),
             all_repo_paths.clone(),
+            default_branch.clone(),
         )
         .await
         {
@@ -730,6 +742,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
         web_updates_tx,
         config.max_coworkers,
         shared_push_manager,
+        default_branch,
     )?);
     info!(
         "Max coworkers limit: {} (dev: {}, reserving {} for reviewers)",
@@ -848,8 +861,8 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                     let nudge_msg = Message::text(
                         "system",
                         format!(
-                            "@lead PR #{} merged into main. Run `git pull` to stay current.",
-                            pr_number
+                            "@lead PR #{} merged into {}. Run `git pull` to stay current.",
+                            pr_number, state.default_branch
                         ),
                     );
                     if let Err(e) = state.send_and_broadcast(&nudge_msg) {

--- a/src/web.rs
+++ b/src/web.rs
@@ -59,6 +59,8 @@ pub struct WebState {
     pub push_manager: Option<Arc<PushManager>>,
     /// Paths to all repos in the project (for multi-repo PR URL resolution)
     pub all_repo_paths: Vec<std::path::PathBuf>,
+    /// Default branch name (e.g. "main" or "master")
+    pub default_branch: String,
 }
 
 /// Types of real-time updates sent to clients
@@ -184,7 +186,7 @@ pub struct RepoStatus {
 }
 
 /// Fetch repository status via gh CLI
-fn fetch_repo_status() -> RepoStatus {
+fn fetch_repo_status(default_branch: &str) -> RepoStatus {
     let mut status = RepoStatus::default();
 
     // Fetch latest commit on default branch
@@ -209,11 +211,15 @@ fn fetch_repo_status() -> RepoStatus {
         }
     }
 
-    // Fetch CI status from latest workflow run on main branch
+    // Fetch CI status from latest workflow run on default branch
+    let actions_url = format!(
+        "repos/{{owner}}/{{repo}}/actions/runs?branch={}&per_page=1",
+        default_branch
+    );
     if let Ok(output) = std::process::Command::new("gh")
         .args([
             "api",
-            "repos/{owner}/{repo}/actions/runs?branch=main&per_page=1",
+            &actions_url,
             "--jq",
             ".workflow_runs[0] | {status: .status, conclusion: .conclusion}",
         ])
@@ -402,7 +408,8 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
         .unwrap_or_default();
 
     // Fetch repo status (blocking I/O)
-    let repo_status = tokio::task::spawn_blocking(fetch_repo_status)
+    let default_branch = state.default_branch.clone();
+    let repo_status = tokio::task::spawn_blocking(move || fetch_repo_status(&default_branch))
         .await
         .unwrap_or_default();
 
@@ -774,6 +781,7 @@ mod tests {
             channel_post_tx,
             push_manager: None,
             all_repo_paths: Vec::new(),
+            default_branch: "main".to_string(),
         });
 
         let json = r#"{"type": "send_message", "content": "hello from mobile"}"#;

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -125,6 +125,7 @@ pub async fn start_webhook_server(
     config: WebhookConfig,
     coworker_manager: Option<CoworkerManager>,
     all_repo_paths: Vec<std::path::PathBuf>,
+    default_branch: String,
 ) -> crate::Result<(
     mpsc::Receiver<WebhookEvent>,
     broadcast::Sender<WebUpdate>,
@@ -164,6 +165,7 @@ pub async fn start_webhook_server(
         channel_post_tx: mobile_tx,
         push_manager: push_manager.clone(),
         all_repo_paths,
+        default_branch,
     });
 
     // CORS layer for development (allows requests from Vite dev server)
@@ -820,7 +822,12 @@ fn handle_check_run(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json::Err
             .is_none();
 
     let ci_failed_on_default_branch = if is_failure && is_on_default_branch {
-        let default_branch = branch.unwrap_or("main");
+        let default_branch = event
+            .repository
+            .default_branch
+            .as_deref()
+            .or(branch)
+            .unwrap_or("main");
         Some(format!(
             "@lead CI check '{}' failed on {} — investigate ASAP",
             event.check_run.name, default_branch,

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -28,7 +28,7 @@ pub enum WorktreeError {
     #[error("Git command failed: {0}")]
     GitError(String),
 
-    #[error("Branch {0} exists but is not merged to main")]
+    #[error("Branch {0} exists but is not merged to the default branch")]
     UnmergedBranch(String),
 
     #[error("IO error: {0}")]
@@ -225,7 +225,7 @@ impl WorktreeManager {
 
     /// Check if a coworker's worktree branch has commits beyond the base (detached HEAD).
     ///
-    /// Returns `true` if the branch has unique commits that are not on the main branch.
+    /// Returns `true` if the branch has unique commits that are not on the default branch.
     /// Returns `false` if the branch has no commits beyond the base, or if the
     /// worktree is in detached HEAD state with no branch.
     pub fn has_commits_beyond_base(&self, coworker_name: &str) -> bool {
@@ -466,7 +466,7 @@ fn repo_name_from_path(repo_path: &Path) -> WorktreeResult<String> {
 }
 
 /// Detect the default branch (main or master) for a repository.
-fn detect_default_branch(repo_root: &Path) -> Option<String> {
+pub fn detect_default_branch(repo_root: &Path) -> Option<String> {
     // Try origin/HEAD first
     let output = Command::new("git")
         .current_dir(repo_root)


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Detects the repo's default branch at daemon startup via `git symbolic-ref refs/remotes/origin/HEAD` (with fallback to checking for main/master branches)
- Stores the detected branch in `DaemonState` and passes it through to `WebState` and the webhook server
- Replaces hardcoded `branch=main` in GitHub API calls for CI status (web.rs, chat app.rs)
- Uses `repository.default_branch` from webhook payloads instead of hardcoded "main" fallback
- Makes `detect_default_branch()` public so it can be reused across the codebase

## Files changed
- **src/worktree.rs** — Made `detect_default_branch()` public; updated error message and doc comment
- **src/daemon/mod.rs** — Added `default_branch` field to `DaemonState`; detect at startup before webhook server starts
- **src/web.rs** — Added `default_branch` to `WebState`; parameterized `fetch_repo_status()` to use it
- **src/webhook.rs** — Added `default_branch` param to `start_webhook_server()`; use `event.repository.default_branch` instead of "main" fallback
- **src/bin/midtown/cli/chat/app.rs** — Added `detect_default_branch_for_repo()` helper using `gh api`; parameterized CI status query

## Test plan
- [x] `cargo test` — all tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt` — properly formatted
- [x] Verified remaining "main" references are only in detection logic, fallbacks, test fixtures, and docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)