### PR TITLE
fix(web-ui): Prevent horizontal scrolling and lowercase tmux tab [Midtown #11]

### DIFF
--- a/web-app/src/App.svelte
+++ b/web-app/src/App.svelte
@@ -112,7 +112,7 @@
         class:active={activeTab === 'tmux'}
         onclick={() => (activeTab = 'tmux')}
       >
-        Tmux
+        tmux
       </button>
     </nav>
 

--- a/web-app/src/lib/Tmux.svelte
+++ b/web-app/src/lib/Tmux.svelte
@@ -22,8 +22,9 @@
 
   function getViewportCols() {
     if (!paneEl) return 80
-    // Use the pane content element's width minus padding (12px each side)
-    const usable = paneEl.clientWidth - 24
+    // Use the pane content element's width minus padding (12px each side = 24px)
+    // plus extra 20px to account for UI chrome/scrollbars and prevent horizontal scrolling
+    const usable = paneEl.clientWidth - 44
     return Math.max(80, Math.floor(usable / CHAR_WIDTH_PX))
   }
 


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Add 20px additional padding to tmux viewport width calculation to prevent horizontal scrolling on narrow viewports (total 44px now vs previous 24px)
- Change "Tmux" tab label to "tmux" (lowercase) per user request

## Changes
- `web-app/src/lib/Tmux.svelte`: Updated `getViewportCols()` to subtract 44px instead of 24px from `clientWidth`
- `web-app/src/App.svelte`: Changed tab label from "Tmux" to "tmux"

## Test plan
- [x] Web-app builds successfully (`npm run build`)
- [x] Rust clippy passes
- [ ] Manual verification: Open web UI on narrow viewport, confirm no horizontal scroll in tmux tab
- [ ] Tab shows "tmux" instead of "Tmux"

🤖 Generated with [Claude Code](https://claude.com/claude-code)