### PR TITLE
feat: nudge task owner when someone else updates their task [Midtown #711]

### DIFF
--- a/agents/lead-settings.json
+++ b/agents/lead-settings.json
@@ -7,6 +7,18 @@
       }]
     }],
     "PostToolUse": [{
+      "matcher": "TaskUpdate",
+      "hooks": [{
+        "type": "command",
+        "command": "{bin} hook task"
+      }]
+    }, {
+      "matcher": "TaskCreate",
+      "hooks": [{
+        "type": "command",
+        "command": "{bin} hook task"
+      }]
+    }, {
       "hooks": [{
         "type": "command",
         "command": "{bin} hook insight"

--- a/src/bin/midtown/cli/hooks.rs
+++ b/src/bin/midtown/cli/hooks.rs
@@ -521,12 +521,25 @@ fn handle_task_hook() -> Result<Response, String> {
         );
     }
 
-    // On TaskCreate, notify daemon to immediately check for pending tasks.
-    // This has a 5s timeout via DaemonClient, so it won't block indefinitely.
-    if tool_name == "TaskCreate"
-        && let Ok(client) = crate::client::DaemonClient::connect()
-    {
-        let _ = client.check_pending();
+    // Notify daemon for follow-up actions. Uses a 5s timeout via DaemonClient,
+    // so it won't block indefinitely.
+    if let Ok(client) = crate::client::DaemonClient::connect() {
+        match tool_name {
+            "TaskCreate" => {
+                let _ = client.check_pending();
+            }
+            "TaskUpdate" => {
+                // Nudge the task owner if someone else updated their task
+                let task_id = tool_input["taskId"]
+                    .as_str()
+                    .or_else(|| tool_input["task_id"].as_str())
+                    .unwrap_or("");
+                if !task_id.is_empty() {
+                    let _ = client.task_updated(task_id, &agent);
+                }
+            }
+            _ => {}
+        }
     }
 
     Ok(Response::Message {

--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -277,6 +277,13 @@ impl DaemonClient {
         self.send("daemon.check-pending", None)
     }
 
+    pub fn task_updated(&self, task_id: &str, updater: &str) -> Result<Response, String> {
+        self.send(
+            "task.updated",
+            Some(serde_json::json!({ "task_id": task_id, "updater": updater })),
+        )
+    }
+
     // Kanban commands
 
     pub fn kanban_data(&self) -> Result<Value, String> {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3654,6 +3654,23 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
             Response::success(request.id, serde_json::json!({"status": "ok"}))
         }
 
+        "task.updated" => {
+            let params = request.params.as_ref();
+            let task_id = params
+                .and_then(|p| p.get("task_id"))
+                .and_then(|v| v.as_str());
+            let updater = params
+                .and_then(|p| p.get("updater"))
+                .and_then(|v| v.as_str());
+
+            match (task_id, updater) {
+                (Some(task_id), Some(updater)) => {
+                    handle_task_updated(request.id, task_id, updater, state)
+                }
+                _ => Response::error(request.id, RpcError::invalid_params()),
+            }
+        }
+
         _ => {
             warn!("Unknown method: {}", request.method);
             Response::error(request.id, RpcError::method_not_found())
@@ -3856,6 +3873,81 @@ fn handle_coworker_asking(
         serde_json::json!({
             "success": true,
             "message": format!("Notified Lead about question from {}", name),
+        }),
+    )
+}
+
+/// Handle task.updated RPC — nudge the task owner when someone else updates their task.
+///
+/// Looks up the task by ID, checks the owner, and if the updater differs from
+/// the owner, sends a nudge so the owner sees the change immediately.
+fn handle_task_updated(
+    id: RequestId,
+    task_id: &str,
+    updater: &str,
+    state: &DaemonState,
+) -> Response {
+    let tasks = crate::tasks::read_tasks();
+    let task = tasks.iter().find(|t| t.id == task_id);
+
+    let Some(task) = task else {
+        info!("task.updated: task {} not found, skipping nudge", task_id);
+        return Response::success(
+            id,
+            serde_json::json!({
+                "nudged": false,
+                "reason": "task not found",
+            }),
+        );
+    };
+
+    let Some(ref owner) = task.owner else {
+        info!(
+            "task.updated: task {} has no owner, skipping nudge",
+            task_id
+        );
+        return Response::success(
+            id,
+            serde_json::json!({
+                "nudged": false,
+                "reason": "task has no owner",
+            }),
+        );
+    };
+
+    if owner == updater {
+        debug!(
+            "task.updated: task {} updated by its owner ({}), no nudge needed",
+            task_id, updater
+        );
+        return Response::success(
+            id,
+            serde_json::json!({
+                "nudged": false,
+                "reason": "updater is owner",
+            }),
+        );
+    }
+
+    let nudge_message = format!(
+        "Your task #{} ({}) was updated by {} — check the latest changes",
+        task_id, task.subject, updater
+    );
+
+    // Nudge the owner (could be a coworker or Lead)
+    if let Err(e) = state.coworkers.nudge(owner, &nudge_message) {
+        debug!("Failed to nudge {} for task update: {}", owner, e);
+    }
+
+    info!(
+        "task.updated: nudged {} about task {} (updated by {})",
+        owner, task_id, updater
+    );
+    Response::success(
+        id,
+        serde_json::json!({
+            "nudged": true,
+            "owner": owner,
         }),
     )
 }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1747,11 +1747,23 @@ mod tests {
 
         let post_tool_hooks = &settings["hooks"]["PostToolUse"];
         assert!(post_tool_hooks.is_array());
+        // Lead has TaskUpdate, TaskCreate, and catch-all insight hooks
+        assert_eq!(
+            post_tool_hooks[0]["matcher"].as_str().unwrap(),
+            "TaskUpdate",
+            "first PostToolUse hook should match TaskUpdate"
+        );
+        assert_eq!(
+            post_tool_hooks[1]["matcher"].as_str().unwrap(),
+            "TaskCreate",
+            "second PostToolUse hook should match TaskCreate"
+        );
         assert!(
-            post_tool_hooks[0]["hooks"][0]["command"]
+            post_tool_hooks[2]["hooks"][0]["command"]
                 .as_str()
                 .unwrap()
-                .ends_with("hook insight")
+                .ends_with("hook insight"),
+            "last PostToolUse hook should be the catch-all insight hook"
         );
 
         // Verify {bin} placeholders were replaced


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Added `task.updated` RPC endpoint in the daemon that looks up task owner and nudges them when a different agent updates their task
- Updated the PostToolUse task hook to call the new RPC on TaskUpdate events
- Added TaskUpdate/TaskCreate hooks to lead-settings.json so the lead's task operations also post to channel and trigger owner nudges
- Channel posts still happen alongside nudges for visibility

## Test plan
- [x] `cargo test` — all 476+ tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Updated `test_lead_settings_json_is_valid` to validate new hook ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)