### PR TITLE
docs: add rule to mention coworkers when updating their active tasks [Midtown #715]

### DIFF
--- a/agents/lead.md
+++ b/agents/lead.md
@@ -189,6 +189,14 @@ TaskUpdate with taskId, owner: "<coworker-name>"
 
 This ensures `midtown status` shows the assignment before the coworker claims it.
 
+## Updating Tasks
+When you update a task that a coworker is actively working on, always @mention them in the channel so they see the change. They won't notice a TaskUpdate on their own.
+
+```bash
+# After updating task description/requirements:
+midtown channel post "@vernon Updated task #714 description — root cause changed, see updated task for details."
+```
+
 ## Grouping Related Tasks
 When creating tasks, prefer combining tightly coupled work into a single task rather than splitting it across multiple tasks that each produce a separate PR.
 


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Adds a new "Updating Tasks" section to the lead system prompt (`agents/lead.md`)
- Establishes the rule that the lead should always @mention coworkers in the channel when updating a task they're actively working on
- Coworkers won't notice a `TaskUpdate` on their own — the channel mention ensures they see the change

## Why this matters
Without an explicit notification, a coworker can keep building against stale requirements after a task description changes mid-flight. This small process rule closes that communication gap.

## Test plan
- [x] Change is documentation-only (no code to test)
- [x] Verified diff is a single, well-scoped addition to `agents/lead.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)