### PR TITLE
feat: show (done) on kanban review cards once review is posted [Midtown #722]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -80,8 +80,10 @@ pub struct KanbanPr {
     pub ci_status: CiStatus,
     /// Reviewer name (extracted from review comment frontmatter)
     pub reviewer: Option<String>,
-    /// When the review comment was posted
+    /// When the reviewer was assigned or the review comment was posted
     pub reviewed_at: Option<DateTime<Utc>>,
+    /// Whether the review has been posted (true) vs reviewer is still working (false)
+    pub review_posted: bool,
     /// Repository name (for multi-repo projects)
     pub repo: Option<String>,
 }
@@ -733,6 +735,7 @@ fn fetch_prs() -> Vec<KanbanPr> {
                 );
 
                 if number > 0 {
+                    let review_posted = reviewer.is_some();
                     prs.push(KanbanPr {
                         number,
                         title,
@@ -741,6 +744,7 @@ fn fetch_prs() -> Vec<KanbanPr> {
                         ci_status,
                         reviewer,
                         reviewed_at,
+                        review_posted,
                         repo: None,
                     });
                 }
@@ -979,6 +983,11 @@ fn fetch_kanban_data_via_rpc() -> Option<(Vec<KanbanPr>, Vec<MergedPr>, Vec<(Str
                 .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
                 .map(|dt| dt.with_timezone(&Utc));
 
+            let review_posted = pr
+                .get("review_posted")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
             let repo = pr
                 .get("repo")
                 .and_then(|v| v.as_str())
@@ -992,6 +1001,7 @@ fn fetch_kanban_data_via_rpc() -> Option<(Vec<KanbanPr>, Vec<MergedPr>, Vec<(Str
                 ci_status,
                 reviewer,
                 reviewed_at,
+                review_posted,
                 repo,
             })
         })

--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -405,7 +405,11 @@ fn draw_kanban_panel(f: &mut Frame, app: &App, area: Rect) -> Vec<Hyperlink> {
             let line2 = format!("  A: {} {}", pr.author, author_duration);
             let line3 = match (&pr.reviewer, &pr.reviewed_at) {
                 (Some(reviewer), Some(at)) => {
-                    format!("  R: {} {}", reviewer, format_duration_minutes(*at))
+                    if pr.review_posted {
+                        format!("  R: {} (done)", reviewer)
+                    } else {
+                        format!("  R: {} {}", reviewer, format_duration_minutes(*at))
+                    }
                 }
                 (Some(reviewer), None) => format!("  R: {}", reviewer),
                 _ => "  R: pending".to_string(),

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -4304,18 +4304,19 @@ fn fetch_kanban_all_prs(
                     let (comment_reviewer, reviewed_at) =
                         extract_reviewer_from_pr_comments(&comments);
 
-                    // Use comment reviewer, or fall back to assigned reviewer
-                    let (reviewer, reviewer_assigned_at) = if let Some(reviewer) = comment_reviewer
-                    {
-                        (Some(reviewer), reviewed_at)
-                    } else if let Some((name, instant)) = reviewer_assignments.get(&number) {
-                        let elapsed = instant.elapsed();
-                        let assigned_at = chrono::Utc::now()
-                            - chrono::Duration::seconds(elapsed.as_secs() as i64);
-                        (Some(name.clone()), Some(assigned_at.to_rfc3339()))
-                    } else {
-                        (None, None)
-                    };
+                    // Use comment reviewer, or fall back to assigned reviewer.
+                    // Track whether the review was actually posted (vs just assigned).
+                    let (reviewer, reviewer_assigned_at, review_posted) =
+                        if let Some(reviewer) = comment_reviewer {
+                            (Some(reviewer), reviewed_at, true)
+                        } else if let Some((name, instant)) = reviewer_assignments.get(&number) {
+                            let elapsed = instant.elapsed();
+                            let assigned_at = chrono::Utc::now()
+                                - chrono::Duration::seconds(elapsed.as_secs() as i64);
+                            (Some(name.clone()), Some(assigned_at.to_rfc3339()), false)
+                        } else {
+                            (None, None, false)
+                        };
 
                     Some(serde_json::json!({
                         "number": number,
@@ -4325,6 +4326,7 @@ fn fetch_kanban_all_prs(
                         "ci_status": ci_status,
                         "reviewer": reviewer,
                         "reviewed_at": reviewer_assigned_at,
+                        "review_posted": review_posted,
                         "repo": repo_label,
                     }))
                 })

--- a/src/web.rs
+++ b/src/web.rs
@@ -335,6 +335,7 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
             let assignment = github_state.pr_reviewers.get(&pr_number);
             let reviewer = assignment.map(|a| a.reviewer.as_str());
             let reviewer_assigned_at = assignment.map(|a| a.assigned_at.to_rfc3339());
+            let review_posted = github_state.reviewed_prs.contains(&pr_number);
             serde_json::json!({
                 "number": pr_number,
                 "title": pr.get("title").and_then(|t| t.as_str()).unwrap_or(""),
@@ -342,6 +343,7 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
                 "status": status,
                 "reviewer": reviewer,
                 "reviewer_assigned_at": reviewer_assigned_at,
+                "review_posted": review_posted,
                 "created_at": pr.get("createdAt").and_then(|c| c.as_str()),
             })
         })

--- a/web-app/src/lib/Kanban.svelte
+++ b/web-app/src/lib/Kanban.svelte
@@ -207,7 +207,7 @@
             </div>
             <div class="card-detail"><span class="pipe">|</span> by: {pr.author}{pr.created_at ? ` (${formatRelativeTime(pr.created_at)})` : ''}</div>
             {#if pr.reviewer}
-              <div class="card-detail"><span class="pipe">|</span> rev: {pr.reviewer}{pr.reviewer_assigned_at ? ` (${formatRelativeTime(pr.reviewer_assigned_at)})` : ''}</div>
+              <div class="card-detail"><span class="pipe">|</span> rev: {pr.reviewer}{pr.review_posted ? ' (done)' : pr.reviewer_assigned_at ? ` (${formatRelativeTime(pr.reviewer_assigned_at)})` : ''}</div>
             {/if}
           </button>
         {/each}

--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -139,6 +139,7 @@ function updateKanbanData(data) {
       status: pr.status,
       reviewer: pr.reviewer,
       reviewer_assigned_at: pr.reviewer_assigned_at,
+      review_posted: pr.review_posted || false,
       created_at: pr.created_at,
       repo: pr.repo || null,
     })),


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Added `review_posted` boolean to kanban PR data, propagated through all layers (daemon RPC → chat TUI, web.rs → web app)
- Review cards now show "(done)" when the reviewer has posted their comment, instead of continuing to count elapsed time
- Cards where a reviewer is assigned but hasn't posted yet still show the elapsed time "(Xm)"
- Daemon kanban RPC uses `extract_reviewer_from_pr_comments` result to distinguish posted vs. assigned
- Web.rs endpoint uses `github_state.reviewed_prs` cache for the same distinction

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo clippy -- -D warnings` passes clean
- [x] `cargo fmt -- --check` passes
- [x] All tests pass (15/15)
- [x] Chat TUI: review cards with posted reviews show "(done)"
- [x] Chat TUI: review cards with assigned-but-not-posted reviewers show elapsed time "(Xm)"
- [x] Web app: same behavior via `review_posted` field in Kanban.svelte

🤖 Generated with [Claude Code](https://claude.com/claude-code)