### PR TITLE
fix: Allow coworkers with CI-passed PRs to go on break [Midtown #4]

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -263,11 +263,14 @@ pub(crate) struct ShutdownDecision {
 ///
 /// A coworker is protected from break if:
 /// - They have in-progress tasks (busy)
-/// - They have open unmerged PRs
+/// - They have open unmerged PRs with CI not yet passed (waiting for CI)
 /// - They are actively reviewing a PR
 /// - They have unblocked dependent tasks
 /// - Their pane content changed recently (within `pane_activity_grace`)
 /// - They have a subagent (Task tool) currently running
+///
+/// Coworkers with open PRs where CI has passed CAN go on break - they're just
+/// waiting for human review, and the daemon will respawn them when feedback arrives.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn decide_idle_shutdowns(
     coworkers: &[CoworkerSnapshot],


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Coworkers with open PRs can now go on break if their CI has passed
- Saves resources by not keeping idle sessions alive during human review
- Daemon will respawn them when review feedback arrives

## Changes
- Modified `decide_idle_shutdowns()` to use `ci_passed_pr_coworkers` parameter (previously unused)
- Added test `idle_shutdown_allows_coworker_with_ci_passed_pr_to_break`
- Removed outdated test that asserted the old "never break" behavior

## Test plan
- [x] Added unit test for the new behavior
- [x] Existing test `idle_shutdown_skips_coworker_with_open_pr_no_ci` verifies CI-not-passed PRs still block break
- [x] All 14 idle_shutdown tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)