### PR TITLE
feat: reduce daemon GitHub API calls with combined review check and repo name cache [Midtown #711]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -339,9 +339,47 @@ pub(crate) struct DaemonState {
     /// Per-coworker pane content hash and last-changed timestamp (for stuck detection).
     /// Maps coworker name → (last_hash, last_changed_at).
     coworker_pane_hashes: std::sync::Mutex<HashMap<String, (u64, Instant)>>,
+    /// Cached GitHub repo full names (owner/repo) by repo path.
+    /// Repo names never change during a daemon session, so we cache indefinitely.
+    repo_name_cache: std::sync::RwLock<HashMap<PathBuf, String>>,
 }
 
 impl DaemonState {
+    /// Get the GitHub full name (owner/repo) for a repo path, using cache.
+    ///
+    /// On first call for a given path, runs `gh repo view --json nameWithOwner`.
+    /// Subsequent calls return the cached value without any API call.
+    fn get_repo_full_name(&self, repo_path: &std::path::Path) -> String {
+        // Fast path: check cache
+        {
+            let cache = self.repo_name_cache.read().unwrap();
+            if let Some(name) = cache.get(repo_path) {
+                return name.clone();
+            }
+        }
+
+        // Slow path: fetch from GitHub API and cache
+        let full_name = std::process::Command::new("gh")
+            .current_dir(repo_path)
+            .args([
+                "repo",
+                "view",
+                "--json",
+                "nameWithOwner",
+                "--jq",
+                ".nameWithOwner",
+            ])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_default();
+
+        let mut cache = self.repo_name_cache.write().unwrap();
+        cache.insert(repo_path.to_path_buf(), full_name.clone());
+        full_name
+    }
+
     /// Check if the daemon is at the maximum coworker limit (absolute cap).
     fn is_at_coworker_limit(&self) -> bool {
         self.coworkers.list().len() >= self.max_coworkers
@@ -414,6 +452,7 @@ impl DaemonState {
             stuck_tracker: Mutex::new(StuckConditionTracker::new()),
             last_coworker_activity: std::sync::RwLock::new(HashMap::new()),
             coworker_pane_hashes: std::sync::Mutex::new(HashMap::new()),
+            repo_name_cache: std::sync::RwLock::new(HashMap::new()),
         })
     }
 
@@ -3179,50 +3218,56 @@ fn pr_has_claude_review(pr_number: u64, state: &DaemonState) -> bool {
 }
 
 /// Uncached check for Claude review on a PR (makes GitHub API calls).
