### PR TITLE
ci: Add shared build job for E2E tests [Midtown #24]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,30 @@ jobs:
       - name: Run tests
         run: cargo test --all-features
 
+  build-e2e:
+    name: Build E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: midtown-binary
+          path: target/release/midtown
+          retention-days: 1
+
   e2e:
     name: E2E - ${{ matrix.test }}
+    needs: [build-e2e]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -64,6 +86,15 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Download pre-built binary
+        uses: actions/download-artifact@v4
+        with:
+          name: midtown-binary
+          path: target/release
+
+      - name: Make binary executable
+        run: chmod +x target/release/midtown
+
       - name: Install tmux
         run: sudo apt-get update && sudo apt-get install -y tmux
 
@@ -78,9 +109,6 @@ jobs:
 
       - name: Start tmux server
         run: tmux start-server
-
-      - name: Build release binary
-        run: cargo build --release
 
       - name: Run ${{ matrix.test }}
         run: cargo test --release --test ${{ matrix.test }} -- ${{ matrix.flags }}


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Add `build-e2e` job that compiles the release binary once
- Upload binary as artifact for all E2E jobs to download
- E2E jobs now wait for `build-e2e` via `needs` dependency
- Removes redundant `cargo build --release` from each E2E job

## Benefit
Previously, each of the 9 E2E jobs built the release binary independently (~50s each = ~450s total build time, though in parallel). Now a single shared build job builds once, and E2E jobs download the pre-built artifact.

## Test plan
- [ ] Verify `build-e2e` job completes and uploads artifact
- [ ] Verify E2E jobs start only after `build-e2e` completes
- [ ] Verify E2E jobs successfully download and use the artifact
- [ ] Confirm all E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)