### PR TITLE
docs: add architecture principles to CLAUDE.md [Midtown #736]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,53 @@ Nudge decisions are made in `src/rules.rs` (`decide_interrupt_nudges`, `decide_p
 
 `src/agents.rs` generates system prompts. The markdown templates live in `agents/` (lead.md, coworker.md, common.md, personalities.md).
 
+## Architecture Principles
+
+### Webhooks Are Primary, Polling Adapts
+
+Webhooks handle real-time GitHub events. Polling runs at a relaxed cadence (~2 min) as a backstop for missed deliveries and time-based stuck detection. When webhooks are degraded, polling increases cadence to compensate. Polling should never duplicate a decision that a webhook already triggered.
+
+| Concern | Primary owner | Notes |
+|---|---|---|
+| PR needs review → spawn reviewer | Webhook | Polling reconciles if missed |
+| CI failure → notify owner | Webhook | Polling detects time-based stuck conditions |
+| Review comment → nudge owner | Webhook | Polling does not handle this |
+| Merge conflict → nudge owner | Polling | GitHub doesn't webhook this reliably |
+| Auto-merge eligibility | Polling | Time-based: approved + green + no conflicts |
+| Stuck detection | Polling | Inherently time-based |
+
+### Three Communication Paths, Distinct Purposes
+
+- **Initial prompt** — "Here's your mission." One-shot context at spawn time.
+- **Channel** — "Here's what's happening." Ambient team awareness, async.
+- **Nudge** (`tmux send-keys`) — "Pay attention now." Synchronous interrupt for session recovery, urgent PR feedback, task assignment to active coworkers.
+
+Don't nudge for information that can wait for the next channel read.
+
+### Decision Functions Are Pure
+
+Functions in `rules.rs` take immutable data and return decisions. No mutation, no I/O, no async. Phase transitions are returned as data, applied by the caller. If a decision depends on a side effect (spawn success, API call), split into two decisions with an effect in between. The `evaluate_tick()` → `Vec<Effect>` → `execute_effects()` pipeline is the canonical path.
+
+### Daemon Is the Single Authority for State
+
+The daemon owns all coordination state. Coworkers report workflow state via RPC (`midtown` CLI). Pane scraping is a safety net for health checks (stuck, zombie, crash) — not the primary source of workflow information. If RPC and pane scraping disagree, pane scraping wins for health decisions.
+
+### The Channel Is for Communication, Not State
+
+State flows through RPC to the daemon. The channel records events and conversations for awareness. No system should read the channel to determine current state.
+
+### Clear Ownership Between Webhooks and Polling
+
+Each concern has a primary owner. The non-owner path only acts as reconciliation when the primary failed. Enforce via explicit tracking ("webhook handled PR #42"), not passive deduplication (cooldowns).
+
+### Daemon Module Is a Thin Orchestrator
+
+`mod.rs` is the event loop wiring. Domain logic lives in domain modules (`pr.rs`, `health.rs`, `dispatch.rs`, `chat.rs`, `rpc.rs`).
+
+### Names Reflect Actual Responsibility
+
+`SessionMonitorTick` (coworker health), `TaskDispatchTick` (work assignment). Name components for what they do, not their historical origin.
+
 ## Key Patterns
 
 **Effect-based side effects**: Never perform I/O in decision functions. Return `Effect` variants from `rules.rs`, execute them in `effects.rs`. This keeps the core logic pure and testable.


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Adds 8 architecture principles to CLAUDE.md covering daemon design philosophy
- Documents webhook vs polling ownership, communication paths, pure decision functions, state authority, channel role, ownership tracking, thin orchestrator pattern, and naming conventions
- Includes a responsibility table mapping each concern to its primary owner (webhook or polling)

## Test plan
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` passes (docs-only change, no code affected)
- [x] Content reviewed against existing Architecture section for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)