### PR TITLE
fix: prevent duplicate lead windows on midtown restart [Midtown #733]

### DIFF
--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -789,9 +789,11 @@ pub fn handle_restart() -> Result<Response, String> {
         std::thread::sleep(poll_interval);
     }
 
-    // Start daemon and webserver (session already exists, so it will
-    // re-discover coworkers; handle_start also launches the webserver)
-    let result = handle_start(false, None, vec![])?;
+    // Start daemon and webserver only — the tmux session and lead window
+    // already exist (we kept them above). Passing daemon_only=true prevents
+    // handle_start from entering the session-creation path, which could
+    // race with check_and_respawn_lead to create duplicate lead windows.
+    let result = handle_start(true, None, vec![])?;
 
     // Restart the chat pane to pick up code changes.
     // Use respawn-pane -k to atomically kill the old process and start a new

--- a/src/daemon/constants.rs
+++ b/src/daemon/constants.rs
@@ -62,6 +62,11 @@ pub(super) const CHANNEL_ROTATION_RETAIN_MINUTES: i64 = 60;
 /// How often to check if the lead window is still alive (10 seconds)
 pub(super) const LEAD_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(10);
 
+/// Grace period after daemon startup before the lead health check activates (30 seconds).
+/// Prevents races where a freshly started daemon (e.g., after `midtown restart`)
+/// tries to respawn the lead window before the tmux session is fully settled.
+pub(super) const LEAD_HEALTH_CHECK_STARTUP_GRACE: Duration = Duration::from_secs(30);
+
 /// Interval for checking orphaned tasks (5 seconds)
 pub(super) const ORPHAN_CHECK_INTERVAL_SECS: u64 = 5;
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -912,8 +912,12 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
     // Set up lead typing indicator check interval
     let mut lead_typing_interval = interval(LEAD_TYPING_CHECK_INTERVAL);
 
-    // Set up lead health check interval (recreates lead window if killed)
+    // Set up lead health check interval (recreates lead window if killed).
+    // Track daemon start time so we can skip health checks during the startup
+    // grace period, preventing races with `midtown restart` where the daemon
+    // tries to respawn a lead window before the tmux session is fully settled.
     let mut lead_health_interval = interval(LEAD_HEALTH_CHECK_INTERVAL);
+    let daemon_start_instant = tokio::time::Instant::now();
 
     // Start PR polling background task
     let (pr_poll_shutdown_tx, pr_poll_shutdown_rx) = watch::channel(false);
@@ -1102,15 +1106,19 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                 check_lead_typing(&state).await;
             }
 
-            // Check if lead window is still alive; recreate if killed
+            // Check if lead window is still alive; recreate if killed.
+            // Skip during the startup grace period to avoid races with
+            // `midtown restart` where the lead window is still settling.
             _ = lead_health_interval.tick() => {
-                let session = lead_session_name.clone();
-                let workdir = lead_workdir.clone();
-                let project = lead_project_name.clone();
-                let additional = lead_additional_dirs.clone();
-                tokio::task::spawn_blocking(move || {
-                    check_and_respawn_lead(&session, &workdir, &project, &additional);
-                }).await.ok();
+                if daemon_start_instant.elapsed() >= LEAD_HEALTH_CHECK_STARTUP_GRACE {
+                    let session = lead_session_name.clone();
+                    let workdir = lead_workdir.clone();
+                    let project = lead_project_name.clone();
+                    let additional = lead_additional_dirs.clone();
+                    tokio::task::spawn_blocking(move || {
+                        check_and_respawn_lead(&session, &workdir, &project, &additional);
+                    }).await.ok();
+                }
             }
 
             // Periodic orphan check, duplicate detection, and worktree cleanup


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Pass `daemon_only=true` in `handle_restart`'s call to `handle_start` — the tmux session and lead window already exist, so we only need to restart the daemon and webserver
- Add 30-second startup grace period to the daemon's lead health check (`check_and_respawn_lead`) to prevent races where `tokio::time::interval`'s immediate first tick tries to respawn the lead before things settle

## Root cause
`handle_restart` called `handle_start(false, ...)` which enters the session-creation path. While there was a guard (`session_exists`), the combination of multiple code paths that could create lead windows (the CLI's `handle_start`, the daemon's `check_and_respawn_lead` health check) created race conditions during restart.

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` — all 619 tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt -- --check` — properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)