### PR TITLE
refactor: extract DaemonState and remaining helpers from daemon/mod.rs [Midtown #734]

### DIFF
--- a/src/daemon/constants.rs
+++ b/src/daemon/constants.rs
@@ -51,8 +51,8 @@ pub use crate::github_state::PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS;
 /// How long a coworker must be idle before being sent on a break (30 seconds)
 pub(super) const IDLE_BREAK_DURATION: Duration = Duration::from_secs(30);
 
-/// How often to check for idle coworkers (30 seconds)
-pub(super) const IDLE_CHECK_INTERVAL: Duration = Duration::from_secs(30);
+/// How often to run the session monitor tick (idle shutdown, nudges, stuck detection) (30 seconds)
+pub(super) const SESSION_MONITOR_INTERVAL: Duration = Duration::from_secs(30);
 
 /// How often to check lead pane activity for typing indicator (3 seconds)
 pub(super) const LEAD_TYPING_CHECK_INTERVAL: Duration = Duration::from_secs(3);
@@ -78,8 +78,8 @@ pub(super) const LEAD_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(10);
 /// tries to respawn the lead window before the tmux session is fully settled.
 pub(super) const LEAD_HEALTH_CHECK_STARTUP_GRACE: Duration = Duration::from_secs(30);
 
-/// Interval for checking orphaned tasks (5 seconds)
-pub(super) const ORPHAN_CHECK_INTERVAL_SECS: u64 = 5;
+/// Interval for task dispatch: orphan recovery, duplicate detection, spawning, cleanup (5 seconds)
+pub(super) const TASK_DISPATCH_INTERVAL_SECS: u64 = 5;
 
 /// Minimum time a coworker must be alive before being sent on a break (5 minutes)
 /// This prevents spawn storms where coworkers are rapidly sent on breaks.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -12,9 +12,12 @@ pub(crate) mod effects;
 pub(crate) mod events;
 mod health;
 mod helpers;
+mod plugins;
 mod pr;
 mod rpc;
+mod setup;
 pub(crate) mod snapshot;
+mod state;
 mod trackers;
 mod webhook_fwd;
 
@@ -28,653 +31,23 @@ pub use trackers::{
     OrphanTracker, PrIssueTracker, PrIssueType, StuckConditionTracker, StuckConditionType,
 };
 
-use std::collections::{HashMap, HashSet};
-use std::fs::File;
-use std::io::Write;
+pub use state::DaemonConfig;
+pub(crate) use state::DaemonState;
+
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Instant;
 
-use fs2::FileExt;
 use tokio::net::UnixListener;
 use tokio::signal::unix::{SignalKind, signal};
-use tokio::sync::{Mutex, RwLock, broadcast, watch};
+use tokio::sync::{broadcast, watch};
 use tokio::time::interval;
 use tracing::{debug, error, info, warn};
 
-use crate::channel::Channel;
-use crate::config;
 use crate::coworker::CoworkerManager;
 use crate::message::Message;
 use crate::rpc::RequestId;
-use crate::web::{self, WebUpdate};
 use crate::webhook::{WebhookConfig, start_webhook_server};
 use crate::worktree::WorktreeManager;
-
-/// Configuration for the daemon server.
-#[derive(Debug, Clone)]
-pub struct DaemonConfig {
-    /// Path to the Unix socket.
-    pub socket_path: PathBuf,
-    /// Path to the PID file for singleton enforcement.
-    pub pid_file_path: PathBuf,
-    /// Working directory for spawned coworkers.
-    pub workdir: PathBuf,
-    /// Enable verbose logging.
-    pub verbose: bool,
-    /// Port for the webhook server (None to disable).
-    pub webhook_port: Option<u16>,
-    /// GitHub webhook secret for signature verification.
-    pub webhook_secret: Option<String>,
-    /// Interval in seconds to restart webhook forwarder (for reliability).
-    pub webhook_restart_interval_secs: u64,
-    /// Interval in seconds to poll PRs for actionable issues.
-    pub pr_poll_interval_secs: u64,
-    /// Enable chat monitor for @mention routing. Default: true.
-    pub chat_monitor_enabled: bool,
-    /// Maximum number of concurrent coworkers. Default: 16.
-    pub max_coworkers: usize,
-    /// Explicit project name (from --project flag). Overrides auto-detection.
-    pub project_name: Option<String>,
-    /// GitHub username for `gh` CLI authentication.
-    /// When set, runs `gh auth switch --user <github_user>` at daemon startup.
-    pub github_user: Option<String>,
-}
-
-impl Default for DaemonConfig {
-    fn default() -> Self {
-        let project_name = crate::paths::detect_repo_name().unwrap_or_default();
-
-        // Load config.toml for base daemon settings.
-        // Merge: global daemon section < project daemon section < env vars
-        let daemon_section = if project_name.is_empty() {
-            crate::config::GlobalConfig::load().daemon
-        } else {
-            crate::config::get_project_daemon_config(&project_name)
-        };
-
-        // Webhook port: env var -> config.toml -> auto-assign per project
-        // Note: MIDTOWN_WEBHOOK_PORT=0 disables webhook entirely
-        let webhook_port = match std::env::var("MIDTOWN_WEBHOOK_PORT").ok() {
-            Some(s) => s
-                .parse()
-                .ok()
-                .map(|p: u16| if p == 0 { None } else { Some(p) })
-                .unwrap_or(Some(DEFAULT_WEBHOOK_PORT)),
-            None => match daemon_section.webhook_port {
-                Some(0) => None,
-                Some(p) => Some(p),
-                None => {
-                    // Auto-assign a unique port per project, or use default if no project
-                    if project_name.is_empty() {
-                        Some(DEFAULT_WEBHOOK_PORT)
-                    } else {
-                        Some(crate::config::assign_webhook_port(&project_name))
-                    }
-                }
-            },
-        };
-
-        // Webhook secret: env var -> config.toml -> None
-        let webhook_secret = std::env::var("MIDTOWN_WEBHOOK_SECRET")
-            .ok()
-            .or_else(|| daemon_section.webhook_secret.clone());
-
-        // Restart interval: env var -> config.toml -> default
-        let webhook_restart_interval_secs = std::env::var("MIDTOWN_WEBHOOK_RESTART_INTERVAL")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .or(daemon_section.webhook_restart_interval_secs)
-            .unwrap_or(DEFAULT_WEBHOOK_RESTART_INTERVAL_SECS);
-
-        // PR poll interval: env var -> config.toml -> default
-        let pr_poll_interval_secs = std::env::var("MIDTOWN_PR_POLL_INTERVAL")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .or(daemon_section.pr_poll_interval_secs)
-            .unwrap_or(DEFAULT_PR_POLL_INTERVAL_SECS);
-
-        // Chat monitor: env var -> config.toml -> true (enabled by default)
-        let chat_monitor_enabled = match std::env::var("MIDTOWN_CHAT_MONITOR").ok() {
-            Some(s) => s != "0",
-            None => daemon_section.chat_monitor_enabled.unwrap_or(true),
-        };
-
-        // GitHub user: env var -> config.toml -> None
-        let github_user = std::env::var("MIDTOWN_GITHUB_USER")
-            .ok()
-            .or_else(|| daemon_section.github_user.clone());
-
-        // Max concurrent coworkers: env var > project config > global config > default (16)
-        let max_coworkers = std::env::var("MIDTOWN_MAX_COWORKERS")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .or_else(|| {
-                if project_name.is_empty() {
-                    crate::config::GlobalConfig::load().default.max_coworkers()
-                } else {
-                    crate::config::get_project_config(&project_name).max_coworkers()
-                }
-            })
-            .unwrap_or(DEFAULT_MAX_COWORKERS);
-
-        let workdir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-
-        // Ensure project config.toml exists (create minimal one if missing)
-        if !project_name.is_empty() {
-            let _ = crate::config::ensure_project_config(&project_name, &workdir);
-        }
-
-        Self {
-            // Use repo-specific socket path to isolate daemons per project
-            socket_path: crate::paths::daemon_socket(),
-            // Use repo-specific PID file for singleton enforcement
-            pid_file_path: crate::paths::daemon_pid_file(),
-            workdir,
-            verbose: false,
-            webhook_port,
-            webhook_secret,
-            webhook_restart_interval_secs,
-            pr_poll_interval_secs,
-            chat_monitor_enabled,
-            max_coworkers,
-            project_name: None,
-            github_user,
-        }
-    }
-}
-
-/// Ensure required Claude Code plugins are installed.
-///
-/// Reads the required plugins list from config, checks which are already
-/// installed, and installs any missing ones. Failures are logged as warnings
-/// but don't block daemon startup.
-async fn ensure_plugins_installed() {
-    let required = crate::config::get_required_plugins();
-    if required.is_empty() {
-        debug!("No required plugins configured");
-        return;
-    }
-
-    info!("Checking {} required plugins", required.len());
-
-    // Get list of installed plugins
-    let installed = match get_installed_plugins().await {
-        Ok(plugins) => plugins,
-        Err(e) => {
-            warn!("Failed to check installed plugins: {}", e);
-            return;
-        }
-    };
-
-    // Find missing plugins
-    let missing: Vec<_> = required
-        .iter()
-        .filter(|p| !installed.contains(*p))
-        .collect();
-
-    if missing.is_empty() {
-        info!("All required plugins are installed");
-        return;
-    }
-
-    info!("Installing {} missing plugins", missing.len());
-
-    // Install missing plugins
-    for plugin in missing {
-        match install_plugin(plugin).await {
-            Ok(()) => info!("Installed plugin: {}", plugin),
-            Err(e) => warn!("Failed to install plugin {}: {}", plugin, e),
-        }
-    }
-}
-
-/// Get list of installed plugin IDs.
-async fn get_installed_plugins() -> Result<HashSet<String>, String> {
-    let output = tokio::process::Command::new("claude")
-        .args(["plugin", "list", "--json"])
-        .output()
-        .await
-        .map_err(|e| format!("Failed to run claude plugin list: {}", e))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("claude plugin list failed: {}", stderr));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    // Parse JSON output - it's an array of objects with "id" field
-    let plugins: Vec<serde_json::Value> = serde_json::from_str(&stdout)
-        .map_err(|e| format!("Failed to parse plugin list JSON: {}", e))?;
-
-    let ids: HashSet<String> = plugins
-        .iter()
-        .filter_map(|p| p.get("id").and_then(|id| id.as_str()).map(String::from))
-        .collect();
-
-    Ok(ids)
-}
-
-/// Install a plugin by name.
-async fn install_plugin(name: &str) -> Result<(), String> {
-    let output = tokio::process::Command::new("claude")
-        .args(["plugin", "add", name])
-        .output()
-        .await
-        .map_err(|e| format!("Failed to run claude plugin add: {}", e))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(stderr.to_string());
-    }
-
-    Ok(())
-}
-
-/// Unified cache for PR-to-coworker mappings.
-///
-/// Replaces the previous separate fields (`cached_open_pr_branches`,
-/// `cached_merged_pr_coworkers`) with a single struct. Merged refresh timing
-/// uses the shared `CooldownTracker` rather than a standalone timestamp.
-struct PrCoworkerCache {
-    /// Coworker names extracted from open PR branch names.
-    /// Updated every PR poll tick (~30s).
-    open_pr_owners: HashSet<String>,
-    /// Coworker names from recently merged PR branch names.
-    /// Updated every `MERGED_PRS_FETCH_INTERVAL_SECS` (5 minutes via CooldownTracker).
-    merged_pr_owners: HashSet<String>,
-    /// Coworker names whose open PR has all CI checks passing.
-    /// Used by snapshot to determine PR break eligibility.
-    ci_passed_pr_owners: HashSet<String>,
-}
-
-impl PrCoworkerCache {
-    fn new() -> Self {
-        Self {
-            open_pr_owners: HashSet::new(),
-            merged_pr_owners: HashSet::new(),
-            ci_passed_pr_owners: HashSet::new(),
-        }
-    }
-}
-
-/// Shared daemon state.
-pub(crate) struct DaemonState {
-    coworkers: CoworkerManager,
-    channel: Channel,
-    socket_path: PathBuf,
-    /// Consolidated per-coworker lifecycle state (phase + last activity).
-    /// Bundles what was previously `coworker_phases` and `last_coworker_activity`
-    /// into a single map. Entries are created on spawn and cleared on shutdown.
-    coworker_lifecycles: RwLock<HashMap<String, crate::rules::CoworkerLifecycle>>,
-    /// Tracker to avoid spamming the same PR issues
-    pr_issue_tracker: Mutex<PrIssueTracker>,
-    /// Repository name (primary repo)
-    repo_name: String,
-    /// Default branch name (detected at startup, e.g. "main" or "master")
-    default_branch: String,
-    /// Paths to all repos in the project (primary + additional)
-    all_repo_paths: Vec<PathBuf>,
-    /// Unified cooldown tracker for orphan spawning and task nudge rate limiting.
-    cooldowns: std::sync::Mutex<crate::rules::CooldownTracker>,
-    /// Tracks orphaned worktrees — detection time, warning cooldown, and auto-pruning
-    orphan_tracker: std::sync::RwLock<OrphanTracker>,
-    /// Persistent GitHub state (PR reviewer assignments, etc.)
-    github_state: Mutex<crate::github_state::GitHubState>,
-    /// Broadcast sender for pushing channel messages to WebSocket clients
-    web_updates_tx: Option<tokio::sync::broadcast::Sender<WebUpdate>>,
-    /// Consolidated lead typing indicator state (pane hash, working flag, last activity).
-    lead_typing: std::sync::Mutex<trackers::LeadTypingState>,
-    /// Maximum number of concurrent coworkers
-    max_coworkers: usize,
-    /// Web Push notification manager for sending notifications to PWA clients
-    /// (shared with the webserver to avoid race conditions on subscription storage)
-    push_manager: Option<std::sync::Arc<crate::push::PushManager>>,
-    /// Scheduled time to nudge all coworkers after a usage limit expires.
-    /// When a coworker hits an API usage/rate limit, we parse the expiry and store it here.
-    /// The main loop checks this and nudges everyone when the time arrives.
-    usage_limit_nudge_at: Mutex<Option<tokio::time::Instant>>,
-    /// Persistent reminder state (one-shot condition-based notifications)
-    reminder_state: std::sync::Mutex<crate::reminders::ReminderState>,
-    /// Hash of the last PR poll response body, used to skip re-processing when data hasn't changed.
-    /// This doesn't reduce API calls, but avoids redundant lock acquisition and issue detection
-    /// when the PR state hasn't changed between poll cycles.
-    last_pr_poll_hash: Mutex<u64>,
-    /// Unified cache for PR-to-coworker mappings (open + merged + CI status).
-    pr_coworker_cache: std::sync::RwLock<PrCoworkerCache>,
-    /// Saved session IDs for coworkers on PR break, keyed by coworker name.
-    /// When a coworker is shut down for PR break (CI passing, idle), we save their
-    /// session ID here so they can be resumed with `--resume <id>` when PR activity
-    /// (review comments, CI failure, etc.) requires them back.
-    pr_break_sessions: std::sync::RwLock<HashMap<String, String>>,
-    /// Tracks stuck conditions that warrant nudging the lead (no review, unresolved feedback, etc.)
-    stuck_tracker: Mutex<StuckConditionTracker>,
-    /// Per-coworker pane content hash and last-changed timestamp (for stuck detection).
-    /// Maps coworker name → (last_hash, last_changed_at).
-    coworker_pane_hashes: std::sync::Mutex<HashMap<String, (u64, Instant)>>,
-    /// Cached GitHub repo full names (owner/repo) by repo path.
-    /// Repo names never change during a daemon session, so we cache indefinitely.
-    repo_name_cache: std::sync::RwLock<HashMap<PathBuf, String>>,
-    /// User display name from config (e.g. "Ben"). Used to recognize user @mentions
-    /// and identify user-sent messages when the display name differs from "user".
-    user_display_name: Option<String>,
-    /// Per-coworker zombie respawn attempt counter. Tracks how many times each
-    /// coworker has been respawned as a zombie without recovering. Reset when a
-    /// coworker is spawned normally (non-zombie path). Used to cap respawn loops.
-    zombie_respawn_counts: std::sync::Mutex<HashMap<String, u32>>,
-    /// Timestamp of the last received webhook event (monotonic).
-    /// Used by the PR poll task to determine webhook health: if recent,
-    /// polling uses a relaxed interval; if stale or absent, polling is aggressive.
-    last_webhook_event_at: Mutex<Option<tokio::time::Instant>>,
-}
-
-impl DaemonState {
-    /// Get the GitHub full name (owner/repo) for a repo path, using cache.
-    ///
-    /// On first call for a given path, runs `gh repo view --json nameWithOwner`.
-    /// Subsequent calls return the cached value without any API call.
-    fn get_repo_full_name(&self, repo_path: &std::path::Path) -> String {
-        // Fast path: check cache
-        {
-            let cache = self.repo_name_cache.read().unwrap();
-            if let Some(name) = cache.get(repo_path) {
-                return name.clone();
-            }
-        }
-
-        // Slow path: fetch from GitHub API and cache
-        let full_name = std::process::Command::new("gh")
-            .current_dir(repo_path)
-            .args([
-                "repo",
-                "view",
-                "--json",
-                "nameWithOwner",
-                "--jq",
-                ".nameWithOwner",
-            ])
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-            .unwrap_or_default();
-
-        let mut cache = self.repo_name_cache.write().unwrap();
-        cache.insert(repo_path.to_path_buf(), full_name.clone());
-        full_name
-    }
-
-    /// Check if the daemon is at the maximum coworker limit (absolute cap).
-    fn is_at_coworker_limit(&self) -> bool {
-        self.coworkers.list().len() >= self.max_coworkers
-    }
-
-    /// Check if the daemon is at the dev coworker limit.
-    /// Reserves `REVIEW_HEADROOM` slots for reviewers, but always allows at least 1 dev slot.
-    fn is_at_dev_limit(&self) -> bool {
-        let dev_cap = self.max_coworkers.saturating_sub(REVIEW_HEADROOM).max(1);
-        self.coworkers.list().len() >= dev_cap
-    }
-
-    /// Check if a PR has a review comment from a Claude coworker.
-    ///
-    /// Uses `github_state` as the single source of truth. First checks the
-    /// persistent cache; if not found, makes GitHub API calls and caches
-    /// positive results permanently (review status is monotonic).
-    async fn is_pr_reviewed(&self, pr_number: u64) -> bool {
-        // Fast path: check github_state cache (single source of truth)
-        {
-            let github_state = self.github_state.lock().await;
-            if github_state.has_cached_review(pr_number) {
-                debug!(
-                    "PR #{} has cached Claude review (skipping API call)",
-                    pr_number
-                );
-                return true;
-            }
-        }
-
-        // Slow path: check via API calls
-        let has_review = pr::pr_has_claude_review_uncached(pr_number);
-
-        // Cache positive results (review status is monotonic)
-        if has_review {
-            let mut github_state = self.github_state.lock().await;
-            github_state.mark_reviewed_pr(pr_number);
-        }
-
-        has_review
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn new(
-        socket_path: PathBuf,
-        coworkers: CoworkerManager,
-        repo_name: String,
-        all_repo_paths: Vec<PathBuf>,
-        channel: Channel,
-        web_updates_tx: Option<tokio::sync::broadcast::Sender<WebUpdate>>,
-        max_coworkers: usize,
-        push_manager: Option<std::sync::Arc<crate::push::PushManager>>,
-        default_branch: String,
-    ) -> crate::Result<Self> {
-        // Load persistent GitHub state
-        let github_state =
-            crate::github_state::load_state_for_repo(&repo_name).unwrap_or_else(|e| {
-                warn!("Failed to load github-state.json: {}, using defaults", e);
-                crate::github_state::GitHubState::default()
-            });
-
-        // Load persistent reminder state
-        let reminder_path = crate::paths::reminders_file_for_repo(&repo_name);
-        let reminder_state =
-            crate::reminders::ReminderState::load(&reminder_path).unwrap_or_else(|e| {
-                warn!("Failed to load reminders.json: {}, using defaults", e);
-                crate::reminders::ReminderState::default()
-            });
-
-        let user_display_name = config::get_user_display_name_for_project(&repo_name);
-
-        Ok(Self {
-            coworkers,
-            channel,
-            socket_path,
-            coworker_lifecycles: RwLock::new(HashMap::new()),
-            pr_issue_tracker: Mutex::new(PrIssueTracker::new()),
-            repo_name,
-            default_branch,
-            all_repo_paths,
-            cooldowns: std::sync::Mutex::new(crate::rules::CooldownTracker::new()),
-            orphan_tracker: std::sync::RwLock::new(OrphanTracker::new()),
-            github_state: Mutex::new(github_state),
-            web_updates_tx,
-            max_coworkers,
-            push_manager,
-            usage_limit_nudge_at: Mutex::new(None),
-            lead_typing: std::sync::Mutex::new(trackers::LeadTypingState::default()),
-            reminder_state: std::sync::Mutex::new(reminder_state),
-            last_pr_poll_hash: Mutex::new(0),
-            pr_coworker_cache: std::sync::RwLock::new(PrCoworkerCache::new()),
-            pr_break_sessions: std::sync::RwLock::new(HashMap::new()),
-            stuck_tracker: Mutex::new(StuckConditionTracker::new()),
-            coworker_pane_hashes: std::sync::Mutex::new(HashMap::new()),
-            repo_name_cache: std::sync::RwLock::new(HashMap::new()),
-            user_display_name,
-            zombie_respawn_counts: std::sync::Mutex::new(HashMap::new()),
-            last_webhook_event_at: Mutex::new(None),
-        })
-    }
-
-    /// Spawn a coworker and initialize its lifecycle state.
-    ///
-    /// Wraps `CoworkerManager::spawn_with_name` and inserts a fresh
-    /// `CoworkerLifecycle` entry on success, ensuring stale timestamps
-    /// from any previous incarnation are replaced.
-    async fn spawn_coworker(&self, config: &crate::tmux::ClaudeLaunchConfig) -> crate::Result<()> {
-        self.coworkers.spawn_with_name(config)?;
-        let mut lc = self.coworker_lifecycles.write().await;
-        lc.insert(
-            config.name.clone(),
-            crate::rules::CoworkerLifecycle::new_spawn(),
-        );
-        // Clear zombie respawn counter on successful spawn
-        {
-            let mut counts = self.zombie_respawn_counts.lock().unwrap();
-            counts.remove(&config.name);
-        }
-        Ok(())
-    }
-
-    /// Check if a sender name represents the user (either "user" or the configured display name).
-    fn is_user_sender(&self, from: &str) -> bool {
-        from.eq_ignore_ascii_case("user")
-            || self
-                .user_display_name
-                .as_ref()
-                .is_some_and(|dn| dn.eq_ignore_ascii_case(from))
-    }
-
-    /// Send a message to the channel and broadcast it to WebSocket clients.
-    fn send_and_broadcast(&self, message: &Message) -> crate::Result<()> {
-        self.channel.send(message)?;
-        if let Some(ref tx) = self.web_updates_tx {
-            web::broadcast_channel_message(tx, message);
-        }
-        Ok(())
-    }
-
-    /// Send a web push notification to all subscribed PWA clients.
-    ///
-    /// This is fire-and-forget: push sending runs in a background task.
-    fn send_push_notification(&self, title: &str, body: &str, tag: &str) {
-        if let Some(ref pm) = self.push_manager {
-            let payload = crate::push::PushPayload {
-                title: title.to_string(),
-                body: body.to_string(),
-                tag: Some(tag.to_string()),
-                url: None,
-            };
-            let subs = pm.load_subscriptions();
-            if subs.is_empty() {
-                return;
-            }
-            // Clone the Arc to share the same PushManager instance with the async task
-            let pm = pm.clone();
-            tokio::spawn(async move {
-                pm.send_to_all(&payload).await;
-            });
-        }
-    }
-
-    /// Broadcast a coworker status change to WebSocket clients.
-    fn broadcast_coworker_update(&self, name: &str, status: &str, current_task: Option<&str>) {
-        if let Some(ref tx) = self.web_updates_tx {
-            web::broadcast_coworker_status(tx, name, status, current_task);
-        }
-    }
-}
-
-/// Acquire an exclusive lock on the PID file.
-///
-/// This enforces singleton behavior - only one daemon can run per repository.
-/// Load additional WorktreeManagers for multi-repo projects.
-///
-/// Reads the project config to find additional repos (beyond the primary/workdir)
-/// and creates a WorktreeManager for each. Failures are logged but don't prevent
-/// the daemon from starting - the primary repo always works.
-fn load_additional_worktree_managers(
-    project_name: &str,
-    config: &DaemonConfig,
-) -> Vec<WorktreeManager> {
-    let full_config = match crate::config::load_full_project_config(project_name) {
-        Some(c) => c,
-        None => return vec![],
-    };
-
-    let primary = config.workdir.to_string_lossy().to_string();
-    let repos = full_config.project.repos();
-
-    repos
-        .into_iter()
-        .filter(|r| {
-            // Skip the primary repo (it's already handled by the main WorktreeManager)
-            let repo_path = std::path::Path::new(r);
-            repo_path
-                .canonicalize()
-                .ok()
-                .and_then(|canon| {
-                    std::path::Path::new(&primary)
-                        .canonicalize()
-                        .ok()
-                        .map(|p| canon != p)
-                })
-                .unwrap_or_else(|| *r != primary.as_str())
-        })
-        .filter_map(
-            |repo_path| match WorktreeManager::new(std::path::PathBuf::from(repo_path)) {
-                Ok(mgr) => {
-                    info!("Additional repo for coworker worktrees: {}", repo_path);
-                    Some(mgr)
-                }
-                Err(e) => {
-                    warn!("Failed to create worktree manager for {}: {}", repo_path, e);
-                    None
-                }
-            },
-        )
-        .collect()
-}
-
-/// The lock is held for the lifetime of the returned File handle.
-///
-/// Returns an error if another daemon is already running (lock already held).
-fn acquire_pid_lock(pid_path: &PathBuf) -> crate::Result<File> {
-    // Ensure parent directory exists
-    if let Some(parent) = pid_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-
-    // Open or create the PID file
-    let mut file = File::options()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(pid_path)?;
-
-    // Try to acquire an exclusive lock (non-blocking)
-    match file.try_lock_exclusive() {
-        Ok(()) => {
-            // We got the lock - write our PID
-            let pid = std::process::id();
-            file.set_len(0)?; // Truncate any old content
-            writeln!(file, "{}", pid)?;
-            file.sync_all()?;
-            Ok(file)
-        }
-        Err(e) => {
-            // Lock is held by another process
-            // Try to read the existing PID for a better error message
-            let existing_pid = std::fs::read_to_string(pid_path)
-                .ok()
-                .and_then(|s| s.trim().parse::<u32>().ok());
-
-            let msg = match existing_pid {
-                Some(pid) => format!(
-                    "Another daemon is already running (PID {}). Stop it first with 'midtown stop'.",
-                    pid
-                ),
-                None => format!(
-                    "Another daemon is already running. Stop it first with 'midtown stop'. ({})",
-                    e
-                ),
-            };
-
-            Err(crate::Error::Io(std::io::Error::other(msg)))
-        }
-    }
-}
 
 /// Run the daemon server with the given configuration.
 ///
@@ -712,7 +85,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
         .init();
 
     // Ensure required plugins are installed (non-blocking, logs warnings on failure)
-    ensure_plugins_installed().await;
+    plugins::ensure_plugins_installed().await;
 
     // Switch gh CLI to the configured GitHub user (fail loudly if switch fails)
     if let Some(ref github_user) = config.github_user {
@@ -741,7 +114,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
     }
 
     // Acquire exclusive lock on PID file to enforce singleton behavior
-    let pid_file = acquire_pid_lock(&config.pid_file_path)?;
+    let pid_file = setup::acquire_pid_lock(&config.pid_file_path)?;
     info!("Acquired PID lock: {}", config.pid_file_path.display());
 
     // Ensure parent directory exists for socket
@@ -772,7 +145,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
         .unwrap_or_else(|| repo_name.clone());
 
     // Create channel for the repo
-    let channel = Channel::for_repo(&repo_name)?;
+    let channel = crate::channel::Channel::for_repo(&repo_name)?;
     info!("Channel: {}", channel.base_dir().display());
 
     // Remove existing socket file if present
@@ -814,7 +187,8 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
         })?;
 
     // For multi-repo projects, create worktree managers for additional repos
