### PR TITLE
feat: Move PR issue nudging from polling to webhook handlers [Midtown #728]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1066,6 +1066,22 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                     );
                 }
 
+                // Nudge PR owner immediately on review state change (approved / changes_requested)
+                if let Some(review_change) = webhook_event.review_state_change {
+                    let state = Arc::clone(&state);
+                    tokio::spawn(async move {
+                        pr::handle_webhook_review_state_change(&state, review_change).await;
+                    });
+                }
+
+                // Nudge PR owner immediately on CI failure
+                if let Some(ci_failure) = webhook_event.pr_ci_failure {
+                    let state = Arc::clone(&state);
+                    tokio::spawn(async move {
+                        pr::handle_webhook_ci_failure(&state, ci_failure).await;
+                    });
+                }
+
                 // Cache review status immediately from webhook data (avoids API calls)
                 if let Some(pr_number) = webhook_event.reviewed_pr {
                     debug!(

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -1528,3 +1528,318 @@ pub(super) async fn handle_pr_comment_nudge(
         add_eyes_reaction(repo, node).await;
     }
 }
+
+/// Handle a formal review state change (approved / changes_requested) from a webhook.
+///
+/// This provides immediate nudging when a reviewer submits a formal review,
+/// instead of waiting for the next polling cycle to detect the state change.
+/// The `PrIssueTracker` cooldown prevents duplicate nudges if polling also fires.
+pub(super) async fn handle_webhook_review_state_change(
+    state: &DaemonState,
+    change: crate::webhook::PrReviewStateChange,
+) {
+    let pr_number = change.pr_number;
+    let issue_type = match change.state {
+        crate::webhook::ReviewState::Approved => PrIssueType::Approved,
+        crate::webhook::ReviewState::ChangesRequested => PrIssueType::ChangesRequested,
+    };
+
+    // Check cooldown — polling may have already nudged for this issue
+    {
+        let tracker = state.pr_issue_tracker.lock().await;
+        if !tracker.should_nudge(pr_number, issue_type) {
+            debug!(
+                "PR #{} {} nudge on cooldown (already handled), skipping webhook nudge",
+                pr_number, issue_type
+            );
+            return;
+        }
+    }
+
+    // Resolve owner: use webhook data if available, otherwise look up async
+    let owner = match change.owner_coworker {
+        Some(ref o) => Some(o.clone()),
+        None => get_pr_owner_coworker_async(pr_number).await,
+    };
+
+    let Some(owner) = owner else {
+        debug!(
+            "PR #{} has no coworker owner, skipping webhook {} nudge",
+            pr_number, issue_type
+        );
+        return;
+    };
+
+    let nudge_msg = format!(
+        "PR #{} — {}: {}",
+        pr_number,
+        issue_type,
+        get_issue_action(issue_type)
+    );
+
+    // Get active coworkers for the decision function
+    let active_coworkers: Vec<String> = state
+        .coworkers
+        .list()
+        .iter()
+        .map(|c| c.name.clone())
+        .collect();
+
+    let action = crate::rules::decide_pr_issue_action(
+        &owner,
+        &active_coworkers,
+        state.is_at_dev_limit(),
+        &nudge_msg,
+    );
+
+    let nudged = match action {
+        crate::rules::PrAction::NudgeOwner {
+            owner: ref o,
+            message: ref msg,
+        } => match state.coworkers.nudge(o, msg) {
+            Ok(()) => {
+                info!(
+                    "Webhook: nudged {} about {} on PR #{}",
+                    o, issue_type, pr_number
+                );
+                true
+            }
+            Err(e) => {
+                warn!(
+                    "Webhook: failed to nudge {} about {} on PR #{}: {}",
+                    o, issue_type, pr_number, e
+                );
+                false
+            }
+        },
+        crate::rules::PrAction::SpawnOwner {
+            owner: ref o,
+            message: ref msg,
+        } => {
+            info!(
+                "Webhook: PR #{} owner {} is not active, spawning to address {}",
+                pr_number, o, issue_type
+            );
+            let saved_session = {
+                let sessions = state.pr_break_sessions.read().unwrap();
+                sessions.get(o).cloned()
+            };
+            if saved_session.is_some() {
+                info!("Resuming saved PR break session for {}", o);
+            }
+            let session_mode = match saved_session.as_deref() {
+                Some(sid) => crate::tmux::SessionMode::ResumeSession(sid.to_string()),
+                None => crate::tmux::SessionMode::Resume,
+            };
+            let config = crate::tmux::ClaudeLaunchConfig::coworker(
+                o.clone(),
+                state.repo_name.clone(),
+                session_mode,
+                Some(msg.clone()),
+            );
+            match state.spawn_coworker(&config).await {
+                Ok(_) => {
+                    if saved_session.is_some() {
+                        let mut sessions = state.pr_break_sessions.write().unwrap();
+                        sessions.remove(o);
+                    }
+                    info!(
+                        "Webhook: spawned {} to address {} on PR #{}",
+                        o, issue_type, pr_number
+                    );
+                    state.broadcast_coworker_update(o, "running", None);
+                    let call_msg = Message::text(
+                        "midtown",
+                        crate::daemon_messages::called_in_pr_issue(
+                            o,
+                            &issue_type.to_string(),
+                            pr_number,
+                            crate::config::get_personality(),
+                        ),
+                    );
+                    if let Err(e) = state.send_and_broadcast(&call_msg) {
+                        warn!("Failed to post call-in message: {}", e);
+                    }
+                    true
+                }
+                Err(e) => {
+                    warn!(
+                        "Webhook: failed to spawn {} for PR #{} {}: {}",
+                        o, pr_number, issue_type, e
+                    );
+                    false
+                }
+            }
+        }
+        crate::rules::PrAction::PostToChannel { message: ref msg } => {
+            let channel_msg = Message::new("midtown", msg.clone(), MessageType::Text);
+            if let Err(e) = state.send_and_broadcast(&channel_msg) {
+                warn!("Failed to post PR issue to channel: {}", e);
+            }
+            true
+        }
+        crate::rules::PrAction::Skip { ref reason } => {
+            debug!("Webhook: {}", reason);
+            false
+        }
+    };
+
+    if nudged {
+        let mut tracker = state.pr_issue_tracker.lock().await;
+        tracker.record_nudge(pr_number, issue_type);
+    }
+}
+
+/// Handle a CI check failure on a PR branch from a webhook.
+///
+/// This provides immediate nudging when CI fails on a PR, instead of waiting
+/// for the next polling cycle. The `PrIssueTracker` cooldown prevents duplicate
+/// nudges if polling also fires.
+pub(super) async fn handle_webhook_ci_failure(
+    state: &DaemonState,
+    failure: crate::webhook::PrCiFailure,
+) {
+    let pr_number = failure.pr_number;
+
+    // Check cooldown
+    {
+        let tracker = state.pr_issue_tracker.lock().await;
+        if !tracker.should_nudge(pr_number, PrIssueType::CiFailed) {
+            debug!(
+                "PR #{} CI failure nudge on cooldown, skipping webhook nudge",
+                pr_number
+            );
+            return;
+        }
+    }
+
+    // Resolve owner
+    let owner = match failure.owner_coworker {
+        Some(ref o) => Some(o.clone()),
+        None => get_pr_owner_coworker_async(pr_number).await,
+    };
+
+    let Some(owner) = owner else {
+        debug!(
+            "PR #{} has no coworker owner, skipping webhook CI failure nudge",
+            pr_number
+        );
+        return;
+    };
+
+    let nudge_msg = format!(
+        "PR #{} — CI check '{}' failed: please investigate",
+        pr_number, failure.check_name
+    );
+
+    let active_coworkers: Vec<String> = state
+        .coworkers
+        .list()
+        .iter()
+        .map(|c| c.name.clone())
+        .collect();
+
+    let action = crate::rules::decide_pr_issue_action(
+        &owner,
+        &active_coworkers,
+        state.is_at_dev_limit(),
+        &nudge_msg,
+    );
+
+    let nudged = match action {
+        crate::rules::PrAction::NudgeOwner {
+            owner: ref o,
+            message: ref msg,
+        } => match state.coworkers.nudge(o, msg) {
+            Ok(()) => {
+                info!(
+                    "Webhook: nudged {} about CI failure on PR #{}",
+                    o, pr_number
+                );
+                true
+            }
+            Err(e) => {
+                warn!(
+                    "Webhook: failed to nudge {} about CI failure on PR #{}: {}",
+                    o, pr_number, e
+                );
+                false
+            }
+        },
+        crate::rules::PrAction::SpawnOwner {
+            owner: ref o,
+            message: ref msg,
+        } => {
+            info!(
+                "Webhook: PR #{} owner {} is not active, spawning to address CI failure",
+                pr_number, o
+            );
+            let saved_session = {
+                let sessions = state.pr_break_sessions.read().unwrap();
+                sessions.get(o).cloned()
+            };
+            if saved_session.is_some() {
+                info!("Resuming saved PR break session for {}", o);
+            }
+            let session_mode = match saved_session.as_deref() {
+                Some(sid) => crate::tmux::SessionMode::ResumeSession(sid.to_string()),
+                None => crate::tmux::SessionMode::Resume,
+            };
+            let config = crate::tmux::ClaudeLaunchConfig::coworker(
+                o.clone(),
+                state.repo_name.clone(),
+                session_mode,
+                Some(msg.clone()),
+            );
+            match state.spawn_coworker(&config).await {
+                Ok(_) => {
+                    if saved_session.is_some() {
+                        let mut sessions = state.pr_break_sessions.write().unwrap();
+                        sessions.remove(o);
+                    }
+                    info!(
+                        "Webhook: spawned {} to address CI failure on PR #{}",
+                        o, pr_number
+                    );
+                    state.broadcast_coworker_update(o, "running", None);
+                    let call_msg = Message::text(
+                        "midtown",
+                        crate::daemon_messages::called_in_pr_issue(
+                            o,
+                            "CI failed",
+                            pr_number,
+                            crate::config::get_personality(),
+                        ),
+                    );
+                    if let Err(e) = state.send_and_broadcast(&call_msg) {
+                        warn!("Failed to post call-in message: {}", e);
+                    }
+                    true
+                }
+                Err(e) => {
+                    warn!(
+                        "Webhook: failed to spawn {} for PR #{} CI failure: {}",
+                        o, pr_number, e
+                    );
+                    false
+                }
+            }
+        }
+        crate::rules::PrAction::PostToChannel { message: ref msg } => {
+            let channel_msg = Message::new("midtown", msg.clone(), MessageType::Text);
+            if let Err(e) = state.send_and_broadcast(&channel_msg) {
+                warn!("Failed to post PR CI failure to channel: {}", e);
+            }
+            true
+        }
+        crate::rules::PrAction::Skip { ref reason } => {
+            debug!("Webhook: {}", reason);
+            false
+        }
+    };
+
+    if nudged {
+        let mut tracker = state.pr_issue_tracker.lock().await;
+        tracker.record_nudge(pr_number, PrIssueType::CiFailed);
+    }
+}

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -55,6 +55,48 @@ pub struct WebhookEvent {
     /// PR number that received a Claude review comment (for caching review status).
     /// Set when an `issue_comment` webhook contains a review signature.
     pub reviewed_pr: Option<u64>,
+    /// A formal review state change (approved / changes_requested) — triggers immediate
+    /// nudge of the PR owner instead of waiting for the next polling cycle.
+    pub review_state_change: Option<PrReviewStateChange>,
+    /// A CI check failure on a PR branch — triggers immediate nudge of the PR owner.
+    pub pr_ci_failure: Option<PrCiFailure>,
+}
+
+/// Structured data about a formal PR review state change (approved or changes requested).
+///
+/// Populated by the `pull_request_review` webhook handler so the daemon can
+/// immediately nudge the PR owner rather than waiting for the next poll cycle.
+#[derive(Debug, Clone)]
+pub struct PrReviewStateChange {
+    /// PR number
+    pub pr_number: u64,
+    /// The coworker who owns the PR (from branch prefix or body frontmatter)
+    pub owner_coworker: Option<String>,
+    /// The reviewer who submitted the review
+    pub reviewer: String,
+    /// Whether the review was approved or requested changes
+    pub state: ReviewState,
+}
+
+/// The state of a formal PR review.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReviewState {
+    Approved,
+    ChangesRequested,
+}
+
+/// Structured data about a CI check failure on a PR branch.
+///
+/// Populated by the `check_run` webhook handler so the daemon can
+/// immediately nudge the PR owner rather than waiting for the next poll cycle.
+#[derive(Debug, Clone)]
+pub struct PrCiFailure {
+    /// PR number
+    pub pr_number: u64,
+    /// The coworker who owns the PR (from branch prefix or body frontmatter)
+    pub owner_coworker: Option<String>,
+    /// Name of the failed check
+    pub check_name: String,
 }
 
 /// Identifies a GitHub comment for the reactions API.
