### PR TITLE
chore: Bump version to v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "midtown"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "axum",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midtown"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "Midtown - a multi-Claude Code workspace manager, inspired by Gastown"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- midtown: Lead -->

## Summary
- Bump version from 0.4.1 to 0.4.2

## v0.4.2 Changelog

### Daemon Stability Fixes
- Fix bell notification only to chat pane (#508)
- Webhook midtown marker detection (#513)
- Recognize comment-based PR reviews in stuck detection (#511)
- Fix compaction detection false positives (#515)
- Fix has_queued_nudges() to use has_compaction_indicator (#516)
- Remove double nudge delivery for stuck conditions (#509)
- Check task storage path before nudging (#510)
- Filter orphan worktrees by merged PRs for squash-merge (#507)
- Treat task_id 0 as "no task" in tmux window display (#506)

### Features
- Create reviewer-specific system prompt merging all sources (#512)
- PWA service worker updates + E2E tests (#514)
- Update logo with new stacked blocks design (#501)
- Add `midtown e2e` CLI for containerized E2E testing (#486)
- Add full_stack_e2e.rs integration tests for real Claude Code (#487)
- Protect active coworkers from break, add conservative compaction recovery (#491)

### Performance
- Run coordination E2E tests directly on CI runner (#502)
- Optimize chat TUI rendering and memory usage (#498)
- Add performance tests for chat TUI (#494)

### Bug Fixes
- Prevent task-level spawn race with in-flight tracking (#500)
- Prevent spawn race condition with check-before-insert (#499)
- Fix task spawn race (#503)
- Clean up cooldown state when coworkers shut down (#492)
- Prevent duplicate lead windows on restart (#485)

### Refactoring
- Consolidate per-coworker state into unified CoworkerRecord (#484)

### Docs & CI
- Skip plugin install test (requires auth) (#504)
- Add channel message discipline to reviewer prompt (#496)
- Add lead notifications for verification milestones (#493)
- Update CI workflow for containerized E2E (#489)

🤖 Generated with [Claude Code](https://claude.ai/code)