### PR TITLE
feat: Add `midtown coworker view <name>` command [Midtown #723]

### DIFF
--- a/agents/common.md
+++ b/agents/common.md
@@ -1,3 +1,11 @@
+## Useful Commands
+
+```bash
+midtown coworker view <name>  # View a coworker's current terminal output
+```
+
+Use `midtown coworker view` to check on what a coworker is doing without switching tmux windows. This captures and prints the coworker's tmux pane content.
+
 ## GitHub Etiquette
 
 **IMPORTANT**: Always include your name in GitHub content so events are attributed to you:

--- a/agents/lead.md
+++ b/agents/lead.md
@@ -61,7 +61,8 @@ midtown channel read
 ```bash
 midtown status               # Check daemon and coworker status
 midtown coworker call-in     # Call in a new coworker
-midtown coworker shutdown <name>  # Shutdown a coworker
+midtown coworker break <name>    # Send a coworker on a break
+midtown coworker view <name>     # View a coworker's current terminal output
 midtown channel post "msg"   # Post to team channel
 midtown channel read         # Read recent channel messages
 ```

--- a/src/bin/midtown/cli/coworker.rs
+++ b/src/bin/midtown/cli/coworker.rs
@@ -22,6 +22,11 @@ pub enum CoworkerCommand {
     },
     /// List all coworkers
     List,
+    /// View a coworker's current terminal output
+    View {
+        /// Name of the coworker to view
+        name: String,
+    },
     /// Nudge a coworker to check in
     Nudge {
         /// Name of the coworker to nudge
@@ -64,8 +69,24 @@ pub fn handle(cmd: &CoworkerCommand, client: &DaemonClient) -> Result<Response, 
         }
         CoworkerCommand::Break { name } => client.coworker_break(name),
         CoworkerCommand::List => client.coworker_list(),
+        CoworkerCommand::View { name } => handle_view(name),
         CoworkerCommand::Nudge { name, message } => client.coworker_nudge(name, message.as_deref()),
         CoworkerCommand::NudgeConfig { command } => handle_nudge_config(command, client),
+    }
+}
+
+fn handle_view(name: &str) -> Result<Response, String> {
+    let repo_name =
+        midtown::paths::detect_repo_name().ok_or_else(|| "Not in a git repository".to_string())?;
+    let session = format!("{}{}", midtown::tmux::SESSION_PREFIX, repo_name);
+    let target = format!("{}:{}", session, name);
+
+    match midtown::tmux::capture_pane(&target) {
+        Some(content) => Ok(Response::message(content)),
+        None => Err(format!(
+            "Could not capture pane for coworker '{}'. Is the coworker running?",
+            name
+        )),
     }
 }
 


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Adds a new `midtown coworker view <name>` CLI command that captures and prints a coworker's tmux pane content
- Documents the command in both the common agent prompt (available to all agents) and the lead agent prompt
- Fixes the lead.md command reference from `shutdown` to `break` to match the actual CLI

## Implementation
The command works locally via `tmux capture-pane` — no daemon RPC needed since the caller shares the tmux session with target coworkers.

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] `cargo test` passes
- [x] Manual test: `midtown coworker view pleasant` runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)