### PR TITLE
feat: detect and recover coworkers stuck in compaction/queued-prompt states [Midtown #738]

### DIFF
--- a/src/daemon/constants.rs
+++ b/src/daemon/constants.rs
@@ -114,6 +114,15 @@ pub(super) const MAX_ZOMBIE_RESPAWN_ATTEMPTS: u32 = 3;
 /// and restarted with its current task.
 pub(super) const COWORKER_STUCK_DURATION: Duration = Duration::from_secs(300);
 
+/// Cooldown between compaction recovery attempts for the same coworker (3 minutes).
+/// Prevents spamming Escape if the detection fires repeatedly.
+pub(super) const COMPACTION_RECOVERY_COOLDOWN: Duration = Duration::from_secs(180);
+
+/// Cooldown between queued-prompt recovery attempts for the same coworker (60 seconds).
+/// Shorter than compaction because the fix (Escape) is lightweight and the state
+/// can recur quickly after nudges are delivered.
+pub(super) const QUEUED_PROMPT_RECOVERY_COOLDOWN: Duration = Duration::from_secs(60);
+
 /// Extra buffer added to usage limit expiry times before nudging (30 seconds).
 /// Gives the API a moment to actually reset before we ask coworkers to retry.
 pub(super) const USAGE_LIMIT_NUDGE_BUFFER: Duration = Duration::from_secs(30);

--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -95,6 +95,10 @@ pub enum Effect {
     },
     /// Clear a saved PR break session after successful resume.
     ClearPrBreakSession { name: String },
+    /// Send raw tmux keys to a coworker (e.g., Escape, Enter) without the
+    /// nudge text mechanism. Used for recovering stuck states like compaction
+    /// whirlpools or queued prompts.
+    SendRawKeys { name: String, keys: String },
     /// Assign a reviewer to a PR in github_state and persist.
     AssignReviewer {
         pr_number: u64,
@@ -333,6 +337,13 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 ps.github.assign_reviewer(pr_number, &reviewer_name, source);
                 if let Err(e) = ps.save_for_repo(&state.repo_name) {
                     warn!("Failed to save daemon-state.json: {}", e);
+                }
+            }
+            Effect::SendRawKeys { name, keys } => {
+                if let Err(e) =
+                    crate::tmux::send_keys_raw(state.coworkers.session_name(), &name, &keys)
+                {
+                    warn!("Failed to send raw keys to {}: {}", name, e);
                 }
             }
             Effect::PostSystemMessage { message } => {

--- a/src/daemon/events.rs
+++ b/src/daemon/events.rs
@@ -49,6 +49,7 @@ pub async fn evaluate_tick(
             // Health checks: idle shutdown, stuck detection, usage limits.
             effects.extend(super::health::check_and_shutdown_idle_coworkers(snap, state).await);
             effects.extend(super::health::check_and_restart_stuck_coworkers(snap, state).await);
+            effects.extend(super::health::check_and_recover_stuck_ui(snap, state));
             effects.extend(super::health::check_for_usage_limits(snap));
             effects.extend(super::health::maybe_nudge_usage_limit_expiry(snap));
             effects

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -545,6 +545,91 @@ pub(super) fn maybe_nudge_usage_limit_expiry(snap: &snapshot::WorldSnapshot) -> 
     effects
 }
 
+/// Detect coworkers stuck in compaction (whirlpool) or with queued prompts,
+/// and send the appropriate recovery keypress (Escape or Enter).
+///
+/// Uses per-coworker cooldowns to avoid spamming keys on every tick.
+pub(super) fn check_and_recover_stuck_ui(
+    snap: &snapshot::WorldSnapshot,
+    state: &DaemonState,
+) -> Vec<Effect> {
+    if snap.active_coworkers.is_empty() {
+        return vec![];
+    }
+
+    let recoveries = crate::rules::decide_stuck_ui_recoveries(&snap.pane_contents);
+
+    let mut effects = Vec::new();
+
+    for recovery in recoveries {
+        match recovery {
+            crate::rules::StuckUiRecovery::InterruptCompaction { name } => {
+                let should_act = {
+                    let cooldowns = state.cooldowns.lock().unwrap();
+                    cooldowns.check("compaction_recovery", &name, COMPACTION_RECOVERY_COOLDOWN)
+                };
+                if !should_act {
+                    debug!("Compaction recovery cooldown active for {}", name);
+                    continue;
+                }
+
+                info!(
+                    "Coworker {} stuck in compaction — sending Escape to interrupt",
+                    name
+                );
+                effects.push(Effect::SendRawKeys {
+                    name: name.clone(),
+                    keys: "Escape".to_string(),
+                });
+                effects.push(Effect::RecordCooldown {
+                    category: "compaction_recovery".to_string(),
+                    key: name.clone(),
+                });
+                effects.push(Effect::PostToChannel {
+                    sender: "midtown".to_string(),
+                    message: format!("🌀 Interrupted stuck compaction for {} (sent Escape)", name),
+                });
+            }
+            crate::rules::StuckUiRecovery::InterruptQueuedNudges { name } => {
+                let should_act = {
+                    let cooldowns = state.cooldowns.lock().unwrap();
+                    cooldowns.check(
+                        "queued_prompt_recovery",
+                        &name,
+                        QUEUED_PROMPT_RECOVERY_COOLDOWN,
+                    )
+                };
+                if !should_act {
+                    debug!("Queued prompt recovery cooldown active for {}", name);
+                    continue;
+                }
+
+                info!(
+                    "Coworker {} has queued nudges not being processed — sending Escape to interrupt",
+                    name
+                );
+                effects.push(Effect::SendRawKeys {
+                    name: name.clone(),
+                    keys: "Escape".to_string(),
+                });
+                effects.push(Effect::RecordCooldown {
+                    category: "queued_prompt_recovery".to_string(),
+                    key: name.clone(),
+                });
+                effects.push(Effect::PostToChannel {
+                    sender: "midtown".to_string(),
+                    message: format!(
+                        "📨 Interrupted {} to process queued nudges (sent Escape)",
+                        name
+                    ),
+                });
+            }
+        }
+    }
+
+    effects
+}
+
 pub(super) async fn check_and_respawn_zombies(
     snap: &snapshot::WorldSnapshot,
     state: &DaemonState,

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -512,6 +512,84 @@ pub(crate) fn decide_stuck_coworker_restarts(
 }
 
 // ---------------------------------------------------------------------------
+// Compaction whirlpool & queued prompt detection
+// ---------------------------------------------------------------------------
+
+/// Action to recover a coworker from a stuck UI state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StuckUiRecovery {
+    /// Coworker is stuck in compaction (whirlpool/baking). Send Escape.
+    InterruptCompaction { name: String },
+    /// Coworker has queued nudge messages sitting in the input but is not
+    /// processing them. Send Escape to interrupt and let Claude pick them up.
+    InterruptQueuedNudges { name: String },
+}
+
+/// Detect coworkers stuck in Claude Code's compaction state.
+///
+/// Compaction shows a status line like `(esc to interrupt · 18m 50s · ↓ 0 tokens)`.
+/// The verb varies ("Whirlpooling", "Baking", etc.) so we match on the stable
+/// signature `esc to interrupt` instead.
+///
+/// Returns the names of coworkers that should receive an Escape keypress.
+/// The caller is responsible for cooldown enforcement.
+pub(crate) fn detect_compaction_stuck(pane_contents: &HashMap<String, String>) -> Vec<String> {
+    pane_contents
+        .iter()
+        .filter(|(_name, content)| content.contains("esc to interrupt"))
+        .map(|(name, _content)| name.clone())
+        .collect()
+}
+
+/// Detect coworkers with queued nudge messages that aren't being processed.
+///
+/// When a coworker is at a prompt with queued messages (lines starting with `❯`
+/// visible in the pane below the active prompt), it needs an Enter or Escape
+/// to start processing them. We look for `❯` lines that appear in the pane
+/// content, which indicates nudges were delivered but haven't been submitted.
+///
+/// We detect this by looking for the `❯` character followed by text, which
+/// appears when nudge messages are queued but sitting unprocessed at the prompt.
+pub(crate) fn detect_queued_prompt_stuck(pane_contents: &HashMap<String, String>) -> Vec<String> {
+    pane_contents
+        .iter()
+        .filter(|(_name, content)| {
+            // Look for queued nudge messages: lines starting with ❯ followed by text.
+            // These appear when nudge messages were sent but the coworker hasn't
+            // pressed Enter to submit them. The ❯ is Claude Code's prompt indicator.
+            let has_queued = content.lines().any(|line| {
+                let trimmed = line.trim();
+                trimmed.starts_with('❯') && trimmed.len() > "❯".len() + 1
+            });
+            // Only flag if NOT currently in compaction (that's a separate recovery)
+            let in_compaction = content.contains("esc to interrupt");
+            has_queued && !in_compaction
+        })
+        .map(|(name, _content)| name.clone())
+        .collect()
+}
+
+/// Pure decision: determine which coworkers need UI recovery actions.
+///
+/// Checks pane contents for two stuck states and returns the appropriate
+/// recovery actions. Cooldown tracking is the caller's responsibility.
+pub(crate) fn decide_stuck_ui_recoveries(
+    pane_contents: &HashMap<String, String>,
+) -> Vec<StuckUiRecovery> {
+    let mut recoveries = Vec::new();
+
+    for name in detect_compaction_stuck(pane_contents) {
+        recoveries.push(StuckUiRecovery::InterruptCompaction { name });
+    }
+
+    for name in detect_queued_prompt_stuck(pane_contents) {
+        recoveries.push(StuckUiRecovery::InterruptQueuedNudges { name });
+    }
+
+    recoveries
+}
+
+// ---------------------------------------------------------------------------
 // Blank-pane zombie detection
 // ---------------------------------------------------------------------------
 
@@ -1737,6 +1815,171 @@ mod tests {
         let zombies =
             detect_blank_pane_zombies(&blank, &start_times, now, chrono::Duration::seconds(20));
         assert!(zombies.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Compaction whirlpool & queued prompt detection tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn compaction_detected_with_whirlpool_verb() {
+        let mut panes = HashMap::new();
+        panes.insert(
+            "york".to_string(),
+            "  Whirlpooling your conversation…\n  (esc to interrupt · 18m 50s · ↓ 0 tokens)\n"
+                .to_string(),
+        );
+        let stuck = detect_compaction_stuck(&panes);
+        assert_eq!(stuck, vec!["york"]);
+    }
+
+    #[test]
+    fn compaction_detected_with_baking_verb() {
+        let mut panes = HashMap::new();
+        panes.insert(
+            "amsterdam".to_string(),
+            "  Baking your conversation…\n  (esc to interrupt · 3m 12s · ↓ 42 tokens)\n"
+                .to_string(),
+        );
+        let stuck = detect_compaction_stuck(&panes);
+        assert_eq!(stuck, vec!["amsterdam"]);
+    }
+
+    #[test]
+    fn compaction_detected_with_unknown_verb() {
+        // Future verbs we don't know about yet should still match
+        let mut panes = HashMap::new();
+        panes.insert(
+            "park".to_string(),
+            "  Simmering your conversation…\n  (esc to interrupt · 1m 05s · ↓ 100 tokens)\n"
+                .to_string(),
+        );
+        let stuck = detect_compaction_stuck(&panes);
+        assert_eq!(stuck, vec!["park"]);
+    }
+
+    #[test]
+    fn compaction_not_detected_in_normal_output() {
+        let mut panes = HashMap::new();
+        panes.insert(
+            "york".to_string(),
+            "  Reading file src/main.rs\n  Edit: replaced 3 lines\n  $ cargo build\n".to_string(),
+        );
+        let stuck = detect_compaction_stuck(&panes);
+        assert!(stuck.is_empty());
+    }
+
+    #[test]
+    fn compaction_not_detected_when_pane_mentions_esc_in_code() {
+        // A coworker working on code that mentions "esc to interrupt" literally
+        // should not be flagged — but our detector is intentionally simple.
+        // This test documents the current behavior: the substring match WILL
+        // flag this. In practice this is extremely unlikely in real code output.
+        let mut panes = HashMap::new();
+        panes.insert(
+            "york".to_string(),
+            "  // detect the pattern: esc to interrupt\n  fn check() {}\n".to_string(),
+        );
+        let stuck = detect_compaction_stuck(&panes);
+        // Current behavior: matches. This is an accepted false positive.
+        assert_eq!(stuck.len(), 1);
+    }
+
+    #[test]
+    fn queued_prompt_detected_with_nudge_messages() {
+        let mut panes = HashMap::new();
+        panes.insert(
+            "york".to_string(),
+            "  some output\n❯ You have a new task assignment: task #42\n❯ Check the channel for updates\n".to_string(),
+        );
+        let stuck = detect_queued_prompt_stuck(&panes);
+        assert_eq!(stuck, vec!["york"]);
+    }
+
+    #[test]
+    fn queued_prompt_not_detected_during_compaction() {
+        // If compaction is happening simultaneously, don't also flag queued prompt
+        let mut panes = HashMap::new();
+        panes.insert(
+            "york".to_string(),
+            "  Whirlpooling…\n  (esc to interrupt · 5m 00s · ↓ 0 tokens)\n❯ pending nudge\n"
+                .to_string(),
+        );
+        let stuck = detect_queued_prompt_stuck(&panes);
+        assert!(
+            stuck.is_empty(),
+            "should not flag queued prompt during compaction"
+        );
+    }
+
+    #[test]
+    fn queued_prompt_not_detected_with_bare_prompt() {
+        // Just the ❯ character alone (empty prompt) should NOT trigger
+        let mut panes = HashMap::new();
+        panes.insert("york".to_string(), "  output\n❯ \n".to_string());
+        let stuck = detect_queued_prompt_stuck(&panes);
+        assert!(
+            stuck.is_empty(),
+            "bare prompt character should not trigger recovery"
+        );
+    }
+
+    #[test]
+    fn queued_prompt_not_detected_in_normal_output() {
+        let mut panes = HashMap::new();
+        panes.insert(
+            "york".to_string(),
+            "  $ cargo test\n  running 5 tests\n  test result: ok. 5 passed\n".to_string(),
+        );
+        let stuck = detect_queued_prompt_stuck(&panes);
+        assert!(stuck.is_empty());
+    }
+
+    #[test]
+    fn combined_recovery_returns_both_types() {
+        let mut panes = HashMap::new();
+        // One coworker stuck in compaction
+        panes.insert(
+            "york".to_string(),
+            "  (esc to interrupt · 10m 00s · ↓ 0 tokens)\n".to_string(),
+        );
+        // Another coworker with queued nudges
+        panes.insert("amsterdam".to_string(), "❯ Check the channel\n".to_string());
+
+        let recoveries = decide_stuck_ui_recoveries(&panes);
+        assert_eq!(recoveries.len(), 2);
+
+        let has_compaction = recoveries
+            .iter()
+            .any(|r| matches!(r, StuckUiRecovery::InterruptCompaction { name } if name == "york"));
+        let has_queued = recoveries.iter().any(
+            |r| matches!(r, StuckUiRecovery::InterruptQueuedNudges { name } if name == "amsterdam"),
+        );
+        assert!(has_compaction, "should detect york's compaction");
+        assert!(has_queued, "should detect amsterdam's queued nudges");
+    }
+
+    #[test]
+    fn recovery_empty_for_healthy_coworkers() {
+        let mut panes = HashMap::new();
+        panes.insert(
+            "york".to_string(),
+            "  Reading file\n  Edit complete\n".to_string(),
+        );
+        panes.insert(
+            "amsterdam".to_string(),
+            "  $ cargo build\n  Compiling midtown v0.4.1\n".to_string(),
+        );
+
+        let recoveries = decide_stuck_ui_recoveries(&panes);
+        assert!(recoveries.is_empty());
+    }
+
+    #[test]
+    fn recovery_empty_for_no_coworkers() {
+        let panes: HashMap<String, String> = HashMap::new();
+        let recoveries = decide_stuck_ui_recoveries(&panes);
+        assert!(recoveries.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Adds health check detection for two stuck UI states: compaction whirlpool (`esc to interrupt` pattern) and queued nudge messages (`❯` lines with text)
- Introduces `SendRawKeys` effect variant for sending Escape/Enter via tmux without the nudge text mechanism
- Both recoveries use per-coworker cooldowns (3min for compaction, 60s for queued prompts) to avoid spamming
- 12 new tests covering realistic pane content patterns, edge cases (bare prompts, compaction+queued overlap), and the combined decision function

## Test plan
- [x] All 12 new unit tests pass (`cargo test -- compaction queued_prompt combined_recovery recovery_empty`)
- [x] Full test suite passes (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Formatting clean (`cargo fmt -- --check`)
- [ ] Manual verification: observe daemon recovering a coworker stuck in whirlpool

🤖 Generated with [Claude Code](https://claude.com/claude-code)