### PR TITLE
refactor: extract reviewer prompt to agents/reviewer.md [Midtown #710]

### DIFF
--- a/agents/reviewer-resume.md
+++ b/agents/reviewer-resume.md
@@ -1,0 +1,5 @@
+Resume reviewing PR #{pr_number}. The daemon was restarted and discovered you still running. Continue your code review where you left off.
+
+IMPORTANT: You MUST always post a GitHub comment on the PR, even if no issues are found. If the code-review skill finishes without posting a comment, post a comment yourself using `gh pr comment {pr_number} --body` with the "no issues found" format from the skill.
+
+REFACTOR DETECTION: While reviewing, look for similar changes repeated across multiple locations in the diff. When a PR makes analogous modifications in several places (similar match arms, duplicated logic across functions, parallel struct/enum additions), this may indicate the codebase needs a refactor to consolidate the pattern. If you spot this, mention it in your review comment and post to the channel: `midtown channel post "@lead PR #{pr_number} repeats similar changes in N places (describe pattern). Recommend a refactor task to (suggested approach)."`

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -1,0 +1,5 @@
+First, post a /me status update: `midtown channel post "/me reviewing PR #{pr_number}"` — then run: /code-review:code-review {pr_number}
+
+IMPORTANT: You MUST always post a GitHub comment on the PR, even if no issues are found. If the code-review skill finishes without posting a comment (e.g. because no issues scored above the threshold), post a comment yourself using `gh pr comment {pr_number} --body` with the "no issues found" format from the skill.
+
+REFACTOR DETECTION: While reviewing, look for similar changes repeated across multiple locations in the diff. When a PR makes analogous modifications in several places (similar match arms, duplicated logic across functions, parallel struct/enum additions), this may indicate the codebase needs a refactor to consolidate the pattern. If you spot this, mention it in your review comment and post to the channel: `midtown channel post "@lead PR #{pr_number} repeats similar changes in N places (describe pattern). Recommend a refactor task to (suggested approach)."`

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -32,6 +32,12 @@ const DEFAULT_COMMON_PROMPT: &str = include_str!("../agents/common.md");
 /// Embedded default for personality definitions.
 const DEFAULT_PERSONALITIES: &str = include_str!("../agents/personalities.md");
 
+/// Embedded default for the reviewer launch prompt template.
+const DEFAULT_REVIEWER_PROMPT: &str = include_str!("../agents/reviewer.md");
+
+/// Embedded default for the reviewer resume prompt template.
+const DEFAULT_REVIEWER_RESUME_PROMPT: &str = include_str!("../agents/reviewer-resume.md");
+
 /// Find the git repository root directory.
 fn git_repo_root() -> Option<PathBuf> {
     let output = std::process::Command::new("git")
@@ -266,6 +272,27 @@ pub fn coworker_system_prompt(name: &str) -> String {
     }
     prompt.push_str(&personality_section(name, personality));
     prompt.replace("{name}", name)
+}
+
+/// Build the reviewer launch prompt for a given PR number.
+///
+/// Loads `agents/reviewer.md` (or the embedded default) and replaces
+/// `{pr_number}` with the actual PR number.
+pub fn reviewer_prompt(pr_number: u64) -> String {
+    let template =
+        load_prompt_file("reviewer.md").unwrap_or_else(|| DEFAULT_REVIEWER_PROMPT.to_string());
+    template.replace("{pr_number}", &pr_number.to_string())
+}
+
+/// Build the reviewer resume prompt for a given PR number.
+///
+/// Used when the daemon discovers a reviewer coworker still running after
+/// a restart. Loads `agents/reviewer-resume.md` (or the embedded default)
+/// and replaces `{pr_number}` with the actual PR number.
+pub fn reviewer_resume_prompt(pr_number: u64) -> String {
+    let template = load_prompt_file("reviewer-resume.md")
+        .unwrap_or_else(|| DEFAULT_REVIEWER_RESUME_PROMPT.to_string());
+    template.replace("{pr_number}", &pr_number.to_string())
 }
 
 #[cfg(test)]
@@ -518,6 +545,44 @@ mod tests {
         assert!(
             prompt.contains("GitHub Etiquette"),
             "Coworker prompt should include common content"
+        );
+    }
+
+    #[test]
+    fn test_reviewer_prompt_substitutes_pr_number() {
+        let prompt = reviewer_prompt(42);
+        assert!(prompt.contains("reviewing PR #42"));
+        assert!(prompt.contains("/code-review:code-review 42"));
+        assert!(prompt.contains("gh pr comment 42 --body"));
+        assert!(prompt.contains("PR #42 repeats"));
+        assert!(
+            !prompt.contains("{pr_number}"),
+            "Reviewer prompt should not contain unreplaced {{pr_number}} placeholders"
+        );
+    }
+
+    #[test]
+    fn test_reviewer_resume_prompt_substitutes_pr_number() {
+        let prompt = reviewer_resume_prompt(99);
+        assert!(prompt.contains("Resume reviewing PR #99"));
+        assert!(prompt.contains("gh pr comment 99 --body"));
+        assert!(prompt.contains("PR #99 repeats"));
+        assert!(
+            !prompt.contains("{pr_number}"),
+            "Reviewer resume prompt should not contain unreplaced {{pr_number}} placeholders"
+        );
+    }
+
+    #[test]
+    fn test_reviewer_prompt_contains_required_sections() {
+        let prompt = reviewer_prompt(1);
+        assert!(
+            prompt.contains("IMPORTANT"),
+            "Reviewer prompt should contain IMPORTANT section"
+        );
+        assert!(
+            prompt.contains("REFACTOR DETECTION"),
+            "Reviewer prompt should contain REFACTOR DETECTION section"
         );
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3225,18 +3225,7 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
         // approach of spawning without a prompt and nudging via tmux send-keys,
         // which could fail if the Enter key didn't register.
         // Isolated review coworkers are sent on a break when they go idle (no 5-minute wait).
-        let review_prompt = format!(
-            "First, post a /me status update: `midtown channel post \"/me reviewing PR #{}\"` — then run: /code-review:code-review {}\n\n\
-             IMPORTANT: You MUST always post a GitHub comment on the PR, even if no issues are found. \
-             If the code-review skill finishes without posting a comment (e.g. because no issues scored above the threshold), \
-             post a comment yourself using `gh pr comment {} --body` with the \"no issues found\" format from the skill.\n\n\
-             REFACTOR DETECTION: While reviewing, look for similar changes repeated across multiple locations in the diff. \
-             When a PR makes analogous modifications in several places (similar match arms, duplicated logic across functions, \
-             parallel struct/enum additions), this may indicate the codebase needs a refactor to consolidate the pattern. \
-             If you spot this, mention it in your review comment and post to the channel: \
-             `midtown channel post \"@lead PR #{} repeats similar changes in N places (describe pattern). Recommend a refactor task to (suggested approach).\"`",
-            pr_number, pr_number, pr_number, pr_number
-        );
+        let review_prompt = crate::agents::reviewer_prompt(pr_number);
 
         let reviewer_name = match state.coworkers.next_available_name() {
             Some(name) => name,
@@ -5267,18 +5256,7 @@ async fn nudge_discovered_coworkers(state: &DaemonState) {
             }
         } else if let Some(pr_number) = reviewer_prs.get(&name_lower) {
             // Coworker was assigned to review a PR
-            let prompt = format!(
-                "Resume reviewing PR #{}. The daemon was restarted and discovered you still running. Continue your code review where you left off.\n\n\
-                 IMPORTANT: You MUST always post a GitHub comment on the PR, even if no issues are found. \
-                 If the code-review skill finishes without posting a comment, \
-                 post a comment yourself using `gh pr comment {} --body` with the \"no issues found\" format from the skill.\n\n\
-                 REFACTOR DETECTION: While reviewing, look for similar changes repeated across multiple locations in the diff. \
-                 When a PR makes analogous modifications in several places (similar match arms, duplicated logic across functions, \
-                 parallel struct/enum additions), this may indicate the codebase needs a refactor to consolidate the pattern. \
-                 If you spot this, mention it in your review comment and post to the channel: \
-                 `midtown channel post \"@lead PR #{} repeats similar changes in N places (describe pattern). Recommend a refactor task to (suggested approach).\"`",
-                pr_number, pr_number, pr_number
-            );
+            let prompt = crate::agents::reviewer_resume_prompt(*pr_number);
 
             info!(
                 "Nudging discovered coworker {} to resume review of PR #{}",


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Extracted the reviewer launch prompt from an inline `format!` string in `daemon/mod.rs` to `agents/reviewer.md`
- Extracted the reviewer resume prompt to `agents/reviewer-resume.md`
- Added `reviewer_prompt()` and `reviewer_resume_prompt()` functions in `agents.rs` using the same `include_str!` + `load_prompt_file` pattern as lead/coworker prompts
- Added tests verifying placeholder substitution and required sections

## Test plan
- [x] `cargo test` passes (new tests for reviewer prompt substitution)
- [x] `cargo clippy -- -D warnings` is clean
- [x] No inline reviewer prompt strings remain in daemon/mod.rs
- [x] Generated prompt text matches the original inline version

🤖 Generated with [Claude Code](https://claude.com/claude-code)