### PR TITLE
refactor: rename DaemonEvent variants for clarity [Midtown #2]

### DIFF
--- a/src/daemon/events.rs
+++ b/src/daemon/events.rs
@@ -22,11 +22,12 @@ use super::snapshot::WorldSnapshot;
 /// the remaining inline side effects to the evaluate/execute pattern.
 #[derive(Debug)]
 pub enum DaemonEvent {
-    /// Periodic idle-check tick: idle shutdown, interrupt/prompt nudge, usage limits.
-    IdleCheckTick,
-    /// Periodic orphan-check tick: duplicate detection, orphan recovery, task spawning,
-    /// worktree cleanup, reminders.
-    OrphanCheckTick,
+    /// Periodic session-monitor tick: idle shutdown, interrupt/prompt nudge, stuck
+    /// detection, usage limits.
+    SessionMonitorTick,
+    /// Periodic task-dispatch tick: duplicate detection, orphan recovery, task spawning,
+    /// zombie respawning, reminders.
+    TaskDispatchTick,
 }
 
 /// Evaluate a daemon event against the current world snapshot, returning effects.
@@ -44,7 +45,7 @@ pub async fn evaluate_tick(
     state: &DaemonState,
 ) -> Vec<Effect> {
     match event {
-        DaemonEvent::IdleCheckTick => {
+        DaemonEvent::SessionMonitorTick => {
             let mut effects = Vec::new();
             // Order matters: later calls can override phase transitions from earlier
             // calls. For example, a prompt nudge can supersede an idle shutdown
@@ -57,7 +58,7 @@ pub async fn evaluate_tick(
             effects.extend(super::maybe_nudge_usage_limit_expiry(snap));
             effects
         }
-        DaemonEvent::OrphanCheckTick => {
+        DaemonEvent::TaskDispatchTick => {
             let mut effects = Vec::new();
             effects.extend(super::check_for_duplicate_task_workers(snap));
             effects.extend(super::check_and_recover_orphans(snap, state).await);

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1084,7 +1084,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                 ).await;
             }
 
-            // Periodically check for idle coworkers and shut them down
+            // Periodically monitor coworker sessions: idle shutdown, nudges, stuck detection
             _ = idle_check_interval.tick() => {
                 // Sync internal state with actual tmux windows first
                 if let Err(e) = state.coworkers.sync_with_tmux() {
@@ -1093,7 +1093,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                 // event → snapshot → evaluate → execute
                 let snap = snapshot::collect_world_snapshot(&state).await;
                 let tick_effects = events::evaluate_tick(
-                    &events::DaemonEvent::IdleCheckTick,
+                    &events::DaemonEvent::SessionMonitorTick,
                     &snap,
                     &state,
                 ).await;
@@ -1121,12 +1121,12 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                 }
             }
 
-            // Periodic orphan check, duplicate detection, and worktree cleanup
+            // Periodic task dispatch: orphan recovery, duplicate detection, spawning, cleanup
             _ = orphan_check_interval.tick() => {
                 // event → snapshot → evaluate → execute
                 let snap = snapshot::collect_world_snapshot(&state).await;
                 let tick_effects = events::evaluate_tick(
-                    &events::DaemonEvent::OrphanCheckTick,
+                    &events::DaemonEvent::TaskDispatchTick,
                     &snap,
                     &state,
                 ).await;


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Renamed `IdleCheckTick` → `SessionMonitorTick` to reflect its actual scope: monitoring coworker sessions (idle shutdown, interrupt/prompt nudges, stuck detection, usage limits)
- Renamed `OrphanCheckTick` → `TaskDispatchTick` to reflect its actual scope: dispatching work (orphan recovery, task spawning, duplicate detection, zombie respawning, reminders)
- Updated comments in both `events.rs` and `mod.rs` to match the new naming

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` — all 485 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] No remaining references to old variant names

🤖 Generated with [Claude Code](https://claude.com/claude-code)