### PR TITLE
chore: bump version to 0.4.1 [Midtown #9]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "midtown"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "axum",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midtown"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "Midtown - a multi-Claude Code workspace manager, inspired by Gastown"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Bump version from 0.4.0 to 0.4.1 in preparation for release

## Changelog since v0.4.0

### Features
- Adaptive PR polling based on webhook health (#463)

### Refactors
- Rename DaemonEvent variants for clarity (#462)
- Remove legacy NudgeService and NudgeTracker (#464)
- Tighten pure/impure boundary in daemon decision functions (#466)
- Extract RPC handlers into daemon/rpc.rs (#467)
- Extract health, dispatch, and chat modules from daemon/mod.rs (#468)
- Extract PR management and webhook forwarder from daemon/mod.rs (#469)

### Docs
- Design doc for unified daemon-owned state model (#465)

## Test plan
- [x] `cargo build --release` succeeds
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes

After merge: tag `v0.4.1` and create GitHub release.