### PR TITLE
fix: prevent coworker auto-updates and improve zombie respawn reliability

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -134,18 +134,19 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 }
             }
             Effect::RespawnZombieCoworker { name } => {
-                let session = state.coworkers.session_name();
-                // Kill the blank window first
-                if let Err(e) = crate::tmux::kill_window(session, &name) {
-                    warn!("Failed to kill zombie window {}: {}", name, e);
+                // Shut down properly (kills window + removes from internal registry)
+                if let Err(e) = state.coworkers.shutdown(&name) {
+                    warn!("Failed to shutdown zombie coworker {}: {}", name, e);
+                }
+                // Clean up lifecycle state so respawn starts fresh
+                {
+                    let mut lc = state.coworker_lifecycles.write().await;
+                    lc.remove(&name);
                 }
                 // Brief delay to let tmux clean up
                 tokio::time::sleep(std::time::Duration::from_millis(300)).await;
                 // Respawn with --continue to resume the coworker's conversation
-                match state
-                    .coworkers
-                    .spawn_with_name(&name, true, None, false, None)
-                {
+                match state.spawn_coworker(&name, true, None, false, None).await {
                     Ok(_) => {
                         info!("Respawned zombie coworker {} successfully", name);
                     }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1186,48 +1186,41 @@ pub fn spawn_claude(
     }
 
     if !window_survived {
-        if resume {
-            // --continue failed (likely no conversation to resume) — retry with fresh session
-            tracing::warn!(
-                "Tmux window {}:{} died with --continue, retrying with fresh session",
-                session,
-                name
-            );
+        // First attempt failed — always retry with a fresh session.
+        // This handles both --continue/--resume failures (stale session) and
+        // intermittent blank-pane TUI init failures on fresh sessions.
+        tracing::warn!(
+            "Tmux window {}:{} failed on first attempt (resume={}), retrying with fresh session",
+            session,
+            name,
+            resume,
+        );
 
-            let fresh_session_id = uuid::Uuid::new_v4().to_string();
-            let fresh_session_flag = format!(" --session-id {}", fresh_session_id);
-            let fresh_command = build_claude_command(
-                &env_vars,
-                &fresh_session_flag,
-                &add_dir_flags,
-                &settings_file,
-                &prompt_file,
-                initial_prompt_file.as_deref(),
-            );
+        let fresh_session_id = uuid::Uuid::new_v4().to_string();
+        let fresh_session_flag = format!(" --session-id {}", fresh_session_id);
+        let fresh_command = build_claude_command(
+            &env_vars,
+            &fresh_session_flag,
+            &add_dir_flags,
+            &settings_file,
+            &prompt_file,
+            initial_prompt_file.as_deref(),
+        );
 
-            create_window(session, name, working_dir, Some(&fresh_command))?;
-            set_window_color(session, name)?;
+        create_window(session, name, working_dir, Some(&fresh_command))?;
+        set_window_color(session, name)?;
 
-            if !wait_for_window_stable(session, name) {
-                return Err(Error::Rpc {
-                    code: -32603,
-                    message: format!(
-                        "Tmux window {}:{} was created but immediately closed (retry without --continue also failed)",
-                        session, name
-                    ),
-                });
-            }
-
-            return Ok(fresh_session_id);
+        if !wait_for_window_stable(session, name) {
+            return Err(Error::Rpc {
+                code: -32603,
+                message: format!(
+                    "Tmux window {}:{} was created but immediately closed (retry also failed)",
+                    session, name
+                ),
+            });
         }
 
-        return Err(Error::Rpc {
-            code: -32603,
-            message: format!(
-                "Tmux window {}:{} was created but immediately closed (command likely failed)",
-                session, name
-            ),
-        });
+        return Ok(fresh_session_id);
     }
 
     Ok(coworker_session_id)


### PR DESCRIPTION
## Summary
Three fixes from our zombie investigation that were missing from PR #444:

1. **`DISABLE_AUTOUPDATER=1` env var** — `autoUpdates: false` in the coworker settings JSON does **not** prevent Claude Code from auto-updating. The symlink at `~/.local/bin/claude` gets silently swapped during startup. This env var is the only reliable way to prevent version churn.

2. **Zombie respawn uses `shutdown()` + lifecycle cleanup** — PR #444's `RespawnZombieCoworker` only calls `kill_window()`, leaving stale entries in the coworker registry and lifecycle tracker. This uses `shutdown()` (kills window + removes from registry) and clears lifecycle state before respawning via `spawn_coworker()`.

3. **Retry on any spawn failure, not just `--continue`** — PR #444 only retries with a fresh session when `resume` is true. Blank-pane failures can also happen on fresh sessions, so retry logic now applies unconditionally.

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] Verified: coworker stays on pinned version with `DISABLE_AUTOUPDATER=1`
- [x] Verified: without env var, coworker auto-updates despite `autoUpdates: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)