### PR TITLE
fix: add editorMode to lead settings to prevent external editor launch [Midtown #709]

### DIFF
--- a/agents/lead-settings.json
+++ b/agents/lead-settings.json
@@ -1,4 +1,5 @@
 {
+  "editorMode": "normal",
   "hooks": {
     "Stop": [{
       "hooks": [{


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Adds `"editorMode": "normal"` to `agents/lead-settings.json` to prevent the lead TUI from inheriting the user's global vim mode setting, which causes Cursor.app to open as an external editor when editing prompts.

## Context
When the user has vim mode enabled globally, the lead session inherits that setting and attempts to launch an external editor for prompt editing. This one-line fix pins the lead to `normal` editor mode explicitly.

## Test plan
- [x] Verified the diff is a single-line addition of `"editorMode": "normal"` to the settings JSON
- [ ] After merge, restart the lead session and confirm prompts edit inline without opening Cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)