-    let additional_worktree_managers = load_additional_worktree_managers(&project_name, &config);
+    let additional_worktree_managers =
+        setup::load_additional_worktree_managers(&project_name, &config);
     let coworker_manager = CoworkerManager::with_additional_repos(
         session_name,
         worktree_manager,
@@ -912,8 +286,8 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
     let mut sigterm = signal(SignalKind::terminate())?;
     let mut sigint = signal(SignalKind::interrupt())?;
 
-    // Set up idle check interval
-    let mut idle_check_interval = interval(IDLE_CHECK_INTERVAL);
+    // Set up session monitor interval
+    let mut session_monitor_interval = interval(SESSION_MONITOR_INTERVAL);
 
     // Set up lead typing indicator check interval
     let mut lead_typing_interval = interval(LEAD_TYPING_CHECK_INTERVAL);
@@ -952,11 +326,11 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
         debug!("Chat monitor disabled (MIDTOWN_CHAT_MONITOR=0)");
     }
 
-    // Timer for periodic orphan checking
-    let mut orphan_check_interval =
-        tokio::time::interval(std::time::Duration::from_secs(ORPHAN_CHECK_INTERVAL_SECS));
+    // Timer for periodic task dispatch
+    let mut task_dispatch_interval =
+        tokio::time::interval(std::time::Duration::from_secs(TASK_DISPATCH_INTERVAL_SECS));
     // Skip the first tick (which fires immediately)
