### PR TITLE
fix: Rate-limit orphan worktree detection logs for squash-merged PRs [Midtown #17]

### DIFF
--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -448,8 +448,11 @@ impl CoworkerManager {
                     tracing::info!("Cleaned up empty orphaned worktree for {}", name);
                 }
                 Ok(false) => {
-                    tracing::warn!(
-                        "Orphaned worktree for {} has unmerged commits - flagging to lead",
+                    // Log at debug level - the actual rate-limited warning happens
+                    // in dispatch::cleanup_orphaned_worktrees() via OrphanTracker.
+                    // Logging warn! here would spam every tick (5 seconds).
+                    tracing::debug!(
+                        "Orphaned worktree for {} has unmerged commits - will check filters",
                         name
                     );
                     flagged.push(name);

--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -448,8 +448,12 @@ pub(super) fn cleanup_orphaned_worktrees(state: &DaemonState) {
         return;
     }
 
-    // Record warnings
+    // Record warnings and log (rate-limited by OrphanTracker)
     for name in &due_for_warning {
+        warn!(
+            "Orphaned worktree for {} has unmerged commits - flagging to lead",
+            name
+        );
         tracker.record_warn(name);
     }
     drop(tracker);


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Fixes the daemon spamming `warn!` logs every 5 seconds for orphan worktrees with squash-merged PRs
- The log in `CoworkerManager::cleanup_orphaned_worktrees()` was firing on every tick, even though the actual lead notification was rate-limited by `OrphanTracker`
- Changed the log level from `warn!` to `debug!` in `coworker.rs`, and added a rate-limited `warn!` log in `dispatch.rs` after the OrphanTracker check

## Root Cause
The orphan detection flow had two phases that weren't aligned:
1. `coworker.rs` level: `safe_cleanup()` → `warn!` log (fires every 5 seconds)
2. `dispatch.rs` level: filtering + `OrphanTracker` → channel warning (rate-limited to 1 hour)

The fix aligns the logging with the notification rate-limiting.

## Test plan
- [x] All orphan-related tests pass (`cargo test -- orphan`)
- [x] All filter tests pass (`cargo test -- filter_orphans`)
- [x] Full test suite passes
- [x] `cargo clippy -- -D warnings` passes