@@ -587,6 +629,8 @@ fn handle_pull_request(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json::
         merged_pr,
         ci_failed_on_default_branch: None,
         reviewed_pr: None,
+        review_state_change: None,
+        pr_ci_failure: None,
     }))
 }
 
@@ -619,6 +663,24 @@ fn handle_pull_request_review(body: &[u8]) -> Result<Option<WebhookEvent>, serde
         _ => return Ok(None),
     };
 
+    // Produce a structured review state change for approved/changes_requested
+    // so the daemon can immediately nudge the PR owner via webhook.
+    let review_state_change = match event.review.state.to_lowercase().as_str() {
+        "approved" => Some(PrReviewStateChange {
+            pr_number: event.pull_request.number,
+            owner_coworker: coworker.map(|s| s.to_string()),
+            reviewer: event.review.user.login.clone(),
+            state: ReviewState::Approved,
+        }),
+        "changes_requested" => Some(PrReviewStateChange {
+            pr_number: event.pull_request.number,
+            owner_coworker: coworker.map(|s| s.to_string()),
+            reviewer: event.review.user.login.clone(),
+            state: ReviewState::ChangesRequested,
+        }),
+        _ => None,
+    };
+
     let content = format!("{}{}", mention, action_text);
     Ok(Some(WebhookEvent {
         message: Message::new("github", content, MessageType::Text),
@@ -636,6 +698,8 @@ fn handle_pull_request_review(body: &[u8]) -> Result<Option<WebhookEvent>, serde
         merged_pr: None,
         ci_failed_on_default_branch: None,
         reviewed_pr: None,
+        review_state_change,
+        pr_ci_failure: None,
     }))
 }
 