-    orphan_check_interval.tick().await;
+    task_dispatch_interval.tick().await;
 
     // Timer for periodic channel rotation
     let mut channel_rotation_interval = interval(CHANNEL_ROTATION_CHECK_INTERVAL);
@@ -1099,7 +473,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
             }
 
             // Periodically monitor coworker sessions: idle shutdown, nudges, stuck detection
-            _ = idle_check_interval.tick() => {
+            _ = session_monitor_interval.tick() => {
                 // Sync internal state with actual tmux windows first
                 if let Err(e) = state.coworkers.sync_with_tmux() {
                     warn!("Failed to sync coworker state with tmux: {}", e);
@@ -1136,7 +510,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
             }
 
             // Periodic task dispatch: orphan recovery, duplicate detection, spawning, cleanup
-            _ = orphan_check_interval.tick() => {
+            _ = task_dispatch_interval.tick() => {
                 // event → snapshot → evaluate → execute
                 let snap = snapshot::collect_world_snapshot(&state).await;
                 let tick_effects = events::evaluate_tick(

--- a/src/daemon/plugins.rs
+++ b/src/daemon/plugins.rs
@@ -1,0 +1,95 @@
+//! Plugin management for ensuring required Claude Code plugins are installed.
+//!
+//! Extracted from mod.rs to keep the event loop module thin.
+
+use std::collections::HashSet;
+
+use tracing::{debug, info, warn};
+
+/// Ensure required Claude Code plugins are installed.
+///
+/// Reads the required plugins list from config, checks which are already
+/// installed, and installs any missing ones. Failures are logged as warnings
+/// but don't block daemon startup.
+pub(super) async fn ensure_plugins_installed() {
+    let required = crate::config::get_required_plugins();
+    if required.is_empty() {
+        debug!("No required plugins configured");
+        return;
+    }
+
+    info!("Checking {} required plugins", required.len());
+
+    // Get list of installed plugins
+    let installed = match get_installed_plugins().await {
+        Ok(plugins) => plugins,
+        Err(e) => {
+            warn!("Failed to check installed plugins: {}", e);
+            return;
+        }
+    };
+
+    // Find missing plugins
+    let missing: Vec<_> = required
+        .iter()
+        .filter(|p| !installed.contains(*p))
+        .collect();
+
+    if missing.is_empty() {
+        info!("All required plugins are installed");
+        return;
+    }
+
+    info!("Installing {} missing plugins", missing.len());
+
+    // Install missing plugins
+    for plugin in missing {
+        match install_plugin(plugin).await {
+            Ok(()) => info!("Installed plugin: {}", plugin),
+            Err(e) => warn!("Failed to install plugin {}: {}", plugin, e),
+        }
+    }
+}
+
+/// Get list of installed plugin IDs.
+async fn get_installed_plugins() -> Result<HashSet<String>, String> {
+    let output = tokio::process::Command::new("claude")
+        .args(["plugin", "list", "--json"])
+        .output()
+        .await
+        .map_err(|e| format!("Failed to run claude plugin list: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("claude plugin list failed: {}", stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Parse JSON output - it's an array of objects with "id" field
+    let plugins: Vec<serde_json::Value> = serde_json::from_str(&stdout)
+        .map_err(|e| format!("Failed to parse plugin list JSON: {}", e))?;
+
+    let ids: HashSet<String> = plugins
+        .iter()
+        .filter_map(|p| p.get("id").and_then(|id| id.as_str()).map(String::from))
+        .collect();
+
+    Ok(ids)
+}
+
+/// Install a plugin by name.
+async fn install_plugin(name: &str) -> Result<(), String> {
+    let output = tokio::process::Command::new("claude")
+        .args(["plugin", "add", name])
+        .output()
+        .await
+        .map_err(|e| format!("Failed to run claude plugin add: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(stderr.to_string());
+    }
+
+    Ok(())
+}

--- a/src/daemon/setup.rs
+++ b/src/daemon/setup.rs
@@ -1,0 +1,115 @@
+//! Daemon initialization helpers: PID lock acquisition and worktree loading.
+//!
+//! These functions run once at daemon startup. Extracted from mod.rs to keep
+//! the event loop module thin.
+
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+use fs2::FileExt;
+use tracing::{info, warn};
+
+use super::state::DaemonConfig;
+use crate::worktree::WorktreeManager;
+
+/// Load additional WorktreeManagers for multi-repo projects.
+///
+/// Reads the project config to find additional repos (beyond the primary/workdir)
+/// and creates a WorktreeManager for each. Failures are logged but don't prevent
+/// the daemon from starting - the primary repo always works.
+pub(super) fn load_additional_worktree_managers(
+    project_name: &str,
+    config: &DaemonConfig,
+) -> Vec<WorktreeManager> {
+    let full_config = match crate::config::load_full_project_config(project_name) {
+        Some(c) => c,
+        None => return vec![],
+    };
+
+    let primary = config.workdir.to_string_lossy().to_string();
+    let repos = full_config.project.repos();
+
+    repos
+        .into_iter()
+        .filter(|r| {
+            // Skip the primary repo (it's already handled by the main WorktreeManager)
+            let repo_path = std::path::Path::new(r);
+            repo_path
+                .canonicalize()
+                .ok()
+                .and_then(|canon| {
+                    std::path::Path::new(&primary)
+                        .canonicalize()
+                        .ok()
+                        .map(|p| canon != p)
+                })
+                .unwrap_or_else(|| *r != primary.as_str())
+        })
+        .filter_map(
+            |repo_path| match WorktreeManager::new(std::path::PathBuf::from(repo_path)) {
+                Ok(mgr) => {
+                    info!("Additional repo for coworker worktrees: {}", repo_path);
+                    Some(mgr)
+                }
+                Err(e) => {
+                    warn!("Failed to create worktree manager for {}: {}", repo_path, e);
+                    None
+                }
+            },
+        )
+        .collect()
+}
+
+/// Acquire an exclusive lock on the PID file.
+///
+/// This enforces singleton behavior - only one daemon can run per repository.
+/// The lock is held for the lifetime of the returned File handle.
+///
+/// Returns an error if another daemon is already running (lock already held).
+pub(super) fn acquire_pid_lock(pid_path: &PathBuf) -> crate::Result<File> {
+    // Ensure parent directory exists
+    if let Some(parent) = pid_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    // Open or create the PID file
+    let mut file = File::options()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(pid_path)?;
+
+    // Try to acquire an exclusive lock (non-blocking)
+    match file.try_lock_exclusive() {
+        Ok(()) => {
+            // We got the lock - write our PID
+            let pid = std::process::id();
+            file.set_len(0)?; // Truncate any old content
+            writeln!(file, "{}", pid)?;
+            file.sync_all()?;
+            Ok(file)
+        }
+        Err(e) => {
+            // Lock is held by another process
+            // Try to read the existing PID for a better error message
+            let existing_pid = std::fs::read_to_string(pid_path)
+                .ok()
+                .and_then(|s| s.trim().parse::<u32>().ok());
+
+            let msg = match existing_pid {
+                Some(pid) => format!(
+                    "Another daemon is already running (PID {}). Stop it first with 'midtown stop'.",
+                    pid
+                ),
+                None => format!(
+                    "Another daemon is already running. Stop it first with 'midtown stop'. ({})",
+                    e
+                ),
+            };
+
+            Err(crate::Error::Io(std::io::Error::other(msg)))
+        }
+    }
+}

--- a/src/daemon/state.rs
+++ b/src/daemon/state.rs
@@ -1,0 +1,463 @@
+//! Daemon state types: DaemonConfig, DaemonState, and PrCoworkerCache.
+//!
+//! These are the core data structures that hold the daemon's runtime state.
+//! Extracted from mod.rs to keep the event loop module thin.
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::time::Instant;
+
+use tokio::sync::{Mutex, RwLock};
+use tracing::{debug, warn};
+
+use super::constants::*;
+use super::trackers;
+use crate::channel::Channel;
+use crate::config;
+use crate::coworker::CoworkerManager;
+use crate::message::Message;
+use crate::web::{self, WebUpdate};
+
+/// Configuration for the daemon server.
+#[derive(Debug, Clone)]
+pub struct DaemonConfig {
+    /// Path to the Unix socket.
+    pub socket_path: PathBuf,
+    /// Path to the PID file for singleton enforcement.
+    pub pid_file_path: PathBuf,
+    /// Working directory for spawned coworkers.
+    pub workdir: PathBuf,
+    /// Enable verbose logging.
+    pub verbose: bool,
+    /// Port for the webhook server (None to disable).
+    pub webhook_port: Option<u16>,
+    /// GitHub webhook secret for signature verification.
+    pub webhook_secret: Option<String>,
+    /// Interval in seconds to restart webhook forwarder (for reliability).
+    pub webhook_restart_interval_secs: u64,
+    /// Interval in seconds to poll PRs for actionable issues.
+    pub pr_poll_interval_secs: u64,
+    /// Enable chat monitor for @mention routing. Default: true.
+    pub chat_monitor_enabled: bool,
+    /// Maximum number of concurrent coworkers. Default: 16.
+    pub max_coworkers: usize,
+    /// Explicit project name (from --project flag). Overrides auto-detection.
+    pub project_name: Option<String>,
+    /// GitHub username for `gh` CLI authentication.
+    /// When set, runs `gh auth switch --user <github_user>` at daemon startup.
+    pub github_user: Option<String>,
+}
+
+impl Default for DaemonConfig {
+    fn default() -> Self {
+        let project_name = crate::paths::detect_repo_name().unwrap_or_default();
+
+        // Load config.toml for base daemon settings.
+        // Merge: global daemon section < project daemon section < env vars
+        let daemon_section = if project_name.is_empty() {
+            crate::config::GlobalConfig::load().daemon
+        } else {
+            crate::config::get_project_daemon_config(&project_name)
+        };
+
+        // Webhook port: env var -> config.toml -> auto-assign per project
+        // Note: MIDTOWN_WEBHOOK_PORT=0 disables webhook entirely
+        let webhook_port = match std::env::var("MIDTOWN_WEBHOOK_PORT").ok() {
+            Some(s) => s
+                .parse()
+                .ok()
+                .map(|p: u16| if p == 0 { None } else { Some(p) })
+                .unwrap_or(Some(DEFAULT_WEBHOOK_PORT)),
+            None => match daemon_section.webhook_port {
+                Some(0) => None,
+                Some(p) => Some(p),
+                None => {
+                    // Auto-assign a unique port per project, or use default if no project
+                    if project_name.is_empty() {
+                        Some(DEFAULT_WEBHOOK_PORT)
+                    } else {
+                        Some(crate::config::assign_webhook_port(&project_name))
+                    }
+                }
+            },
+        };
+
+        // Webhook secret: env var -> config.toml -> None
+        let webhook_secret = std::env::var("MIDTOWN_WEBHOOK_SECRET")
+            .ok()
+            .or_else(|| daemon_section.webhook_secret.clone());
+
+        // Restart interval: env var -> config.toml -> default
+        let webhook_restart_interval_secs = std::env::var("MIDTOWN_WEBHOOK_RESTART_INTERVAL")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .or(daemon_section.webhook_restart_interval_secs)
+            .unwrap_or(DEFAULT_WEBHOOK_RESTART_INTERVAL_SECS);
+
+        // PR poll interval: env var -> config.toml -> default
+        let pr_poll_interval_secs = std::env::var("MIDTOWN_PR_POLL_INTERVAL")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .or(daemon_section.pr_poll_interval_secs)
+            .unwrap_or(DEFAULT_PR_POLL_INTERVAL_SECS);
+
+        // Chat monitor: env var -> config.toml -> true (enabled by default)
+        let chat_monitor_enabled = match std::env::var("MIDTOWN_CHAT_MONITOR").ok() {
+            Some(s) => s != "0",
+            None => daemon_section.chat_monitor_enabled.unwrap_or(true),
+        };
+
+        // GitHub user: env var -> config.toml -> None
+        let github_user = std::env::var("MIDTOWN_GITHUB_USER")
+            .ok()
+            .or_else(|| daemon_section.github_user.clone());
+
+        // Max concurrent coworkers: env var > project config > global config > default (16)
+        let max_coworkers = std::env::var("MIDTOWN_MAX_COWORKERS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .or_else(|| {
+                if project_name.is_empty() {
+                    crate::config::GlobalConfig::load().default.max_coworkers()
+                } else {
+                    crate::config::get_project_config(&project_name).max_coworkers()
+                }
+            })
+            .unwrap_or(DEFAULT_MAX_COWORKERS);
+
+        let workdir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+        // Ensure project config.toml exists (create minimal one if missing)
+        if !project_name.is_empty() {
+            let _ = crate::config::ensure_project_config(&project_name, &workdir);
+        }
+
+        Self {
+            // Use repo-specific socket path to isolate daemons per project
+            socket_path: crate::paths::daemon_socket(),
+            // Use repo-specific PID file for singleton enforcement
+            pid_file_path: crate::paths::daemon_pid_file(),
+            workdir,
+            verbose: false,
+            webhook_port,
+            webhook_secret,
+            webhook_restart_interval_secs,
+            pr_poll_interval_secs,
+            chat_monitor_enabled,
+            max_coworkers,
+            project_name: None,
+            github_user,
+        }
+    }
+}
+
+/// Unified cache for PR-to-coworker mappings.
+///
+/// Replaces the previous separate fields (`cached_open_pr_branches`,
+/// `cached_merged_pr_coworkers`) with a single struct. Merged refresh timing
+/// uses the shared `CooldownTracker` rather than a standalone timestamp.
+pub(super) struct PrCoworkerCache {
+    /// Coworker names extracted from open PR branch names.
+    /// Updated every PR poll tick (~30s).
+    pub(super) open_pr_owners: HashSet<String>,
+    /// Coworker names from recently merged PR branch names.
+    /// Updated every `MERGED_PRS_FETCH_INTERVAL_SECS` (5 minutes via CooldownTracker).
+    pub(super) merged_pr_owners: HashSet<String>,
+    /// Coworker names whose open PR has all CI checks passing.
+    /// Used by snapshot to determine PR break eligibility.
+    pub(super) ci_passed_pr_owners: HashSet<String>,
+}
+
+impl PrCoworkerCache {
+    fn new() -> Self {
+        Self {
+            open_pr_owners: HashSet::new(),
+            merged_pr_owners: HashSet::new(),
+            ci_passed_pr_owners: HashSet::new(),
+        }
+    }
+}
+
+/// Shared daemon state.
+pub(crate) struct DaemonState {
+    pub(super) coworkers: CoworkerManager,
+    pub(super) channel: Channel,
+    pub(super) socket_path: PathBuf,
+    /// Consolidated per-coworker lifecycle state (phase + last activity).
+    /// Bundles what was previously `coworker_phases` and `last_coworker_activity`
+    /// into a single map. Entries are created on spawn and cleared on shutdown.
+    pub(super) coworker_lifecycles: RwLock<HashMap<String, crate::rules::CoworkerLifecycle>>,
+    /// Tracker to avoid spamming the same PR issues
+    pub(super) pr_issue_tracker: Mutex<super::PrIssueTracker>,
+    /// Repository name (primary repo)
+    pub(super) repo_name: String,
+    /// Default branch name (detected at startup, e.g. "main" or "master")
+    pub(super) default_branch: String,
+    /// Paths to all repos in the project (primary + additional)
+    pub(super) all_repo_paths: Vec<PathBuf>,
+    /// Unified cooldown tracker for orphan spawning and task nudge rate limiting.
+    pub(super) cooldowns: std::sync::Mutex<crate::rules::CooldownTracker>,
+    /// Tracks orphaned worktrees — detection time, warning cooldown, and auto-pruning
+    pub(super) orphan_tracker: std::sync::RwLock<super::OrphanTracker>,
+    /// Persistent GitHub state (PR reviewer assignments, etc.)
+    pub(super) github_state: Mutex<crate::github_state::GitHubState>,
+    /// Broadcast sender for pushing channel messages to WebSocket clients
+    pub(super) web_updates_tx: Option<tokio::sync::broadcast::Sender<WebUpdate>>,
+    /// Consolidated lead typing indicator state (pane hash, working flag, last activity).
+    pub(super) lead_typing: std::sync::Mutex<trackers::LeadTypingState>,
+    /// Maximum number of concurrent coworkers
+    pub(super) max_coworkers: usize,
+    /// Web Push notification manager for sending notifications to PWA clients
+    /// (shared with the webserver to avoid race conditions on subscription storage)
+    pub(super) push_manager: Option<std::sync::Arc<crate::push::PushManager>>,
+    /// Scheduled time to nudge all coworkers after a usage limit expires.
+    /// When a coworker hits an API usage/rate limit, we parse the expiry and store it here.
+    /// The main loop checks this and nudges everyone when the time arrives.
+    pub(super) usage_limit_nudge_at: Mutex<Option<tokio::time::Instant>>,
+    /// Persistent reminder state (one-shot condition-based notifications)
+    pub(super) reminder_state: std::sync::Mutex<crate::reminders::ReminderState>,
+    /// Hash of the last PR poll response body, used to skip re-processing when data hasn't changed.
+    /// This doesn't reduce API calls, but avoids redundant lock acquisition and issue detection
+    /// when the PR state hasn't changed between poll cycles.
+    pub(super) last_pr_poll_hash: Mutex<u64>,
+    /// Unified cache for PR-to-coworker mappings (open + merged + CI status).
+    pub(super) pr_coworker_cache: std::sync::RwLock<PrCoworkerCache>,
+    /// Saved session IDs for coworkers on PR break, keyed by coworker name.
+    /// When a coworker is shut down for PR break (CI passing, idle), we save their
+    /// session ID here so they can be resumed with `--resume <id>` when PR activity
+    /// (review comments, CI failure, etc.) requires them back.
+    pub(super) pr_break_sessions: std::sync::RwLock<HashMap<String, String>>,
+    /// Tracks stuck conditions that warrant nudging the lead (no review, unresolved feedback, etc.)
+    pub(super) stuck_tracker: Mutex<super::StuckConditionTracker>,
+    /// Per-coworker pane content hash and last-changed timestamp (for stuck detection).
+    /// Maps coworker name → (last_hash, last_changed_at).
+    pub(super) coworker_pane_hashes: std::sync::Mutex<HashMap<String, (u64, Instant)>>,
+    /// Cached GitHub repo full names (owner/repo) by repo path.
+    /// Repo names never change during a daemon session, so we cache indefinitely.
+    pub(super) repo_name_cache: std::sync::RwLock<HashMap<PathBuf, String>>,
+    /// User display name from config (e.g. "Ben"). Used to recognize user @mentions
+    /// and identify user-sent messages when the display name differs from "user".
+    pub(super) user_display_name: Option<String>,
+    /// Per-coworker zombie respawn attempt counter. Tracks how many times each
+    /// coworker has been respawned as a zombie without recovering. Reset when a
+    /// coworker is spawned normally (non-zombie path). Used to cap respawn loops.
+    pub(super) zombie_respawn_counts: std::sync::Mutex<HashMap<String, u32>>,
+    /// Timestamp of the last received webhook event (monotonic).
+    /// Used by the PR poll task to determine webhook health: if recent,
+    /// polling uses a relaxed interval; if stale or absent, polling is aggressive.
+    pub(super) last_webhook_event_at: Mutex<Option<tokio::time::Instant>>,
+}
+
+impl DaemonState {
+    /// Get the GitHub full name (owner/repo) for a repo path, using cache.
+    ///
+    /// On first call for a given path, runs `gh repo view --json nameWithOwner`.
+    /// Subsequent calls return the cached value without any API call.
+    pub(super) fn get_repo_full_name(&self, repo_path: &std::path::Path) -> String {
+        // Fast path: check cache
+        {
+            let cache = self.repo_name_cache.read().unwrap();
+            if let Some(name) = cache.get(repo_path) {
+                return name.clone();
+            }
+        }
+
+        // Slow path: fetch from GitHub API and cache
+        let full_name = std::process::Command::new("gh")
+            .current_dir(repo_path)
+            .args([
+                "repo",
+                "view",
+                "--json",
+                "nameWithOwner",
+                "--jq",
+                ".nameWithOwner",
+            ])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_default();
+
+        let mut cache = self.repo_name_cache.write().unwrap();
+        cache.insert(repo_path.to_path_buf(), full_name.clone());
+        full_name
+    }
+
+    /// Check if the daemon is at the maximum coworker limit (absolute cap).
+    pub(super) fn is_at_coworker_limit(&self) -> bool {
+        self.coworkers.list().len() >= self.max_coworkers
+    }
+
+    /// Check if the daemon is at the dev coworker limit.
+    /// Reserves `REVIEW_HEADROOM` slots for reviewers, but always allows at least 1 dev slot.
+    pub(super) fn is_at_dev_limit(&self) -> bool {
+        let dev_cap = self.max_coworkers.saturating_sub(REVIEW_HEADROOM).max(1);
+        self.coworkers.list().len() >= dev_cap
+    }
+
+    /// Check if a PR has a review comment from a Claude coworker.
+    ///
+    /// Uses `github_state` as the single source of truth. First checks the
+    /// persistent cache; if not found, makes GitHub API calls and caches
+    /// positive results permanently (review status is monotonic).
+    pub(super) async fn is_pr_reviewed(&self, pr_number: u64) -> bool {
+        // Fast path: check github_state cache (single source of truth)
+        {
+            let github_state = self.github_state.lock().await;
+            if github_state.has_cached_review(pr_number) {
+                debug!(
+                    "PR #{} has cached Claude review (skipping API call)",
+                    pr_number
+                );
+                return true;
+            }
+        }
+
+        // Slow path: check via API calls
+        let has_review = super::pr::pr_has_claude_review_uncached(pr_number);
+
+        // Cache positive results (review status is monotonic)
+        if has_review {
+            let mut github_state = self.github_state.lock().await;
+            github_state.mark_reviewed_pr(pr_number);
+        }
+
+        has_review
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
+        socket_path: PathBuf,
+        coworkers: CoworkerManager,
+        repo_name: String,
+        all_repo_paths: Vec<PathBuf>,
+        channel: Channel,
+        web_updates_tx: Option<tokio::sync::broadcast::Sender<WebUpdate>>,
+        max_coworkers: usize,
+        push_manager: Option<std::sync::Arc<crate::push::PushManager>>,
+        default_branch: String,
+    ) -> crate::Result<Self> {
+        // Load persistent GitHub state
+        let github_state =
+            crate::github_state::load_state_for_repo(&repo_name).unwrap_or_else(|e| {
+                warn!("Failed to load github-state.json: {}, using defaults", e);
+                crate::github_state::GitHubState::default()
+            });
+
+        // Load persistent reminder state
+        let reminder_path = crate::paths::reminders_file_for_repo(&repo_name);
+        let reminder_state =
+            crate::reminders::ReminderState::load(&reminder_path).unwrap_or_else(|e| {
+                warn!("Failed to load reminders.json: {}, using defaults", e);
+                crate::reminders::ReminderState::default()
+            });
+
+        let user_display_name = config::get_user_display_name_for_project(&repo_name);
+
+        Ok(Self {
+            coworkers,
+            channel,
+            socket_path,
+            coworker_lifecycles: RwLock::new(HashMap::new()),
+            pr_issue_tracker: Mutex::new(super::PrIssueTracker::new()),
+            repo_name,
+            default_branch,
+            all_repo_paths,
+            cooldowns: std::sync::Mutex::new(crate::rules::CooldownTracker::new()),
+            orphan_tracker: std::sync::RwLock::new(super::OrphanTracker::new()),
+            github_state: Mutex::new(github_state),
+            web_updates_tx,
+            max_coworkers,
+            push_manager,
+            usage_limit_nudge_at: Mutex::new(None),
+            lead_typing: std::sync::Mutex::new(trackers::LeadTypingState::default()),
+            reminder_state: std::sync::Mutex::new(reminder_state),
+            last_pr_poll_hash: Mutex::new(0),
+            pr_coworker_cache: std::sync::RwLock::new(PrCoworkerCache::new()),
+            pr_break_sessions: std::sync::RwLock::new(HashMap::new()),
+            stuck_tracker: Mutex::new(super::StuckConditionTracker::new()),
+            coworker_pane_hashes: std::sync::Mutex::new(HashMap::new()),
+            repo_name_cache: std::sync::RwLock::new(HashMap::new()),
+            user_display_name,
+            zombie_respawn_counts: std::sync::Mutex::new(HashMap::new()),
+            last_webhook_event_at: Mutex::new(None),
+        })
+    }
+
+    /// Spawn a coworker and initialize its lifecycle state.
+    ///
+    /// Wraps `CoworkerManager::spawn_with_name` and inserts a fresh
+    /// `CoworkerLifecycle` entry on success, ensuring stale timestamps
+    /// from any previous incarnation are replaced.
+    pub(super) async fn spawn_coworker(
+        &self,
+        config: &crate::tmux::ClaudeLaunchConfig,
+    ) -> crate::Result<()> {
+        self.coworkers.spawn_with_name(config)?;
+        let mut lc = self.coworker_lifecycles.write().await;
+        lc.insert(
+            config.name.clone(),
+            crate::rules::CoworkerLifecycle::new_spawn(),
+        );
+        // Clear zombie respawn counter on successful spawn
+        {
+            let mut counts = self.zombie_respawn_counts.lock().unwrap();
+            counts.remove(&config.name);
+        }
+        Ok(())
+    }
+
+    /// Check if a sender name represents the user (either "user" or the configured display name).
+    pub(super) fn is_user_sender(&self, from: &str) -> bool {
+        from.eq_ignore_ascii_case("user")
+            || self
+                .user_display_name
+                .as_ref()
+                .is_some_and(|dn| dn.eq_ignore_ascii_case(from))
+    }
+
+    /// Send a message to the channel and broadcast it to WebSocket clients.
+    pub(super) fn send_and_broadcast(&self, message: &Message) -> crate::Result<()> {
+        self.channel.send(message)?;
+        if let Some(ref tx) = self.web_updates_tx {
+            web::broadcast_channel_message(tx, message);
+        }
+        Ok(())
+    }
+
+    /// Send a web push notification to all subscribed PWA clients.
+    ///
+    /// This is fire-and-forget: push sending runs in a background task.
+    pub(super) fn send_push_notification(&self, title: &str, body: &str, tag: &str) {
+        if let Some(ref pm) = self.push_manager {
+            let payload = crate::push::PushPayload {
+                title: title.to_string(),
+                body: body.to_string(),
+                tag: Some(tag.to_string()),
+                url: None,
+            };
+            let subs = pm.load_subscriptions();
+            if subs.is_empty() {
+                return;
+            }
+            // Clone the Arc to share the same PushManager instance with the async task
+            let pm = pm.clone();
+            tokio::spawn(async move {
+                pm.send_to_all(&payload).await;
+            });
+        }
+    }
+
+    /// Broadcast a coworker status change to WebSocket clients.
+    pub(super) fn broadcast_coworker_update(
+        &self,
+        name: &str,
+        status: &str,
+        current_task: Option<&str>,
+    ) {
+        if let Some(ref tx) = self.web_updates_tx {
+            web::broadcast_coworker_status(tx, name, status, current_task);
+        }
+    }
+}


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Extract `DaemonConfig`, `PrCoworkerCache`, and `DaemonState` (with all impl methods) to `src/daemon/state.rs`
- Extract plugin management functions (`ensure_plugins_installed`, `get_installed_plugins`, `install_plugin`) to `src/daemon/plugins.rs`
- Extract initialization helpers (`load_additional_worktree_managers`, `acquire_pid_lock`) to `src/daemon/setup.rs`
- Rename misleading constants: `IDLE_CHECK_INTERVAL` → `SESSION_MONITOR_INTERVAL`, `ORPHAN_CHECK_INTERVAL_SECS` → `TASK_DISPATCH_INTERVAL_SECS`
- `mod.rs` now contains only: module declarations, re-exports, `run()` event loop, and tests (~1675 lines, down from ~2300)

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (all 104 tests)
- [x] `cargo clippy -- -D warnings` passes with no warnings
- [x] `cargo fmt -- --check` passes
- [x] All submodule imports (`effects.rs`, `rpc.rs`, `health.rs`, `chat.rs`, `snapshot.rs`, `pr.rs`, `events.rs`, `dispatch.rs`) continue to resolve `DaemonState` via re-export — zero changes needed in consuming modules