### PR TITLE
feat: adaptive PR polling based on webhook health [Midtown #3]

### DIFF
--- a/src/daemon/constants.rs
+++ b/src/daemon/constants.rs
@@ -17,8 +17,19 @@ pub const DEFAULT_WEBHOOK_RESTART_INTERVAL_SECS: u64 = 300;
 /// Per-project daemons use 47023+.
 pub const DEFAULT_WEBHOOK_PORT: u16 = 47023;
 
-/// Default interval for polling PRs (30 seconds)
+/// Default interval for polling PRs when webhooks are degraded (30 seconds).
+/// Used as the aggressive/fallback interval when webhook events are not flowing.
 pub const DEFAULT_PR_POLL_INTERVAL_SECS: u64 = 30;
+
+/// Relaxed interval for polling PRs when webhooks are healthy (2 minutes).
+/// When webhooks are delivering real-time events, polling serves only as a
+/// backstop for reconciliation, so we can afford a longer interval.
+pub const RELAXED_PR_POLL_INTERVAL_SECS: u64 = 120;
+
+/// Duration without a webhook event before considering webhooks degraded (5 minutes).
+/// If no webhook events have been received within this window (despite open PRs
+/// or other expected activity), the PR poll switches to the aggressive interval.
+pub(super) const WEBHOOK_HEALTH_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Minimum time between nudging the same PR issue (10 minutes)
 pub const PR_NUDGE_COOLDOWN_SECS: u64 = 600;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -362,6 +362,10 @@ pub(crate) struct DaemonState {
     /// coworker has been respawned as a zombie without recovering. Reset when a
     /// coworker is spawned normally (non-zombie path). Used to cap respawn loops.
     zombie_respawn_counts: std::sync::Mutex<HashMap<String, u32>>,
+    /// Timestamp of the last received webhook event (monotonic).
+    /// Used by the PR poll task to determine webhook health: if recent,
+    /// polling uses a relaxed interval; if stale or absent, polling is aggressive.
+    last_webhook_event_at: Mutex<Option<tokio::time::Instant>>,
 }
 
 impl DaemonState {
@@ -497,6 +501,7 @@ impl DaemonState {
             repo_name_cache: std::sync::RwLock::new(HashMap::new()),
             user_display_name,
             zombie_respawn_counts: std::sync::Mutex::new(HashMap::new()),
+            last_webhook_event_at: Mutex::new(None),
         })
     }
 
@@ -928,8 +933,8 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
             pr_poll_task(state, interval_secs, pr_poll_shutdown_rx).await;
         });
         info!(
-            "PR polling started (interval: {}s)",
-            config.pr_poll_interval_secs
+            "PR polling started (adaptive: {}s aggressive / {}s relaxed)",
+            config.pr_poll_interval_secs, RELAXED_PR_POLL_INTERVAL_SECS
         );
     }
 
@@ -993,6 +998,14 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                 }
             } => {
                 debug!("Received webhook message: {}", webhook_event.message.content);
+
+                // Record webhook event timestamp for adaptive PR polling.
+                // The PR poll task reads this to decide between relaxed/aggressive intervals.
+                {
+                    let mut ts = state.last_webhook_event_at.lock().await;
+                    *ts = Some(tokio::time::Instant::now());
+                }
+
                 if let Err(e) = state.send_and_broadcast(&webhook_event.message) {
                     error!("Failed to forward webhook message to channel: {}", e);
                 }
@@ -2201,7 +2214,13 @@ fn delete_stale_github_webhooks(repo: &str) -> bool {
 
 /// Background task that polls PRs for actionable issues.
 ///
-/// Checks all open PRs every `interval_secs` seconds for:
+/// Checks all open PRs on an adaptive interval:
+/// - **Webhooks healthy** (recent event within [`WEBHOOK_HEALTH_TIMEOUT`]): polls every
+///   [`RELAXED_PR_POLL_INTERVAL_SECS`] (2 min) — polling is only a backstop.
+/// - **Webhooks degraded** (no recent events): polls every `aggressive_interval_secs`
+///   (default 30s) to compensate for missing real-time events.
+///
+/// Detects:
 /// - Merge conflicts
 /// - CI failures
 /// - Changes requested
@@ -2210,12 +2229,35 @@ fn delete_stale_github_webhooks(repo: &str) -> bool {
 /// Nudges the PR owner (extracted from branch prefix) or an idle coworker.
 async fn pr_poll_task(
     state: Arc<DaemonState>,
-    interval_secs: u64,
+    aggressive_interval_secs: u64,
     mut shutdown_rx: watch::Receiver<bool>,
 ) {
-    let interval = Duration::from_secs(interval_secs);
+    let aggressive = Duration::from_secs(aggressive_interval_secs);
+    let relaxed = Duration::from_secs(RELAXED_PR_POLL_INTERVAL_SECS);
 
     loop {
+        // Determine interval based on webhook health
+        let interval = {
+            let last_event = state.last_webhook_event_at.lock().await;
+            match *last_event {
+                Some(ts) if ts.elapsed() < WEBHOOK_HEALTH_TIMEOUT => {
+                    debug!(
+                        "PR poll: webhooks healthy (last event {:.0?} ago), using relaxed interval ({}s)",
+                        ts.elapsed(),
+                        RELAXED_PR_POLL_INTERVAL_SECS
+                    );
+                    relaxed
+                }
+                _ => {
+                    debug!(
+                        "PR poll: webhooks degraded or no events yet, using aggressive interval ({}s)",
+                        aggressive_interval_secs
+                    );
+                    aggressive
+                }
+            }
+        };
+
         // Wait for the interval or shutdown signal
         let delay = tokio::time::sleep(interval);
 


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Switches PR polling from a fixed 30s interval to an adaptive system based on webhook health
- When webhooks are healthy (event received within 5 minutes): polls every **2 minutes** as a backstop
- When webhooks are degraded (no recent events): polls every **30s** to compensate for missing real-time events
- Tracks `last_webhook_event_at` timestamp in `DaemonState`, updated on every incoming webhook event
- Existing deduplication (response hash, github_state, pr_issue_tracker cooldowns) remains untouched

## Changes
- `src/daemon/constants.rs`: Added `RELAXED_PR_POLL_INTERVAL_SECS` (120s) and `WEBHOOK_HEALTH_TIMEOUT` (5min)
- `src/daemon/mod.rs`: Added `last_webhook_event_at` field to `DaemonState`, updated on webhook receipt; `pr_poll_task` now dynamically selects interval each iteration

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] All 619 tests pass (485 unit + 134 integration/doc)
- [ ] Manual verification: observe debug logs showing interval switching between relaxed/aggressive based on webhook activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)