### PR TITLE
docs: Add guidance to run E2E locally while waiting for CI [Midtown #20]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,14 @@ midtown e2e run full                        # real Claude, needs auth setup firs
 ./scripts/e2e-container.sh full
 ```
 
+**While waiting for GitHub CI**: After pushing a PR, don't wait idle for CI results. Run the full containerized E2E tests locally:
+
+```bash
+midtown e2e run coordination    # run while CI is in progress
+```
+
+This catches failures faster than waiting for GitHub Actions and keeps you productive. The container environment matches CI, so local passes should match remote passes.
+
 ## Architecture
 
 ### State Machine Daemon


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Adds guidance to CLAUDE.md instructing coworkers to run containerized E2E tests locally while waiting for GitHub CI results
- Helps catch failures faster than waiting for GitHub Actions
- Keeps coworkers productive during CI wait times

## Test plan
- [x] Documentation-only change - no functional tests needed
- [x] Verify formatting renders correctly in markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)