### PR TITLE
fix: Handle Action message type in chat_perf test helper [Midtown #738]

### DIFF
--- a/tests/chat_perf.rs
+++ b/tests/chat_perf.rs
@@ -80,6 +80,9 @@ fn wrap_content(content: &str, width: usize) -> Vec<String> {
 
 /// Simulated message rendering (mirrors render_message logic).
 /// Returns the number of output lines for the message.
+///
+/// This mirrors the actual render_message() function in ui.rs, including
+/// special handling for Action messages which have a "* " prefix.
 fn render_message_line_count(
     msg: &Message,
     width: usize,
@@ -88,8 +91,16 @@ fn render_message_line_count(
 ) -> usize {
     let show_sender = prev_sender.is_none_or(|prev| prev != msg.from);
 
-    // Content width after timestamp gutter
-    let content_width = width.saturating_sub(TIMESTAMP_GUTTER_WIDTH);
+    // Action messages have a "* " prefix that consumes 2 extra characters
+    // See ui.rs render_message() for the actual implementation
+    let extra_prefix = if msg.message_type == MessageType::Action {
+        2 // "* " prefix
+    } else {
+        0
+    };
+
+    // Content width after timestamp gutter (and action prefix if applicable)
+    let content_width = width.saturating_sub(TIMESTAMP_GUTTER_WIDTH + extra_prefix);
     if content_width == 0 {
         return 0;
     }


### PR DESCRIPTION
<!-- midtown: york -->

## Summary

Addresses review feedback from PR #494: The `render_message_line_count` test helper now correctly handles `MessageType::Action` messages.

**The issue:** Action messages in the actual `render_message()` function use a narrower content width to account for the "* " prefix (2 extra characters). The test helper was not accounting for this, causing a small discrepancy in line count calculations.

**The fix:** Added conditional width adjustment for Action messages:
```rust
let extra_prefix = if msg.message_type == MessageType::Action {
    2 // "* " prefix
} else {
    0
};
let content_width = width.saturating_sub(TIMESTAMP_GUTTER_WIDTH + extra_prefix);
```

## Test plan

- [x] All 13 performance tests pass
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt -- --check` passes