### PR TITLE
fix: remove -p flag that put coworkers in print mode instead of interactive TUI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install tmux
         run: sudo apt-get update && sudo apt-get install -y tmux
 
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Run daemon e2e tests
         run: cargo test --release --all-features --test daemon_e2e -- --ignored --test-threads=1
         env:

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1005,7 +1005,7 @@ fn build_claude_command(
     initial_prompt_file: Option<&std::path::Path>,
 ) -> String {
     let initial_prompt_arg = match initial_prompt_file {
-        Some(path) => format!(" -p \"$(cat {})\"", path.display()),
+        Some(path) => format!(" \"$(cat {})\"", path.display()),
         None => String::new(),
     };
 
@@ -2006,9 +2006,34 @@ Claude is now processing the request
             std::path::Path::new("/tmp/prompt.txt"),
             Some(std::path::Path::new("/tmp/initial-prompt.md")),
         );
-        assert!(cmd.contains("-p \"$(cat /tmp/initial-prompt.md)\""));
-        // The -p flag should come after the other flags
+        assert!(cmd.contains("\"$(cat /tmp/initial-prompt.md)\""));
+        assert!(
+            !cmd.contains("-p "),
+            "must not use -p flag (that enables --print mode)"
+        );
+        assert!(
+            !cmd.contains("--print"),
+            "must not use --print flag (coworkers need interactive TUI)"
+        );
+        // The positional prompt should come after the other flags
         assert!(cmd.contains("--append-system-prompt"));
+
+        // The initial prompt must be a bare positional arg at the end of the
+        // command — NOT preceded by any flag like -p or --print. This ensures
+        // claude launches in interactive TUI mode with the prompt pre-filled.
+        let prompt_pos = cmd.find("\"$(cat /tmp/initial-prompt.md)\"").unwrap();
+        let before_prompt = &cmd[..prompt_pos];
+        assert!(
+            !before_prompt.ends_with("-p "),
+            "initial prompt must be a positional arg, not a -p/--print flag value"
+        );
+        // Should be the last thing in the command
+        let after_prompt = &cmd[prompt_pos + "\"$(cat /tmp/initial-prompt.md)\"".len()..];
+        assert!(
+            after_prompt.trim().is_empty(),
+            "initial prompt should be the last argument, got trailing: {:?}",
+            after_prompt
+        );
     }
 
     #[test]

--- a/tests/tmux_e2e.rs
+++ b/tests/tmux_e2e.rs
@@ -1094,3 +1094,61 @@ fn test_blank_pane_content_detection() {
     // Single non-whitespace character
     assert!(midtown::tmux::content_has_output("\n.\n"));
 }
+
+// ── spawn_claude TUI visibility ─────────────────────────────────────
+
+/// Spawning claude with an initial prompt must produce a visible TUI.
+///
+/// Regression test: build_claude_command previously used `-p` to pass the
+/// initial prompt, but `-p` is `--print` mode which disables the interactive
+/// TUI and makes the pane appear blank. The prompt must be a bare positional
+/// argument so claude launches in interactive mode.
+#[test]
+#[ignore]
+#[timeout(30_000)]
+fn test_spawn_claude_with_initial_prompt_renders_tui() {
+    if !tmux_available() {
+        eprintln!("tmux not available, skipping");
+        return;
+    }
+
+    let session = test_session_name();
+    assert!(create_test_session(&session));
+    let _cleanup = SessionCleanup {
+        session: session.clone(),
+    };
+
+    let temp = tempfile::tempdir().unwrap();
+    let dir = temp.path().to_string_lossy().to_string();
+
+    // Spawn claude with an initial prompt — this is the code path that was
+    // broken when -p (--print mode) was used instead of a positional arg.
+    let result = midtown::tmux::spawn_claude(
+        &session,
+        "test-coworker",
+        &dir,
+        None,  // repo_name
+        false, // resume
+        true,  // isolated_tasks (don't pollute shared task list)
+        &[],   // additional_dirs
+        Some("Say hello and wait for instructions."),
+        None, // resume_session_id
+    );
+
+    assert!(result.is_ok(), "spawn_claude failed: {:?}", result.err());
+
+    // spawn_claude already waits up to 8s for output (3s stability + 5s
+    // blank pane check). Give a bit more time for the TUI to render.
+    thread::sleep(Duration::from_secs(3));
+
+    let target = format!("{}:test-coworker", session);
+    let has_output = midtown::tmux::pane_has_output(&target);
+    assert!(
+        has_output,
+        "spawn_claude with initial_prompt must produce a visible TUI — \
+         blank pane means claude launched in --print mode instead of interactive"
+    );
+
+    // Clean up: kill the claude process
+    kill_window(&session, "test-coworker");
+}


### PR DESCRIPTION
## Summary

- **Root cause found**: `build_claude_command()` used `-p "$(cat file)"` to pass initial prompts to coworkers, but `-p` is `--print` mode (non-interactive). This caused every coworker spawned with a task prompt to launch in print mode — no TUI rendered, pane appeared blank.
- **Fix**: Remove `-p` so the initial prompt is passed as a bare positional argument, which launches Claude in interactive TUI mode.
- **E2E test**: Adds `test_spawn_claude_with_initial_prompt_renders_tui` that spawns a real Claude process with an initial prompt and asserts visible TUI output. This test would have caught the original bug.
- **CI**: Installs Claude Code in the E2E job so the new test can run.

## Root Cause Analysis

The `-p` flag in Claude Code means `--print` (process prompt, output text, exit) — NOT "pass a prompt." The prompt is a positional argument. When `-p` was present:

1. Claude launched in non-interactive print mode
2. No TUI rendered (blank pane)
3. Claude processed the prompt via API, wrote to stdout (invisible in tmux without TUI)
4. Claude exited, or the 5-second blank-pane check killed the window
5. Retry logic reused the same `-p` flag, so the retry also failed
6. Zombie detector found blank panes 20+ seconds later

This explains why:
- Blank panes had live processes with child PIDs (API call in progress)
- Some spawns worked (no initial prompt → no `-p` → interactive mode)
- Manual tmux tests couldn't reproduce it (they didn't use `-p`)
- The bug clustered around task assignment spawns (which always have prompts)

## Test plan
- [x] Unit test `test_build_claude_command_with_initial_prompt` asserts `-p` and `--print` are absent
- [x] Unit test verified to FAIL with bug present, PASS with fix
- [x] E2E test `test_spawn_claude_with_initial_prompt_renders_tui` spawns real Claude, asserts TUI visible
- [x] E2E test verified to FAIL with bug present (blank pane), PASS with fix
- [x] `cargo test` — all 604 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)