@@ -685,6 +749,8 @@ fn handle_issue_comment(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json:
         merged_pr: None,
         ci_failed_on_default_branch: None,
         reviewed_pr,
+        review_state_change: None,
+        pr_ci_failure: None,
     }))
 }
 
@@ -727,6 +793,8 @@ fn handle_review_comment(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json
         merged_pr: None,
         ci_failed_on_default_branch: None,
         reviewed_pr: None,
+        review_state_change: None,
+        pr_ci_failure: None,
     }))
 }
 
@@ -770,6 +838,8 @@ fn handle_status(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json::Error>
         merged_pr: None,
         ci_failed_on_default_branch: None,
         reviewed_pr: None,
+        review_state_change: None,
+        pr_ci_failure: None,
     }))
 }
 
@@ -839,6 +909,23 @@ fn handle_check_run(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json::Err
         None
     };
 
+    // Produce a structured CI failure for PR branches so the daemon can
+    // immediately nudge the PR owner via webhook.
+    let pr_ci_failure = if is_failure {
+        event
+            .check_run
+            .check_suite
+            .as_ref()
+            .and_then(|cs| cs.pull_requests.first())
+            .map(|pr| PrCiFailure {
+                pr_number: pr.number,
+                owner_coworker: coworker.map(|s| s.to_string()),
+                check_name: event.check_run.name.clone(),
+            })
+    } else {
+        None
+    };
+
     let content = format!("{}{}", mention, action_text);
     Ok(Some(WebhookEvent {
         message: Message::new("github", content, MessageType::Text),
@@ -847,6 +934,8 @@ fn handle_check_run(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json::Err
         merged_pr: None,
         ci_failed_on_default_branch,
         reviewed_pr: None,
+        review_state_change: None,
+        pr_ci_failure,
     }))
 }
 
