### PR TITLE
fix: Add retry logic for EAGAIN errors in RPC socket reads [Midtown #30]

### DIFF
--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -93,6 +93,10 @@ impl DaemonClient {
     /// Uses timeouts on the Unix socket to prevent indefinite blocking when the
     /// daemon is busy. This is critical for hook processes — without timeouts,
     /// a slow daemon response stalls the Claude Code instance that fired the hook.
+    ///
+    /// Includes retry logic for EAGAIN/EWOULDBLOCK errors (os error 35 on macOS,
+    /// 11 on Linux) which can occur transiently when the socket buffer is temporarily
+    /// unavailable.
     fn send_raw(&self, method: &str, params: Option<Value>) -> Result<Value, String> {
         let mut stream = UnixStream::connect(&self.socket_path)
             .map_err(|e| format!("Connection failed: {}", e))?;
@@ -117,12 +121,29 @@ impl DaemonClient {
         writeln!(stream, "{}", request_json).map_err(|e| format!("Write error: {}", e))?;
         stream.flush().map_err(|e| format!("Flush error: {}", e))?;
 
-        // Read response
+        // Read response with retry logic for EAGAIN/EWOULDBLOCK.
+        // These errors occur when the socket has no data yet but isn't closed.
+        // We retry up to the overall timeout duration.
         let mut reader = BufReader::new(stream);
         let mut response_line = String::new();
-        reader
-            .read_line(&mut response_line)
-            .map_err(|e| format!("Read error: {}", e))?;
+        let start = std::time::Instant::now();
+        let max_duration = std::time::Duration::from_secs(5);
+
+        loop {
+            match reader.read_line(&mut response_line) {
+                Ok(_) => break,
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    // EAGAIN/EWOULDBLOCK - socket temporarily unavailable
+                    if start.elapsed() >= max_duration {
+                        return Err(format!("Read timeout after {:?}", max_duration));
+                    }
+                    // Brief sleep before retry to avoid busy-spinning
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    continue;
+                }
+                Err(e) => return Err(format!("Read error: {}", e)),
+            }
+        }
 
         let rpc_response: JsonRpcResponse = serde_json::from_str(&response_line)
             .map_err(|e| format!("Parse error: {} (response: {})", e, response_line.trim()))?;


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Fix intermittent "Resource temporarily unavailable (os error 35)" errors in RPC calls
- Add retry loop for EAGAIN/EWOULDBLOCK errors with 10ms delay between attempts
- Respects the existing 5-second overall timeout

## Problem
The Unix socket read could fail immediately when the socket buffer was temporarily empty but the connection was still valid. This caused random failures in:
- `midtown status`
- `midtown channel post`
- `midtown state`
- `midtown coworker break`
- Any other CLI command using daemon RPC

## Solution
Instead of treating EAGAIN as a fatal error, retry the read with a small delay (10ms) to avoid busy-spinning. The retry loop continues until either:
1. Data is successfully read
2. The 5-second overall timeout expires

## Test plan
- [x] `cargo build --bin midtown` succeeds
- [x] `cargo clippy -- -D warnings` passes
- [x] Manual testing: `midtown status` works reliably under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)