### PR TITLE
feat: protect active coworkers from break, add conservative compaction recovery [Midtown #738]

### DIFF
--- a/src/daemon/constants.rs
+++ b/src/daemon/constants.rs
@@ -85,6 +85,11 @@ pub(super) const ORPHAN_CHECK_INTERVAL_SECS: u64 = 5;
 /// This prevents spawn storms where coworkers are rapidly sent on breaks.
 pub(super) const MINIMUM_COWORKER_LIFETIME: Duration = Duration::from_secs(300);
 
+/// Grace period for pane activity before a coworker can be sent on break (2 minutes).
+/// If the coworker's tmux pane content changed within this window, they are considered
+/// actively working and must not be sent on break, regardless of task ownership.
+pub(super) const PANE_ACTIVITY_GRACE: Duration = Duration::from_secs(120);
+
 /// Cooldown between orphan recovery spawns (5 seconds)
 /// Only spawn one coworker per tick, with a minimum gap between spawns.
 pub(super) const ORPHAN_SPAWN_COOLDOWN: Duration = Duration::from_secs(5);
@@ -113,6 +118,22 @@ pub(super) const MAX_ZOMBIE_RESPAWN_ATTEMPTS: u32 = 3;
 /// If the tmux pane content hash hasn't changed for this duration, the coworker is killed
 /// and restarted with its current task.
 pub(super) const COWORKER_STUCK_DURATION: Duration = Duration::from_secs(300);
+
+/// Minimum elapsed compaction time before we consider it stuck (5 minutes).
+/// Compaction is a normal, useful operation. Only interrupt if it has been
+/// running for an unusually long time with no progress. Better to leave a
+/// truly-stuck coworker for an extra few minutes than to interrupt legitimate
+/// compaction.
+pub(super) const MIN_COMPACTION_STUCK_DURATION: Duration = Duration::from_secs(300);
+
+/// Cooldown between compaction recovery attempts for the same coworker (3 minutes).
+/// Prevents spamming Escape if the detection fires repeatedly.
+pub(super) const COMPACTION_RECOVERY_COOLDOWN: Duration = Duration::from_secs(180);
+
+/// Cooldown between queued-prompt recovery attempts for the same coworker (60 seconds).
+/// Shorter than compaction because the fix (Escape) is lightweight and the state
+/// can recur quickly after nudges are delivered.
+pub(super) const QUEUED_PROMPT_RECOVERY_COOLDOWN: Duration = Duration::from_secs(60);
 
 /// Extra buffer added to usage limit expiry times before nudging (30 seconds).
 /// Gives the API a moment to actually reset before we ask coworkers to retry.

--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -95,6 +95,10 @@ pub enum Effect {
     },
     /// Clear a saved PR break session after successful resume.
     ClearPrBreakSession { name: String },
+    /// Send raw tmux keys to a coworker (e.g., Escape, Enter) without the
+    /// nudge text mechanism. Used for recovering stuck states like compaction
+    /// whirlpools or queued prompts.
+    SendRawKeys { name: String, keys: String },
     /// Assign a reviewer to a PR in github_state and persist.
     AssignReviewer {
         pr_number: u64,
@@ -333,6 +337,13 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 ps.github.assign_reviewer(pr_number, &reviewer_name, source);
                 if let Err(e) = ps.save_for_repo(&state.repo_name) {
                     warn!("Failed to save daemon-state.json: {}", e);
+                }
+            }
+            Effect::SendRawKeys { name, keys } => {
+                if let Err(e) =
+                    crate::tmux::send_keys_raw(state.coworkers.session_name(), &name, &keys)
+                {
+                    warn!("Failed to send raw keys to {}: {}", name, e);
                 }
             }
             Effect::PostSystemMessage { message } => {

--- a/src/daemon/events.rs
+++ b/src/daemon/events.rs
@@ -49,6 +49,7 @@ pub async fn evaluate_tick(
             // Health checks: idle shutdown, stuck detection, usage limits.
             effects.extend(super::health::check_and_shutdown_idle_coworkers(snap, state).await);
             effects.extend(super::health::check_and_restart_stuck_coworkers(snap, state).await);
+            effects.extend(super::health::check_and_recover_stuck_ui(snap, state));
             effects.extend(super::health::check_for_usage_limits(snap));
             effects.extend(super::health::maybe_nudge_usage_limit_expiry(snap));
             effects

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -156,9 +156,11 @@ pub(super) fn determine_lead_working(
 /// with their name as owner. After 30 seconds of continuous idle, they are
 /// automatically sent on a break.
 ///
-/// IMPORTANT: Coworkers with open PRs or active review assignments are NEVER
-/// sent on a break, regardless of idle time. This ensures they can respond to PR
-/// feedback, merge their work, or complete their review.
+/// IMPORTANT: Coworkers are NEVER sent on a break if any of these apply:
+/// - They have open unmerged PRs (must stay available for review feedback)
+/// - They have active review assignments
+/// - Their tmux pane content changed recently (actively working)
+/// - They have unblocked dependent tasks
 ///
 /// Also enforces a minimum lifetime check - coworkers must be alive for at least
 /// 5 minutes before they can be sent on a break. This prevents spawn storms where
@@ -211,6 +213,7 @@ pub(super) async fn check_and_shutdown_idle_coworkers(
             snap.now_utc,
             IDLE_BREAK_DURATION,
             MINIMUM_COWORKER_LIFETIME,
+            PANE_ACTIVITY_GRACE,
         );
         crate::rules::apply_health_transitions(&mut records, transitions);
         decisions
@@ -221,37 +224,6 @@ pub(super) async fn check_and_shutdown_idle_coworkers(
     // Determine effects for idle coworkers
     for decision in to_shutdown {
         let name = &decision.name;
-
-        // PR break-and-resume: save session ID before shutdown so coworker can resume later
-        if decision.save_session {
-            // Look up the coworker's session ID before shutting down
-            if let Some(cw) = state.coworkers.get(name)
-                && let Some(ref session_id) = cw.session_id
-            {
-                let mut sessions = state.pr_break_sessions.write().unwrap();
-                sessions.insert(name.clone(), session_id.clone());
-                info!(
-                    "Saved session {} for {} (PR break with CI passing)",
-                    session_id, name
-                );
-            }
-
-            let shutdown_msg = daemon_messages::break_pr_ci_passed(name, config::get_personality());
-            effects.push(Effect::PostToChannel {
-                sender: "system".to_string(),
-                message: shutdown_msg,
-            });
-            effects.push(Effect::BroadcastCoworkerUpdate {
-                name: name.clone(),
-                status: "stopped".to_string(),
-                current_task: None,
-            });
-            effects.push(Effect::ShutdownCoworker {
-                name: name.clone(),
-                message: String::new(),
-            });
-            continue;
-        }
 
         // For isolated coworkers (reviewers), verify the review was actually posted
         let (should_shutdown, shutdown_msg) = if decision.is_isolated {
@@ -540,6 +512,94 @@ pub(super) fn maybe_nudge_usage_limit_expiry(snap: &snapshot::WorldSnapshot) -> 
             name: cw.name.clone(),
             message: "continue".to_string(),
         });
+    }
+
+    effects
+}
+
+/// Detect coworkers stuck in compaction (whirlpool) or with queued prompts,
+/// and send the appropriate recovery keypress (Escape or Enter).
+///
+/// Uses per-coworker cooldowns to avoid spamming keys on every tick.
+pub(super) fn check_and_recover_stuck_ui(
+    snap: &snapshot::WorldSnapshot,
+    state: &DaemonState,
+) -> Vec<Effect> {
+    if snap.active_coworkers.is_empty() {
+        return vec![];
+    }
+
+    let recoveries = crate::rules::decide_stuck_ui_recoveries(
+        &snap.pane_contents,
+        MIN_COMPACTION_STUCK_DURATION,
+    );
+
+    let mut effects = Vec::new();
+
+    for recovery in recoveries {
+        match recovery {
+            crate::rules::StuckUiRecovery::InterruptCompaction { name } => {
+                let should_act = {
+                    let cooldowns = state.cooldowns.lock().unwrap();
+                    cooldowns.check("compaction_recovery", &name, COMPACTION_RECOVERY_COOLDOWN)
+                };
+                if !should_act {
+                    debug!("Compaction recovery cooldown active for {}", name);
+                    continue;
+                }
+
+                info!(
+                    "Coworker {} stuck in compaction — sending Escape to interrupt",
+                    name
+                );
+                effects.push(Effect::SendRawKeys {
+                    name: name.clone(),
+                    keys: "Escape".to_string(),
+                });
+                effects.push(Effect::RecordCooldown {
+                    category: "compaction_recovery".to_string(),
+                    key: name.clone(),
+                });
+                effects.push(Effect::PostToChannel {
+                    sender: "midtown".to_string(),
+                    message: format!("🌀 Interrupted stuck compaction for {} (sent Escape)", name),
+                });
+            }
+            crate::rules::StuckUiRecovery::InterruptQueuedNudges { name } => {
+                let should_act = {
+                    let cooldowns = state.cooldowns.lock().unwrap();
+                    cooldowns.check(
+                        "queued_prompt_recovery",
+                        &name,
+                        QUEUED_PROMPT_RECOVERY_COOLDOWN,
+                    )
+                };
+                if !should_act {
+                    debug!("Queued prompt recovery cooldown active for {}", name);
+                    continue;
+                }
+
+                info!(
+                    "Coworker {} has queued nudges not being processed — sending Escape to interrupt",
+                    name
+                );
+                effects.push(Effect::SendRawKeys {
+                    name: name.clone(),
+                    keys: "Escape".to_string(),
+                });
+                effects.push(Effect::RecordCooldown {
+                    category: "queued_prompt_recovery".to_string(),
+                    key: name.clone(),
+                });
+                effects.push(Effect::PostToChannel {
+                    sender: "midtown".to_string(),
+                    message: format!(
+                        "📨 Interrupted {} to process queued nudges (sent Escape)",
+                        name
+                    ),
+                });
+            }
+        }
     }
 
     effects

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -238,9 +238,6 @@ pub(crate) fn apply_health_transitions(
 pub(crate) struct ShutdownDecision {
     pub name: String,
     pub is_isolated: bool,
-    /// When true, the daemon should save the coworker's session ID before shutdown
-    /// so it can be resumed later (e.g., PR break-and-resume when CI passes).
-    pub save_session: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -252,6 +249,13 @@ pub(crate) struct ShutdownDecision {
 /// Takes pre-collected state snapshots and immutable coworker records.
 /// Returns shutdown decisions and health state transitions without performing
 /// any side effects or mutations.
+///
+/// A coworker is protected from break if:
+/// - They have in-progress tasks (busy)
+/// - They have open unmerged PRs
+/// - They are actively reviewing a PR
+/// - They have unblocked dependent tasks
+/// - Their pane content changed recently (within `pane_activity_grace`)
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn decide_idle_shutdowns(
     coworkers: &[CoworkerSnapshot],
@@ -259,12 +263,13 @@ pub(crate) fn decide_idle_shutdowns(
     coworkers_with_open_prs: &HashSet<String>,
     active_reviewers: &HashSet<String>,
     coworkers_with_unblocked_deps: &HashSet<String>,
-    ci_passed_pr_coworkers: &HashSet<String>,
+    _ci_passed_pr_coworkers: &HashSet<String>,
     records: &HashMap<String, CoworkerRecord>,
     now: Instant,
     now_utc: DateTime<Utc>,
     idle_break_duration: Duration,
     minimum_lifetime: Duration,
+    pane_activity_grace: Duration,
 ) -> (Vec<ShutdownDecision>, Vec<HealthTransition>) {
     let mut to_shutdown = Vec::new();
     let mut transitions = Vec::new();
@@ -286,6 +291,14 @@ pub(crate) fn decide_idle_shutdowns(
             continue;
         }
 
+        // Check pane activity: if the pane content changed recently, the coworker
+        // is actively working and must not be sent on break.
+        let pane_recently_active = records
+            .get(coworker)
+            .and_then(|r| r.pane_hash)
+            .map(|(_, last_changed)| now.duration_since(last_changed) < pane_activity_grace)
+            .unwrap_or(false);
+
         let is_busy = busy_coworkers
             .iter()
             .any(|b| b.eq_ignore_ascii_case(coworker));
@@ -298,18 +311,10 @@ pub(crate) fn decide_idle_shutdowns(
         let has_unblocked_deps = coworkers_with_unblocked_deps
             .iter()
             .any(|d| d.eq_ignore_ascii_case(coworker));
-        let has_ci_passed_pr = ci_passed_pr_coworkers
-            .iter()
-            .any(|c| c.eq_ignore_ascii_case(coworker));
 
-        // PR owners with passing CI are eligible for break (save_session=true)
-        if has_open_pr && has_ci_passed_pr && !is_busy && !is_reviewing && !has_unblocked_deps {
-            to_shutdown.push(ShutdownDecision {
-                name: coworker.clone(),
-                is_isolated: cw.isolated_tasks,
-                save_session: true,
-            });
-        } else if is_busy || has_open_pr || is_reviewing || has_unblocked_deps {
+        // Coworkers with open PRs, active tasks, review assignments,
+        // unblocked deps, or recent pane activity are never sent on break.
+        if is_busy || has_open_pr || is_reviewing || has_unblocked_deps || pane_recently_active {
             if matches!(
                 get_health(records, coworker),
                 Some(SessionHealth::Idle { .. })
@@ -323,7 +328,6 @@ pub(crate) fn decide_idle_shutdowns(
             to_shutdown.push(ShutdownDecision {
                 name: coworker.clone(),
                 is_isolated: true,
-                save_session: false,
             });
         } else {
             match get_health(records, coworker) {
@@ -332,7 +336,6 @@ pub(crate) fn decide_idle_shutdowns(
                         to_shutdown.push(ShutdownDecision {
                             name: coworker.clone(),
                             is_isolated: false,
-                            save_session: false,
                         });
                     }
                 }
@@ -509,6 +512,140 @@ pub(crate) fn decide_stuck_coworker_restarts(
         restarts,
         updated_hashes,
     }
+}
+
+// ---------------------------------------------------------------------------
+// Compaction whirlpool & queued prompt detection
+// ---------------------------------------------------------------------------
+
+/// Action to recover a coworker from a stuck UI state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StuckUiRecovery {
+    /// Coworker is stuck in compaction (whirlpool/baking). Send Escape.
+    InterruptCompaction { name: String },
+    /// Coworker has queued nudge messages sitting in the input but is not
+    /// processing them. Send Escape to interrupt and let Claude pick them up.
+    InterruptQueuedNudges { name: String },
+}
+
+/// Detect coworkers stuck in Claude Code's compaction state.
+///
+/// Compaction shows a status line like `(esc to interrupt · 18m 50s · ↓ 0 tokens)`.
+/// The verb varies ("Whirlpooling", "Baking", etc.) so we match on the stable
+/// signature `esc to interrupt` instead.
+///
+/// Only flags coworkers whose compaction has been running for at least
+/// `min_duration` — compaction is a normal, useful operation and we must not
+/// interrupt short-running compactions.
+///
+/// Returns the names of coworkers that should receive an Escape keypress.
+/// The caller is responsible for cooldown enforcement.
+pub(crate) fn detect_compaction_stuck(
+    pane_contents: &HashMap<String, String>,
+    min_duration: Duration,
+) -> Vec<String> {
+    pane_contents
+        .iter()
+        .filter(|(_name, content)| {
+            // Find the compaction status line and parse the elapsed time
+            content.lines().any(|line| {
+                if !line.contains("esc to interrupt") {
+                    return false;
+                }
+                // Parse duration from pattern like "· 18m 50s ·" or "· 5m 00s ·"
+                match parse_compaction_duration(line) {
+                    Some(elapsed) => elapsed >= min_duration,
+                    // If we can't parse the duration, be conservative and don't interrupt
+                    None => false,
+                }
+            })
+        })
+        .map(|(name, _content)| name.clone())
+        .collect()
+}
+
+/// Parse the elapsed duration from a compaction status line.
+///
+/// Expected format: `(esc to interrupt · 18m 50s · ↓ 0 tokens)`
+/// Returns the parsed duration, or None if the format doesn't match.
+fn parse_compaction_duration(line: &str) -> Option<Duration> {
+    // Look for the pattern "· Xm Ys ·" after "esc to interrupt"
+    let after_esc = line.split("esc to interrupt").nth(1)?;
+
+    let mut total_secs: u64 = 0;
+    let mut found_time = false;
+
+    for part in after_esc.split_whitespace() {
+        if let Some(m) = part.strip_suffix('m')
+            && let Ok(mins) = m.parse::<u64>()
+        {
+            total_secs += mins * 60;
+            found_time = true;
+        } else if let Some(s) = part.strip_suffix('s')
+            && let Ok(secs) = s.parse::<u64>()
+        {
+            total_secs += secs;
+            found_time = true;
+        }
+    }
+
+    if found_time {
+        Some(Duration::from_secs(total_secs))
+    } else {
+        None
+    }
+}
+
+/// Detect coworkers with queued nudge messages that aren't being processed.
+///
+/// When a coworker is at a prompt with queued messages (lines starting with `❯`
+/// visible in the pane below the active prompt), it needs an Enter or Escape
+/// to start processing them. We look for `❯` lines that appear in the pane
+/// content, which indicates nudges were delivered but haven't been submitted.
+///
+/// We detect this by looking for the `❯` character followed by text, which
+/// appears when nudge messages are queued but sitting unprocessed at the prompt.
+pub(crate) fn detect_queued_prompt_stuck(pane_contents: &HashMap<String, String>) -> Vec<String> {
+    pane_contents
+        .iter()
+        .filter(|(_name, content)| {
+            // Look for queued nudge messages: lines starting with ❯ followed by text.
+            // These appear when nudge messages were sent but the coworker hasn't
+            // pressed Enter to submit them. The ❯ is Claude Code's prompt indicator.
+            let has_queued = content.lines().any(|line| {
+                let trimmed = line.trim();
+                trimmed.starts_with('❯') && trimmed.len() > "❯".len() + 1
+            });
+            // Only flag if NOT currently in compaction (that's a separate recovery)
+            let in_compaction = content.contains("esc to interrupt");
+            has_queued && !in_compaction
+        })
+        .map(|(name, _content)| name.clone())
+        .collect()
+}
+
+/// Pure decision: determine which coworkers need UI recovery actions.
+///
+/// Checks pane contents for two stuck states and returns the appropriate
+/// recovery actions. Cooldown tracking is the caller's responsibility.
+///
+/// `min_compaction_duration` sets the minimum elapsed time before a
+/// compaction is considered stuck. Short compactions are normal and useful.
+pub(crate) fn decide_stuck_ui_recoveries(
+    pane_contents: &HashMap<String, String>,
+    min_compaction_duration: Duration,
+) -> Vec<StuckUiRecovery> {
+    let mut recoveries = Vec::new();
+
+    for name in detect_compaction_stuck(pane_contents, min_compaction_duration) {
+        recoveries.push(StuckUiRecovery::InterruptCompaction { name });
+    }
+
+    for name in detect_queued_prompt_stuck(pane_contents) {
+        recoveries.push(StuckUiRecovery::InterruptQueuedNudges { name });
+    }
+
+    recoveries
 }
 
 // ---------------------------------------------------------------------------
@@ -1084,13 +1221,13 @@ mod tests {
             Utc::now(),
             Duration::from_secs(30),
             Duration::from_secs(300),
+            Duration::from_secs(120),
         );
         apply_health_transitions(&mut phases, transitions);
 
         assert_eq!(decisions.len(), 1);
         assert_eq!(decisions[0].name, "york");
         assert!(!decisions[0].is_isolated);
-        assert!(!decisions[0].save_session);
         assert!(get_health(&phases, "york").is_none());
     }
 
@@ -1116,6 +1253,7 @@ mod tests {
             Utc::now(),
             Duration::from_secs(30),
             Duration::from_secs(300),
+            Duration::from_secs(120),
         );
         apply_health_transitions(&mut phases, transitions);
 
@@ -1146,6 +1284,7 @@ mod tests {
             Utc::now(),
             Duration::from_secs(30),
             Duration::from_secs(300),
+            Duration::from_secs(120),
         );
 
         assert!(decisions.is_empty());
@@ -1173,6 +1312,7 @@ mod tests {
             Utc::now(),
             Duration::from_secs(30),
             Duration::from_secs(300),
+            Duration::from_secs(120),
         );
 
         assert!(decisions.is_empty());
@@ -1200,6 +1340,7 @@ mod tests {
             Utc::now(),
             Duration::from_secs(30),
             Duration::from_secs(300),
+            Duration::from_secs(120),
         );
         apply_health_transitions(&mut phases, transitions);
 
@@ -1230,6 +1371,7 @@ mod tests {
             Utc::now(),
             Duration::from_secs(30),
             Duration::from_secs(300),
+            Duration::from_secs(120),
         );
         apply_health_transitions(&mut phases, transitions);
 
@@ -1255,6 +1397,7 @@ mod tests {
             Utc::now(),
             Duration::from_secs(30),
             Duration::from_secs(300),
+            Duration::from_secs(120),
         );
 
         assert_eq!(decisions.len(), 1);
@@ -1279,6 +1422,7 @@ mod tests {
             Utc::now(),
             Duration::from_secs(30),
             Duration::from_secs(300),
+            Duration::from_secs(120),
         );
         apply_health_transitions(&mut phases, transitions);
 
@@ -1288,7 +1432,7 @@ mod tests {
     }
 
     #[test]
-    fn idle_shutdown_pr_break_with_ci_passed() {
+    fn idle_shutdown_skips_coworker_with_open_pr_even_ci_passed() {
         let coworkers = vec![cw("york", 10)];
         let phases = lifecycle_with(
             "york",
@@ -1297,7 +1441,7 @@ mod tests {
             },
         );
 
-        // york has an open PR AND CI is passing — should trigger PR break (save_session=true)
+        // york has an open PR AND CI is passing — should still be protected (never break with open PR)
         let (decisions, _transitions) = decide_idle_shutdowns(
             &coworkers,
             &set(&[]),
@@ -1310,15 +1454,17 @@ mod tests {
             Utc::now(),
             Duration::from_secs(30),
             Duration::from_secs(300),
+            Duration::from_secs(120),
         );
 
-        assert_eq!(decisions.len(), 1);
-        assert_eq!(decisions[0].name, "york");
-        assert!(decisions[0].save_session);
+        assert!(
+            decisions.is_empty(),
+            "coworkers with open PRs should never be sent on break"
+        );
     }
 
     #[test]
-    fn idle_shutdown_pr_break_not_triggered_without_ci() {
+    fn idle_shutdown_skips_coworker_with_open_pr_no_ci() {
         let coworkers = vec![cw("york", 10)];
         let phases = lifecycle_with(
             "york",
@@ -1340,37 +1486,92 @@ mod tests {
             Utc::now(),
             Duration::from_secs(30),
             Duration::from_secs(300),
+            Duration::from_secs(120),
         );
 
         assert!(decisions.is_empty());
     }
 
     #[test]
-    fn idle_shutdown_pr_break_not_triggered_if_busy() {
+    fn idle_shutdown_skips_coworker_with_recent_pane_activity() {
         let coworkers = vec![cw("york", 10)];
-        let phases = lifecycle_with(
-            "york",
-            SessionHealth::Idle {
-                since: Instant::now() - Duration::from_secs(60),
+        // york has a pane_hash that changed recently (10 seconds ago)
+        let mut phases = HashMap::new();
+        phases.insert(
+            "york".to_string(),
+            CoworkerRecord {
+                health: Some(SessionHealth::Idle {
+                    since: Instant::now() - Duration::from_secs(60),
+                }),
+                last_activity: None,
+                workflow_phase: None,
+                task_id: None,
+                workflow_updated_at: None,
+                pane_hash: Some((12345, Instant::now() - Duration::from_secs(10))),
+                zombie_respawn_count: 0,
             },
         );
 
-        // york has open PR, CI passed, but is busy — should NOT trigger break
+        // york is idle and has no tasks/PRs, but pane changed 10s ago — should NOT break
         let (decisions, _transitions) = decide_idle_shutdowns(
             &coworkers,
-            &set(&["york"]),
-            &set(&["york"]),
             &set(&[]),
             &set(&[]),
-            &set(&["york"]),
+            &set(&[]),
+            &set(&[]),
+            &set(&[]),
             &phases,
             Instant::now(),
             Utc::now(),
             Duration::from_secs(30),
             Duration::from_secs(300),
+            Duration::from_secs(120),
         );
 
-        assert!(decisions.is_empty());
+        assert!(
+            decisions.is_empty(),
+            "coworkers with recent pane activity should not be sent on break"
+        );
+    }
+
+    #[test]
+    fn idle_shutdown_allows_break_with_stale_pane() {
+        let coworkers = vec![cw("york", 10)];
+        // york has a pane_hash that last changed 5 minutes ago (well beyond grace period)
+        let mut phases = HashMap::new();
+        phases.insert(
+            "york".to_string(),
+            CoworkerRecord {
+                health: Some(SessionHealth::Idle {
+                    since: Instant::now() - Duration::from_secs(60),
+                }),
+                last_activity: None,
+                workflow_phase: None,
+                task_id: None,
+                workflow_updated_at: None,
+                pane_hash: Some((12345, Instant::now() - Duration::from_secs(300))),
+                zombie_respawn_count: 0,
+            },
+        );
+
+        // york is idle, no tasks/PRs, pane unchanged for 5 minutes — should break
+        let (decisions, _transitions) = decide_idle_shutdowns(
+            &coworkers,
+            &set(&[]),
+            &set(&[]),
+            &set(&[]),
+            &set(&[]),
+            &set(&[]),
+            &phases,
+            Instant::now(),
+            Utc::now(),
+            Duration::from_secs(30),
+            Duration::from_secs(300),
+            Duration::from_secs(120),
+        );
+
+        assert_eq!(decisions.len(), 1);
+        assert_eq!(decisions[0].name, "york");
     }
 
     // -----------------------------------------------------------------------
@@ -1737,6 +1938,230 @@ mod tests {
         let zombies =
             detect_blank_pane_zombies(&blank, &start_times, now, chrono::Duration::seconds(20));
         assert!(zombies.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Compaction whirlpool & queued prompt detection tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn compaction_detected_with_whirlpool_verb_long_duration() {
+        let mut panes = HashMap::new();
+        panes.insert(
+            "york".to_string(),
+            "  Whirlpooling your conversation…\n  (esc to interrupt · 18m 50s · ↓ 0 tokens)\n"
+                .to_string(),
+        );
+        // 18m 50s > 5 min threshold — should trigger
+        let stuck = detect_compaction_stuck(&panes, Duration::from_secs(300));
+        assert_eq!(stuck, vec!["york"]);
+    }
+
+    #[test]
+    fn compaction_not_detected_with_short_duration() {
+        let mut panes = HashMap::new();
+        panes.insert(
+            "amsterdam".to_string(),
+            "  Baking your conversation…\n  (esc to interrupt · 3m 12s · ↓ 42 tokens)\n"
+                .to_string(),
+        );
+        // 3m 12s < 5 min threshold — should NOT trigger (compaction is normal)
+        let stuck = detect_compaction_stuck(&panes, Duration::from_secs(300));
+        assert!(
+            stuck.is_empty(),
+            "short compaction should not be interrupted"
+        );
+    }
+
+    #[test]
+    fn compaction_detected_at_exact_threshold() {
+        let mut panes = HashMap::new();
+        panes.insert(
+            "park".to_string(),
+            "  Simmering your conversation…\n  (esc to interrupt · 5m 00s · ↓ 100 tokens)\n"
+                .to_string(),
+        );
+        // 5m 00s = 5 min threshold — should trigger
+        let stuck = detect_compaction_stuck(&panes, Duration::from_secs(300));
+        assert_eq!(stuck, vec!["park"]);
+    }
+
+    #[test]
+    fn compaction_not_detected_just_under_threshold() {
+        let mut panes = HashMap::new();
+        panes.insert(
+            "park".to_string(),
+            "  Simmering your conversation…\n  (esc to interrupt · 4m 59s · ↓ 100 tokens)\n"
+                .to_string(),
+        );
+        let stuck = detect_compaction_stuck(&panes, Duration::from_secs(300));
+        assert!(
+            stuck.is_empty(),
+            "compaction just under threshold should not be interrupted"
+        );
+    }
+
+    #[test]
+    fn compaction_not_detected_in_normal_output() {
+        let mut panes = HashMap::new();
+        panes.insert(
+            "york".to_string(),
+            "  Reading file src/main.rs\n  Edit: replaced 3 lines\n  $ cargo build\n".to_string(),
+        );
+        let stuck = detect_compaction_stuck(&panes, Duration::from_secs(300));
+        assert!(stuck.is_empty());
+    }
+
+    #[test]
+    fn compaction_not_detected_when_pane_mentions_esc_in_code() {
+        // "esc to interrupt" in code output but no parseable duration — conservative: don't interrupt
+        let mut panes = HashMap::new();
+        panes.insert(
+            "york".to_string(),
+            "  // detect the pattern: esc to interrupt\n  fn check() {}\n".to_string(),
+        );
+        let stuck = detect_compaction_stuck(&panes, Duration::from_secs(300));
+        // Can't parse duration from code comment → conservative: don't interrupt
+        assert!(
+            stuck.is_empty(),
+            "unparseable duration should not trigger (conservative)"
+        );
+    }
+
+    #[test]
+    fn parse_compaction_duration_works() {
+        assert_eq!(
+            parse_compaction_duration("  (esc to interrupt · 18m 50s · ↓ 0 tokens)"),
+            Some(Duration::from_secs(18 * 60 + 50))
+        );
+        assert_eq!(
+            parse_compaction_duration("  (esc to interrupt · 0m 30s · ↓ 0 tokens)"),
+            Some(Duration::from_secs(30))
+        );
+        assert_eq!(
+            parse_compaction_duration("  (esc to interrupt · 5m 00s · ↓ 100 tokens)"),
+            Some(Duration::from_secs(300))
+        );
+        assert_eq!(
+            parse_compaction_duration("  // detect the pattern: esc to interrupt"),
+            None,
+        );
+    }
+
+    #[test]
+    fn queued_prompt_detected_with_nudge_messages() {
+        let mut panes = HashMap::new();
+        panes.insert(
+            "york".to_string(),
+            "  some output\n❯ You have a new task assignment: task #42\n❯ Check the channel for updates\n".to_string(),
+        );
+        let stuck = detect_queued_prompt_stuck(&panes);
+        assert_eq!(stuck, vec!["york"]);
+    }
+
+    #[test]
+    fn queued_prompt_not_detected_during_compaction() {
+        // If compaction is happening simultaneously, don't also flag queued prompt
+        let mut panes = HashMap::new();
+        panes.insert(
+            "york".to_string(),
+            "  Whirlpooling…\n  (esc to interrupt · 5m 00s · ↓ 0 tokens)\n❯ pending nudge\n"
+                .to_string(),
+        );
+        let stuck = detect_queued_prompt_stuck(&panes);
+        assert!(
+            stuck.is_empty(),
+            "should not flag queued prompt during compaction"
+        );
+    }
+
+    #[test]
+    fn queued_prompt_not_detected_with_bare_prompt() {
+        // Just the ❯ character alone (empty prompt) should NOT trigger
+        let mut panes = HashMap::new();
+        panes.insert("york".to_string(), "  output\n❯ \n".to_string());
+        let stuck = detect_queued_prompt_stuck(&panes);
+        assert!(
+            stuck.is_empty(),
+            "bare prompt character should not trigger recovery"
+        );
+    }
+
+    #[test]
+    fn queued_prompt_not_detected_in_normal_output() {
+        let mut panes = HashMap::new();
+        panes.insert(
+            "york".to_string(),
+            "  $ cargo test\n  running 5 tests\n  test result: ok. 5 passed\n".to_string(),
+        );
+        let stuck = detect_queued_prompt_stuck(&panes);
+        assert!(stuck.is_empty());
+    }
+
+    #[test]
+    fn combined_recovery_returns_both_types() {
+        let mut panes = HashMap::new();
+        // One coworker stuck in compaction (10 min — well above threshold)
+        panes.insert(
+            "york".to_string(),
+            "  (esc to interrupt · 10m 00s · ↓ 0 tokens)\n".to_string(),
+        );
+        // Another coworker with queued nudges
+        panes.insert("amsterdam".to_string(), "❯ Check the channel\n".to_string());
+
+        let recoveries = decide_stuck_ui_recoveries(&panes, Duration::from_secs(300));
+        assert_eq!(recoveries.len(), 2);
+
+        let has_compaction = recoveries
+            .iter()
+            .any(|r| matches!(r, StuckUiRecovery::InterruptCompaction { name } if name == "york"));
+        let has_queued = recoveries.iter().any(
+            |r| matches!(r, StuckUiRecovery::InterruptQueuedNudges { name } if name == "amsterdam"),
+        );
+        assert!(has_compaction, "should detect york's compaction");
+        assert!(has_queued, "should detect amsterdam's queued nudges");
+    }
+
+    #[test]
+    fn combined_recovery_skips_short_compaction() {
+        let mut panes = HashMap::new();
+        // Compaction running for only 2 minutes — below threshold
+        panes.insert(
+            "york".to_string(),
+            "  (esc to interrupt · 2m 00s · ↓ 0 tokens)\n".to_string(),
+        );
+        panes.insert("amsterdam".to_string(), "❯ Check the channel\n".to_string());
+
+        let recoveries = decide_stuck_ui_recoveries(&panes, Duration::from_secs(300));
+        // Only the queued nudge should trigger, not the short compaction
+        assert_eq!(recoveries.len(), 1);
+        assert!(matches!(
+            &recoveries[0],
+            StuckUiRecovery::InterruptQueuedNudges { name } if name == "amsterdam"
+        ));
+    }
+
+    #[test]
+    fn recovery_empty_for_healthy_coworkers() {
+        let mut panes = HashMap::new();
+        panes.insert(
+            "york".to_string(),
+            "  Reading file\n  Edit complete\n".to_string(),
+        );
+        panes.insert(
+            "amsterdam".to_string(),
+            "  $ cargo build\n  Compiling midtown v0.4.1\n".to_string(),
+        );
+
+        let recoveries = decide_stuck_ui_recoveries(&panes, Duration::from_secs(300));
+        assert!(recoveries.is_empty());
+    }
+
+    #[test]
+    fn recovery_empty_for_no_coworkers() {
+        let panes: HashMap<String, String> = HashMap::new();
+        let recoveries = decide_stuck_ui_recoveries(&panes, Duration::from_secs(300));
+        assert!(recoveries.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- **Never send coworkers on break while they have open unmerged PRs** — removes the "PR break with CI passed" path entirely. Coworkers must stay available to address review feedback.
- **Pane activity grace period** — if a coworker's tmux pane changed within the last 2 minutes, they're considered actively working and won't be sent on break, even if they have no in-progress tasks.
- **Conservative compaction recovery** (incorporates york's PR #490) — detects stuck compaction via `esc to interrupt` pane pattern, but only interrupts if compaction has been running for 5+ minutes. Parses elapsed time directly from the status line `(esc to interrupt · 18m 50s · ↓ 0 tokens)`.
- **Queued prompt recovery** — detects nudge messages sitting unprocessed at the Claude Code prompt and sends Escape to unblock.
- Adds `SendRawKeys` effect for tmux key injection without the nudge text mechanism.
- 20+ new/updated tests covering pane activity, compaction duration parsing, threshold behavior, and combined recovery scenarios.

Supersedes PR #490.

## Test plan
- [x] All tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Formatting clean (`cargo fmt -- --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)