@@ -1511,5 +1600,175 @@ mod tests {
         assert_eq!(activity.pr_number, 77);
         assert_eq!(activity.owner_coworker.as_deref(), Some("madison"));
         assert_eq!(activity.actor, "lexington");
+    }
+
+    #[test]
+    fn test_review_approved_produces_state_change() {
+        let payload = r#"{
+            "action": "submitted",
+            "review": {
+                "id": 200,
+                "state": "approved",
+                "user": {"login": "reviewer_bot"}
+            },
+            "pull_request": {
+                "number": 42,
+                "head": {"ref": "broadway/fix-bug"},
+                "body": "Some PR description"
+            },
+            "repository": {"full_name": "org/repo"}
+        }"#;
+
+        let event = handle_pull_request_review(payload.as_bytes())
+            .unwrap()
+            .unwrap();
+        let change = event.review_state_change.unwrap();
+        assert_eq!(change.pr_number, 42);
+        assert_eq!(change.owner_coworker.as_deref(), Some("broadway"));
+        assert_eq!(change.reviewer, "reviewer_bot");
+        assert_eq!(change.state, ReviewState::Approved);
+        // CI failure should be None for review events
+        assert!(event.pr_ci_failure.is_none());
+    }
+
+    #[test]
+    fn test_review_changes_requested_produces_state_change() {
+        let payload = r#"{
+            "action": "submitted",
+            "review": {
+                "id": 201,
+                "state": "changes_requested",
+                "user": {"login": "reviewer_bot"}
+            },
+            "pull_request": {
+                "number": 55,
+                "head": {"ref": "columbus/add-feature"},
+                "body": "<!-- midtown: columbus -->\n\nDescription"
+            },
+            "repository": {"full_name": "org/repo"}
+        }"#;
+
+        let event = handle_pull_request_review(payload.as_bytes())
+            .unwrap()
+            .unwrap();
+        let change = event.review_state_change.unwrap();
+        assert_eq!(change.pr_number, 55);
+        assert_eq!(change.owner_coworker.as_deref(), Some("columbus"));
+        assert_eq!(change.reviewer, "reviewer_bot");
+        assert_eq!(change.state, ReviewState::ChangesRequested);
+    }
+
+    #[test]
+    fn test_review_commented_no_state_change() {
+        let payload = r#"{
+            "action": "submitted",
+            "review": {
+                "id": 202,
+                "state": "commented",
+                "user": {"login": "reviewer_bot"}
+            },
+            "pull_request": {
+                "number": 42,
+                "head": {"ref": "broadway/fix-bug"}
+            },
+            "repository": {"full_name": "org/repo"}
+        }"#;
+
+        let event = handle_pull_request_review(payload.as_bytes())
+            .unwrap()
+            .unwrap();
+        // "commented" reviews should NOT produce a state change
+        assert!(event.review_state_change.is_none());
+    }
+
+    #[test]
+    fn test_check_run_failure_on_pr_produces_ci_failure() {
+        let payload = r#"{
+            "action": "completed",
+            "check_run": {
+                "name": "Build",
+                "status": "completed",
+                "conclusion": "failure",
+                "check_suite": {
+                    "head_sha": "abc123",
+                    "head_branch": "park/implement-thing",
+                    "pull_requests": [{"number": 99}]
+                }
+            },
+            "repository": {"full_name": "org/repo", "default_branch": "main"}
+        }"#;
+
+        let event = handle_check_run(payload.as_bytes()).unwrap().unwrap();
+        let failure = event.pr_ci_failure.unwrap();
+        assert_eq!(failure.pr_number, 99);
+        assert_eq!(failure.owner_coworker.as_deref(), Some("park"));
+        assert_eq!(failure.check_name, "Build");
+        // Should NOT flag as default-branch CI failure
+        assert!(event.ci_failed_on_default_branch.is_none());
+    }
+
+    #[test]
+    fn test_check_run_success_on_pr_no_ci_failure() {
+        let payload = r#"{
+            "action": "completed",
+            "check_run": {
+                "name": "Build",
+                "status": "completed",
+                "conclusion": "success",
+                "check_suite": {
+                    "head_sha": "abc123",
+                    "head_branch": "park/implement-thing",
+                    "pull_requests": [{"number": 99}]
+                }
+            },
+            "repository": {"full_name": "org/repo", "default_branch": "main"}
+        }"#;
+
+        let event = handle_check_run(payload.as_bytes()).unwrap().unwrap();
+        assert!(event.pr_ci_failure.is_none());
+    }
+
+    #[test]
+    fn test_check_run_failure_on_main_no_pr_ci_failure() {
+        let payload = r#"{
+            "action": "completed",
+            "check_run": {
+                "name": "Build",
+                "status": "completed",
+                "conclusion": "failure",
+                "check_suite": {
+                    "head_sha": "abc123",
+                    "head_branch": "main",
+                    "pull_requests": []
+                }
+            },
+            "repository": {"full_name": "org/repo", "default_branch": "main"}
+        }"#;
+
+        let event = handle_check_run(payload.as_bytes()).unwrap().unwrap();
+        // No PR associated → no pr_ci_failure
+        assert!(event.pr_ci_failure.is_none());
+        // But it should flag as default-branch CI failure
+        assert!(event.ci_failed_on_default_branch.is_some());
+    }
+
+    #[test]
+    fn test_pull_request_opened_no_review_state_change() {
+        let payload = r#"{
+            "action": "opened",
+            "number": 42,
+            "pull_request": {
+                "title": "Add feature",
+                "user": {"login": "btucker"},
+                "merged": false,
+                "head": {"ref": "broadway/add-feature"}
+            },
+            "repository": {"full_name": "org/repo"}
+        }"#;
+
+        let event = handle_pull_request(payload.as_bytes()).unwrap().unwrap();
+        // PR opened events should not produce review state changes or CI failures
+        assert!(event.review_state_change.is_none());
+        assert!(event.pr_ci_failure.is_none());
     }
 }


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- **Webhook-driven nudging**: PR owners are now nudged immediately when a reviewer submits a formal review (approved/changes_requested) or when CI fails on their PR branch, instead of waiting up to 2 minutes for the next polling cycle
- **New structured webhook fields**: `PrReviewStateChange` and `PrCiFailure` structs carry actionable data from webhook handlers through the event pipeline to the daemon
- **Natural deduplication**: The existing `PrIssueTracker` cooldown mechanism prevents double-nudging when polling also detects the same condition — no changes needed to polling code

## Architecture
The change follows the existing webhook → `mpsc` channel → daemon event loop pattern:

1. `webhook.rs`: `handle_pull_request_review` now produces `review_state_change` for approved/changes_requested reviews; `handle_check_run` now produces `pr_ci_failure` for failures on PR branches
2. `daemon/mod.rs`: The webhook event handler dispatches these to new async handlers via `tokio::spawn`
3. `daemon/pr.rs`: Two new handler functions (`handle_webhook_review_state_change`, `handle_webhook_ci_failure`) use the same `decide_pr_issue_action` pure decision function and spawn/nudge logic as existing polling handlers

## Test plan
- [x] 7 new unit tests covering all webhook-driven nudge scenarios
- [x] Full test suite passes (481 lib tests + integration tests)
- [x] Clippy clean with `-D warnings`
- [x] Verified new fields are `None` for unrelated webhook events (PR opened, review comments, etc.)


🤖 Generated with [Claude Code](https://claude.com/claude-code)