+///
+/// Fetches both reviews and comments in a single API call to reduce GitHub API usage.
 fn pr_has_claude_review_uncached(pr_number: u64) -> bool {
-    // Check formal reviews first
-    let reviews_output = std::process::Command::new("gh")
+    let output = std::process::Command::new("gh")
         .args([
             "pr",
             "view",
             &pr_number.to_string(),
             "--json",
-            "reviews",
-            "-q",
-            ".reviews[].body",
+            "reviews,comments",
         ])
         .output();
 
-    if let Ok(output) = reviews_output
-        && output.status.success()
-    {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        if text_contains_review_signature(&stdout) {
-            return true;
-        }
-    }
-
-    // Check comments (where coworkers post their reviews)
-    let comments_output = std::process::Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            &pr_number.to_string(),
-            "--json",
-            "comments",
-            "-q",
-            ".comments[].body",
-        ])
-        .output();
-
-    match comments_output {
+    match output {
         Ok(output) if output.status.success() => {
             let stdout = String::from_utf8_lossy(&output.stdout);
-            text_contains_review_signature(&stdout)
+            let json: serde_json::Value = match serde_json::from_str(&stdout) {
+                Ok(v) => v,
+                Err(e) => {
+                    debug!("Failed to parse review JSON for PR #{}: {}", pr_number, e);
+                    return false;
+                }
+            };
+
+            // Check formal reviews
+            if let Some(reviews) = json.get("reviews").and_then(|v| v.as_array()) {
+                for review in reviews {
+                    if let Some(body) = review.get("body").and_then(|b| b.as_str())
+                        && text_contains_review_signature(body)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            // Check comments (where coworkers post their reviews)
+            if let Some(comments) = json.get("comments").and_then(|v| v.as_array()) {
+                for comment in comments {
+                    if let Some(body) = comment.get("body").and_then(|b| b.as_str())
+                        && text_contains_review_signature(body)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            false
         }
         _ => {
-            debug!("Failed to check comments for PR #{}", pr_number);
-            // Assume no review on error (will try again later)
+            debug!("Failed to fetch reviews/comments for PR #{}", pr_number);
             false
         }
     }
@@ -4103,22 +4148,8 @@ fn handle_kanban_data(id: RequestId, state: &DaemonState) -> Response {
             None
         };
 
-        // Resolve owner/name once — used by both the GraphQL query and repo metadata
-        let full_name = std::process::Command::new("gh")
-            .current_dir(repo_path)
-            .args([
-                "repo",
-                "view",
-                "--json",
-                "nameWithOwner",
-                "--jq",
-                ".nameWithOwner",
-            ])
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-            .unwrap_or_default();
+        // Resolve owner/name via cache (only hits API on first call per repo path)
+        let full_name = state.get_repo_full_name(repo_path);
 
         let label = repo_path
             .file_name()

--- a/src/web.rs
+++ b/src/web.rs
@@ -61,6 +61,9 @@ pub struct WebState {
     pub all_repo_paths: Vec<std::path::PathBuf>,
     /// Default branch name (e.g. "main" or "master")
     pub default_branch: String,
+    /// Cached GitHub repo full names (owner/repo) by repo path.
+    /// Repo names never change during a session, so we cache indefinitely.
+    pub repo_name_cache: std::sync::RwLock<std::collections::HashMap<std::path::PathBuf, String>>,
 }
 
 /// Types of real-time updates sent to clients
@@ -414,18 +417,25 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
         .unwrap_or_default();
 
     // Build repo metadata for multi-repo PR URL resolution
-    let repo_paths = state.all_repo_paths.clone();
-    let repo_statuses: Vec<serde_json::Value> = if repo_paths.len() > 1 {
-        tokio::task::spawn_blocking(move || {
-            repo_paths
-                .iter()
-                .map(|repo_path| {
-                    let label = repo_path
-                        .file_name()
-                        .and_then(|s| s.to_str())
-                        .unwrap_or("unknown")
-                        .to_string();
-                    let full_name = std::process::Command::new("gh")
+    let repo_statuses: Vec<serde_json::Value> = if state.all_repo_paths.len() > 1 {
+        state
+            .all_repo_paths
+            .iter()
+            .map(|repo_path| {
+                let label = repo_path
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+
+                // Check cache first
+                let full_name = {
+                    let cache = state.repo_name_cache.read().unwrap();
+                    cache.get(repo_path).cloned()
+                };
+
+                let full_name = full_name.unwrap_or_else(|| {
+                    let name = std::process::Command::new("gh")
                         .current_dir(repo_path)
                         .args([
                             "repo",
@@ -440,15 +450,17 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
                         .filter(|o| o.status.success())
                         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
                         .unwrap_or_default();
-                    serde_json::json!({
-                        "label": label,
-                        "fullName": full_name,
-                    })
+                    let mut cache = state.repo_name_cache.write().unwrap();
+                    cache.insert(repo_path.clone(), name.clone());
+                    name
+                });
+
+                serde_json::json!({
+                    "label": label,
+                    "fullName": full_name,
                 })
-                .collect()
-        })
-        .await
-        .unwrap_or_default()
+            })
+            .collect()
     } else {
         Vec::new()
     };
@@ -782,6 +794,7 @@ mod tests {
             push_manager: None,
             all_repo_paths: Vec::new(),
             default_branch: "main".to_string(),
+            repo_name_cache: std::sync::RwLock::new(std::collections::HashMap::new()),
         });
 
         let json = r#"{"type": "send_message", "content": "hello from mobile"}"#;

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -166,6 +166,7 @@ pub async fn start_webhook_server(
         push_manager: push_manager.clone(),
         all_repo_paths,
         default_branch,
+        repo_name_cache: std::sync::RwLock::new(std::collections::HashMap::new()),
     });
 
     // CORS layer for development (allows requests from Vite dev server)


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Combined two sequential `gh pr view` API calls in review detection (`--json reviews` + `--json comments`) into a single `--json reviews,comments` call, halving API usage for this path
- Added indefinite `repo_name_cache` on `DaemonState` and `WebState` for `gh repo view --json nameWithOwner` lookups — repo names don't change during a session, so we only hit the API once per repo path
- Webhook-cached review status (fast path) was already correctly prioritized before API calls — no changes needed there

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo clippy -- -D warnings` passes clean
- [x] `cargo fmt -- --check` passes
- [x] All tests pass (15/15 doc tests, unit tests)
- [x] Review detection still checks both formal reviews and comments
- [x] Cache miss correctly falls through to API call, cache hit skips it

🤖 Generated with [Claude Code](https://claude.com/claude-code)