### PR TITLE
refactor: replace coworker file-based state with daemon RPC [Midtown #730]

### DIFF
--- a/src/bin/midtown/cli/hooks.rs
+++ b/src/bin/midtown/cli/hooks.rs
@@ -579,43 +579,39 @@ fn handle_task_hook() -> Result<Response, String> {
         );
     }
 
-    // Safety-net: write structured state for TaskUpdate operations.
-    // The primary mechanism is `midtown state`, but this catches transitions
-    // if the coworker forgets to call it explicitly.
-    if tool_name == "TaskUpdate" && agent != "lead" {
-        let task_id_num = tool_input["taskId"]
-            .as_str()
-            .or_else(|| tool_input["task_id"].as_str())
-            .and_then(|s| s.parse::<u32>().ok());
-
-        let phase = tool_input["status"]
-            .as_str()
-            .and_then(|status| {
-                use midtown::coworker_state::WorkflowPhase;
-                match status {
-                    "in_progress" => Some(WorkflowPhase::Developing),
-                    "completed" => Some(WorkflowPhase::Completed),
-                    _ => None,
-                }
-            })
-            .or_else(|| {
-                // Owner-only update (no status change) → Claiming
-                if tool_input.get("owner").is_some() {
-                    Some(midtown::coworker_state::WorkflowPhase::Claiming)
-                } else {
-                    None
-                }
-            });
-
-        if let Some(phase) = phase {
-            let report = midtown::coworker_state::CoworkerStateReport::new(phase, task_id_num);
-            let _ = midtown::coworker_state::write_state(&repo, &agent, &report);
-        }
-    }
-
     // Notify daemon for follow-up actions. Uses a 5s timeout via DaemonClient,
     // so it won't block indefinitely.
     if let Ok(client) = crate::client::DaemonClient::connect() {
+        // Safety-net: report structured state for TaskUpdate operations via RPC.
+        // The primary mechanism is `midtown state`, but this catches transitions
+        // if the coworker forgets to call it explicitly.
+        if tool_name == "TaskUpdate" && agent != "lead" {
+            let task_id_num = tool_input["taskId"]
+                .as_str()
+                .or_else(|| tool_input["task_id"].as_str())
+                .and_then(|s| s.parse::<u32>().ok());
+
+            let phase_str = tool_input["status"]
+                .as_str()
+                .and_then(|status| match status {
+                    "in_progress" => Some("developing"),
+                    "completed" => Some("completed"),
+                    _ => None,
+                })
+                .or_else(|| {
+                    // Owner-only update (no status change) → Claiming
+                    if tool_input.get("owner").is_some() {
+                        Some("claiming")
+                    } else {
+                        None
+                    }
+                });
+
+            if let Some(phase_str) = phase_str {
+                let _ = client.coworker_report_state(&agent, phase_str, task_id_num);
+            }
+        }
+
         match tool_name {
             "TaskCreate" => {
                 let _ = client.check_pending();

--- a/src/bin/midtown/cli/mod.rs
+++ b/src/bin/midtown/cli/mod.rs
@@ -77,18 +77,37 @@ pub fn handle_chat() -> Result<(), String> {
     chat::run()
 }
 
-/// Handle `midtown state <phase> [--task <id>]` — writes structured coworker state.
+/// Handle `midtown state <phase> [--task <id>]` — reports coworker state via daemon RPC.
 ///
 /// Called explicitly by coworkers to report their workflow phase.
-/// Writes a JSON state file that the daemon reads for tmux tab display.
+/// Sends state to the daemon which stores it in memory and updates tmux tab display.
+/// Falls back to file-based state if the daemon is unreachable.
 pub fn handle_state(
     phase: midtown::coworker_state::WorkflowPhase,
     task_id: Option<u32>,
 ) -> Result<Response, String> {
     let agent = std::env::var("MIDTOWN_AGENT").unwrap_or_else(|_| "unknown".to_string());
+
+    // Convert phase to the snake_case string the RPC endpoint expects
+    let phase_str = match phase {
+        midtown::coworker_state::WorkflowPhase::Claiming => "claiming",
+        midtown::coworker_state::WorkflowPhase::Developing => "developing",
+        midtown::coworker_state::WorkflowPhase::Testing => "testing",
+        midtown::coworker_state::WorkflowPhase::PullRequest => "pull_request",
+        midtown::coworker_state::WorkflowPhase::Reviewing => "reviewing",
+        midtown::coworker_state::WorkflowPhase::Debugging => "debugging",
+        midtown::coworker_state::WorkflowPhase::Completed => "completed",
+        midtown::coworker_state::WorkflowPhase::Idle => "idle",
+    };
+
+    // Try RPC first (daemon is the authority for state)
+    if let Ok(client) = crate::client::DaemonClient::connect() {
+        return client.coworker_report_state(&agent, phase_str, task_id);
+    }
+
+    // Fallback: write to file if daemon is unreachable (e.g., during startup)
     let repo =
         hooks::detect_git_repo_public().ok_or_else(|| "Not in a git repository".to_string())?;
-
     let report = midtown::coworker_state::CoworkerStateReport::new(phase, task_id);
     midtown::coworker_state::write_state(&repo, &agent, &report)
         .map_err(|e| format!("Failed to write state: {}", e))?;

--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -205,6 +205,19 @@ impl DaemonClient {
         self.send("coworker.nudge", Some(args))
     }
 
+    pub fn coworker_report_state(
+        &self,
+        name: &str,
+        phase: &str,
+        task_id: Option<u32>,
+    ) -> Result<Response, String> {
+        let mut params = serde_json::json!({ "name": name, "phase": phase });
+        if let Some(id) = task_id {
+            params["task_id"] = serde_json::json!(id);
+        }
+        self.send("coworker.report-state", Some(params))
+    }
+
     pub fn coworker_asking(&self, name: &str, question: &str) -> Result<Response, String> {
         self.send(
             "coworker.asking",

--- a/src/coworker_state.rs
+++ b/src/coworker_state.rs
@@ -1,13 +1,15 @@
 //! Structured coworker state reporting.
 //!
-//! Coworkers report their workflow phase and current task via a JSON state file.
-//! The daemon reads these files to update tmux tab names and web UI status
-//! without parsing freeform `/me` channel messages.
+//! Coworkers report their workflow phase and current task via daemon RPC
+//! (`coworker.report-state`). The daemon stores state in memory and uses it
+//! to update tmux tab names and web UI status without parsing freeform `/me`
+//! channel messages.
 //!
-//! State file location: `~/.midtown/coworkers/<repo>/<name>/state.json`
+//! Legacy file-based state (`~/.midtown/coworkers/<repo>/<name>/state.json`)
+//! is retained as a fallback when the daemon is unreachable and for migration.
 //!
 //! The `/me` messages remain in the channel for human-readable history, but
-//! state decisions and display are driven by structured data in the state file.
+//! state decisions and display are driven by structured data from the daemon.
 
 use std::path::PathBuf;
 

--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -90,6 +90,11 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 }
                 // Clear state file so next session doesn't read stale phase
                 crate::coworker_state::clear_state(&state.repo_name, &name);
+                // Clean up in-memory state report
+                {
+                    let mut reports = state.coworker_state_reports.write().unwrap();
+                    reports.remove(&name);
+                }
                 // Clean up lifecycle state for the shut-down coworker
                 {
                     let mut lc = state.coworker_lifecycles.write().await;
@@ -143,6 +148,11 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 }
                 // Clear state file so respawned session doesn't read stale phase
                 crate::coworker_state::clear_state(&state.repo_name, &name);
+                // Clean up in-memory state report
+                {
+                    let mut reports = state.coworker_state_reports.write().unwrap();
+                    reports.remove(&name);
+                }
                 // Clean up lifecycle state so respawn starts fresh
                 {
                     let mut lc = state.coworker_lifecycles.write().await;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -359,6 +359,11 @@ pub(crate) struct DaemonState {
     /// User display name from config (e.g. "Ben"). Used to recognize user @mentions
     /// and identify user-sent messages when the display name differs from "user".
     user_display_name: Option<String>,
+    /// In-memory coworker state reports (phase + task), keyed by coworker name.
+    /// Replaces file-based state.json — coworkers report state via RPC, daemon
+    /// stores it here and uses it for tmux tab display and web UI updates.
+    coworker_state_reports:
+        std::sync::RwLock<HashMap<String, crate::coworker_state::CoworkerStateReport>>,
     /// Per-coworker zombie respawn attempt counter. Tracks how many times each
     /// coworker has been respawned as a zombie without recovering. Reset when a
     /// coworker is spawned normally (non-zombie path). Used to cap respawn loops.
@@ -501,6 +506,7 @@ impl DaemonState {
             coworker_pane_hashes: std::sync::Mutex::new(HashMap::new()),
             repo_name_cache: std::sync::RwLock::new(HashMap::new()),
             user_display_name,
+            coworker_state_reports: std::sync::RwLock::new(HashMap::new()),
             zombie_respawn_counts: std::sync::Mutex::new(HashMap::new()),
             last_webhook_event_at: Mutex::new(None),
         })

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -139,6 +139,23 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
 
         "coworker.list" => handle_coworker_list(request.id, state),
 
+        "coworker.report-state" => {
+            let params = request.params.as_ref();
+            let name = params.and_then(|p| p.get("name")).and_then(|v| v.as_str());
+            let phase = params.and_then(|p| p.get("phase")).and_then(|v| v.as_str());
+            let task_id = params
+                .and_then(|p| p.get("task_id"))
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u32);
+
+            match (name, phase) {
+                (Some(name), Some(phase)) => {
+                    handle_coworker_report_state(request.id, name, phase, task_id, state)
+                }
+                _ => Response::error(request.id, RpcError::invalid_params()),
+            }
+        }
+
         "coworker.nudge" => {
             let params = request.params.as_ref();
             let name = params.and_then(|p| p.get("name")).and_then(|v| v.as_str());
@@ -396,6 +413,63 @@ fn handle_coworker_list(id: RequestId, state: &DaemonState) -> Response {
     )
 }
 
+/// Handle coworker.report-state RPC method.
+///
+/// Stores the coworker's workflow phase in daemon memory and updates the
+/// tmux tab display. Replaces the previous file-based state.json approach
+/// so the daemon is the single authority for coworker state.
+fn handle_coworker_report_state(
+    id: RequestId,
+    name: &str,
+    phase_str: &str,
+    task_id: Option<u32>,
+    state: &DaemonState,
+) -> Response {
+    // Parse the phase string into a WorkflowPhase enum
+    let phase = match phase_str {
+        "claiming" => crate::coworker_state::WorkflowPhase::Claiming,
+        "developing" => crate::coworker_state::WorkflowPhase::Developing,
+        "testing" => crate::coworker_state::WorkflowPhase::Testing,
+        "pull_request" | "pull-request" => crate::coworker_state::WorkflowPhase::PullRequest,
+        "reviewing" => crate::coworker_state::WorkflowPhase::Reviewing,
+        "debugging" => crate::coworker_state::WorkflowPhase::Debugging,
+        "completed" => crate::coworker_state::WorkflowPhase::Completed,
+        "idle" => crate::coworker_state::WorkflowPhase::Idle,
+        _ => {
+            return Response::error(
+                id,
+                RpcError::new(-32602, format!("Unknown phase: {}", phase_str)),
+            );
+        }
+    };
+
+    let report = crate::coworker_state::CoworkerStateReport::new(phase, task_id);
+    let status_display = report.display_status();
+
+    // Store in daemon memory
+    {
+        let mut reports = state.coworker_state_reports.write().unwrap();
+        reports.insert(name.to_string(), report);
+    }
+
+    // Update tmux tab display
+    if let Err(e) = state
+        .coworkers
+        .update_status_formatted(name, &status_display)
+    {
+        debug!("Failed to update tmux tab for {}: {}", name, e);
+    }
+
+    info!("Coworker {} reported state: {}", name, status_display);
+    Response::success(
+        id,
+        serde_json::json!({
+            "success": true,
+            "message": format!("{} → {}", name, status_display),
+        }),
+    )
+}
+
 /// Handle coworker.nudge RPC method.
 ///
 /// Sends the nudge directly to the coworker's tmux window without posting to the channel,
@@ -597,22 +671,28 @@ pub(super) async fn handle_channel_post(
             }
 
             // Update tmux tab for coworkers when they post /me actions.
-            // Prefer structured state from state.json (written by hooks) over
+            // Prefer structured state from daemon memory (reported via RPC) over
             // parsing the freeform /me message text with keyword matching.
             if msg_type == MessageType::Action {
-                let result = if let Some(report) =
-                    crate::coworker_state::read_state(&state.repo_name, from)
-                {
-                    // Use pre-formatted status from state file (bypasses parse_status)
-                    state
-                        .coworkers
-                        .update_status_formatted(from, &report.display_status())
-                } else {
-                    // Fallback: parse /me message text with keyword matching
-                    state.coworkers.update_status_display(from, Some(&content))
+                let has_rpc_state = {
+                    let reports = state.coworker_state_reports.read().unwrap();
+                    if let Some(report) = reports.get(from) {
+                        let display = report.display_status();
+                        drop(reports);
+                        let r = state.coworkers.update_status_formatted(from, &display);
+                        if let Err(e) = r {
+                            debug!("Failed to update tmux tab for {}: {}", from, e);
+                        }
+                        true
+                    } else {
+                        false
+                    }
                 };
-                if let Err(e) = result {
-                    debug!("Failed to update tmux tab for {}: {}", from, e);
+                if !has_rpc_state {
+                    // Fallback: parse /me message text with keyword matching
+                    if let Err(e) = state.coworkers.update_status_display(from, Some(&content)) {
+                        debug!("Failed to update tmux tab for {}: {}", from, e);
+                    }
                 }
             }
 


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Coworkers now report workflow phase via `coworker.report-state` RPC instead of writing `state.json` files to disk
- The daemon stores state in an in-memory `coworker_state_reports` map and becomes the single authority for coworker workflow state
- CLI `midtown state` sends RPC with file-write fallback when daemon is unreachable (e.g., during startup)
- Hooks safety-net for TaskUpdate transitions uses RPC instead of direct file writes
- The `channel.post` handler reads from daemon memory instead of `state.json` on disk

## Why this matters
The previous pattern trusted the filesystem — any process could write bogus state to `state.json`, and the daemon had no validation or ownership of the data it was displaying. Now all state flows through the daemon's RPC interface, which validates the phase string and stores it in memory. This aligns with the architectural principle that the daemon should be the single authority for all state.

## Test plan
- [x] All 474 unit tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)