### PR TITLE
refactor: unify review tracking and lead typing state [Midtown #719]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -20,9 +20,7 @@ pub use constants::{
 };
 use effects::Effect;
 use helpers::*;
-pub use trackers::{
-    PrIssueTracker, PrIssueType, PrReviewTracker, StuckConditionTracker, StuckConditionType,
-};
+pub use trackers::{PrIssueTracker, PrIssueType, StuckConditionTracker, StuckConditionType};
 
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
@@ -283,8 +281,6 @@ pub(crate) struct DaemonState {
     coworker_phases: RwLock<HashMap<String, crate::rules::CoworkerPhase>>,
     /// Tracker to avoid spamming the same PR issues
     pr_issue_tracker: Mutex<PrIssueTracker>,
-    /// Tracker for PRs assigned for review
-    pr_review_tracker: Mutex<PrReviewTracker>,
     /// Repository name (primary repo)
     repo_name: String,
     /// Default branch name (detected at startup, e.g. "main" or "master")
@@ -299,12 +295,8 @@ pub(crate) struct DaemonState {
     github_state: Mutex<crate::github_state::GitHubState>,
     /// Broadcast sender for pushing channel messages to WebSocket clients
     web_updates_tx: Option<tokio::sync::broadcast::Sender<WebUpdate>>,
-    /// Hash of last captured lead pane content (for typing indicator change detection)
-    last_lead_pane_hash: std::sync::Mutex<u64>,
-    /// Whether the lead is currently working (for typing indicator dedup)
-    lead_working: std::sync::Mutex<bool>,
-    /// When the lead's pane last showed activity (for typing grace period)
-    last_lead_activity: std::sync::Mutex<Option<Instant>>,
+    /// Consolidated lead typing indicator state (pane hash, working flag, last activity).
+    lead_typing: std::sync::Mutex<trackers::LeadTypingState>,
     /// Maximum number of concurrent coworkers
     max_coworkers: usize,
     /// Web Push notification manager for sending notifications to PWA clients
@@ -429,7 +421,6 @@ impl DaemonState {
             nudged_messages: std::sync::RwLock::new(HashSet::new()),
             coworker_phases: RwLock::new(HashMap::new()),
             pr_issue_tracker: Mutex::new(PrIssueTracker::new()),
-            pr_review_tracker: Mutex::new(PrReviewTracker::new()),
             repo_name,
             default_branch,
             all_repo_paths,
@@ -440,9 +431,7 @@ impl DaemonState {
             max_coworkers,
             push_manager,
             usage_limit_nudge_at: Mutex::new(None),
-            last_lead_pane_hash: std::sync::Mutex::new(0),
-            lead_working: std::sync::Mutex::new(false),
-            last_lead_activity: std::sync::Mutex::new(None),
+            lead_typing: std::sync::Mutex::new(trackers::LeadTypingState::default()),
             reminder_state: std::sync::Mutex::new(reminder_state),
             last_pr_poll_hash: Mutex::new(0),
             reviewed_prs_cache: std::sync::RwLock::new(reviewed_prs_cache),
@@ -1124,36 +1113,28 @@ async fn check_lead_typing(state: &DaemonState) {
     content.hash(&mut hasher);
     let new_hash = hasher.finish();
 
-    let prev_hash = {
-        let mut h = state.last_lead_pane_hash.lock().unwrap();
-        let prev = *h;
-        *h = new_hash;
-        prev
-    };
-
-    let pane_changed = prev_hash != 0 && new_hash != prev_hash;
     let now = Instant::now();
 
-    // Update last-activity timestamp when pane content changes
-    if pane_changed {
-        *state.last_lead_activity.lock().unwrap() = Some(now);
-    }
+    // Single lock for all lead typing state
+    let (is_working, prev_working) = {
+        let mut lt = state.lead_typing.lock().unwrap();
+        let pane_changed = lt.pane_hash != 0 && new_hash != lt.pane_hash;
+        lt.pane_hash = new_hash;
 
-    // Determine working state using grace period: stay "working" until
-    // no pane changes have occurred for LEAD_TYPING_GRACE_PERIOD.
-    let is_working = determine_lead_working(
-        pane_changed,
-        *state.last_lead_activity.lock().unwrap(),
-        now,
-        LEAD_TYPING_GRACE_PERIOD,
-    );
+        if pane_changed {
+            lt.last_activity = Some(now);
+        }
 
-    // Only broadcast on state transitions
-    let prev_working = {
-        let mut w = state.lead_working.lock().unwrap();
-        let prev = *w;
-        *w = is_working;
-        prev
+        let is_working = determine_lead_working(
+            pane_changed,
+            lt.last_activity,
+            now,
+            LEAD_TYPING_GRACE_PERIOD,
+        );
+
+        let prev = lt.working;
+        lt.working = is_working;
+        (is_working, prev)
     };
 
     if is_working != prev_working {
@@ -1292,21 +1273,11 @@ async fn check_and_shutdown_idle_coworkers(
         let name = &decision.name;
 
         // For isolated coworkers (reviewers), verify the review was actually posted
-        // (pr_review_tracker and github_state are mutable async state — kept on DaemonState)
         let (should_shutdown, shutdown_msg) = if decision.is_isolated {
             // Look up the PR this reviewer was assigned to
-            // Try in-memory tracker first
             let pr_number = {
-                let tracker = state.pr_review_tracker.lock().await;
-                tracker.pr_for_coworker(name)
-            };
-            let pr_number = match pr_number {
-                Some(pr) => Some(pr),
-                None => {
-                    // Fall back to persistent state
-                    let github_state = state.github_state.lock().await;
-                    github_state.pr_for_reviewer(name)
-                }
+                let github_state = state.github_state.lock().await;
+                github_state.pr_for_reviewer(name)
             };
 
             match pr_number {
@@ -2336,8 +2307,8 @@ async fn poll_prs_for_issues(
         tracker.cleanup();
     }
     {
-        let mut review_tracker = state.pr_review_tracker.lock().await;
-        review_tracker.cleanup_preserving(&active_coworker_names);
+        let mut github_state = state.github_state.lock().await;
+        github_state.cleanup_expired_preserving(&active_coworker_names);
     }
 
     // Filter to only open PRs (defense-in-depth: gh pr list --state open should only return
@@ -2588,8 +2559,8 @@ async fn check_for_stuck_conditions(state: &DaemonState, prs: &[serde_json::Valu
         if review_decision.is_empty() && age_secs >= STUCK_NO_REVIEW_DURATION.as_secs() {
             // Check if a reviewer is assigned (daemon tried to self-heal)
             let is_assigned = {
-                let review_tracker = state.pr_review_tracker.lock().await;
-                review_tracker.is_assigned(pr_number)
+                let github_state = state.github_state.lock().await;
+                github_state.is_assigned(pr_number)
             };
 
             tracker.track(&pr_id, StuckConditionType::NoReview);
@@ -2725,8 +2696,8 @@ async fn check_for_stuck_conditions(state: &DaemonState, prs: &[serde_json::Valu
             .count();
 
         let current_review_count = {
-            let review_tracker = state.pr_review_tracker.lock().await;
-            review_tracker.active_count()
+            let github_state = state.github_state.lock().await;
+            github_state.active_count()
         };
 
         // Backlog exists when more PRs need review than we can handle
@@ -2784,8 +2755,8 @@ fn nudge_lead_stuck(state: &DaemonState, message: &str) {
 async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value]) {
     // Check rate limit
     let current_review_count = {
-        let tracker = state.pr_review_tracker.lock().await;
-        tracker.active_count()
+        let github_state = state.github_state.lock().await;
+        github_state.active_count()
     };
 
     if current_review_count >= MAX_CONCURRENT_REVIEWS {
@@ -2839,17 +2810,11 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
             // If so, leave the assignment in place so the idle shutdown path can
             // properly send them off with break_review_complete() instead of break_no_pr().
             let reviewer_still_running = {
-                let tracker = state.pr_review_tracker.lock().await;
-                if let Some(reviewer_name) = tracker.get_reviewer(pr_number) {
+                let github_state = state.github_state.lock().await;
+                if let Some(reviewer_name) = github_state.get_reviewer(pr_number) {
                     state.coworkers.get(reviewer_name).is_some()
                 } else {
-                    // Check persistent state too
-                    let github_state = state.github_state.lock().await;
-                    if let Some(reviewer_name) = github_state.get_reviewer(pr_number) {
-                        state.coworkers.get(reviewer_name).is_some()
-                    } else {
-                        false
-                    }
+                    false
                 }
             };
 
@@ -2860,31 +2825,14 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
                 );
             } else {
                 // Free the tracker slot — the review completed and the reviewer is gone
-                {
-                    let mut tracker = state.pr_review_tracker.lock().await;
-                    if tracker.is_assigned(pr_number) {
-                        debug!(
-                            "PR #{} review completed, freeing tracker slot (in-memory)",
-                            pr_number
-                        );
-                        tracker.mark_reviewed(pr_number);
-                    }
-                }
-                // Also clean up persistent state
-                {
-                    let mut github_state = state.github_state.lock().await;
-                    if github_state.is_assigned(pr_number) {
-                        debug!(
-                            "PR #{} review completed, freeing tracker slot (persistent)",
-                            pr_number
-                        );
-                        github_state.remove_assignment(pr_number);
-                        if let Err(e) = crate::github_state::save_state_for_repo(
-                            &state.repo_name,
-                            &github_state,
-                        ) {
-                            warn!("Failed to save github-state.json: {}", e);
-                        }
+                let mut github_state = state.github_state.lock().await;
+                if github_state.is_assigned(pr_number) {
+                    debug!("PR #{} review completed, freeing tracker slot", pr_number);
+                    github_state.remove_assignment(pr_number);
+                    if let Err(e) =
+                        crate::github_state::save_state_for_repo(&state.repo_name, &github_state)
+                    {
+                        warn!("Failed to save github-state.json: {}", e);
                     }
                 }
             }
@@ -3012,20 +2960,13 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
             continue;
         }
 
-        // Check if already assigned for review (check both in-memory and persistent state).
+        // Check if already assigned for review.
         // This runs AFTER review detection so completed reviews are always detected,
         // but prevents spawning duplicate reviewers for PRs already under review.
         {
-            let tracker = state.pr_review_tracker.lock().await;
-            if tracker.is_assigned(pr_number) {
-                debug!("PR #{} already assigned for review (in-memory)", pr_number);
-                continue;
-            }
-        }
-        {
             let github_state = state.github_state.lock().await;
             if github_state.is_assigned(pr_number) {
-                debug!("PR #{} already assigned for review (persistent)", pr_number);
+                debug!("PR #{} already assigned for review", pr_number);
                 continue;
             }
         }
@@ -3066,13 +3007,7 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
             Ok(new_coworker) => {
                 state.broadcast_coworker_update(&new_coworker, "running", None);
 
-                // Record the assignment (in-memory)
-                {
-                    let mut tracker = state.pr_review_tracker.lock().await;
-                    tracker.assign(pr_number, &new_coworker);
-                }
-
-                // Persist the assignment to github-state.json
+                // Record the assignment in persistent state
                 {
                     let mut github_state = state.github_state.lock().await;
                     github_state.assign_reviewer(pr_number, &new_coworker);
@@ -4127,11 +4062,11 @@ fn get_all_tasks() -> Vec<serde_json::Value> {
 /// Returns open PRs with author, reviewer, CI status, and timestamps,
 /// plus recently merged PRs for the Done column.
 fn handle_kanban_data(id: RequestId, state: &DaemonState) -> Response {
-    // Get reviewer assignments from PrReviewTracker (best-effort via try_lock)
-    let reviewer_assignments: HashMap<u64, (String, Instant)> = state
-        .pr_review_tracker
+    // Get reviewer assignments from GitHubState (best-effort via try_lock)
+    let reviewer_assignments: HashMap<u64, crate::github_state::PrReviewerAssignment> = state
+        .github_state
         .try_lock()
-        .map(|tracker| tracker.active_assignments())
+        .map(|gs| gs.active_assignments())
         .unwrap_or_default();
 
     // Fetch PRs and repo metadata from all repos in the project.
@@ -4236,7 +4171,7 @@ query($owner: String!, $repo: String!) {
 /// Returns `(open_prs, merged_prs)` formatted for the kanban board.
 /// Falls back to empty vectors on failure.
 fn fetch_kanban_all_prs(
-    reviewer_assignments: &HashMap<u64, (String, Instant)>,
+    reviewer_assignments: &HashMap<u64, crate::github_state::PrReviewerAssignment>,
     name_with_owner: &str,
     repo_path: &std::path::Path,
     repo_label: Option<&str>,
@@ -4340,11 +4275,12 @@ fn fetch_kanban_all_prs(
                     let (reviewer, reviewer_assigned_at, review_posted) =
                         if let Some(reviewer) = comment_reviewer {
                             (Some(reviewer), reviewed_at, true)
-                        } else if let Some((name, instant)) = reviewer_assignments.get(&number) {
-                            let elapsed = instant.elapsed();
-                            let assigned_at = chrono::Utc::now()
-                                - chrono::Duration::seconds(elapsed.as_secs() as i64);
-                            (Some(name.clone()), Some(assigned_at.to_rfc3339()), false)
+                        } else if let Some(assignment) = reviewer_assignments.get(&number) {
+                            (
+                                Some(assignment.reviewer.clone()),
+                                Some(assignment.assigned_at.to_rfc3339()),
+                                false,
+                            )
                         } else {
                             (None, None, false)
                         };
@@ -5857,168 +5793,6 @@ mod tests {
         assert_eq!(truncate_str("hello", 10), "hello");
         assert_eq!(truncate_str("hello world", 8), "hello...");
         assert_eq!(truncate_str("hi", 2), "hi");
-    }
-
-    // PrReviewTracker tests
-    #[test]
-    fn test_pr_review_tracker_new() {
-        let tracker = PrReviewTracker::new();
-        assert_eq!(tracker.active_count(), 0);
-        assert!(!tracker.is_assigned(42));
-    }
-
-    #[test]
-    fn test_pr_review_tracker_assign() {
-        let mut tracker = PrReviewTracker::new();
-        tracker.assign(42, "lexington");
-
-        assert!(tracker.is_assigned(42));
-        assert!(!tracker.is_assigned(43));
-        assert_eq!(tracker.active_count(), 1);
-    }
-
-    #[test]
-    fn test_pr_review_tracker_mark_reviewed() {
-        let mut tracker = PrReviewTracker::new();
-        tracker.assign(42, "lexington");
-        assert!(tracker.is_assigned(42));
-
-        tracker.mark_reviewed(42);
-        assert!(!tracker.is_assigned(42));
-        assert_eq!(tracker.active_count(), 0);
-    }
-
-    #[test]
-    fn test_pr_review_tracker_multiple_assignments() {
-        let mut tracker = PrReviewTracker::new();
-        tracker.assign(42, "lexington");
-        tracker.assign(43, "park");
-
-        assert!(tracker.is_assigned(42));
-        assert!(tracker.is_assigned(43));
-        assert_eq!(tracker.active_count(), 2);
-    }
-
-    #[test]
-    fn test_pr_review_tracker_pr_for_coworker() {
-        let mut tracker = PrReviewTracker::new();
-        tracker.assign(42, "lexington");
-        tracker.assign(43, "park");
-
-        assert_eq!(tracker.pr_for_coworker("lexington"), Some(42));
-        assert_eq!(tracker.pr_for_coworker("park"), Some(43));
-        assert_eq!(tracker.pr_for_coworker("york"), None);
-
-        // After marking reviewed, should return None
-        tracker.mark_reviewed(42);
-        assert_eq!(tracker.pr_for_coworker("lexington"), None);
-    }
-
-    #[test]
-    fn test_pr_review_tracker_active_reviewers() {
-        let mut tracker = PrReviewTracker::new();
-        tracker.assign(42, "lexington");
-        tracker.assign(43, "park");
-        tracker.assign(44, "lexington"); // duplicate reviewer
-
-        let reviewers = tracker.active_reviewers();
-        assert!(reviewers.contains("lexington"));
-        assert!(reviewers.contains("park"));
-        // Should deduplicate
-        assert_eq!(reviewers.len(), 2);
-    }
-
-    #[test]
-    fn test_pr_review_tracker_active_reviewers_after_mark_reviewed() {
-        let mut tracker = PrReviewTracker::new();
-        tracker.assign(42, "lexington");
-        tracker.assign(43, "park");
-
-        // Mark lexington's review as done
-        tracker.mark_reviewed(42);
-
-        let reviewers = tracker.active_reviewers();
-        assert!(!reviewers.contains("lexington"));
-        assert!(reviewers.contains("park"));
-        assert_eq!(reviewers.len(), 1);
-    }
-
-    #[test]
-    fn test_pr_review_tracker_get_reviewer() {
-        let mut tracker = PrReviewTracker::new();
-        tracker.assign(42, "lexington");
-        tracker.assign(43, "park");
-
-        assert_eq!(tracker.get_reviewer(42), Some("lexington"));
-        assert_eq!(tracker.get_reviewer(43), Some("park"));
-        assert_eq!(tracker.get_reviewer(99), None);
-
-        // get_reviewer should return the name even after mark_reviewed removes it
-        tracker.mark_reviewed(42);
-        assert_eq!(tracker.get_reviewer(42), None);
-    }
-
-    #[test]
-    fn test_pr_review_tracker_get_reviewer_ignores_timeout() {
-        let mut tracker = PrReviewTracker::new();
-        // Simulate an expired assignment (> 10 minutes old)
-        tracker.assign_at(
-            42,
-            "broadway",
-            Instant::now() - Duration::from_secs(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS + 60),
-        );
-
-        // is_assigned should return false (expired)
-        assert!(!tracker.is_assigned(42));
-        // get_reviewer should still return the name (ignores timeout)
-        assert_eq!(tracker.get_reviewer(42), Some("broadway"));
-    }
-
-    #[test]
-    fn test_cleanup_preserves_active_coworkers() {
-        let mut tracker = PrReviewTracker::new();
-
-        // Simulate an expired assignment (> 10 minutes old) for an active coworker
-        tracker.assign_at(
-            42,
-            "broadway",
-            Instant::now() - Duration::from_secs(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS + 60),
-        );
-        // And a fresh assignment for another coworker
-        tracker.assign(43, "park");
-
-        // broadway is still active (running as a coworker)
-        let active: HashSet<String> = ["broadway".to_string()].into_iter().collect();
-
-        // cleanup_preserving should keep broadway's assignment alive
-        tracker.cleanup_preserving(&active);
-
-        // broadway's assignment should be preserved because they're still active
-        assert_eq!(tracker.pr_for_coworker("broadway"), Some(42));
-        assert!(tracker.active_reviewers().contains("broadway"));
-
-        // park's fresh assignment should also still be there
-        assert_eq!(tracker.pr_for_coworker("park"), Some(43));
-    }
-
-    #[test]
-    fn test_cleanup_removes_expired_inactive_coworkers() {
-        let mut tracker = PrReviewTracker::new();
-
-        // Simulate an expired assignment for an inactive coworker
-        tracker.assign_at(
-            42,
-            "broadway",
-            Instant::now() - Duration::from_secs(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS + 60),
-        );
-
-        // broadway is NOT active
-        let active: HashSet<String> = HashSet::new();
-
-        tracker.cleanup_preserving(&active);
-
-        // broadway's assignment should be removed
-        assert_eq!(tracker.pr_for_coworker("broadway"), None);
     }
 
     // Stuck condition tracker tests

--- a/src/daemon/snapshot.rs
+++ b/src/daemon/snapshot.rs
@@ -142,13 +142,8 @@ pub async fn collect_world_snapshot(state: &DaemonState) -> WorldSnapshot {
 
     // ── Reviewer state ──────────────────────────────────────────────────
     let active_reviewers = {
-        let tracker = state.pr_review_tracker.lock().await;
-        let mut reviewers = tracker.active_reviewers();
         let github_state = state.github_state.lock().await;
-        for reviewer_name in github_state.assigned_reviewers() {
-            reviewers.insert(reviewer_name.to_string());
-        }
-        reviewers
+        github_state.active_reviewers()
     };
 
     // ── Dependency state ──────────────────────────────────────────────────

--- a/src/daemon/trackers.rs
+++ b/src/daemon/trackers.rs
@@ -3,12 +3,10 @@
 //! These trackers prevent the daemon from spamming the same PR issues
 //! or assigning duplicate reviews.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-use super::constants::{
-    PR_NUDGE_COOLDOWN_SECS, PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS, STUCK_NUDGE_COOLDOWN_SECS,
-};
+use super::constants::{PR_NUDGE_COOLDOWN_SECS, STUCK_NUDGE_COOLDOWN_SECS};
 
 // ---------------------------------------------------------------------------
 // PrIssueType
@@ -96,122 +94,18 @@ impl PrIssueTracker {
 }
 
 // ---------------------------------------------------------------------------
-// PrReviewTracker
+// LeadTypingState
 // ---------------------------------------------------------------------------
 
-/// Tracks which PRs have been assigned for review to avoid duplicates.
-#[derive(Debug, Default)]
-pub struct PrReviewTracker {
-    /// Map of pr_number -> (assigned_coworker, assignment_time)
-    assigned: HashMap<u64, (String, Instant)>,
-}
-
-impl PrReviewTracker {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Check if a PR has been assigned for review recently
-    pub fn is_assigned(&self, pr_number: u64) -> bool {
-        match self.assigned.get(&pr_number) {
-            Some((_, assigned_at)) => {
-                assigned_at.elapsed() < Duration::from_secs(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS)
-            }
-            None => false,
-        }
-    }
-
-    /// Get the assigned reviewer name for a PR (ignoring timeout).
-    /// Used to check if a reviewer is still running before cleaning up assignments.
-    pub fn get_reviewer(&self, pr_number: u64) -> Option<&str> {
-        self.assigned.get(&pr_number).map(|(name, _)| name.as_str())
-    }
-
-    /// Record a review assignment
-    pub fn assign(&mut self, pr_number: u64, coworker: &str) {
-        self.assigned
-            .insert(pr_number, (coworker.to_string(), Instant::now()));
-    }
-
-    /// Get the number of active review assignments
-    pub fn active_count(&self) -> usize {
-        self.assigned
-            .values()
-            .filter(|(_, t)| t.elapsed() < Duration::from_secs(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS))
-            .count()
-    }
-
-    /// Clean up stale assignments
-    pub fn cleanup(&mut self) {
-        let timeout = Duration::from_secs(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS);
-        self.assigned.retain(|_, (_, t)| t.elapsed() < timeout);
-    }
-
-    /// Clean up stale assignments, but preserve assignments for active coworkers.
-    ///
-    /// This prevents reviewers from losing their PR assignment tracking while
-    /// they are still actively running (e.g., a review taking longer than the
-    /// timeout). Assignments for inactive coworkers are cleaned up normally.
-    /// Active coworkers' assignments are refreshed so timeout-based lookups
-    /// (active_reviewers, pr_for_coworker) continue to work.
-    pub fn cleanup_preserving(&mut self, active_coworkers: &HashSet<String>) {
-        let timeout = Duration::from_secs(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS);
-        let now = Instant::now();
-        self.assigned.retain(|_, (name, t)| {
-            if t.elapsed() < timeout {
-                return true;
-            }
-            // Expired, but coworker is still active — refresh the timestamp
-            if active_coworkers.contains(name) {
-                *t = now;
-                return true;
-            }
-            false
-        });
-    }
-
-    /// Mark a PR as reviewed (remove from tracking)
-    pub fn mark_reviewed(&mut self, pr_number: u64) {
-        self.assigned.remove(&pr_number);
-    }
-
-    /// Get the PR number assigned to a specific coworker.
-    pub fn pr_for_coworker(&self, coworker: &str) -> Option<u64> {
-        self.assigned
-            .iter()
-            .find(|(_, (name, assigned_at))| {
-                name == coworker
-                    && assigned_at.elapsed()
-                        < Duration::from_secs(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS)
-            })
-            .map(|(pr_number, _)| *pr_number)
-    }
-
-    /// Record a review assignment with a specific timestamp (for testing).
-    #[cfg(test)]
-    pub fn assign_at(&mut self, pr_number: u64, coworker: &str, at: Instant) {
-        self.assigned.insert(pr_number, (coworker.to_string(), at));
-    }
-
-    /// Get all active review assignments as (pr_number, (coworker_name, assigned_at)).
-    pub fn active_assignments(&self) -> HashMap<u64, (String, Instant)> {
-        let timeout = Duration::from_secs(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS);
-        self.assigned
-            .iter()
-            .filter(|(_, (_, t))| t.elapsed() < timeout)
-            .map(|(pr, (name, instant))| (*pr, (name.clone(), *instant)))
-            .collect()
-    }
-
-    /// Get the set of coworker names that are actively assigned to review PRs.
-    pub fn active_reviewers(&self) -> HashSet<String> {
-        let timeout = Duration::from_secs(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS);
-        self.assigned
-            .values()
-            .filter(|(_, t)| t.elapsed() < timeout)
-            .map(|(name, _)| name.clone())
-            .collect()
-    }
+/// Consolidated state for the lead's typing indicator.
+///
+/// Groups pane hash, working flag, and last-activity timestamp into a single
+/// struct so that `check_lead_typing` can acquire one lock instead of three.
+#[derive(Default)]
+pub(crate) struct LeadTypingState {
+    pub pane_hash: u64,
+    pub working: bool,
+    pub last_activity: Option<Instant>,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/github_state.rs
+++ b/src/github_state.rs
@@ -195,6 +195,38 @@ impl GitHubState {
         self.reviewed_prs.insert(pr_number);
     }
 
+    /// Count active (non-expired) review assignments.
+    pub fn active_count(&self) -> usize {
+        let now = Utc::now();
+        let timeout = chrono::Duration::seconds(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS as i64);
+        self.pr_reviewers
+            .values()
+            .filter(|a| now.signed_duration_since(a.assigned_at) < timeout)
+            .count()
+    }
+
+    /// Get the set of coworker names with active (non-expired) review assignments.
+    pub fn active_reviewers(&self) -> std::collections::HashSet<String> {
+        let now = Utc::now();
+        let timeout = chrono::Duration::seconds(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS as i64);
+        self.pr_reviewers
+            .values()
+            .filter(|a| now.signed_duration_since(a.assigned_at) < timeout)
+            .map(|a| a.reviewer.clone())
+            .collect()
+    }
+
+    /// Get all active (non-expired) review assignments.
+    pub fn active_assignments(&self) -> HashMap<u64, PrReviewerAssignment> {
+        let now = Utc::now();
+        let timeout = chrono::Duration::seconds(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS as i64);
+        self.pr_reviewers
+            .iter()
+            .filter(|(_, a)| now.signed_duration_since(a.assigned_at) < timeout)
+            .map(|(pr, a)| (*pr, a.clone()))
+            .collect()
+    }
+
     /// Clean up review cache entries for PRs that are no longer open.
     fn cleanup_closed_review_cache(&mut self, open_pr_numbers: &[u64]) {
         let open_set: std::collections::HashSet<_> = open_pr_numbers.iter().collect();
@@ -429,5 +461,69 @@ mod tests {
 
         // Should be removed (expired + inactive)
         assert!(!state.pr_reviewers.contains_key(&42));
+    }
+
+    #[test]
+    fn test_active_count() {
+        let mut state = GitHubState::default();
+        state.assign_reviewer(42, "lexington");
+        state.assign_reviewer(43, "park");
+
+        assert_eq!(state.active_count(), 2);
+
+        // Expire one assignment
+        if let Some(a) = state.pr_reviewers.get_mut(&42) {
+            a.assigned_at = Utc::now()
+                - chrono::Duration::seconds(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS as i64 + 1);
+        }
+
+        assert_eq!(state.active_count(), 1);
+    }
+
+    #[test]
+    fn test_active_reviewers() {
+        let mut state = GitHubState::default();
+        state.assign_reviewer(42, "lexington");
+        state.assign_reviewer(43, "park");
+        state.assign_reviewer(44, "lexington"); // duplicate reviewer name
+
+        let reviewers = state.active_reviewers();
+        assert!(reviewers.contains("lexington"));
+        assert!(reviewers.contains("park"));
+        assert_eq!(reviewers.len(), 2); // deduped
+
+        // Expire lexington's assignment on PR 44
+        if let Some(a) = state.pr_reviewers.get_mut(&44) {
+            a.assigned_at = Utc::now()
+                - chrono::Duration::seconds(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS as i64 + 1);
+        }
+
+        // lexington still has PR 42 (fresh)
+        let reviewers = state.active_reviewers();
+        assert!(reviewers.contains("lexington"));
+        assert!(reviewers.contains("park"));
+    }
+
+    #[test]
+    fn test_active_assignments() {
+        let mut state = GitHubState::default();
+        state.assign_reviewer(42, "lexington");
+        state.assign_reviewer(43, "park");
+
+        let assignments = state.active_assignments();
+        assert_eq!(assignments.len(), 2);
+        assert_eq!(assignments[&42].reviewer, "lexington");
+        assert_eq!(assignments[&43].reviewer, "park");
+
+        // Expire one
+        if let Some(a) = state.pr_reviewers.get_mut(&42) {
+            a.assigned_at = Utc::now()
+                - chrono::Duration::seconds(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS as i64 + 1);
+        }
+
+        let assignments = state.active_assignments();
+        assert_eq!(assignments.len(), 1);
+        assert!(!assignments.contains_key(&42));
+        assert!(assignments.contains_key(&43));
     }
 }


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Consolidate three separate `std::sync::Mutex` fields (`last_lead_pane_hash`, `lead_working`, `last_lead_activity`) into a single `LeadTypingState` struct, reducing lock acquisitions from 3 to 1 in `check_lead_typing()`
- Eliminate `PrReviewTracker` entirely — `GitHubState` is now the single source of truth for PR review assignments, removing dual-write/dual-read patterns across ~12 call sites
- Add `active_count()`, `active_reviewers()`, and `active_assignments()` convenience methods to `GitHubState` with timeout filtering, plus tests for each

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] All 496 unit tests + 15 doctests pass
- [x] New GitHubState tests verify active_count, active_reviewers, active_assignments
- [x] Kanban data still includes reviewer info (uses `PrReviewerAssignment` directly)
- [x] Snapshot correctly collects active_reviewers from single source

🤖 Generated with [Claude Code](https://claude.com/claude-code)