### PR TITLE
feat: consolidate persistent state into unified daemon-state.json [Midtown #731]

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -166,13 +166,13 @@ pub(super) async fn nudge_discovered_coworkers(state: &DaemonState) {
         }
     }
 
-    // Check reviewer assignments from github-state.json
+    // Check reviewer assignments from daemon-state.json
     let reviewer_prs: std::collections::HashMap<String, u64> = {
-        let github_state = state.github_state.lock().await;
+        let ps = state.persistent_state.lock().await;
         discovered
             .iter()
             .filter_map(|name| {
-                github_state
+                ps.github
                     .pr_for_reviewer(name)
                     .map(|pr| (name.to_lowercase(), pr))
             })

--- a/src/daemon/events.rs
+++ b/src/daemon/events.rs
@@ -66,7 +66,7 @@ pub async fn evaluate_tick(
             effects.extend(super::dispatch::check_and_recover_orphans(snap, state));
             effects.extend(super::dispatch::spawn_for_pending_tasks(snap, state));
             effects.extend(super::health::check_and_respawn_zombies(snap, state));
-            effects.extend(super::health::check_and_fire_reminders(snap, state));
+            effects.extend(super::health::check_and_fire_reminders(snap, state).await);
             effects
         }
     }

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -751,18 +751,18 @@ pub(super) fn check_and_respawn_zombies(
     effects
 }
 
-pub(super) fn check_and_fire_reminders(
+pub(super) async fn check_and_fire_reminders(
     snap: &snapshot::WorldSnapshot,
     state: &DaemonState,
 ) -> Vec<Effect> {
     // Convert snapshot HashSet to Vec for evaluate_trigger compatibility
     let open_pr_coworkers: Vec<String> = snap.coworkers_with_open_prs.iter().cloned().collect();
 
-    let mut reminder_state = state.reminder_state.lock().unwrap();
+    let mut ps = state.persistent_state.lock().await;
     let mut fired_any = false;
     let mut effects = Vec::new();
 
-    for reminder in &mut reminder_state.reminders {
+    for reminder in &mut ps.reminders.reminders {
         if reminder.fired {
             continue;
         }
@@ -783,11 +783,11 @@ pub(super) fn check_and_fire_reminders(
         }
     }
 
-    if fired_any {
-        let path = crate::paths::reminders_file_for_repo(&snap.repo_name);
-        if let Err(e) = reminder_state.save(&path) {
-            error!("Failed to save reminders after firing: {}", e);
-        }
+    if fired_any && let Err(e) = ps.save_for_repo(&snap.repo_name) {
+        error!(
+            "Failed to save daemon-state.json after firing reminders: {}",
+            e
+        );
     }
 
     effects

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -15,6 +15,7 @@ mod helpers;
 mod pr;
 mod rpc;
 pub(crate) mod snapshot;
+pub(crate) mod state;
 mod trackers;
 mod webhook_fwd;
 
@@ -320,8 +321,8 @@ pub(crate) struct DaemonState {
     cooldowns: std::sync::Mutex<crate::rules::CooldownTracker>,
     /// Tracks orphaned worktrees — detection time, warning cooldown, and auto-pruning
     orphan_tracker: std::sync::RwLock<OrphanTracker>,
-    /// Persistent GitHub state (PR reviewer assignments, etc.)
-    github_state: Mutex<crate::github_state::GitHubState>,
+    /// Unified persistent state (GitHub + reminders), saved to daemon-state.json.
+    persistent_state: Mutex<state::DaemonPersistentState>,
     /// Broadcast sender for pushing channel messages to WebSocket clients
     web_updates_tx: Option<tokio::sync::broadcast::Sender<WebUpdate>>,
     /// Consolidated lead typing indicator state (pane hash, working flag, last activity).
@@ -335,8 +336,6 @@ pub(crate) struct DaemonState {
     /// When a coworker hits an API usage/rate limit, we parse the expiry and store it here.
     /// The main loop checks this and nudges everyone when the time arrives.
     usage_limit_nudge_at: Mutex<Option<tokio::time::Instant>>,
-    /// Persistent reminder state (one-shot condition-based notifications)
-    reminder_state: std::sync::Mutex<crate::reminders::ReminderState>,
     /// Hash of the last PR poll response body, used to skip re-processing when data hasn't changed.
     /// This doesn't reduce API calls, but avoids redundant lock acquisition and issue detection
     /// when the PR state hasn't changed between poll cycles.
@@ -419,14 +418,14 @@ impl DaemonState {
 
     /// Check if a PR has a review comment from a Claude coworker.
     ///
-    /// Uses `github_state` as the single source of truth. First checks the
-    /// persistent cache; if not found, makes GitHub API calls and caches
+    /// Uses the persistent state cache as the single source of truth. First
+    /// checks the cache; if not found, makes GitHub API calls and caches
     /// positive results permanently (review status is monotonic).
     async fn is_pr_reviewed(&self, pr_number: u64) -> bool {
-        // Fast path: check github_state cache (single source of truth)
+        // Fast path: check persistent cache (single source of truth)
         {
-            let github_state = self.github_state.lock().await;
-            if github_state.has_cached_review(pr_number) {
+            let ps = self.persistent_state.lock().await;
+            if ps.github.has_cached_review(pr_number) {
                 debug!(
                     "PR #{} has cached Claude review (skipping API call)",
                     pr_number
@@ -440,8 +439,8 @@ impl DaemonState {
 
         // Cache positive results (review status is monotonic)
         if has_review {
-            let mut github_state = self.github_state.lock().await;
-            github_state.mark_reviewed_pr(pr_number);
+            let mut ps = self.persistent_state.lock().await;
+            ps.github.mark_reviewed_pr(pr_number);
         }
 
         has_review
@@ -459,19 +458,11 @@ impl DaemonState {
         push_manager: Option<std::sync::Arc<crate::push::PushManager>>,
         default_branch: String,
     ) -> crate::Result<Self> {
-        // Load persistent GitHub state
-        let github_state =
-            crate::github_state::load_state_for_repo(&repo_name).unwrap_or_else(|e| {
-                warn!("Failed to load github-state.json: {}, using defaults", e);
-                crate::github_state::GitHubState::default()
-            });
-
-        // Load persistent reminder state
-        let reminder_path = crate::paths::reminders_file_for_repo(&repo_name);
-        let reminder_state =
-            crate::reminders::ReminderState::load(&reminder_path).unwrap_or_else(|e| {
-                warn!("Failed to load reminders.json: {}, using defaults", e);
-                crate::reminders::ReminderState::default()
+        // Load unified persistent state (migrates from legacy files if needed)
+        let persistent_state = state::DaemonPersistentState::load_for_repo(&repo_name)
+            .unwrap_or_else(|e| {
+                warn!("Failed to load daemon-state.json: {}, using defaults", e);
+                state::DaemonPersistentState::default()
             });
 
         let user_display_name = config::get_user_display_name_for_project(&repo_name);
@@ -487,13 +478,12 @@ impl DaemonState {
             all_repo_paths,
             cooldowns: std::sync::Mutex::new(crate::rules::CooldownTracker::new()),
             orphan_tracker: std::sync::RwLock::new(OrphanTracker::new()),
-            github_state: Mutex::new(github_state),
+            persistent_state: Mutex::new(persistent_state),
             web_updates_tx,
             max_coworkers,
             push_manager,
             usage_limit_nudge_at: Mutex::new(None),
             lead_typing: std::sync::Mutex::new(trackers::LeadTypingState::default()),
-            reminder_state: std::sync::Mutex::new(reminder_state),
             last_pr_poll_hash: Mutex::new(0),
             pr_coworker_cache: std::sync::RwLock::new(PrCoworkerCache::new()),
             pr_break_sessions: std::sync::RwLock::new(HashMap::new()),
@@ -1019,16 +1009,13 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                     });
                 }
 
-                // Queue a reviewer spawn after the delay (persisted in github-state.json)
+                // Queue a reviewer spawn after the delay (persisted in daemon-state.json)
                 if let Some(pr_number) = webhook_event.needs_review {
                     let spawn_after = chrono::Utc::now()
                         + chrono::Duration::seconds(PR_REVIEW_DELAY_SECS as i64);
-                    let mut github_state = state.github_state.lock().await;
-                    github_state.add_pending_review_spawn(pr_number, spawn_after);
-                    if let Err(e) = crate::github_state::save_state_for_repo(
-                        &state.repo_name,
-                        &github_state,
-                    ) {
+                    let mut ps = state.persistent_state.lock().await;
+                    ps.github.add_pending_review_spawn(pr_number, spawn_after);
+                    if let Err(e) = ps.save_for_repo(&state.repo_name) {
                         warn!("Failed to persist pending review spawn: {}", e);
                     }
                     info!(
@@ -1072,8 +1059,8 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                         "Webhook: caching review status for PR #{} (review comment detected)",
                         pr_number
                     );
-                    let mut github_state = state.github_state.lock().await;
-                    github_state.mark_reviewed_pr(pr_number);
+                    let mut ps = state.persistent_state.lock().await;
+                    ps.github.mark_reviewed_pr(pr_number);
                 }
 
                 // Route @mentions in webhook messages directly (chat monitor skips

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -321,8 +321,8 @@ async fn poll_prs_for_issues(
         tracker.cleanup();
     }
     {
-        let mut github_state = state.github_state.lock().await;
-        github_state.cleanup_expired_preserving(&active_coworker_names);
+        let mut ps = state.persistent_state.lock().await;
+        ps.github.cleanup_expired_preserving(&active_coworker_names);
     }
     {
         let mut cooldowns = state.cooldowns.lock().unwrap();
@@ -396,11 +396,11 @@ async fn poll_prs_for_issues(
             .iter()
             .filter_map(|pr| pr.get("number").and_then(|n| n.as_u64()))
             .collect();
-        let mut github_state = state.github_state.lock().await;
-        github_state.cleanup_closed_prs(&open_pr_numbers);
-        github_state.cleanup_expired_preserving(&active_coworker_names);
-        if let Err(e) = crate::github_state::save_state_for_repo(&state.repo_name, &github_state) {
-            warn!("Failed to save github-state.json after cleanup: {}", e);
+        let mut ps = state.persistent_state.lock().await;
+        ps.github.cleanup_closed_prs(&open_pr_numbers);
+        ps.github.cleanup_expired_preserving(&active_coworker_names);
+        if let Err(e) = ps.save_for_repo(&state.repo_name) {
+            warn!("Failed to save daemon-state.json after cleanup: {}", e);
         }
     }
 
@@ -623,8 +623,8 @@ async fn check_for_stuck_conditions(state: &DaemonState, prs: &[serde_json::Valu
         if review_decision.is_empty() && age_secs >= STUCK_NO_REVIEW_DURATION.as_secs() {
             // Check if a reviewer is assigned (daemon tried to self-heal)
             let is_assigned = {
-                let github_state = state.github_state.lock().await;
-                github_state.is_assigned(pr_number)
+                let ps = state.persistent_state.lock().await;
+                ps.github.is_assigned(pr_number)
             };
 
             tracker.track(&pr_id, StuckConditionType::NoReview);
@@ -782,8 +782,8 @@ async fn check_for_stuck_conditions(state: &DaemonState, prs: &[serde_json::Valu
             .count();
 
         let current_review_count = {
-            let github_state = state.github_state.lock().await;
-            github_state.active_count()
+            let ps = state.persistent_state.lock().await;
+            ps.github.active_count()
         };
 
         // Backlog exists when more PRs need review than we can handle
@@ -841,8 +841,8 @@ fn nudge_lead_stuck(state: &DaemonState, message: &str) {
 async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value]) {
     // Check rate limit
     let current_review_count = {
-        let github_state = state.github_state.lock().await;
-        github_state.active_count()
+        let ps = state.persistent_state.lock().await;
+        ps.github.active_count()
     };
 
     if current_review_count >= MAX_CONCURRENT_REVIEWS {
@@ -896,8 +896,8 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
             // If so, leave the assignment in place so the idle shutdown path can
             // properly send them off with break_review_complete() instead of break_no_pr().
             let reviewer_still_running = {
-                let github_state = state.github_state.lock().await;
-                if let Some(reviewer_name) = github_state.get_reviewer(pr_number) {
+                let ps = state.persistent_state.lock().await;
+                if let Some(reviewer_name) = ps.github.get_reviewer(pr_number) {
                     state.coworkers.get(reviewer_name).is_some()
                 } else {
                     false
@@ -911,14 +911,12 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
                 );
             } else {
                 // Free the tracker slot — the review completed and the reviewer is gone
-                let mut github_state = state.github_state.lock().await;
-                if github_state.is_assigned(pr_number) {
+                let mut ps = state.persistent_state.lock().await;
+                if ps.github.is_assigned(pr_number) {
                     debug!("PR #{} review completed, freeing tracker slot", pr_number);
-                    github_state.remove_assignment(pr_number);
-                    if let Err(e) =
-                        crate::github_state::save_state_for_repo(&state.repo_name, &github_state)
-                    {
-                        warn!("Failed to save github-state.json: {}", e);
+                    ps.github.remove_assignment(pr_number);
+                    if let Err(e) = ps.save_for_repo(&state.repo_name) {
+                        warn!("Failed to save daemon-state.json: {}", e);
                     }
                 }
             }
@@ -1068,8 +1066,8 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
         // This runs AFTER review detection so completed reviews are always detected,
         // but prevents spawning duplicate reviewers for PRs already under review.
         {
-            let github_state = state.github_state.lock().await;
-            if github_state.is_assigned(pr_number) {
+            let ps = state.persistent_state.lock().await;
+            if ps.github.is_assigned(pr_number) {
                 debug!("PR #{} already assigned for review", pr_number);
                 continue;
             }
@@ -1118,12 +1116,10 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
 
                 // Record the assignment in persistent state
                 {
-                    let mut github_state = state.github_state.lock().await;
-                    github_state.assign_reviewer(pr_number, &new_coworker);
-                    if let Err(e) =
-                        crate::github_state::save_state_for_repo(&state.repo_name, &github_state)
-                    {
-                        warn!("Failed to save github-state.json: {}", e);
+                    let mut ps = state.persistent_state.lock().await;
+                    ps.github.assign_reviewer(pr_number, &new_coworker);
+                    if let Err(e) = ps.save_for_repo(&state.repo_name) {
+                        warn!("Failed to save daemon-state.json: {}", e);
                     }
                 }
 
@@ -1186,11 +1182,10 @@ async fn spawn_reviewers_for_prs(state: &DaemonState, prs: &[serde_json::Value])
 pub(super) async fn process_pending_review_spawns(state: &DaemonState) {
     // Drain ready spawns from persistent state
     let ready_prs = {
-        let mut github_state = state.github_state.lock().await;
-        let ready = github_state.drain_ready_review_spawns();
+        let mut ps = state.persistent_state.lock().await;
+        let ready = ps.github.drain_ready_review_spawns();
         if !ready.is_empty()
-            && let Err(e) =
-                crate::github_state::save_state_for_repo(&state.repo_name, &github_state)
+            && let Err(e) = ps.save_for_repo(&state.repo_name)
         {
             warn!("Failed to persist review spawn drain: {}", e);
         }

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -214,13 +214,13 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
 
             match (trigger, message) {
                 (Some("all-work-merged"), Some(msg)) => {
-                    handle_reminder_create(request.id, msg, state)
+                    handle_reminder_create(request.id, msg, state).await
                 }
                 _ => Response::error(request.id, RpcError::invalid_params()),
             }
         }
 
-        "reminder.list" => handle_reminder_list(request.id, state),
+        "reminder.list" => handle_reminder_list(request.id, state).await,
 
         "reminder.cancel" => {
             let id = request
@@ -230,7 +230,7 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
                 .and_then(|v| v.as_str());
 
             match id {
-                Some(id) => handle_reminder_cancel(request.id, id, state),
+                Some(id) => handle_reminder_cancel(request.id, id, state).await,
                 None => Response::error(request.id, RpcError::invalid_params()),
             }
         }
@@ -765,16 +765,15 @@ fn handle_channel_read(id: RequestId, all: bool, state: &DaemonState) -> Respons
 }
 
 /// Handle reminder.create RPC method.
-fn handle_reminder_create(id: RequestId, message: &str, state: &DaemonState) -> Response {
-    let mut reminder_state = state.reminder_state.lock().unwrap();
-    let reminder_id = reminder_state.add(
+async fn handle_reminder_create(id: RequestId, message: &str, state: &DaemonState) -> Response {
+    let mut ps = state.persistent_state.lock().await;
+    let reminder_id = ps.reminders.add(
         crate::reminders::ReminderTrigger::AllWorkMerged,
         message.to_string(),
     );
 
-    let path = crate::paths::reminders_file_for_repo(&state.repo_name);
-    if let Err(e) = reminder_state.save(&path) {
-        error!("Failed to save reminders: {}", e);
+    if let Err(e) = ps.save_for_repo(&state.repo_name) {
+        error!("Failed to save daemon-state.json: {}", e);
     }
 
     let confirmation = format!(
@@ -786,9 +785,9 @@ fn handle_reminder_create(id: RequestId, message: &str, state: &DaemonState) -> 
 }
 
 /// Handle reminder.list RPC method.
-fn handle_reminder_list(id: RequestId, state: &DaemonState) -> Response {
-    let reminder_state = state.reminder_state.lock().unwrap();
-    let active = reminder_state.active();
+async fn handle_reminder_list(id: RequestId, state: &DaemonState) -> Response {
+    let ps = state.persistent_state.lock().await;
+    let active = ps.reminders.active();
 
     if active.is_empty() {
         return Response::success(id, serde_json::json!({ "message": "No active reminders." }));
@@ -812,12 +811,11 @@ fn handle_reminder_list(id: RequestId, state: &DaemonState) -> Response {
 }
 
 /// Handle reminder.cancel RPC method.
-fn handle_reminder_cancel(id: RequestId, reminder_id: &str, state: &DaemonState) -> Response {
-    let mut reminder_state = state.reminder_state.lock().unwrap();
-    if reminder_state.cancel(reminder_id) {
-        let path = crate::paths::reminders_file_for_repo(&state.repo_name);
-        if let Err(e) = reminder_state.save(&path) {
-            error!("Failed to save reminders: {}", e);
+async fn handle_reminder_cancel(id: RequestId, reminder_id: &str, state: &DaemonState) -> Response {
+    let mut ps = state.persistent_state.lock().await;
+    if ps.reminders.cancel(reminder_id) {
+        if let Err(e) = ps.save_for_repo(&state.repo_name) {
+            error!("Failed to save daemon-state.json: {}", e);
         }
         let msg = format!("Reminder {} cancelled.", reminder_id);
         info!("{}", msg);
@@ -986,9 +984,9 @@ fn get_all_tasks() -> Vec<serde_json::Value> {
 fn handle_kanban_data(id: RequestId, state: &DaemonState) -> Response {
     // Get reviewer assignments from GitHubState (best-effort via try_lock)
     let reviewer_assignments: HashMap<u64, crate::github_state::PrReviewerAssignment> = state
-        .github_state
+        .persistent_state
         .try_lock()
-        .map(|gs| gs.active_assignments())
+        .map(|ps| ps.github.active_assignments())
         .unwrap_or_default();
 
     // Fetch PRs and repo metadata from all repos in the project.

--- a/src/daemon/snapshot.rs
+++ b/src/daemon/snapshot.rs
@@ -168,13 +168,13 @@ pub async fn collect_world_snapshot(state: &DaemonState) -> WorldSnapshot {
 
     // ── Reviewer state ──────────────────────────────────────────────────
     let (active_reviewers, reviewer_pr_assignments) = {
-        let github_state = state.github_state.lock().await;
-        let reviewers = github_state.active_reviewers();
+        let ps = state.persistent_state.lock().await;
+        let reviewers = ps.github.active_reviewers();
         // Collect reviewer → PR assignments for all active coworkers
         let assignments: HashMap<String, u64> = active_coworkers
             .iter()
             .filter_map(|cw| {
-                github_state
+                ps.github
                     .pr_for_reviewer(&cw.name)
                     .map(|pr| (cw.name.clone(), pr))
             })

--- a/src/daemon/state.rs
+++ b/src/daemon/state.rs
@@ -1,0 +1,217 @@
+//! Unified persistent state for the midtown daemon.
+//!
+//! Consolidates what was previously spread across multiple JSON files
+//! (github-state.json, reminders.json) into a single daemon-state.json.
+//! Loaded once at startup, saved after any mutation.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{self, ErrorKind};
+use tracing::{debug, warn};
+
+use crate::github_state::GitHubState;
+use crate::reminders::ReminderState;
+
+/// All persistent daemon state in one struct.
+///
+/// Serialized to `~/.midtown/projects/<repo>/daemon-state.json`.
+/// Contains GitHub PR state and one-shot reminders. Loaded at startup
+/// and saved after every mutation.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DaemonPersistentState {
+    /// GitHub PR reviewer assignments, review cache, pending spawns.
+    #[serde(default)]
+    pub github: GitHubState,
+
+    /// One-shot condition-based reminders.
+    #[serde(default)]
+    pub reminders: ReminderState,
+}
+
+impl DaemonPersistentState {
+    /// Load from the unified state file for a repository.
+    ///
+    /// If `daemon-state.json` doesn't exist, attempts migration from the
+    /// legacy separate files (github-state.json, reminders.json). If those
+    /// don't exist either, returns default state.
+    pub fn load_for_repo(repo: &str) -> io::Result<Self> {
+        let path = crate::paths::daemon_state_file_for_repo(repo);
+        match fs::read_to_string(&path) {
+            Ok(contents) => {
+                let state: Self = serde_json::from_str(&contents).map_err(|e| {
+                    warn!("Failed to parse daemon-state.json: {}", e);
+                    io::Error::new(ErrorKind::InvalidData, e)
+                })?;
+                debug!(
+                    "Loaded daemon state: {} PR reviewers, {} reminders",
+                    state.github.pr_reviewers.len(),
+                    state.reminders.reminders.len()
+                );
+                Ok(state)
+            }
+            Err(e) if e.kind() == ErrorKind::NotFound => {
+                debug!("daemon-state.json not found, attempting migration from legacy files");
+                Self::migrate_from_legacy(repo)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Save to the unified state file atomically (temp file + rename).
+    pub fn save_for_repo(&self, repo: &str) -> io::Result<()> {
+        let path = crate::paths::daemon_state_file_for_repo(repo);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let contents = serde_json::to_string_pretty(self)?;
+        let tmp_path = path.with_extension("json.tmp");
+        fs::write(&tmp_path, &contents)?;
+        fs::rename(&tmp_path, &path)?;
+        debug!(
+            "Saved daemon state: {} PR reviewers, {} reminders",
+            self.github.pr_reviewers.len(),
+            self.reminders.reminders.len()
+        );
+        Ok(())
+    }
+
+    /// Migrate from legacy separate files into the unified format.
+    ///
+    /// Loads github-state.json and reminders.json if they exist,
+    /// combines them into a single DaemonPersistentState, saves as
+    /// daemon-state.json, then removes the old files.
+    fn migrate_from_legacy(repo: &str) -> io::Result<Self> {
+        let github = crate::github_state::load_state_for_repo(repo).unwrap_or_else(|e| {
+            if e.kind() != ErrorKind::NotFound {
+                warn!(
+                    "Failed to load legacy github-state.json during migration: {}",
+                    e
+                );
+            }
+            GitHubState::default()
+        });
+
+        let reminder_path = crate::paths::reminders_file_for_repo(repo);
+        let reminders = ReminderState::load(&reminder_path).unwrap_or_else(|e| {
+            if e.kind() != ErrorKind::NotFound {
+                warn!(
+                    "Failed to load legacy reminders.json during migration: {}",
+                    e
+                );
+            }
+            ReminderState::default()
+        });
+
+        let state = Self { github, reminders };
+
+        // Save the unified file
+        if let Err(e) = state.save_for_repo(repo) {
+            warn!("Failed to save migrated daemon-state.json: {}", e);
+            return Err(e);
+        }
+
+        // Clean up legacy files (best-effort, don't fail if removal fails)
+        let github_path = crate::paths::github_state_file_for_repo(repo);
+        if github_path.exists() {
+            let _ = fs::remove_file(&github_path);
+            debug!("Removed legacy github-state.json after migration");
+        }
+        if reminder_path.exists() {
+            let _ = fs::remove_file(&reminder_path);
+            debug!("Removed legacy reminders.json after migration");
+        }
+
+        Ok(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_default_state() {
+        let state = DaemonPersistentState::default();
+        assert!(state.github.pr_reviewers.is_empty());
+        assert!(state.reminders.reminders.is_empty());
+    }
+
+    #[test]
+    fn test_save_and_load_roundtrip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("daemon-state.json");
+
+        let mut state = DaemonPersistentState::default();
+        state.github.assign_reviewer(42, "lexington");
+        state.reminders.add(
+            crate::reminders::ReminderTrigger::AllWorkMerged,
+            "Deploy".to_string(),
+        );
+
+        // Save directly to path
+        let contents = serde_json::to_string_pretty(&state).unwrap();
+        fs::write(&path, &contents).unwrap();
+
+        // Load directly from path
+        let loaded: DaemonPersistentState =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(loaded.github.get_reviewer(42), Some("lexington"));
+        assert_eq!(loaded.reminders.reminders.len(), 1);
+        assert_eq!(loaded.reminders.reminders[0].message, "Deploy");
+    }
+
+    #[test]
+    fn test_serde_default_handles_missing_fields() {
+        // Forward compatibility: missing sections get defaults
+        let json = r#"{"github": {}}"#;
+        let state: DaemonPersistentState = serde_json::from_str(json).unwrap();
+        assert!(state.reminders.reminders.is_empty());
+
+        let json = r#"{"reminders": {"reminders": []}}"#;
+        let state: DaemonPersistentState = serde_json::from_str(json).unwrap();
+        assert!(state.github.pr_reviewers.is_empty());
+    }
+
+    #[test]
+    fn test_empty_json_uses_defaults() {
+        let json = "{}";
+        let state: DaemonPersistentState = serde_json::from_str(json).unwrap();
+        assert!(state.github.pr_reviewers.is_empty());
+        assert!(state.reminders.reminders.is_empty());
+    }
+
+    #[test]
+    fn test_full_roundtrip_with_all_fields() {
+        let mut state = DaemonPersistentState::default();
+
+        // Populate github state
+        state.github.assign_reviewer(1, "broadway");
+        state.github.assign_reviewer(2, "park");
+        state.github.mark_reviewed_pr(10);
+        state
+            .github
+            .add_pending_review_spawn(3, chrono::Utc::now() + chrono::Duration::seconds(60));
+
+        // Populate reminders
+        state.reminders.add(
+            crate::reminders::ReminderTrigger::AllWorkMerged,
+            "Cut release".to_string(),
+        );
+        state.reminders.add(
+            crate::reminders::ReminderTrigger::AllWorkMerged,
+            "Deploy staging".to_string(),
+        );
+
+        // Serialize and deserialize
+        let json = serde_json::to_string_pretty(&state).unwrap();
+        let loaded: DaemonPersistentState = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(loaded.github.pr_reviewers.len(), 2);
+        assert_eq!(loaded.github.get_reviewer(1), Some("broadway"));
+        assert_eq!(loaded.github.get_reviewer(2), Some("park"));
+        assert!(loaded.github.has_cached_review(10));
+        assert_eq!(loaded.github.pending_review_spawns.len(), 1);
+        assert_eq!(loaded.reminders.reminders.len(), 2);
+    }
+}

--- a/src/github_state.rs
+++ b/src/github_state.rs
@@ -298,28 +298,13 @@ impl GitHubState {
     }
 }
 
-/// Load GitHub state for the current repository.
-pub fn load_state() -> io::Result<GitHubState> {
-    let path = crate::paths::github_state_file();
-    GitHubState::load(&path)
-}
-
-/// Save GitHub state for the current repository.
-pub fn save_state(state: &GitHubState) -> io::Result<()> {
-    let path = crate::paths::github_state_file();
-    state.save(&path)
-}
-
-/// Load GitHub state for a specific repository.
+/// Load GitHub state for a specific repository (legacy file).
+///
+/// Used only by migration code in `daemon::state`. New code should use
+/// `DaemonPersistentState::load_for_repo()` instead.
 pub fn load_state_for_repo(repo: &str) -> io::Result<GitHubState> {
     let path = crate::paths::github_state_file_for_repo(repo);
     GitHubState::load(&path)
-}
-
-/// Save GitHub state for a specific repository.
-pub fn save_state_for_repo(repo: &str, state: &GitHubState) -> io::Result<()> {
-    let path = crate::paths::github_state_file_for_repo(repo);
-    state.save(&path)
 }
 
 #[cfg(test)]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -231,20 +231,22 @@ pub fn github_state_file_for_repo(repo: &str) -> PathBuf {
     projects_dir_for_repo(repo).join("github-state.json")
 }
 
-/// Get the GitHub state file path for the current repository.
-///
-/// Detects the repo name from the current git working directory.
-/// Falls back to "default" if not in a git repository.
-pub fn github_state_file() -> PathBuf {
-    let repo = detect_repo_name().unwrap_or_else(|| "default".to_string());
-    github_state_file_for_repo(&repo)
-}
-
 /// Get the reminders file path for a specific repository.
 ///
 /// Returns `~/.midtown/projects/<repo>/reminders.json`.
 pub fn reminders_file_for_repo(repo: &str) -> PathBuf {
     projects_dir_for_repo(repo).join("reminders.json")
+}
+
+/// Get the unified daemon state file path for a specific repository.
+///
+/// Returns `~/.midtown/projects/<repo>/daemon-state.json`.
+///
+/// This file stores all persistent daemon state:
+/// - GitHub PR reviewer assignments, review cache, pending spawns
+/// - One-shot reminders
+pub fn daemon_state_file_for_repo(repo: &str) -> PathBuf {
+    projects_dir_for_repo(repo).join("daemon-state.json")
 }
 
 /// Get the daemon socket path for a specific repository.

--- a/src/web.rs
+++ b/src/web.rs
@@ -499,9 +499,10 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
         })
         .collect();
 
-    // Load GitHub state to get reviewer assignments (local file, cheap)
-    let github_state =
-        crate::github_state::load_state_for_repo(&state.config.repo).unwrap_or_default();
+    // Load persistent state to get reviewer assignments (local file, cheap)
+    let persistent_state =
+        crate::daemon::state::DaemonPersistentState::load_for_repo(&state.config.repo)
+            .unwrap_or_default();
 
     // --- PR data: prefer daemon RPC, fall back to cached gh CLI calls ---
     let repo_name = state.config.repo.clone();
@@ -534,7 +535,7 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
             // RPC returns "ci_status" / "reviewer" / "reviewed_at"; gh CLI returns
             // "isDraft" / "reviewDecision". Handle both shapes.
             // Look up reviewer from persistent state (covers both RPC and CLI shapes)
-            let assignment = github_state.pr_reviewers.get(&pr_number);
+            let assignment = persistent_state.github.pr_reviewers.get(&pr_number);
             let reviewer = pr
                 .get("reviewer")
                 .and_then(|v| v.as_str())
@@ -546,7 +547,7 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
             let review_posted = pr
                 .get("review_posted")
                 .and_then(|v| v.as_bool())
-                .unwrap_or_else(|| github_state.reviewed_prs.contains(&pr_number));
+                .unwrap_or_else(|| persistent_state.github.reviewed_prs.contains(&pr_number));
             let status = if pr.get("ci_status").is_some() {
                 // RPC shape: derive review status from review_posted and reviewer
                 if review_posted {


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Replaces separate `github-state.json` and `reminders.json` with a single `daemon-state.json` managed by `DaemonPersistentState` in `src/daemon/state.rs`
- Auto-migrates from legacy files on first load (reads old files, writes unified, removes old)
- Atomic save via temp file + rename for crash safety
- All 7 save callsites and all read callsites updated to use the unified state
- Reminder RPC handlers made async (previously std::sync::Mutex, now tokio::sync::Mutex)

## Details

**New file:** `src/daemon/state.rs`
- `DaemonPersistentState` struct wrapping `GitHubState` + `ReminderState` with `#[serde(default)]` on both for forward compatibility
- `load_for_repo()` / `save_for_repo()` with atomic write pattern
- `migrate_from_legacy()` for seamless transition from old file layout

**Modified files:**
- `daemon/mod.rs` — `github_state` + `reminder_state` fields → single `persistent_state: Mutex<DaemonPersistentState>`
- `daemon/pr.rs` — 4 save callsites + all github_state lock usages
- `daemon/rpc.rs` — reminder handlers now async, github_state → persistent_state
- `daemon/health.rs` — reminder evaluation now async
- `daemon/events.rs` — `.await` on fire_reminders call
- `daemon/snapshot.rs`, `daemon/dispatch.rs` — read-only github_state → persistent_state
- `web.rs` — loads from unified file instead of legacy github-state.json
- `github_state.rs` — removed unused standalone load/save functions (kept `load_state_for_repo` for migration)
- `paths.rs` — added `daemon_state_file_for_repo()`, removed unused `github_state_file()`

## Test plan
- [x] All 613 existing tests pass
- [x] Clippy clean (`-D warnings`)
- [x] 5 new unit tests for DaemonPersistentState serialization, defaults, and roundtrip
- [ ] E2E: daemon starts cleanly with no state files (fresh)
- [ ] E2E: daemon migrates from legacy files to daemon-state.json on startup
- [ ] E2E: reminders and PR reviewer assignments persist across daemon restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)