### PR TITLE
feat: add PrReviewTracker, refactor lead typing state, and remove exec prefix [Midtown #724]

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1682,7 +1682,7 @@ Claude is now processing the request
         assert!(cmd.contains("--dangerously-skip-permissions"));
         assert!(cmd.contains("--settings /tmp/settings.json"));
         assert!(cmd.contains("--append-system-prompt \"$(cat /tmp/prompt.txt)\""));
-        assert!(cmd.starts_with("export MIDTOWN_AGENT='lex'; exec claude"));
+        assert!(cmd.starts_with("export MIDTOWN_AGENT='lex'; claude"));
         assert!(!cmd.contains("-p "));
     }
 


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- **New `PrReviewTracker`** — in-memory tracker for PR review assignments that replaces hot-path lookups against persistent `GitHubState`. Falls back to `github_state.json` for assignments that predate the current daemon session. Includes comprehensive test coverage (12 new tests).
- **Lead typing state refactored** — split consolidated `LeadTypingState` struct back into individual mutex fields (`last_lead_pane_hash`, `lead_working`, `last_lead_activity`), removing a struct that was only used in one function.
- **Removed `exec` prefix** from claude spawn commands in `build_claude_command` and `build_lead_command`. The `exec` was replacing the shell process with claude, which disrupted tmux's PTY tracking and caused blank screens on boot failures. Without `exec`, the shell remains as the parent process for proper tmux process detection.
- **Fixed test** — updated `test_build_claude_command_with_session_id` to match the `exec` removal.

## Test plan
- [x] All 463 tests pass locally
- [x] Clippy clean with `-D warnings`
- [x] `cargo fmt` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)