### PR TITLE
chore: bump version to 0.4.0 [Midtown #1]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "midtown"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "axum",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midtown"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2024"
 description = "Midtown - a multi-Claude Code workspace manager, inspired by Gastown"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Bumps version from 0.3.3 to 0.4.0 in Cargo.toml
- Tag `v0.4.0` pushed to origin

## Test plan
- [x] `cargo build --release` succeeds
- [x] `cargo test` all tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean