### PR TITLE
fix: Use "lead" as default agent in hook attributions [Midtown #33]

### DIFF
--- a/src/bin/midtown/cli/hooks.rs
+++ b/src/bin/midtown/cli/hooks.rs
@@ -293,7 +293,9 @@ fn handle_idle_hook() -> Result<Response, String> {
     let channel =
         midtown::Channel::for_repo(&repo).map_err(|e| format!("Failed to open channel: {}", e))?;
 
-    let agent = std::env::var("MIDTOWN_AGENT").unwrap_or_else(|_| "coworker".to_string());
+    // Coworkers have MIDTOWN_AGENT set to their name at spawn time (see tmux.rs).
+    // Lead sessions don't have this set, so default to "lead".
+    let agent = std::env::var("MIDTOWN_AGENT").unwrap_or_else(|_| "lead".to_string());
     let personality = midtown::config::get_personality();
 
     hook_log(&repo, &format!("idle: {} posting idle status", agent));
@@ -521,7 +523,9 @@ fn handle_task_hook() -> Result<Response, String> {
     let context: serde_json::Value =
         serde_json::from_str(&input).map_err(|e| format!("Failed to parse JSON: {}", e))?;
 
-    let agent = std::env::var("MIDTOWN_AGENT").unwrap_or_else(|_| "coworker".to_string());
+    // Coworkers have MIDTOWN_AGENT set to their name at spawn time (see tmux.rs).
+    // Lead sessions don't have this set, so default to "lead".
+    let agent = std::env::var("MIDTOWN_AGENT").unwrap_or_else(|_| "lead".to_string());
 
     let repo = detect_git_repo().ok_or("Not in a git repository")?;
     let channel =
@@ -650,7 +654,9 @@ fn handle_ask_hook() -> Result<Response, String> {
     let context: serde_json::Value =
         serde_json::from_str(&input).map_err(|e| format!("Failed to parse JSON: {}", e))?;
 
-    let agent = std::env::var("MIDTOWN_AGENT").unwrap_or_else(|_| "coworker".to_string());
+    // Coworkers have MIDTOWN_AGENT set to their name at spawn time (see tmux.rs).
+    // Lead sessions don't have this set, so default to "lead".
+    let agent = std::env::var("MIDTOWN_AGENT").unwrap_or_else(|_| "lead".to_string());
 
     let tool_input = &context["tool_input"];
     let questions = extract_ask_questions(tool_input);


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary

When the Lead uses TaskCreate/TaskUpdate, channel messages were incorrectly attributed as `coworker:` instead of `lead:`.

**Before:**
```
[16:14:05] coworker: created task: Fix web UI blocking tmux resize
```

**After:**
```
[16:14:05] lead: created task: Fix web UI blocking tmux resize
```

## Root cause

The hook handlers defaulted `MIDTOWN_AGENT` to `"coworker"` when unset. However:
- Coworkers have `MIDTOWN_AGENT` set to their name at spawn time (via `tmux.rs:1322`)
- The Lead doesn't have this env var set

## Changes

Changed the default from `"coworker"` to `"lead"` in three hook handlers:
- `handle_idle_hook` - idle status messages
- `handle_task_hook` - task create/update messages  
- `handle_ask_hook` - AskUserQuestion notifications

## Test plan

- [x] All tests pass (`cargo test`)
- [x] Clippy passes with no warnings
- [x] Code formatting verified