### PR TITLE
docs: add lead maintenance instructions to CLAUDE.md [Midtown #721]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,10 +102,16 @@ Event sources (timer ticks, webhooks, RPC, signals)
 
 ## Lead Maintenance
 
-If you are the Lead, periodically pull main, rebuild the release target, and restart midtown to pick up changes from merged PRs:
+If you are the Lead, whenever a PR is merged into main, pull, rebuild, and restart so the running daemon and coworkers pick up the changes:
 
 ```bash
 git pull && cargo build --release && midtown restart
+```
+
+Post to the channel when done so the team knows the new code is live:
+
+```bash
+midtown channel post "Pulled main, rebuilt release, and restarted midtown."
 ```
 
 ## Pull Requests


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Adds a "Lead Maintenance" section to CLAUDE.md instructing the Lead to pull main, rebuild the release target, and restart midtown whenever a PR merges
- Includes a follow-up instruction to notify the channel after completing the rebuild

## Test plan
- [x] Documentation-only change, no code affected
- [x] Verify CLAUDE.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)