### PR TITLE
fix: Validate branch prefixes against COWORKER_NAMES before spawning

### DIFF
--- a/src/daemon/helpers.rs
+++ b/src/daemon/helpers.rs
@@ -700,6 +700,37 @@ mod tests {
         );
     }
 
+    #[test]
+    fn coworker_from_branch_rejects_common_branch_prefixes() {
+        // Bug fix: branches like "fix/feature" should NOT create a coworker named "fix"
+        // These common branch prefixes are not valid coworker names
+        assert_eq!(
+            coworker_from_branch("fix/blank-pane-false-positive"),
+            None,
+            "fix/ prefix should NOT be treated as a coworker name"
+        );
+        assert_eq!(
+            coworker_from_branch("feature/new-thing"),
+            None,
+            "feature/ prefix should NOT be treated as a coworker name"
+        );
+        assert_eq!(
+            coworker_from_branch("bugfix/issue-123"),
+            None,
+            "bugfix/ prefix should NOT be treated as a coworker name"
+        );
+        assert_eq!(
+            coworker_from_branch("hotfix/urgent"),
+            None,
+            "hotfix/ prefix should NOT be treated as a coworker name"
+        );
+        assert_eq!(
+            coworker_from_branch("chore/update-deps"),
+            None,
+            "chore/ prefix should NOT be treated as a coworker name"
+        );
+    }
+
     // -------------------------------------------------------------------------
     // text_contains_review_signature — detects Claude reviews
     // -------------------------------------------------------------------------

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -311,7 +311,9 @@ pub(super) async fn poll_prs_for_issues(
         let title = pr.get("title").and_then(|s| s.as_str()).unwrap_or("");
 
         // Extract owner from branch prefix (e.g., "amsterdam/feature" -> "amsterdam")
-        let owner = head_ref.split('/').next().unwrap_or("");
+        // IMPORTANT: Use coworker_from_branch() to validate against COWORKER_NAMES.
+        // Raw split('/') would allow invalid names like "fix" from "fix/feature" branches.
+        let owner = coworker_from_branch(head_ref).unwrap_or_default();
 
         // Check for actionable issues
         let issues = detect_pr_issues(pr);
@@ -357,8 +359,12 @@ pub(super) async fn poll_prs_for_issues(
             );
 
             // Decide action using pure decision function
-            let action =
-                decide_pr_issue_action(owner, &active_coworkers, state.is_at_dev_limit(), &message);
+            let action = decide_pr_issue_action(
+                &owner,
+                &active_coworkers,
+                state.is_at_dev_limit(),
+                &message,
+            );
 
             effects.extend(pr_action_to_effects(
                 action, pr_number, title, issue_type, state,
@@ -1108,7 +1114,9 @@ async fn collect_reviewer_effects_with_source(
             // Nudge the PR author — review is complete but PR is still open
             let head_ref = pr.get("headRefName").and_then(|s| s.as_str()).unwrap_or("");
             let title = pr.get("title").and_then(|s| s.as_str()).unwrap_or("");
-            let owner = head_ref.split('/').next().unwrap_or("");
+            // IMPORTANT: Use coworker_from_branch() to validate against COWORKER_NAMES.
+            // Raw split('/') would allow invalid names like "fix" from "fix/feature" branches.
+            let owner = coworker_from_branch(head_ref).unwrap_or_default();
 
             if !owner.is_empty() {
                 let should_nudge = {
@@ -1131,7 +1139,7 @@ async fn collect_reviewer_effects_with_source(
                         .collect();
 
                     let action = crate::rules::decide_review_complete_action(
-                        owner,
+                        &owner,
                         &active_coworkers,
                         state.is_at_dev_limit(),
                         &nudge_msg,


### PR DESCRIPTION
## Summary
- Branches like `fix/feature` were being treated as having a coworker owner named "fix" because the code used raw `split('/').next()` to extract the owner
- This caused the daemon to spawn coworkers with invalid names (like "fix" instead of valid avenue names)
- Now uses `coworker_from_branch()` which validates the branch prefix against `COWORKER_NAMES` and returns `None` for non-coworker branch prefixes

## Test plan
- [x] Added test `coworker_from_branch_rejects_common_branch_prefixes` that verifies branches like `fix/`, `feature/`, `bugfix/`, etc. return `None`
- [x] All existing `coworker_from_branch` tests pass
- [x] Build and clippy pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)