### PR TITLE
feat: Add user display name config for chat and @mentions [Midtown #721]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -149,6 +149,8 @@ pub struct App {
     pub input_text: String,
     /// Cursor position within input_text
     pub input_cursor: usize,
+    /// User display name from config (None = "user")
+    pub user_display_name: Option<String>,
 }
 
 /// Interval between kanban data refreshes (30 seconds)
@@ -195,6 +197,7 @@ impl App {
             input_mode: false,
             input_text: String::new(),
             input_cursor: 0,
+            user_display_name: midtown::config::get_user_display_name(),
         };
 
         // Initial load
@@ -467,12 +470,13 @@ impl App {
             return;
         }
 
+        let sender = self.user_display_name.as_deref().unwrap_or("user");
         let sent = if let Some(ref client) = self.daemon_client {
             // Route through daemon so it can nudge the Lead
-            client.channel_post_as(&text, "user").is_ok()
+            client.channel_post_as(&text, sender).is_ok()
         } else if let Some(ref channel) = self.channel {
             // Fallback: direct write (won't trigger Lead nudge)
-            let message = Message::text("user", &text);
+            let message = Message::text(sender, &text);
             channel.send(&message).is_ok()
         } else {
             false
@@ -1298,6 +1302,7 @@ mod tests {
             input_mode: false,
             input_text: String::new(),
             input_cursor: 0,
+            user_display_name: None,
         };
 
         let (pending, in_progress, completed) = app.tasks_by_status();
@@ -1346,6 +1351,7 @@ mod tests {
             input_mode: false,
             input_text: String::new(),
             input_cursor: 0,
+            user_display_name: None,
         };
 
         let visible = app.visible_messages();

--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -90,7 +90,7 @@ fn is_dim_sender(sender: &str) -> bool {
 /// Get color for a sender name
 fn get_sender_color(name: &str) -> Color {
     match name.to_lowercase().as_str() {
-        "lead" => Color::LightYellow,
+        "lead" | "user" => Color::LightYellow,
         "daemon" => Color::DarkGray,
         "github" => Color::DarkGray,
         "system" => Color::DarkGray,
@@ -100,6 +100,12 @@ fn get_sender_color(name: &str) -> Color {
                 if name.to_lowercase() == *avenue {
                     return *color;
                 }
+            }
+            // Custom user display names get the same color as lead/user
+            if midtown::config::get_user_display_name()
+                .is_some_and(|dn| dn.eq_ignore_ascii_case(name))
+            {
+                return Color::LightYellow;
             }
             // Default for unknown names
             Color::White
@@ -721,7 +727,13 @@ fn draw_chat_panel(f: &mut Frame, app: &mut App, area: Rect) {
     let mut prev_sender: Option<&str> = None;
 
     for msg in visible.iter() {
-        let msg_lines = render_message(msg, inner.width as usize, prev_sender, &current_tasks);
+        let msg_lines = render_message(
+            msg,
+            inner.width as usize,
+            prev_sender,
+            &current_tasks,
+            app.user_display_name.as_deref(),
+        );
         lines.extend(msg_lines);
         prev_sender = Some(&msg.from);
     }
@@ -883,10 +895,17 @@ fn render_message(
     width: usize,
     prev_sender: Option<&str>,
     current_tasks: &HashMap<String, String>,
+    user_display_name: Option<&str>,
 ) -> Vec<Line<'static>> {
     let local_time = msg.timestamp.with_timezone(&Local);
     let time = local_time.format("%H:%M").to_string();
-    let color = get_sender_color(&msg.from);
+    // Substitute user display name for rendering (internal "user" stays for routing)
+    let display_from: String = if msg.from == "user" {
+        user_display_name.unwrap_or("user").to_string()
+    } else {
+        msg.from.clone()
+    };
+    let color = get_sender_color(&display_from);
 
     // Determine if we need to show the sender name
     let show_sender = prev_sender.is_none_or(|prev| prev != msg.from);
@@ -917,7 +936,13 @@ fn render_message(
                 result.push(Line::from(""));
             }
             let current_task = current_tasks.get(&msg.from.to_lowercase());
-            result.push(build_sender_line(msg, color, current_task, width));
+            result.push(build_sender_line(
+                &display_from,
+                &msg.message_type,
+                color,
+                current_task,
+                width,
+            ));
         }
 
         // Add content lines with timestamp and "* " prefix
@@ -963,7 +988,13 @@ fn render_message(
         }
         // Look up the sender's current task (case-insensitive)
         let current_task = current_tasks.get(&msg.from.to_lowercase());
-        result.push(build_sender_line(msg, color, current_task, width));
+        result.push(build_sender_line(
+            &display_from,
+            &msg.message_type,
+            color,
+            current_task,
+            width,
+        ));
     }
 
     // Add content lines with timestamp/indent prefix
@@ -987,19 +1018,20 @@ fn render_message(
 ///
 /// Format: "**name**" or "**name** - Task subject" (task is not bold)
 fn build_sender_line(
-    msg: &Message,
+    display_name: &str,
+    message_type: &MessageType,
     color: Color,
     current_task: Option<&String>,
     width: usize,
 ) -> Line<'static> {
-    match msg.message_type {
+    match message_type {
         MessageType::System => Line::from(vec![Span::styled(
             String::from("<system>"),
             Style::default().fg(Color::DarkGray),
         )]),
         _ => {
             let mut spans = vec![Span::styled(
-                msg.from.clone(),
+                display_name.to_string(),
                 Style::default().fg(color).add_modifier(Modifier::BOLD),
             )];
 
@@ -1007,7 +1039,7 @@ fn build_sender_line(
             if let Some(task) = current_task {
                 // Calculate available space for task (width - name - " - ")
                 // Use chars().count() for UTF-8 safe length calculation
-                let prefix_len = msg.from.chars().count() + 3; // " - " = 3 chars
+                let prefix_len = display_name.chars().count() + 3; // " - " = 3 chars
                 let available = width.saturating_sub(prefix_len);
 
                 if available > 5 {
@@ -1381,8 +1413,8 @@ mod tests {
 
         // New layout: name line, then 3 content lines (timestamp + 2 continuations)
         // Total = 4 lines: sender, timestamp+line1, indent+line2, indent+line3
-        let short_lines = render_message(&short_name_msg, 80, None, &current_tasks);
-        let long_lines = render_message(&long_name_msg, 80, None, &current_tasks);
+        let short_lines = render_message(&short_name_msg, 80, None, &current_tasks, None);
+        let long_lines = render_message(&long_name_msg, 80, None, &current_tasks, None);
 
         assert_eq!(short_lines.len(), 4, "Expected 4 lines: sender + 3 content");
         assert_eq!(long_lines.len(), 4, "Expected 4 lines: sender + 3 content");
@@ -1428,15 +1460,15 @@ mod tests {
         let current_tasks = HashMap::new();
 
         // First message (no previous sender) - shows sender line + timestamp line
-        let lines1 = render_message(&msg1, 80, None, &current_tasks);
+        let lines1 = render_message(&msg1, 80, None, &current_tasks, None);
         assert_eq!(lines1.len(), 2); // sender line + timestamp+content line
 
         // Second message from same sender - shows only timestamp + content (no sender)
-        let lines2 = render_message(&msg2, 80, Some("columbus"), &current_tasks);
+        let lines2 = render_message(&msg2, 80, Some("columbus"), &current_tasks, None);
         assert_eq!(lines2.len(), 1); // just timestamp + content
 
         // Different sender - shows blank line + sender line + timestamp line
-        let lines3 = render_message(&msg2, 80, Some("lexington"), &current_tasks);
+        let lines3 = render_message(&msg2, 80, Some("lexington"), &current_tasks, None);
         assert_eq!(lines3.len(), 3); // blank + sender line + timestamp+content line
 
         // Verify first message has sender name on first line
@@ -1468,7 +1500,7 @@ mod tests {
         // Action messages now follow standard format:
         // Line 0: actor name (when sender changes)
         // Line 1: " HH:MM * message" with * in actor color
-        let lines = render_message(&msg, 80, None, &current_tasks);
+        let lines = render_message(&msg, 80, None, &current_tasks, None);
         assert_eq!(lines.len(), 2, "Expected 2 lines: actor name + message");
 
         // First line should be actor name
@@ -1529,7 +1561,7 @@ mod tests {
         let current_tasks = HashMap::new();
 
         // System messages now render through standard path: sender line + timestamp line
-        let lines = render_message(&msg, 80, None, &current_tasks);
+        let lines = render_message(&msg, 80, None, &current_tasks, None);
         assert_eq!(lines.len(), 2); // sender line + content line
 
         // First line is the sender name (<system>)
@@ -1613,7 +1645,7 @@ mod tests {
         let mut all_lines: Vec<Line> = Vec::new();
         let mut prev_sender: Option<&str> = None;
         for msg in &messages {
-            let msg_lines = render_message(msg, 80, prev_sender, &current_tasks);
+            let msg_lines = render_message(msg, 80, prev_sender, &current_tasks, None);
             all_lines.extend(msg_lines);
             prev_sender = Some(&msg.from);
         }
@@ -1707,7 +1739,7 @@ mod tests {
         let mut at_bottom_lines: Vec<Line> = Vec::new();
         let mut prev_sender: Option<&str> = None;
         for msg in at_bottom_messages {
-            at_bottom_lines.extend(render_message(msg, 80, prev_sender, &current_tasks));
+            at_bottom_lines.extend(render_message(msg, 80, prev_sender, &current_tasks, None));
             prev_sender = Some(&msg.from);
         }
 
@@ -1716,7 +1748,7 @@ mod tests {
         let mut scrolled_up_lines: Vec<Line> = Vec::new();
         let mut prev_sender: Option<&str> = None;
         for msg in scrolled_up_messages {
-            scrolled_up_lines.extend(render_message(msg, 80, prev_sender, &current_tasks));
+            scrolled_up_lines.extend(render_message(msg, 80, prev_sender, &current_tasks, None));
             prev_sender = Some(&msg.from);
         }
 
@@ -1829,7 +1861,7 @@ mod tests {
             message_type: MessageType::Text,
         };
 
-        let daemon_lines = render_message(&daemon_msg, 80, Some("madison"), &current_tasks);
+        let daemon_lines = render_message(&daemon_msg, 80, Some("madison"), &current_tasks, None);
         assert!(
             count_blank_lines(&daemon_lines) == 1,
             "Should have blank line before daemon message after regular sender"
@@ -1843,7 +1875,7 @@ mod tests {
             timestamp: Utc::now(),
             message_type: MessageType::Text,
         };
-        let daemon_lines2 = render_message(&daemon_msg2, 80, Some("daemon"), &current_tasks);
+        let daemon_lines2 = render_message(&daemon_msg2, 80, Some("daemon"), &current_tasks, None);
         assert_eq!(
             count_blank_lines(&daemon_lines2),
             0,
@@ -1858,7 +1890,7 @@ mod tests {
             timestamp: Utc::now(),
             message_type: MessageType::Text,
         };
-        let github_lines = render_message(&github_msg, 80, Some("daemon"), &current_tasks);
+        let github_lines = render_message(&github_msg, 80, Some("daemon"), &current_tasks, None);
         assert_eq!(
             count_blank_lines(&github_lines),
             1,
@@ -1873,7 +1905,7 @@ mod tests {
             timestamp: Utc::now(),
             message_type: MessageType::Text,
         };
-        let park_lines = render_message(&park_msg, 80, Some("daemon"), &current_tasks);
+        let park_lines = render_message(&park_msg, 80, Some("daemon"), &current_tasks, None);
         assert_eq!(
             count_blank_lines(&park_lines),
             1,
@@ -1913,7 +1945,7 @@ mod tests {
             timestamp: Utc::now(),
             message_type: MessageType::Text,
         };
-        let github_lines = render_message(&github_msg, 80, Some("daemon"), &current_tasks);
+        let github_lines = render_message(&github_msg, 80, Some("daemon"), &current_tasks, None);
         assert_eq!(
             count_blank_lines(&github_lines),
             1,
@@ -1928,7 +1960,7 @@ mod tests {
             timestamp: Utc::now(),
             message_type: MessageType::Text,
         };
-        let daemon_lines = render_message(&daemon_msg, 80, Some("github"), &current_tasks);
+        let daemon_lines = render_message(&daemon_msg, 80, Some("github"), &current_tasks, None);
         assert_eq!(
             count_blank_lines(&daemon_lines),
             1,
@@ -1936,7 +1968,7 @@ mod tests {
         );
 
         // Test 3: coworker -> github should have a blank line
-        let github_lines2 = render_message(&github_msg, 80, Some("park"), &current_tasks);
+        let github_lines2 = render_message(&github_msg, 80, Some("park"), &current_tasks, None);
         assert_eq!(
             count_blank_lines(&github_lines2),
             1,
@@ -1951,7 +1983,7 @@ mod tests {
             timestamp: Utc::now(),
             message_type: MessageType::Text,
         };
-        let park_lines = render_message(&park_msg, 80, Some("github"), &current_tasks);
+        let park_lines = render_message(&park_msg, 80, Some("github"), &current_tasks, None);
         assert_eq!(
             count_blank_lines(&park_lines),
             1,
@@ -1959,7 +1991,7 @@ mod tests {
         );
 
         // Test 5: github content should still be DarkGray (visual distinction preserved)
-        let github_lines3 = render_message(&github_msg, 80, None, &current_tasks);
+        let github_lines3 = render_message(&github_msg, 80, None, &current_tasks, None);
         // The content line is line index 1 (after sender line)
         // Content spans should be DarkGray
         assert!(
@@ -1997,7 +2029,7 @@ mod tests {
             "Fix chat TUI timestamp formatting".to_string(),
         );
 
-        let lines = render_message(&msg, 80, None, &current_tasks);
+        let lines = render_message(&msg, 80, None, &current_tasks, None);
 
         // First line should be sender name with task
         let first_line_content: String =
@@ -2017,7 +2049,7 @@ mod tests {
 
         // Test without a current task - should just show name
         let empty_tasks = HashMap::new();
-        let lines_no_task = render_message(&msg, 80, None, &empty_tasks);
+        let lines_no_task = render_message(&msg, 80, None, &empty_tasks, None);
         let first_line_no_task: String = lines_no_task[0]
             .spans
             .iter()
@@ -2052,7 +2084,7 @@ mod tests {
         );
 
         // Narrow width should truncate the task
-        let lines = render_message(&msg, 30, None, &current_tasks);
+        let lines = render_message(&msg, 30, None, &current_tasks, None);
         let first_line_content: String =
             lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
 
@@ -2080,7 +2112,7 @@ mod tests {
         let mut current_tasks = HashMap::new();
         current_tasks.insert("park".to_string(), "Fix something".to_string());
 
-        let lines = render_message(&msg, 80, None, &current_tasks);
+        let lines = render_message(&msg, 80, None, &current_tasks, None);
         let first_line_content: String =
             lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -251,6 +251,10 @@ pub struct ProjectConfig {
     /// Personality variant for agent voice in channel/GitHub (normal, fun, wild)
     #[serde(default)]
     pub personality: Option<Personality>,
+
+    /// User display name shown in chat and @mentions (default: "user")
+    #[serde(default)]
+    pub user_display_name: Option<String>,
 }
 
 impl ProjectConfig {
@@ -265,6 +269,10 @@ impl ProjectConfig {
             chat_min_width: other.chat_min_width.or(self.chat_min_width),
             max_coworkers: other.max_coworkers.or(self.max_coworkers),
             personality: other.personality.or(self.personality),
+            user_display_name: other
+                .user_display_name
+                .clone()
+                .or_else(|| self.user_display_name.clone()),
         }
     }
 
@@ -293,6 +301,11 @@ impl ProjectConfig {
     /// Get personality with fallback to Normal.
     pub fn personality(&self) -> Personality {
         self.personality.unwrap_or_default()
+    }
+
+    /// Get user display name, or None if not configured (falls back to "user").
+    pub fn user_display_name(&self) -> Option<&str> {
+        self.user_display_name.as_deref()
     }
 }
 
@@ -426,6 +439,9 @@ impl GlobalConfig {
 
 # Personality for coworker messages: "normal", "fun", or "wild"
 # personality = "normal"
+
+# Your display name shown in chat and @mentions (default: "user")
+# user_display_name = "Ben"
 
 [plugins]
 # Required plugins to install for all projects
@@ -669,6 +685,26 @@ pub fn get_personality() -> Personality {
     config.personality()
 }
 
+/// Get the user display name for the current project, if configured.
+pub fn get_user_display_name() -> Option<String> {
+    let project_name = get_project_name().unwrap_or_default();
+
+    let config = if project_name.is_empty() {
+        GlobalConfig::load().default
+    } else {
+        get_project_config(&project_name)
+    };
+
+    config.user_display_name().map(|s| s.to_string())
+}
+
+/// Get the user display name for a specific project, if configured.
+pub fn get_user_display_name_for_project(project_name: &str) -> Option<String> {
+    get_project_config(project_name)
+        .user_display_name()
+        .map(|s| s.to_string())
+}
+
 /// Get the current project name from git repo root directory.
 fn get_project_name() -> Option<String> {
     crate::paths::detect_repo_name()
@@ -741,6 +777,7 @@ bin_command = "custom-command"
             chat_min_width: Some(160),
             max_coworkers: Some(8),
             personality: Some(Personality::Fun),
+            user_display_name: None,
         };
 
         let project = ProjectConfig {
@@ -749,6 +786,7 @@ bin_command = "custom-command"
             chat_min_width: Some(200),
             max_coworkers: None, // Not overridden
             personality: None,   // Not overridden
+            user_display_name: None,
         };
 
         let merged = global.merge(&project);
@@ -768,6 +806,7 @@ bin_command = "custom-command"
             chat_min_width: None,
             max_coworkers: Some(8),
             personality: None,
+            user_display_name: None,
         };
 
         let project = ProjectConfig {
@@ -776,6 +815,7 @@ bin_command = "custom-command"
             chat_min_width: None,
             max_coworkers: Some(4),
             personality: None,
+            user_display_name: None,
         };
 
         let merged = global.merge(&project);
@@ -1037,6 +1077,7 @@ personality = "normal"
             chat_min_width: None,
             max_coworkers: None,
             personality: Some(Personality::Normal),
+            user_display_name: None,
         };
         let project = ProjectConfig {
             bin_command: None,
@@ -1044,9 +1085,50 @@ personality = "normal"
             chat_min_width: None,
             max_coworkers: None,
             personality: Some(Personality::Wild),
+            user_display_name: None,
         };
         let merged = global.merge(&project);
         assert_eq!(merged.personality(), Personality::Wild);
+    }
+
+    #[test]
+    fn test_user_display_name_merge() {
+        // Global sets display name, project doesn't override
+        let global = ProjectConfig {
+            user_display_name: Some("Ben".to_string()),
+            ..ProjectConfig::default()
+        };
+        let project = ProjectConfig::default();
+        let merged = global.merge(&project);
+        assert_eq!(merged.user_display_name(), Some("Ben"));
+
+        // Project overrides global
+        let project = ProjectConfig {
+            user_display_name: Some("Alice".to_string()),
+            ..ProjectConfig::default()
+        };
+        let merged = global.merge(&project);
+        assert_eq!(merged.user_display_name(), Some("Alice"));
+
+        // Neither sets it
+        let global = ProjectConfig::default();
+        let project = ProjectConfig::default();
+        let merged = global.merge(&project);
+        assert_eq!(merged.user_display_name(), None);
+    }
+
+    #[test]
+    fn test_user_display_name_deserialization() {
+        let toml_str = r#"
+            user_display_name = "Ben"
+        "#;
+        let config: ProjectConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.user_display_name(), Some("Ben"));
+
+        // Missing field should be None
+        let toml_str = "";
+        let config: ProjectConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.user_display_name(), None);
     }
 
     #[test]

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -346,6 +346,9 @@ pub(crate) struct DaemonState {
     /// Cached GitHub repo full names (owner/repo) by repo path.
     /// Repo names never change during a daemon session, so we cache indefinitely.
     repo_name_cache: std::sync::RwLock<HashMap<PathBuf, String>>,
+    /// User display name from config (e.g. "Ben"). Used to recognize user @mentions
+    /// and identify user-sent messages when the display name differs from "user".
+    user_display_name: Option<String>,
 }
 
 impl DaemonState {
@@ -423,6 +426,8 @@ impl DaemonState {
                 crate::reminders::ReminderState::default()
             });
 
+        let user_display_name = config::get_user_display_name_for_project(&repo_name);
+
         Ok(Self {
             coworkers,
             channel,
@@ -446,6 +451,7 @@ impl DaemonState {
             stuck_tracker: Mutex::new(StuckConditionTracker::new()),
             coworker_pane_hashes: std::sync::Mutex::new(HashMap::new()),
             repo_name_cache: std::sync::RwLock::new(HashMap::new()),
+            user_display_name,
         })
     }
 
@@ -469,6 +475,15 @@ impl DaemonState {
             crate::rules::CoworkerLifecycle::new_spawn(),
         );
         Ok(())
+    }
+
+    /// Check if a sender name represents the user (either "user" or the configured display name).
+    fn is_user_sender(&self, from: &str) -> bool {
+        from.eq_ignore_ascii_case("user")
+            || self
+                .user_display_name
+                .as_ref()
+                .is_some_and(|dn| dn.eq_ignore_ascii_case(from))
     }
 
     /// Send a message to the channel and broadcast it to WebSocket clients.
@@ -1000,9 +1015,10 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                 }
             } => {
                 let content = &mobile_post.content;
+                let sender = state.user_display_name.as_deref().unwrap_or("user");
                 handle_channel_post(
                     RequestId::Null,
-                    "user",
+                    sender,
                     content,
                     &state,
                 ).await;
@@ -2046,13 +2062,15 @@ async fn chat_monitor_loop(
                             Ok(msg) => {
                                 // Skip messages from protected senders (loop protection),
                                 // but first check for @lead mentions that need nudging.
-                                if SKIP_SENDERS.iter().any(|&s| s.eq_ignore_ascii_case(&msg.from)) {
+                                if SKIP_SENDERS.iter().any(|&s| s.eq_ignore_ascii_case(&msg.from))
+                                    || state.is_user_sender(&msg.from)
+                                {
                                     // System/daemon messages may contain @lead that still
                                     // needs to trigger a nudge (e.g., orphaned worktree
                                     // warnings). Route @lead before skipping.
-                                    // Exclude "user" — user messages with @lead are already
-                                    // handled in handle_channel_post to avoid double-nudging.
-                                    if !msg.from.eq_ignore_ascii_case("user")
+                                    // Exclude user messages — already handled in
+                                    // handle_channel_post to avoid double-nudging.
+                                    if !state.is_user_sender(&msg.from)
                                         && msg.content.to_lowercase().contains("@lead")
                                     {
                                         let nudge_text = format!("{}: {}", msg.from, msg.content);
@@ -3740,7 +3758,7 @@ async fn handle_channel_post(
             }
 
             // Nudge lead when user messages arrive (from web UI or TUI input)
-            if from == "user" {
+            if state.is_user_sender(from) {
                 // Check if user is @mentioning specific coworkers or @all
                 let has_coworker_mentions =
                     !extract_mentions(&content).is_empty() || contains_at_all(&content);
@@ -3807,17 +3825,28 @@ async fn handle_channel_post(
             }
 
             // Send bell notification and push notification for @user mentions
-            if content_lower.contains("@user") && from != "user" {
+            // Also recognize @<display_name> if configured (e.g., @Ben)
+            let has_user_mention = content_lower.contains("@user")
+                || state
+                    .user_display_name
+                    .as_ref()
+                    .is_some_and(|dn| content_lower.contains(&format!("@{}", dn.to_lowercase())));
+            if has_user_mention && !state.is_user_sender(from) {
                 info!("Bell notification: @user mentioned by {}", from);
                 if let Err(e) = state.coworkers.notify_user() {
                     warn!("Failed to send bell notification for @user mention: {}", e);
                 }
+                let display = state.user_display_name.as_deref().unwrap_or("user");
                 let summary = if content.len() > 100 {
                     format!("{}...", &content[..97])
                 } else {
                     content.clone()
                 };
-                state.send_push_notification(&format!("@user from {}", from), &summary, "mention");
+                state.send_push_notification(
+                    &format!("@{} from {}", display, from),
+                    &summary,
+                    "mention",
+                );
             }
 
             Response::success(


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Adds `user_display_name` config field to `ProjectConfig` (global and per-project)
- Chat TUI shows configured name instead of "user" in sender labels
- Channel messages use display name as the `from` field
- Daemon recognizes @display_name alongside @user for bell/push notifications
- Display name sender is treated as skip-sender in chat monitor (prevents double-routing)
- Config template includes the new setting with example

## Configuration
```toml
[default]
user_display_name = "Ben"
```

## Files changed
- `src/config.rs` — New field, merge logic, getters, template, tests
- `src/daemon/mod.rs` — `is_user_sender()` helper, @mention recognition, mobile post sender
- `src/bin/midtown/cli/chat/app.rs` — Display name field on App, use in message posting
- `src/bin/midtown/cli/chat/ui.rs` — Render display name in sender lines, color matching

## Test plan
- [x] Config merge tests (global, project override, None)
- [x] TOML deserialization test
- [x] All existing tests pass (465 lib + 98 bin + integration)
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)