### PR TITLE
fix: include chat pane when recreating lead window [Midtown #710]

### DIFF
--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -652,33 +652,8 @@ pub fn handle_start(
         // Set up hook to update status bar color based on active window
         let _ = midtown::tmux::setup_status_bar_hook(&session);
 
-        // Set up chat TUI based on layout configuration
-        let bin_command = midtown::config::get_bin_command();
-        let (chat_layout, chat_min_width) = midtown::config::get_chat_layout();
-
-        // Determine whether to use split or window layout
-        let use_split = match chat_layout {
-            midtown::config::ChatLayout::Split => true,
-            midtown::config::ChatLayout::Window => false,
-            midtown::config::ChatLayout::Auto => {
-                // Check terminal width and use split if wide enough
-                midtown::tmux::get_session_width(&session)
-                    .map(|w| w >= chat_min_width)
-                    .unwrap_or(true) // Default to split if can't determine width
-            }
-        };
-
-        if use_split {
-            // Split layout: chat pane on the right (30% width)
-            if let Err(e) = midtown::tmux::create_chat_split(&session, &bin_command) {
-                eprintln!("Warning: Failed to create chat split: {}", e);
-            }
-        } else {
-            // Window layout: chat in separate window
-            if let Err(e) = midtown::tmux::create_chat_window(&session, &bin_command) {
-                eprintln!("Warning: Failed to create chat window: {}", e);
-            }
-        }
+        // Set up chat TUI (split pane or separate window based on config)
+        midtown::tmux::setup_chat_pane(&session);
 
         // Write marker file indicating Lead was initialized by midtown
         let marker_path = lead_initialized_marker(&primary_repo);
@@ -1199,6 +1174,9 @@ fn ensure_lead_has_settings(session: &str, repo: &Path) -> Result<(), String> {
             &claude_cmd,
         ])
         .status();
+
+    // Set up chat pane (split or separate window based on config)
+    midtown::tmux::setup_chat_pane(session);
 
     // Write the marker file
     if let Some(parent) = marker_path.parent() {

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1106,6 +1106,35 @@ pub fn get_session_width(session: &str) -> Option<u16> {
     width_str.trim().parse().ok()
 }
 
+/// Set up the chat pane for the lead session.
+///
+/// Determines whether to use a split pane or separate window based on
+/// the chat layout configuration and terminal width, then creates the
+/// appropriate chat interface.
+///
+/// This is the single entry point for chat pane setup — used both during
+/// initial session creation and when recreating the lead window.
+pub fn setup_chat_pane(session: &str) {
+    let bin_command = crate::config::get_bin_command();
+    let (chat_layout, chat_min_width) = crate::config::get_chat_layout();
+
+    let use_split = match chat_layout {
+        crate::config::ChatLayout::Split => true,
+        crate::config::ChatLayout::Window => false,
+        crate::config::ChatLayout::Auto => get_session_width(session)
+            .map(|w| w >= chat_min_width)
+            .unwrap_or(true),
+    };
+
+    if use_split {
+        if let Err(e) = create_chat_split(session, &bin_command) {
+            eprintln!("Warning: Failed to create chat split: {}", e);
+        }
+    } else if let Err(e) = create_chat_window(session, &bin_command) {
+        eprintln!("Warning: Failed to create chat window: {}", e);
+    }
+}
+
 /// Create a new window in the session for the chat TUI.
 ///
 /// This is used when the terminal is too narrow for a split layout.


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Extracted chat layout decision logic into `tmux::setup_chat_pane()` shared helper
- Added `setup_chat_pane()` call to `ensure_lead_has_settings()` so the chat TUI is created when the lead window is reinitialized
- Replaced inline chat setup in `handle_start()` with the shared helper to eliminate duplication

## Bug
When the lead window was recreated (e.g. via `midtown attach` after a version upgrade), `ensure_lead_has_settings()` respawned the Claude pane but never set up the chat TUI — leaving the user without the chat split/window.

## Fix
The chat layout decision (split vs separate window based on config + terminal width) was duplicated in `handle_start()`. This PR extracts it into `tmux::setup_chat_pane()` and calls it from both:
1. `handle_start()` — initial session creation
2. `ensure_lead_has_settings()` — lead window recreation

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 642 tests pass
- [x] Manual: `ensure_lead_has_settings()` path now includes chat pane setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)