### PR TITLE
fix: remove exec prefix from claude spawn commands [Midtown #724]

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1682,7 +1682,7 @@ Claude is now processing the request
         assert!(cmd.contains("--dangerously-skip-permissions"));
         assert!(cmd.contains("--settings /tmp/settings.json"));
         assert!(cmd.contains("--append-system-prompt \"$(cat /tmp/prompt.txt)\""));
-        assert!(cmd.starts_with("export MIDTOWN_AGENT='lex'; exec claude"));
+        assert!(cmd.starts_with("export MIDTOWN_AGENT='lex'; claude"));
         assert!(!cmd.contains("-p "));
     }
 


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Removes the `exec` prefix from claude spawn commands in `src/tmux.rs` for both coworker and lead spawns
- `exec` replaces the shell process with claude, which can cause the TUI to not render properly in tmux panes — coworkers appear to hang with blank screens even though they may be working
- Updates the test assertion to match the new command format (no `exec` prefix)

## Changes
- `src/tmux.rs`: Remove `exec` from `build_claude_command()` output (2 lines)
- `src/tmux.rs`: Update `test_build_claude_command_with_session_id` assertion to expect `claude` instead of `exec claude`

## Test plan
- [x] Unit test updated and passing (`test_build_claude_command_with_session_id`)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes