### PR TITLE
fix: bypass permissions mode no longer triggers stuck prompt detection [Midtown #739]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -2147,6 +2147,38 @@ https://github.com/org/repo/blob/abc123/CLAUDE.md#L5-L7
         assert_eq!(crate::rules::detect_interactive_prompt(""), None);
     }
 
+    #[test]
+    fn test_detect_interactive_prompt_bypass_permissions_not_stuck() {
+        // When bypass permissions mode is active, the pane shows permission text
+        // alongside the bypass indicator. This should NOT be detected as a stuck prompt.
+        let pane = "Claude wants to run: cargo test\n  Allow once  Allow always  Deny\n  ⏵⏵ bypass permissions on (shift+tab to cycle)";
+        assert_eq!(
+            crate::rules::detect_interactive_prompt(pane),
+            None,
+            "bypass permissions mode should not trigger interactive prompt detection"
+        );
+    }
+
+    #[test]
+    fn test_detect_interactive_prompt_bypass_permissions_plan_not_stuck() {
+        // Plan approval prompt with bypass mode active should not be detected
+        let pane = r#"
+  ╭──────────────────────────────────────────────────────────╮
+  │ Plan: Add authentication endpoint                        │
+  │                                                          │
+  │  1. Yes, and bypass permissions                          │
+  │  2. Yes, clear context and bypass permissions            │
+  │  3. No, and tell Claude what to do differently           │
+  ╰──────────────────────────────────────────────────────────╯
+  ⏵⏵ bypass permissions on (shift+tab to cycle)
+        "#;
+        assert_eq!(
+            crate::rules::detect_interactive_prompt(pane),
+            None,
+            "bypass permissions mode should suppress plan approval detection"
+        );
+    }
+
     // Usage limit detection tests
     #[test]
     fn test_parse_usage_limit_duration_minutes() {

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -481,7 +481,17 @@ const INTERACTIVE_PROMPT_PATTERNS: &[(&str, &str)] = &[
 ];
 
 /// Check if pane content contains an interactive prompt that needs human input.
+///
+/// Returns `None` when bypass permissions mode is active (indicated by
+/// `"⏵⏵ bypass permissions on"` in the pane), since the agent is
+/// auto-approving permissions and is NOT stuck waiting for input.
 pub(crate) fn detect_interactive_prompt(pane_content: &str) -> Option<&'static str> {
+    // When bypass permissions mode is active, the pane still shows permission/plan
+    // prompt text but the agent is auto-approving — not stuck.
+    if pane_content.contains("bypass permissions on") {
+        return None;
+    }
+
     for (pattern, label) in INTERACTIVE_PROMPT_PATTERNS {
         if pane_content.contains(pattern) {
             return Some(label);


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Fixed false positive where bypass permissions mode was detected as a stuck permission prompt
- Added early return in `detect_interactive_prompt()` to suppress all pattern matching when `"bypass permissions on"` is in the pane
- Added 2 regression tests covering permission request and plan approval scenarios with bypass mode active

## Test plan
- [x] New tests fail before fix, pass after
- [x] All 8 existing `detect_interactive_prompt` tests still pass
- [x] Full test suite (610 tests) passes
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)