### PR TITLE
refactor: consolidate coworker lifecycle state into single struct [Midtown #717]

### DIFF
--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -104,10 +104,6 @@ pub struct CoworkerManager {
     /// Queue for lead nudges. A background thread waits for the lead's input to
     /// be empty before delivering each nudge, so the daemon loop is never blocked.
     lead_nudge_tx: mpsc::Sender<String>,
-    /// Shared activity map — cleared on spawn to prevent stale timestamps from
-    /// previous incarnations triggering false "silent coworker" warnings.
-    /// Set by the daemon after construction via `set_activity_map()`.
-    activity_map: Option<Arc<std::sync::RwLock<HashMap<String, std::time::Instant>>>>,
 }
 
 impl CoworkerManager {
@@ -155,7 +151,6 @@ impl CoworkerManager {
             session_name: session,
             discovered_on_startup: Arc::new(RwLock::new(Vec::new())),
             lead_nudge_tx,
-            activity_map: None,
         };
 
         // Discover existing coworkers from tmux on startup
@@ -174,17 +169,6 @@ impl CoworkerManager {
     /// Returns the tmux session name (e.g., "midtown-projectname").
     pub fn session_name(&self) -> &str {
         &self.session_name
-    }
-
-    /// Set the shared activity map for clearing stale entries on spawn.
-    ///
-    /// Called by the daemon after constructing `DaemonState` to share the
-    /// `last_coworker_activity` map with the coworker manager.
-    pub fn set_activity_map(
-        &mut self,
-        map: Arc<std::sync::RwLock<HashMap<String, std::time::Instant>>>,
-    ) {
-        self.activity_map = Some(map);
     }
 
     /// Take the list of coworker names discovered from tmux on startup.
@@ -887,13 +871,6 @@ impl CoworkerManager {
         {
             let mut coworkers = self.coworkers.write().unwrap();
             coworkers.insert(name.to_string(), coworker);
-        }
-
-        // Clear stale activity timestamps from any previous incarnation
-        // to prevent false "silent coworker" warnings.
-        if let Some(ref activity_map) = self.activity_map {
-            let mut activity = activity_map.write().unwrap();
-            activity.remove(name);
         }
 
         tracing::info!(

--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -55,8 +55,8 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 isolated,
             } => {
                 match state
-                    .coworkers
-                    .spawn_with_name(&name, true, Some(&prompt), isolated)
+                    .spawn_coworker(&name, true, Some(&prompt), isolated)
+                    .await
                 {
                     Ok(_) => {
                         info!("Respawned coworker {} successfully", name);
@@ -75,6 +75,11 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 }
                 if let Err(e) = state.coworkers.shutdown(&name) {
                     warn!("Failed to shut down coworker {}: {}", name, e);
+                }
+                // Clean up lifecycle state for the shut-down coworker
+                {
+                    let mut lc = state.coworker_lifecycles.write().await;
+                    lc.remove(&name);
                 }
             }
             Effect::NudgeCoworker { name, message } => {

--- a/src/daemon/events.rs
+++ b/src/daemon/events.rs
@@ -36,7 +36,7 @@ pub enum DaemonEvent {
 /// effects. The caller executes all returned effects via `execute_effects`.
 ///
 /// Some check functions still take `&DaemonState` for mutable tracker state
-/// (coworker_phases, cooldowns, etc.) and inline spawns that cannot yet be
+/// (coworker_lifecycles, cooldowns, etc.) and inline spawns that cannot yet be
 /// expressed as pure effects (spawn success/failure determines follow-up effects).
 pub async fn evaluate_tick(
     event: &DaemonEvent,
@@ -60,8 +60,8 @@ pub async fn evaluate_tick(
         DaemonEvent::OrphanCheckTick => {
             let mut effects = Vec::new();
             effects.extend(super::check_for_duplicate_task_workers(snap));
-            effects.extend(super::check_and_recover_orphans(snap, state));
-            effects.extend(super::spawn_for_pending_tasks(snap, state));
+            effects.extend(super::check_and_recover_orphans(snap, state).await);
+            effects.extend(super::spawn_for_pending_tasks(snap, state).await);
             effects.extend(super::check_and_fire_reminders(snap, state));
             effects
         }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -276,9 +276,10 @@ pub(crate) struct DaemonState {
     coworkers: CoworkerManager,
     channel: Channel,
     socket_path: PathBuf,
-    /// Per-coworker lifecycle phase (idle, interrupted, prompted).
-    /// Replaces separate `idle_since`, `interrupted_since`, `prompted_nudged` maps.
-    coworker_phases: RwLock<HashMap<String, crate::rules::CoworkerPhase>>,
+    /// Consolidated per-coworker lifecycle state (phase + last activity).
+    /// Bundles what was previously `coworker_phases` and `last_coworker_activity`
+    /// into a single map. Entries are created on spawn and cleared on shutdown.
+    coworker_lifecycles: RwLock<HashMap<String, crate::rules::CoworkerLifecycle>>,
     /// Tracker to avoid spamming the same PR issues
     pr_issue_tracker: Mutex<PrIssueTracker>,
     /// Repository name (primary repo)
@@ -324,9 +325,6 @@ pub(crate) struct DaemonState {
     cached_merged_pr_coworkers: std::sync::RwLock<HashSet<String>>,
     /// Tracks stuck conditions that warrant nudging the lead (no review, unresolved feedback, etc.)
     stuck_tracker: Mutex<StuckConditionTracker>,
-    /// Tracks when each coworker last posted to the channel (for silent coworker detection).
-    /// Shared with `CoworkerManager` so stale entries are cleared on spawn.
-    last_coworker_activity: Arc<std::sync::RwLock<HashMap<String, Instant>>>,
     /// Per-coworker pane content hash and last-changed timestamp (for stuck detection).
     /// Maps coworker name → (last_hash, last_changed_at).
     coworker_pane_hashes: std::sync::Mutex<HashMap<String, (u64, Instant)>>,
@@ -386,7 +384,7 @@ impl DaemonState {
     #[allow(clippy::too_many_arguments)]
     fn new(
         socket_path: PathBuf,
-        mut coworkers: CoworkerManager,
+        coworkers: CoworkerManager,
         repo_name: String,
         all_repo_paths: Vec<PathBuf>,
         channel: Channel,
@@ -413,16 +411,11 @@ impl DaemonState {
                 crate::reminders::ReminderState::default()
             });
 
-        // Share the activity map with CoworkerManager so it can clear stale
-        // timestamps inside spawn_with_name() rather than at every call site.
-        let last_coworker_activity = Arc::new(std::sync::RwLock::new(HashMap::new()));
-        coworkers.set_activity_map(last_coworker_activity.clone());
-
         Ok(Self {
             coworkers,
             channel,
             socket_path,
-            coworker_phases: RwLock::new(HashMap::new()),
+            coworker_lifecycles: RwLock::new(HashMap::new()),
             pr_issue_tracker: Mutex::new(PrIssueTracker::new()),
             repo_name,
             default_branch,
@@ -441,10 +434,31 @@ impl DaemonState {
             cached_open_pr_branches: std::sync::RwLock::new(Vec::new()),
             cached_merged_pr_coworkers: std::sync::RwLock::new(HashSet::new()),
             stuck_tracker: Mutex::new(StuckConditionTracker::new()),
-            last_coworker_activity,
             coworker_pane_hashes: std::sync::Mutex::new(HashMap::new()),
             repo_name_cache: std::sync::RwLock::new(HashMap::new()),
         })
+    }
+
+    /// Spawn a coworker and initialize its lifecycle state.
+    ///
+    /// Wraps `CoworkerManager::spawn_with_name` and inserts a fresh
+    /// `CoworkerLifecycle` entry on success, ensuring stale timestamps
+    /// from any previous incarnation are replaced.
+    async fn spawn_coworker(
+        &self,
+        name: &str,
+        unique: bool,
+        prompt: Option<&str>,
+        isolated: bool,
+    ) -> crate::Result<()> {
+        self.coworkers
+            .spawn_with_name(name, unique, prompt, isolated)?;
+        let mut lc = self.coworker_lifecycles.write().await;
+        lc.insert(
+            name.to_string(),
+            crate::rules::CoworkerLifecycle::new_spawn(),
+        );
+        Ok(())
     }
 
     /// Send a message to the channel and broadcast it to WebSocket clients.
@@ -926,7 +940,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                     if let Err(e) = state.send_and_broadcast(&nudge_msg) {
                         warn!("Failed to post merge nudge for PR #{}: {}", pr_number, e);
                     }
-                    route_mentions(&state, &nudge_msg);
+                    route_mentions(&state, &nudge_msg).await;
                 }
 
                 // Nudge lead when a CI check fails on the default branch
@@ -955,7 +969,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
 
                 // Route @mentions in webhook messages directly (chat monitor skips
                 // "github" sender for loop protection, so we handle it here)
-                route_mentions(&state, &webhook_event.message);
+                route_mentions(&state, &webhook_event.message).await;
             }
 
             // Process user channel posts through the daemon (handles nudge, etc.)
@@ -971,7 +985,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                     "user",
                     content,
                     &state,
-                );
+                ).await;
             }
 
             // Periodically check for idle coworkers and shut them down
@@ -1253,7 +1267,7 @@ async fn check_and_shutdown_idle_coworkers(
 
     // Pure decision: who should be shut down?
     let to_shutdown = {
-        let mut phases = state.coworker_phases.write().await;
+        let mut phases = state.coworker_lifecycles.write().await;
         crate::rules::decide_idle_shutdowns(
             &snap.coworker_snapshots,
             &snap.busy_coworkers,
@@ -1392,7 +1406,7 @@ async fn check_and_nudge_interrupted_coworkers(
 
     // Pure decision: who should be nudged?
     let to_nudge = {
-        let mut phases = state.coworker_phases.write().await;
+        let mut phases = state.coworker_lifecycles.write().await;
         crate::rules::decide_interrupt_nudges(
             &snap.coworker_snapshots,
             &snap.pane_contents,
@@ -1440,7 +1454,7 @@ async fn check_and_nudge_prompted_coworkers(
 
     // Pure decision: which coworkers need lead attention?
     let to_nudge = {
-        let mut phases = state.coworker_phases.write().await;
+        let mut phases = state.coworker_lifecycles.write().await;
         crate::rules::decide_prompt_nudges(
             &snap.coworker_snapshots,
             &snap.pane_contents,
@@ -2037,7 +2051,7 @@ async fn chat_monitor_loop(
                                     continue;
                                 }
                                 // Route any @mentions in the message
-                                route_mentions(&state, &msg);
+                                route_mentions(&state, &msg).await;
                             }
                             Err(e) => {
                                 debug!("Failed to parse channel message: {} (line: {})", e, line);
@@ -2071,7 +2085,7 @@ async fn chat_monitor_loop(
 /// - Nudge them with the message context
 ///
 /// Also supports @all to broadcast to every active coworker and the lead.
-fn route_mentions(state: &DaemonState, msg: &Message) {
+async fn route_mentions(state: &DaemonState, msg: &Message) {
     // Check for @all broadcast first
     if contains_at_all(&msg.content) {
         route_at_all(state, msg);
@@ -2120,10 +2134,7 @@ fn route_mentions(state: &DaemonState, msg: &Message) {
                 message: ref m,
             } => {
                 info!("Spawning mentioned coworker {} (not currently running)", n);
-                match state
-                    .coworkers
-                    .spawn_with_name(n, true, Some(m.as_str()), false)
-                {
+                match state.spawn_coworker(n, true, Some(m.as_str()), false).await {
                     Ok(_) => {
                         info!("Spawned coworker {} via @mention", n);
                         let spawn_msg = Message::text(
@@ -2444,8 +2455,8 @@ async fn poll_prs_for_issues(
                         pr_number, o, issue_type
                     );
                     match state
-                        .coworkers
-                        .spawn_with_name(o, true, Some(msg.as_str()), false)
+                        .spawn_coworker(o, true, Some(msg.as_str()), false)
+                        .await
                     {
                         Ok(_) => {
                             info!(
@@ -2640,10 +2651,12 @@ async fn check_for_stuck_conditions(state: &DaemonState, prs: &[serde_json::Valu
     // --- Scenario 4: Silent coworker (claimed task, no channel activity) ---
     {
         let busy_coworkers = crate::tasks::get_busy_coworkers_for_repo(&state.repo_name);
-        let activity = state.last_coworker_activity.read().unwrap();
+        let lifecycles = state.coworker_lifecycles.read().await;
 
         for name in &busy_coworkers {
-            let last_activity = activity.get(name.as_str());
+            let last_activity: Option<Instant> = lifecycles
+                .get(name.as_str())
+                .and_then(|lc| lc.last_activity);
             let is_silent = match last_activity {
                 Some(last) => last.elapsed() >= STUCK_SILENT_COWORKER_DURATION,
                 // No activity recorded — coworker hasn't posted to channel yet.
@@ -2922,12 +2935,10 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
                                 "PR #{} owner {} is idle/on a break, spawning to address completed review",
                                 pr_number, o
                             );
-                            match state.coworkers.spawn_with_name(
-                                o,
-                                true,
-                                Some(msg.as_str()),
-                                false,
-                            ) {
+                            match state
+                                .spawn_coworker(o, true, Some(msg.as_str()), false)
+                                .await
+                            {
                                 Ok(_) => {
                                     info!(
                                         "Spawned {} to address completed review on PR #{}",
@@ -3398,7 +3409,7 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
                 .unwrap_or("lead");
 
             match message {
-                Some(msg) => handle_channel_post(request.id, from, msg, state),
+                Some(msg) => handle_channel_post(request.id, from, msg, state).await,
                 None => Response::error(request.id, RpcError::invalid_params()),
             }
         }
@@ -3448,7 +3459,7 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
         "daemon.check-pending" => {
             info!("Check-pending triggered via RPC");
             let snap = snapshot::collect_world_snapshot(state).await;
-            let pending_effects = spawn_for_pending_tasks(&snap, state);
+            let pending_effects = spawn_for_pending_tasks(&snap, state).await;
             effects::execute_effects(pending_effects, state).await;
             Response::success(request.id, serde_json::json!({"status": "ok"}))
         }
@@ -3662,7 +3673,12 @@ fn unescape_shell_artifacts(s: &str) -> String {
 /// For coworkers, the action text is also reflected in their tmux tab name.
 ///
 /// Also detects feedback requests from coworkers and nudges the Lead.
-fn handle_channel_post(id: RequestId, from: &str, message: &str, state: &DaemonState) -> Response {
+async fn handle_channel_post(
+    id: RequestId,
+    from: &str,
+    message: &str,
+    state: &DaemonState,
+) -> Response {
     // Clean up shell escaping artifacts (e.g. "\!" from bash history expansion escaping)
     let message = unescape_shell_artifacts(message);
 
@@ -3681,8 +3697,14 @@ fn handle_channel_post(id: RequestId, from: &str, message: &str, state: &DaemonS
 
             // Track last activity time for coworker (used for silent coworker detection)
             if is_coworker_sender(from) {
-                let mut activity = state.last_coworker_activity.write().unwrap();
-                activity.insert(from.to_string(), Instant::now());
+                let mut lifecycles = state.coworker_lifecycles.write().await;
+                lifecycles
+                    .entry(from.to_string())
+                    .or_insert_with(|| crate::rules::CoworkerLifecycle {
+                        phase: None,
+                        last_activity: None,
+                    })
+                    .last_activity = Some(Instant::now());
             }
 
             // Update tmux tab for coworkers when they post /me actions
@@ -3701,7 +3723,7 @@ fn handle_channel_post(id: RequestId, from: &str, message: &str, state: &DaemonS
                 let has_lead_mention = content.to_lowercase().contains("@lead");
 
                 // Route @mentions in user messages directly to coworkers
-                route_mentions(state, &msg);
+                route_mentions(state, &msg).await;
 
                 // Only nudge lead if there are no coworker @mentions (regular
                 // message for the lead) or if the user also @mentioned the lead.
@@ -4683,8 +4705,8 @@ async fn handle_pr_comment_nudge(state: &DaemonState, activity: crate::webhook::
                 pr_number, o
             );
             match state
-                .coworkers
-                .spawn_with_name(o, true, Some(msg.as_str()), false)
+                .spawn_coworker(o, true, Some(msg.as_str()), false)
+                .await
             {
                 Ok(_) => {
                     info!(
@@ -4751,7 +4773,7 @@ async fn handle_pr_comment_nudge(state: &DaemonState, activity: crate::webhook::
 ///
 /// Rate limiting: Only spawns ONE coworker per tick with a cooldown between
 /// spawns to prevent window flashing from spawn storms.
-fn check_and_recover_orphans(
+async fn check_and_recover_orphans(
     snap: &snapshot::WorldSnapshot,
     state: &DaemonState,
 ) -> Vec<effects::Effect> {
@@ -4805,8 +4827,8 @@ fn check_and_recover_orphans(
     // retain their worktree and branch. This is the same path as normal task
     // assignment, just reusing the previous coworker name.
     match state
-        .coworkers
-        .spawn_with_name(&recovery.owner, false, Some(&prompt), false)
+        .spawn_coworker(&recovery.owner, false, Some(&prompt), false)
+        .await
     {
         Ok(_) => {
             info!("Respawned coworker {} successfully", recovery.owner);
@@ -5138,7 +5160,7 @@ fn cleanup_orphaned_worktrees(state: &DaemonState) {
 /// Handles two cases:
 /// 1. Pending tasks with owners - spawn/nudge the assigned coworker if not running
 /// 2. Pending tasks without owners - spawn a new coworker, assign the task, and nudge
-fn spawn_for_pending_tasks(
+async fn spawn_for_pending_tasks(
     snap: &snapshot::WorldSnapshot,
     state: &DaemonState,
 ) -> Vec<effects::Effect> {
@@ -5196,10 +5218,7 @@ fn spawn_for_pending_tasks(
                 );
                 // Spawn inline — post-spawn effects depend on spawn result
                 let prompt = format!("You've been assigned task #{}: {}. Get started!", tid, subj);
-                match state
-                    .coworkers
-                    .spawn_with_name(o, true, Some(&prompt), false)
-                {
+                match state.spawn_coworker(o, true, Some(&prompt), false).await {
                     Ok(_) => {
                         info!("Spawned coworker {} for pending task #{}", o, tid);
                         effects.push(Effect::BroadcastCoworkerUpdate {
@@ -5372,8 +5391,8 @@ fn spawn_for_pending_tasks(
             // Step 3b: Spawn a new coworker with the pre-assigned name and prompt
             // Spawn inline — post-spawn effects depend on spawn result
             match state
-                .coworkers
-                .spawn_with_name(&coworker_name, false, Some(&prompt), false)
+                .spawn_coworker(&coworker_name, false, Some(&prompt), false)
+                .await
             {
                 Ok(_) => {
                     info!(

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -99,6 +99,63 @@ pub(crate) enum CoworkerPhase {
     Prompted { fingerprint: String },
 }
 
+/// Consolidated per-coworker lifecycle state.
+///
+/// Bundles the coworker's current phase (idle/interrupted/prompted) and their
+/// last channel activity timestamp into a single entry. This replaces the
+/// separate `coworker_phases` and `last_coworker_activity` HashMaps with one
+/// `HashMap<String, CoworkerLifecycle>`, ensuring both are cleared together
+/// on spawn and shutdown.
+#[derive(Debug, Clone)]
+pub(crate) struct CoworkerLifecycle {
+    /// Current lifecycle phase (idle, interrupted, prompted), or `None` if
+    /// the coworker is actively working (no special phase).
+    pub phase: Option<CoworkerPhase>,
+    /// When the coworker last posted to the channel. `None` if no activity
+    /// has been recorded yet (e.g., freshly spawned).
+    pub last_activity: Option<Instant>,
+}
+
+impl CoworkerLifecycle {
+    /// Create a fresh lifecycle entry for a newly spawned coworker.
+    pub fn new_spawn() -> Self {
+        Self {
+            phase: None,
+            last_activity: Some(Instant::now()),
+        }
+    }
+}
+
+/// Get the current phase for a coworker, if any.
+pub(crate) fn get_phase(
+    lifecycles: &HashMap<String, CoworkerLifecycle>,
+    name: &str,
+) -> Option<CoworkerPhase> {
+    lifecycles.get(name).and_then(|l| l.phase.clone())
+}
+
+/// Set the phase for a coworker, creating the lifecycle entry if needed.
+pub(crate) fn set_phase(
+    lifecycles: &mut HashMap<String, CoworkerLifecycle>,
+    name: &str,
+    phase: CoworkerPhase,
+) {
+    lifecycles
+        .entry(name.to_string())
+        .or_insert_with(|| CoworkerLifecycle {
+            phase: None,
+            last_activity: None,
+        })
+        .phase = Some(phase);
+}
+
+/// Clear the phase for a coworker (without removing the lifecycle entry).
+pub(crate) fn clear_phase(lifecycles: &mut HashMap<String, CoworkerLifecycle>, name: &str) {
+    if let Some(lc) = lifecycles.get_mut(name) {
+        lc.phase = None;
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Lifecycle decision types
 // ---------------------------------------------------------------------------
@@ -138,7 +195,7 @@ pub(crate) fn decide_idle_shutdowns(
     coworkers_with_open_prs: &HashSet<String>,
     active_reviewers: &HashSet<String>,
     coworkers_with_unblocked_deps: &HashSet<String>,
-    phases: &mut HashMap<String, CoworkerPhase>,
+    lifecycles: &mut HashMap<String, CoworkerLifecycle>,
     now: Instant,
     now_utc: DateTime<Utc>,
     idle_break_duration: Duration,
@@ -152,8 +209,11 @@ pub(crate) fn decide_idle_shutdowns(
         // Check minimum lifetime
         let lifetime = now_utc.signed_duration_since(cw.started_at);
         if lifetime < chrono::Duration::from_std(minimum_lifetime).unwrap_or_default() {
-            if matches!(phases.get(coworker), Some(CoworkerPhase::Idle { .. })) {
-                phases.remove(coworker);
+            if matches!(
+                get_phase(lifecycles, coworker),
+                Some(CoworkerPhase::Idle { .. })
+            ) {
+                clear_phase(lifecycles, coworker);
             }
             continue;
         }
@@ -172,8 +232,11 @@ pub(crate) fn decide_idle_shutdowns(
             .any(|d| d.eq_ignore_ascii_case(coworker));
 
         if is_busy || has_open_pr || is_reviewing || has_unblocked_deps {
-            if matches!(phases.get(coworker), Some(CoworkerPhase::Idle { .. })) {
-                phases.remove(coworker);
+            if matches!(
+                get_phase(lifecycles, coworker),
+                Some(CoworkerPhase::Idle { .. })
+            ) {
+                clear_phase(lifecycles, coworker);
             }
         } else if cw.isolated_tasks {
             // Isolated coworkers (reviewers) go on break immediately when idle
@@ -182,9 +245,9 @@ pub(crate) fn decide_idle_shutdowns(
                 is_isolated: true,
             });
         } else {
-            match phases.get(coworker) {
+            match get_phase(lifecycles, coworker) {
                 Some(CoworkerPhase::Idle { since }) => {
-                    if now.duration_since(*since) >= idle_break_duration {
+                    if now.duration_since(since) >= idle_break_duration {
                         to_shutdown.push(ShutdownDecision {
                             name: coworker.clone(),
                             is_isolated: false,
@@ -194,15 +257,15 @@ pub(crate) fn decide_idle_shutdowns(
                 // Don't overwrite Interrupted or Prompted — those take priority
                 Some(CoworkerPhase::Interrupted { .. } | CoworkerPhase::Prompted { .. }) => {}
                 None => {
-                    phases.insert(coworker.clone(), CoworkerPhase::Idle { since: now });
+                    set_phase(lifecycles, coworker, CoworkerPhase::Idle { since: now });
                 }
             }
         }
     }
 
-    // Remove shutdown coworkers from tracking
+    // Clear phase for shutdown coworkers (entry preserved for last_activity)
     for decision in &to_shutdown {
-        phases.remove(&decision.name);
+        clear_phase(lifecycles, &decision.name);
     }
 
     to_shutdown
@@ -215,7 +278,7 @@ pub(crate) fn decide_idle_shutdowns(
 pub(crate) fn decide_interrupt_nudges(
     coworkers: &[CoworkerSnapshot],
     pane_contents: &HashMap<String, String>,
-    phases: &mut HashMap<String, CoworkerPhase>,
+    lifecycles: &mut HashMap<String, CoworkerLifecycle>,
     now: Instant,
     nudge_duration: Duration,
 ) -> Vec<InterruptNudge> {
@@ -228,10 +291,10 @@ pub(crate) fn decide_interrupt_nudges(
             Some(content) => content,
             None => {
                 if matches!(
-                    phases.get(coworker),
+                    get_phase(lifecycles, coworker),
                     Some(CoworkerPhase::Interrupted { .. })
                 ) {
-                    phases.remove(coworker);
+                    clear_phase(lifecycles, coworker);
                 }
                 continue;
             }
@@ -241,26 +304,30 @@ pub(crate) fn decide_interrupt_nudges(
             || pane_content.contains("What should Claude do instead?");
 
         if is_interrupted {
-            match phases.get(coworker) {
+            match get_phase(lifecycles, coworker) {
                 Some(CoworkerPhase::Interrupted { since }) => {
-                    if now.duration_since(*since) >= nudge_duration {
+                    if now.duration_since(since) >= nudge_duration {
                         to_nudge.push(InterruptNudge {
                             name: coworker.clone(),
                         });
-                        phases.remove(coworker);
+                        clear_phase(lifecycles, coworker);
                     }
                 }
                 _ => {
                     // Transition to Interrupted (overwriting Idle or absent)
-                    phases.insert(coworker.clone(), CoworkerPhase::Interrupted { since: now });
+                    set_phase(
+                        lifecycles,
+                        coworker,
+                        CoworkerPhase::Interrupted { since: now },
+                    );
                 }
             }
         } else if matches!(
-            phases.get(coworker),
+            get_phase(lifecycles, coworker),
             Some(CoworkerPhase::Interrupted { .. })
         ) {
             // No longer interrupted — clear the phase
-            phases.remove(coworker);
+            clear_phase(lifecycles, coworker);
         }
     }
 
@@ -274,7 +341,7 @@ pub(crate) fn decide_interrupt_nudges(
 pub(crate) fn decide_prompt_nudges(
     coworkers: &[CoworkerSnapshot],
     pane_contents: &HashMap<String, String>,
-    phases: &mut HashMap<String, CoworkerPhase>,
+    lifecycles: &mut HashMap<String, CoworkerLifecycle>,
 ) -> Vec<PromptNudge> {
     let mut to_nudge = Vec::new();
 
@@ -289,8 +356,11 @@ pub(crate) fn decide_prompt_nudges(
         let pane_content = match pane_contents.get(coworker) {
             Some(content) => content,
             None => {
-                if matches!(phases.get(coworker), Some(CoworkerPhase::Prompted { .. })) {
-                    phases.remove(coworker);
+                if matches!(
+                    get_phase(lifecycles, coworker),
+                    Some(CoworkerPhase::Prompted { .. })
+                ) {
+                    clear_phase(lifecycles, coworker);
                 }
                 continue;
             }
@@ -300,11 +370,15 @@ pub(crate) fn decide_prompt_nudges(
             Some(label) => {
                 let fingerprint = label.to_string();
                 let already_nudged = matches!(
-                    phases.get(coworker),
-                    Some(CoworkerPhase::Prompted { fingerprint: prev }) if prev == &fingerprint
+                    get_phase(lifecycles, coworker),
+                    Some(CoworkerPhase::Prompted { fingerprint: prev }) if prev == fingerprint
                 );
                 if !already_nudged {
-                    phases.insert(coworker.clone(), CoworkerPhase::Prompted { fingerprint });
+                    set_phase(
+                        lifecycles,
+                        coworker,
+                        CoworkerPhase::Prompted { fingerprint },
+                    );
                     to_nudge.push(PromptNudge {
                         name: coworker.clone(),
                         label: label.to_string(),
@@ -312,8 +386,11 @@ pub(crate) fn decide_prompt_nudges(
                 }
             }
             None => {
-                if matches!(phases.get(coworker), Some(CoworkerPhase::Prompted { .. })) {
-                    phases.remove(coworker);
+                if matches!(
+                    get_phase(lifecycles, coworker),
+                    Some(CoworkerPhase::Prompted { .. })
+                ) {
+                    clear_phase(lifecycles, coworker);
                 }
             }
         }
@@ -904,6 +981,19 @@ mod tests {
         items.iter().map(|s| s.to_string()).collect()
     }
 
+    /// Create a lifecycle map with a single coworker in the given phase.
+    fn lifecycle_with(name: &str, phase: CoworkerPhase) -> HashMap<String, CoworkerLifecycle> {
+        let mut map = HashMap::new();
+        map.insert(
+            name.to_string(),
+            CoworkerLifecycle {
+                phase: Some(phase),
+                last_activity: None,
+            },
+        );
+        map
+    }
+
     // -----------------------------------------------------------------------
     // decide_idle_shutdowns tests
     // -----------------------------------------------------------------------
@@ -911,10 +1001,8 @@ mod tests {
     #[test]
     fn idle_shutdown_after_timeout() {
         let coworkers = vec![cw("york", 10)];
-        let mut phases = HashMap::new();
-        // york has been idle for 60s already
-        phases.insert(
-            "york".to_string(),
+        let mut phases = lifecycle_with(
+            "york",
             CoworkerPhase::Idle {
                 since: Instant::now() - Duration::from_secs(60),
             },
@@ -936,15 +1024,14 @@ mod tests {
         assert_eq!(decisions.len(), 1);
         assert_eq!(decisions[0].name, "york");
         assert!(!decisions[0].is_isolated);
-        assert!(!phases.contains_key("york"));
+        assert!(get_phase(&phases, "york").is_none());
     }
 
     #[test]
     fn idle_shutdown_skips_busy_coworker() {
         let coworkers = vec![cw("york", 10)];
-        let mut phases = HashMap::new();
-        phases.insert(
-            "york".to_string(),
+        let mut phases = lifecycle_with(
+            "york",
             CoworkerPhase::Idle {
                 since: Instant::now() - Duration::from_secs(60),
             },
@@ -965,15 +1052,14 @@ mod tests {
 
         assert!(decisions.is_empty());
         // Busy coworker removed from idle tracking
-        assert!(!phases.contains_key("york"));
+        assert!(get_phase(&phases, "york").is_none());
     }
 
     #[test]
     fn idle_shutdown_skips_coworker_with_open_pr() {
         let coworkers = vec![cw("york", 10)];
-        let mut phases = HashMap::new();
-        phases.insert(
-            "york".to_string(),
+        let mut phases = lifecycle_with(
+            "york",
             CoworkerPhase::Idle {
                 since: Instant::now() - Duration::from_secs(60),
             },
@@ -998,9 +1084,8 @@ mod tests {
     #[test]
     fn idle_shutdown_skips_active_reviewer() {
         let coworkers = vec![cw("york", 10)];
-        let mut phases = HashMap::new();
-        phases.insert(
-            "york".to_string(),
+        let mut phases = lifecycle_with(
+            "york",
             CoworkerPhase::Idle {
                 since: Instant::now() - Duration::from_secs(60),
             },
@@ -1025,9 +1110,8 @@ mod tests {
     #[test]
     fn idle_shutdown_skips_coworker_with_unblocked_deps() {
         let coworkers = vec![cw("york", 10)];
-        let mut phases = HashMap::new();
-        phases.insert(
-            "york".to_string(),
+        let mut phases = lifecycle_with(
+            "york",
             CoworkerPhase::Idle {
                 since: Instant::now() - Duration::from_secs(60),
             },
@@ -1048,15 +1132,14 @@ mod tests {
 
         assert!(decisions.is_empty());
         // Coworker with unblocked deps removed from idle tracking
-        assert!(!phases.contains_key("york"));
+        assert!(get_phase(&phases, "york").is_none());
     }
 
     #[test]
     fn idle_shutdown_skips_young_coworker() {
         let coworkers = vec![cw("york", 2)]; // Only 2 minutes old
-        let mut phases = HashMap::new();
-        phases.insert(
-            "york".to_string(),
+        let mut phases = lifecycle_with(
+            "york",
             CoworkerPhase::Idle {
                 since: Instant::now() - Duration::from_secs(60),
             },
@@ -1077,13 +1160,13 @@ mod tests {
 
         assert!(decisions.is_empty());
         // Young coworker also removed from idle tracking
-        assert!(!phases.contains_key("york"));
+        assert!(get_phase(&phases, "york").is_none());
     }
 
     #[test]
     fn idle_shutdown_isolated_coworker_immediate() {
         let coworkers = vec![cw_isolated("reviewer", 10)];
-        let mut phases = HashMap::new();
+        let mut phases: HashMap<String, CoworkerLifecycle> = HashMap::new();
 
         let decisions = decide_idle_shutdowns(
             &coworkers,
@@ -1106,7 +1189,7 @@ mod tests {
     #[test]
     fn idle_shutdown_starts_tracking_newly_idle() {
         let coworkers = vec![cw("york", 10)];
-        let mut phases = HashMap::new();
+        let mut phases: HashMap<String, CoworkerLifecycle> = HashMap::new();
 
         let decisions = decide_idle_shutdowns(
             &coworkers,
@@ -1123,7 +1206,7 @@ mod tests {
 
         // No shutdown yet — just started tracking
         assert!(decisions.is_empty());
-        assert!(phases.contains_key("york"));
+        assert!(get_phase(&phases, "york").is_some());
     }
 
     // -----------------------------------------------------------------------
@@ -1135,9 +1218,8 @@ mod tests {
         let coworkers = vec![cw("york", 10)];
         let mut pane_contents = HashMap::new();
         pane_contents.insert("york".to_string(), "Some output\nInterrupted\n".to_string());
-        let mut phases = HashMap::new();
-        phases.insert(
-            "york".to_string(),
+        let mut phases = lifecycle_with(
+            "york",
             CoworkerPhase::Interrupted {
                 since: Instant::now() - Duration::from_secs(90),
             },
@@ -1154,7 +1236,7 @@ mod tests {
         assert_eq!(nudges.len(), 1);
         assert_eq!(nudges[0].name, "york");
         // Tracking reset after nudge
-        assert!(!phases.contains_key("york"));
+        assert!(get_phase(&phases, "york").is_none());
     }
 
     #[test]
@@ -1162,9 +1244,8 @@ mod tests {
         let coworkers = vec![cw("york", 10)];
         let mut pane_contents = HashMap::new();
         pane_contents.insert("york".to_string(), "Interrupted".to_string());
-        let mut phases = HashMap::new();
-        phases.insert(
-            "york".to_string(),
+        let mut phases = lifecycle_with(
+            "york",
             CoworkerPhase::Interrupted {
                 since: Instant::now() - Duration::from_secs(10),
             },
@@ -1180,7 +1261,7 @@ mod tests {
 
         assert!(nudges.is_empty());
         // Still tracking
-        assert!(phases.contains_key("york"));
+        assert!(get_phase(&phases, "york").is_some());
     }
 
     #[test]
@@ -1188,9 +1269,8 @@ mod tests {
         let coworkers = vec![cw("york", 10)];
         let mut pane_contents = HashMap::new();
         pane_contents.insert("york".to_string(), "All good, working fine".to_string());
-        let mut phases = HashMap::new();
-        phases.insert(
-            "york".to_string(),
+        let mut phases = lifecycle_with(
+            "york",
             CoworkerPhase::Interrupted {
                 since: Instant::now() - Duration::from_secs(90),
             },
@@ -1206,7 +1286,7 @@ mod tests {
 
         assert!(nudges.is_empty());
         // Tracking cleared
-        assert!(!phases.contains_key("york"));
+        assert!(get_phase(&phases, "york").is_none());
     }
 
     #[test]
@@ -1217,7 +1297,7 @@ mod tests {
             "york".to_string(),
             "What should Claude do instead?".to_string(),
         );
-        let mut phases = HashMap::new();
+        let mut phases: HashMap<String, CoworkerLifecycle> = HashMap::new();
 
         let nudges = decide_interrupt_nudges(
             &coworkers,
@@ -1228,7 +1308,7 @@ mod tests {
         );
 
         assert!(nudges.is_empty());
-        assert!(phases.contains_key("york"));
+        assert!(get_phase(&phases, "york").is_some());
     }
 
     // -----------------------------------------------------------------------
@@ -1243,7 +1323,7 @@ mod tests {
             "york".to_string(),
             "Some output\nAllow once\nAllow always".to_string(),
         );
-        let mut phases = HashMap::new();
+        let mut phases: HashMap<String, CoworkerLifecycle> = HashMap::new();
 
         let nudges = decide_prompt_nudges(&coworkers, &pane_contents, &mut phases);
 
@@ -1251,7 +1331,7 @@ mod tests {
         assert_eq!(nudges[0].name, "york");
         assert_eq!(nudges[0].label, "permission request");
         assert!(
-            matches!(phases.get("york"), Some(CoworkerPhase::Prompted { fingerprint }) if fingerprint == "permission request")
+            matches!(get_phase(&phases, "york"), Some(CoworkerPhase::Prompted { fingerprint }) if fingerprint == "permission request")
         );
     }
 
@@ -1260,9 +1340,8 @@ mod tests {
         let coworkers = vec![cw("york", 10)];
         let mut pane_contents = HashMap::new();
         pane_contents.insert("york".to_string(), "Allow once\nAllow always".to_string());
-        let mut phases = HashMap::new();
-        phases.insert(
-            "york".to_string(),
+        let mut phases = lifecycle_with(
+            "york",
             CoworkerPhase::Prompted {
                 fingerprint: "permission request".to_string(),
             },
@@ -1281,9 +1360,8 @@ mod tests {
             "york".to_string(),
             "Yes, and don't ask again for this project".to_string(),
         );
-        let mut phases = HashMap::new();
-        phases.insert(
-            "york".to_string(),
+        let mut phases = lifecycle_with(
+            "york",
             CoworkerPhase::Prompted {
                 fingerprint: "permission request".to_string(),
             },
@@ -1300,9 +1378,8 @@ mod tests {
         let coworkers = vec![cw("york", 10)];
         let mut pane_contents = HashMap::new();
         pane_contents.insert("york".to_string(), "Working normally".to_string());
-        let mut phases = HashMap::new();
-        phases.insert(
-            "york".to_string(),
+        let mut phases = lifecycle_with(
+            "york",
             CoworkerPhase::Prompted {
                 fingerprint: "permission request".to_string(),
             },
@@ -1311,7 +1388,7 @@ mod tests {
         let nudges = decide_prompt_nudges(&coworkers, &pane_contents, &mut phases);
 
         assert!(nudges.is_empty());
-        assert!(!phases.contains_key("york"));
+        assert!(get_phase(&phases, "york").is_none());
     }
 
     #[test]
@@ -1323,7 +1400,7 @@ mod tests {
         }];
         let mut pane_contents = HashMap::new();
         pane_contents.insert("lead".to_string(), "Allow once\nAllow always".to_string());
-        let mut phases = HashMap::new();
+        let mut phases: HashMap<String, CoworkerLifecycle> = HashMap::new();
 
         let nudges = decide_prompt_nudges(&coworkers, &pane_contents, &mut phases);
 


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Consolidates the separate `coworker_phases` map and `last_coworker_activity` map in `DaemonState` into a single `coworker_lifecycles: HashMap<String, CoworkerLifecycle>` map
- The new `CoworkerLifecycle` struct bundles phase tracking (Idle/Prompted/Interrupted) with last-activity timestamps, eliminating the need to keep two maps in sync
- Lifecycle entries are now explicitly created on spawn and cleaned up on shutdown via effects, making the coworker state machine more coherent
- Fixes `handle_channel_post` to be async, avoiding a `blocking_write` panic when updating lifecycle state from an async context

## Test plan
- [x] All 595 tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Fmt clean (`cargo fmt -- --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)