### PR TITLE
docs: clarify coworkers should @user when replying to human messages [Midtown #716]

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -70,9 +70,12 @@ midtown channel post "@lead yes, the auth module exports a validate function"
 
 # Another coworker asked something → @mention them
 midtown channel post "@columbus the endpoint is at /api/v1/auth"
+
+# The user (human) asked you something → @mention them
+midtown channel post "@user yes, the test suite covers that case"
 ```
 
-Without the @mention, the daemon cannot route your reply and the other person may never see it.
+Without the @mention, the daemon cannot route your reply and the other person may never see it. Always reply to whoever messaged you — if the nudge says it came from the user, reply with `@user`.
 
 ### Idle Status (No Feedback Needed)
 When you become idle, post your status in your own voice without requesting feedback. Include the keyword `idle`, `waiting`, or `blocked` for status parsing:


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Adds `@user` reply example to the coworker system prompt's "Replying to Messages" section
- Clarifies that when a coworker receives a message from the human user, they should reply with `@user` so the daemon routes the response correctly
- Updates the explanatory text to reinforce: always @mention whoever messaged you

## Why this matters
The daemon uses @mentions for message routing. Without an explicit `@user` example, coworkers could reply to human messages without the @mention, causing the response to get lost in the channel rather than being routed back to the user.

## Test plan
- [x] Change is documentation-only (no code to test)
- [x] Verified diff is a clean addition to `agents/coworker.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)