### PR TITLE
fix: restore exec prefix in claude spawn commands [Midtown #726]

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -908,7 +908,7 @@ fn build_claude_command(
     };
 
     format!(
-        "{}; claude --dangerously-skip-permissions{}{} --setting-sources project,local --settings {} --append-system-prompt \"$(cat {})\"{}",
+        "{}; exec claude --dangerously-skip-permissions{}{} --setting-sources project,local --settings {} --append-system-prompt \"$(cat {})\"{}",
         env_vars,
         session_flag,
         add_dir_flags,
@@ -1062,7 +1062,7 @@ fn build_lead_command(
     add_dir_flags: &str,
 ) -> String {
     format!(
-        "export CLAUDE_CODE_TASK_LIST_ID='{}'; claude --dangerously-skip-permissions --settings {} --append-system-prompt \"$(cat {})\"{}",
+        "export CLAUDE_CODE_TASK_LIST_ID='{}'; exec claude --dangerously-skip-permissions --settings {} --append-system-prompt \"$(cat {})\"{}",
         task_list_id,
         settings_file.display(),
         prompt_file.display(),
@@ -1705,7 +1705,7 @@ Claude is now processing the request
         assert!(cmd.contains("--dangerously-skip-permissions"));
         assert!(cmd.contains("--settings /tmp/settings.json"));
         assert!(cmd.contains("--append-system-prompt \"$(cat /tmp/prompt.txt)\""));
-        assert!(cmd.starts_with("export MIDTOWN_AGENT='lex'; claude"));
+        assert!(cmd.starts_with("export MIDTOWN_AGENT='lex'; exec claude"));
         assert!(!cmd.contains("-p "));
     }
 


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Restores `exec` prefix before `claude` in `build_claude_command()` and `build_lead_command()` in `src/tmux.rs`
- Without `exec`, `sh` remains the tmux pane process and `claude` runs as a child — this prevents crossterm from entering raw mode, causing blank coworker TUI windows
- Updates test assertion in `test_build_claude_command_with_session_id` to expect `exec claude`

## Root Cause
Commit 595d7eb removed `exec` from spawn commands. The lead's TTY (which uses `exec`) shows `-icanon -echo` (raw mode, TUI works), while coworker TTYs without `exec` show `echoe echoke echoctl` (cooked mode, no TUI rendering).

## Test plan
- [x] All 6 `build_claude_command` unit tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [ ] After deploy: verify coworker tmux panes show TUI content (not blank)
- [ ] After deploy: verify `stty -f <coworker-tty>` shows raw mode flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)