### PR TITLE
feat: add refactor-detection instruction to reviewer launch prompt [Midtown #1]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3228,8 +3228,13 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
             "First, post a /me status update: `midtown channel post \"/me reviewing PR #{}\"` — then run: /code-review:code-review {}\n\n\
              IMPORTANT: You MUST always post a GitHub comment on the PR, even if no issues are found. \
              If the code-review skill finishes without posting a comment (e.g. because no issues scored above the threshold), \
-             post a comment yourself using `gh pr comment {} --body` with the \"no issues found\" format from the skill.",
-            pr_number, pr_number, pr_number
+             post a comment yourself using `gh pr comment {} --body` with the \"no issues found\" format from the skill.\n\n\
+             REFACTOR DETECTION: While reviewing, look for similar changes repeated across multiple locations in the diff. \
+             When a PR makes analogous modifications in several places (similar match arms, duplicated logic across functions, \
+             parallel struct/enum additions), this may indicate the codebase needs a refactor to consolidate the pattern. \
+             If you spot this, mention it in your review comment and post to the channel: \
+             `midtown channel post \"@lead PR #{} repeats similar changes in N places (describe pattern). Recommend a refactor task to (suggested approach).\"`",
+            pr_number, pr_number, pr_number, pr_number
         );
 
         match state
@@ -5236,8 +5241,13 @@ async fn nudge_discovered_coworkers(state: &DaemonState) {
                 "Resume reviewing PR #{}. The daemon was restarted and discovered you still running. Continue your code review where you left off.\n\n\
                  IMPORTANT: You MUST always post a GitHub comment on the PR, even if no issues are found. \
                  If the code-review skill finishes without posting a comment, \
-                 post a comment yourself using `gh pr comment {} --body` with the \"no issues found\" format from the skill.",
-                pr_number, pr_number
+                 post a comment yourself using `gh pr comment {} --body` with the \"no issues found\" format from the skill.\n\n\
+                 REFACTOR DETECTION: While reviewing, look for similar changes repeated across multiple locations in the diff. \
+                 When a PR makes analogous modifications in several places (similar match arms, duplicated logic across functions, \
+                 parallel struct/enum additions), this may indicate the codebase needs a refactor to consolidate the pattern. \
+                 If you spot this, mention it in your review comment and post to the channel: \
+                 `midtown channel post \"@lead PR #{} repeats similar changes in N places (describe pattern). Recommend a refactor task to (suggested approach).\"`",
+                pr_number, pr_number, pr_number
             );
 
             info!(


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Added a **REFACTOR DETECTION** instruction to the reviewer launch prompt in `spawn_reviewers_for_prs()`
- Added the same instruction to the resume-review nudge prompt in `nudge_discovered_coworkers()`
- Reviewers will now watch for repeated similar changes across a PR diff (similar match arms, duplicated logic, parallel struct/enum additions) and flag potential refactor opportunities to @lead via channel

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy -- -D warnings` passes with no warnings
- [x] `cargo test` all 15 tests pass
- [x] Pre-commit hooks (fmt + clippy) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)