### PR TITLE
fix: prevent duplicate lead windows from zombie detector [Midtown #712]

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -528,6 +528,11 @@ pub(crate) fn detect_blank_pane_zombies(
     blank_pane_coworkers
         .iter()
         .filter(|name| {
+            // The lead window has its own health check (check_and_respawn_lead)
+            // and must never be treated as a zombie coworker.
+            if *name == "lead" {
+                return false;
+            }
             coworker_start_times
                 .get(*name)
                 .map(|started| now_utc.signed_duration_since(*started) >= min_age)
@@ -1910,5 +1915,23 @@ mod tests {
         let zombies =
             detect_blank_pane_zombies(&blank, &start_times, now, chrono::Duration::seconds(20));
         assert!(zombies.is_empty());
+    }
+
+    #[test]
+    fn zombie_detection_skips_lead_window() {
+        let mut blank = HashSet::new();
+        blank.insert("lead".to_string());
+
+        let mut start_times = HashMap::new();
+        let now = chrono::Utc::now();
+        // Lead has been running long enough to pass the age threshold
+        start_times.insert("lead".to_string(), now - chrono::Duration::seconds(60));
+
+        let zombies =
+            detect_blank_pane_zombies(&blank, &start_times, now, chrono::Duration::seconds(20));
+        assert!(
+            zombies.is_empty(),
+            "lead window must never be treated as a zombie"
+        );
     }
 }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1371,6 +1371,16 @@ pub fn spawn_lead(
     project_name: &str,
     additional_dirs: &[PathBuf],
 ) -> crate::Result<()> {
+    // Kill any existing lead windows to prevent duplicates.
+    // This can happen if the lead health check races or a previous
+    // spawn left a stale window behind.
+    if window_exists(session, "lead").unwrap_or(false) {
+        tracing::warn!("Killing existing lead window before respawn");
+        let _ = kill_window(session, "lead");
+        // Brief pause to let tmux clean up
+        std::thread::sleep(std::time::Duration::from_millis(300));
+    }
+
     let prompt_file = write_lead_prompt_file()?;
     let settings_file = write_lead_settings_file()?;
 


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- **Exclude lead from zombie detector**: `detect_blank_pane_zombies` now skips the "lead" window — it has its own health check (`check_and_respawn_lead`) and should never be treated as a zombie coworker
- **Guard `spawn_lead` against duplicates**: Before creating a new lead window, checks for and kills any existing one — prevents duplicate windows from health check races or stale windows

## Context
The daemon's zombie detector was treating the lead window as a coworker, attempting to kill/respawn it through the coworker path. This failed (lead isn't in the coworker registry), but then `check_and_respawn_lead` would create a new lead window alongside the original, resulting in 3 lead windows at indices 0, 6, 7.

## Test plan
- [x] New test `zombie_detection_skips_lead_window` verifies lead is excluded
- [x] All 611 existing tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)