### PR TITLE
refactor: Move startup state recovery to daemon/startup.rs [Midtown #23]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -15,6 +15,7 @@ pub mod helpers;
 mod pr;
 mod rpc;
 pub(crate) mod snapshot;
+mod startup;
 pub(crate) mod state;
 mod trackers;
 mod webhook_fwd;
@@ -956,36 +957,8 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
         REVIEW_HEADROOM
     );
 
-    // Initialize coworker_records for discovered coworkers by reading their state files.
-    // This recovers workflow phase (dev, test, PR, etc.) across daemon restarts.
-    {
-        let discovered_names: Vec<String> = state
-            .coworkers
-            .list()
-            .iter()
-            .map(|c| c.name.clone())
-            .collect();
-        if !discovered_names.is_empty() {
-            let mut records = state.coworker_records.write().await;
-            for name in &discovered_names {
-                if let Some(file_state) = crate::coworker_state::read_state(&repo_name, name) {
-                    info!(
-                        "Recovered state for {}: {} (from state.json)",
-                        name,
-                        file_state.display_status()
-                    );
-                    let mut record = crate::rules::CoworkerRecord::new_spawn();
-                    record.workflow_phase = Some(file_state.phase);
-                    record.task_id = file_state.task_id;
-                    record.workflow_updated_at = Some(file_state.updated_at);
-                    records.insert(name.clone(), record);
-                } else {
-                    // No state file - create a minimal record so the coworker is tracked
-                    records.insert(name.clone(), crate::rules::CoworkerRecord::new_spawn());
-                }
-            }
-        }
-    }
+    // Recover coworker workflow state from their state files across daemon restarts.
+    startup::recover_coworker_records(&repo_name, &state.coworkers, &state.coworker_records).await;
 
     // Set up shutdown signal handler
     let (shutdown_tx, _) = broadcast::channel::<()>(1);

--- a/src/daemon/startup.rs
+++ b/src/daemon/startup.rs
@@ -1,0 +1,58 @@
+//! Startup state recovery for the midtown daemon.
+//!
+//! Handles recovery of coworker workflow state across daemon restarts.
+//! When the daemon starts, it discovers running coworkers from tmux and
+//! recovers their workflow phases from individual state files.
+
+use std::collections::HashMap;
+
+use tokio::sync::RwLock;
+use tracing::info;
+
+use crate::coworker::CoworkerManager;
+use crate::rules::CoworkerRecord;
+
+/// Recover coworker workflow state from their state files.
+///
+/// For each coworker discovered in the tmux session, reads their state.json
+/// to recover:
+/// - Workflow phase (developing, testing, pull-request, etc.)
+/// - Current task ID
+/// - Last workflow update timestamp
+///
+/// This allows the daemon to resume coordination of in-progress work
+/// after a restart without losing context about what each coworker was doing.
+pub async fn recover_coworker_records(
+    repo_name: &str,
+    coworkers: &CoworkerManager,
+    coworker_records: &RwLock<HashMap<String, CoworkerRecord>>,
+) {
+    let discovered_names: Vec<String> = coworkers.list().iter().map(|c| c.name.clone()).collect();
+
+    if discovered_names.is_empty() {
+        return;
+    }
+
+    let mut records = coworker_records.write().await;
+    for name in &discovered_names {
+        if let Some(file_state) = crate::coworker_state::read_state(repo_name, name) {
+            info!(
+                "Recovered state for {}: {} (from state.json)",
+                name,
+                file_state.display_status()
+            );
+            let mut record = CoworkerRecord::new_spawn();
+            record.workflow_phase = Some(file_state.phase);
+            record.task_id = file_state.task_id;
+            record.workflow_updated_at = Some(file_state.updated_at);
+            records.insert(name.to_string(), record);
+        } else {
+            // No state file - create a minimal record so the coworker is tracked
+            records.insert(name.to_string(), CoworkerRecord::new_spawn());
+        }
+    }
+}
+
+// Unit tests for this module would require mocking CoworkerManager, which is complex.
+// The behavior is covered by E2E tests that verify daemon restart recovery works correctly.
+// See tests/daemon_e2e.rs for integration coverage.


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary

Follows the "Daemon Module Is a Thin Orchestrator" principle by extracting startup state recovery logic into a dedicated domain module.

**Changes:**
- Add new `src/daemon/startup.rs` module with `recover_coworker_records()` function
- Update `mod.rs` to call the new function instead of inline logic (~30 lines moved)
- `mod.rs` now focuses purely on event loop wiring

The recovery logic reads coworker `state.json` files to restore workflow phases (developing, testing, PR, etc.) across daemon restarts. This allows the daemon to resume coordination without losing context about what each coworker was doing.

## Test plan

- [x] Builds successfully
- [x] All tests pass
- [x] Clippy passes with no warnings
- [ ] E2E tests (CI will verify daemon restart recovery works correctly)

This is a pure refactor - no behavioral changes, just code organization.