### PR TITLE
fix: Add safety check to prevent killing last tmux window

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -124,6 +124,18 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 }
             }
             Effect::ShutdownCoworker { name, message } => {
+                // Log the shutdown with current window state for debugging
+                let session = state.coworkers.session_name();
+                let windows = crate::tmux::list_windows(session).unwrap_or_default();
+                info!(
+                    coworker = %name,
+                    session = %session,
+                    window_count = windows.len(),
+                    windows = ?windows,
+                    message_preview = %message.chars().take(50).collect::<String>(),
+                    "SHUTDOWN_COWORKER: executing shutdown effect"
+                );
+
                 // Nudge the goodbye message first, then shut down
                 if !message.is_empty()
                     && let Err(e) = state.coworkers.nudge(&name, &message)
@@ -132,6 +144,8 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 }
                 if let Err(e) = state.coworkers.shutdown(&name) {
                     warn!("Failed to shut down coworker {}: {}", name, e);
+                } else {
+                    info!(coworker = %name, "SHUTDOWN_COWORKER: shutdown completed");
                 }
                 // Record stop time for workflow features that need to track coworker lifecycle
                 {

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -119,34 +119,57 @@ pub(super) fn check_and_respawn_lead(
     // Session exists — check how many lead windows are present.
     // Using count_windows_by_name instead of window_exists to detect
     // duplicates that can accumulate from restart races.
-    match crate::tmux::count_windows_by_name(session, "lead") {
+    let lead_check = crate::tmux::count_windows_by_name(session, "lead");
+    let all_windows = crate::tmux::list_windows(session).unwrap_or_default();
+    debug!(
+        session = %session,
+        lead_check = ?lead_check,
+        all_windows = ?all_windows,
+        window_count = all_windows.len(),
+        "LEAD_HEALTH: checking lead window status"
+    );
+
+    match lead_check {
         Ok((0, _)) => {
-            warn!("Lead window missing in session {}, respawning...", session);
+            warn!(
+                session = %session,
+                all_windows = ?all_windows,
+                "LEAD_HEALTH: Lead window missing, will respawn"
+            );
             match crate::tmux::spawn_lead(
                 session,
                 &workdir.to_string_lossy(),
                 project_name,
                 additional_dirs,
             ) {
-                Ok(()) => info!("Successfully respawned lead window"),
-                Err(e) => error!("Failed to respawn lead window: {}", e),
+                Ok(()) => info!("LEAD_HEALTH: Successfully respawned lead window"),
+                Err(e) => error!("LEAD_HEALTH: Failed to respawn lead window: {}", e),
             }
         }
-        Ok((1, _)) => {} // exactly one lead window, all good
+        Ok((1, ids)) => {
+            debug!(
+                session = %session,
+                lead_id = ?ids.first(),
+                "LEAD_HEALTH: exactly one lead window, all good"
+            );
+        }
         Ok((n, ids)) => {
             // Multiple lead windows detected — kill all but the first one
             warn!(
-                "Found {} duplicate lead windows in session {}, cleaning up extras",
-                n, session
+                session = %session,
+                lead_count = n,
+                lead_ids = ?ids,
+                all_windows = ?all_windows,
+                "LEAD_HEALTH: Found duplicate lead windows, cleaning up extras"
             );
             for id in ids.iter().skip(1) {
                 let target = format!("{}:{}", session, id);
-                info!("Killing duplicate lead window {}", target);
+                info!(target = %target, "LEAD_HEALTH: Killing duplicate lead window");
                 let _ = crate::tmux::kill_window_by_target(&target);
             }
         }
         Err(e) => {
-            warn!("Failed to check lead window status: {}", e);
+            warn!(error = %e, "LEAD_HEALTH: Failed to check lead window status");
         }
     }
 

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -375,15 +375,82 @@ pub fn create_window(
 ///
 /// Sends SIGTERM to the pane process before killing the window, because
 /// Claude Code survives the SIGHUP that tmux sends on window destruction.
+///
+/// SAFETY: Refuses to kill the last window in a session, as that would
+/// terminate the session (and potentially the tmux server if it's the only session).
 pub fn kill_window(session: &str, name: &str) -> crate::Result<()> {
+    // Safety check: don't kill the last window in the session
+    let window_count = count_session_windows(session);
+    if window_count <= 1 {
+        tracing::warn!(
+            "Refusing to kill window {}:{} - it's the last window in the session (count={})",
+            session,
+            name,
+            window_count
+        );
+        return Ok(());
+    }
+
     let target = format!("{}:{}", session, name);
-    kill_window_by_target(&target)
+    kill_window_by_target_unchecked(&target)
+}
+
+/// Count the number of windows in a tmux session.
+fn count_session_windows(session: &str) -> usize {
+    let output = match Command::new("tmux")
+        .args(["list-windows", "-t", session, "-F", "#{window_id}"])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return 0,
+    };
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|l| !l.is_empty())
+        .count()
 }
 
 /// Kill a tmux window by its fully-qualified target string (e.g., "session:@0").
 ///
 /// SIGTERMs pane processes first (Claude Code ignores SIGHUP), then kills the window.
+///
+/// SAFETY: Refuses to kill the last window in a session, as that would
+/// terminate the session (and potentially the tmux server if it's the only session).
 pub fn kill_window_by_target(target: &str) -> crate::Result<()> {
+    // Extract session name from target (format: "session:window" or "session:@id")
+    if let Some(session) = target.split(':').next() {
+        let window_count = count_session_windows(session);
+        if window_count <= 1 {
+            tracing::warn!(
+                "Refusing to kill window {} - it's the last window in session {} (count={})",
+                target,
+                session,
+                window_count
+            );
+            return Ok(());
+        }
+    }
+
+    kill_window_by_target_unchecked(target)
+}
+
+/// Kill a tmux window by target WITHOUT the last-window safety check.
+///
+/// Only use this when you've already verified the safety constraint.
+fn kill_window_by_target_unchecked(target: &str) -> crate::Result<()> {
+    // Log the kill attempt with current window state for debugging
+    if let Some(session) = target.split(':').next() {
+        let windows = list_windows_for_debug(session);
+        tracing::info!(
+            target = %target,
+            session = %session,
+            window_count = windows.len(),
+            windows = ?windows,
+            "KILL_WINDOW: attempting to kill window"
+        );
+    }
+
     // SIGTERM the pane process first — Claude Code ignores SIGHUP
     if let Ok(output) = Command::new("tmux")
         .args(["list-panes", "-t", target, "-F", "#{pane_pid}"])
@@ -395,6 +462,7 @@ pub fn kill_window_by_target(target: &str) -> crate::Result<()> {
             .map(|l| l.to_string())
             .collect();
         if !pids.is_empty() {
+            tracing::debug!(target = %target, pids = ?pids, "KILL_WINDOW: sending SIGTERM to pane processes");
             let _ = Command::new("kill")
                 .args(&pids)
                 .stderr(std::process::Stdio::null())
@@ -409,13 +477,32 @@ pub fn kill_window_by_target(target: &str) -> crate::Result<()> {
         .map_err(Error::Io)?;
 
     if !status.success() {
+        tracing::error!(target = %target, "KILL_WINDOW: tmux kill-window failed");
         return Err(Error::Rpc {
             code: -32603,
             message: format!("Failed to kill tmux window: {}", target),
         });
     }
 
+    tracing::info!(target = %target, "KILL_WINDOW: successfully killed window");
     Ok(())
+}
+
+/// List all window names in a session (for debugging, infallible version).
+fn list_windows_for_debug(session: &str) -> Vec<String> {
+    let output = match Command::new("tmux")
+        .args(["list-windows", "-t", session, "-F", "#{window_name}"])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return vec![],
+    };
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
 }
 
 /// Collect PIDs of all pane processes in a session.
@@ -1174,13 +1261,47 @@ pub fn count_windows_by_name(session: &str, name: &str) -> crate::Result<(usize,
 pub fn kill_all_windows_by_name(session: &str, name: &str) -> crate::Result<usize> {
     let (count, ids) = count_windows_by_name(session, name)?;
 
+    // Log entry point with full state
+    let all_windows = list_windows_for_debug(session);
+    tracing::info!(
+        session = %session,
+        target_name = %name,
+        matching_count = count,
+        matching_ids = ?ids,
+        total_windows = all_windows.len(),
+        all_windows = ?all_windows,
+        "KILL_ALL_WINDOWS: evaluating kill request"
+    );
+
     if count == 0 {
         return Ok(0);
     }
 
+    // Safety check: don't kill if these are the only windows in the session
+    let total_windows = count_session_windows(session);
+    if total_windows <= count {
+        tracing::warn!(
+            "KILL_ALL_WINDOWS: Refusing to kill all {} '{}' windows - would leave session {} empty (total={})",
+            count,
+            name,
+            session,
+            total_windows
+        );
+        return Ok(0);
+    }
+
+    tracing::info!(
+        session = %session,
+        target_name = %name,
+        killing_count = count,
+        ids = ?ids,
+        "KILL_ALL_WINDOWS: proceeding with kill"
+    );
+
     for id in &ids {
         // Kill by window ID (e.g., "@0") which is always unique
         let target = format!("{}:{}", session, id);
+        tracing::info!(target = %target, "KILL_ALL_WINDOWS: killing window");
 
         // SIGTERM pane processes first — Claude Code ignores SIGHUP
         if let Ok(output) = Command::new("tmux")
@@ -1686,6 +1807,17 @@ pub fn spawn_lead(
     project_name: &str,
     additional_dirs: &[PathBuf],
 ) -> crate::Result<()> {
+    // Log entry with current window state
+    let windows_before = list_windows_for_debug(session);
+    tracing::info!(
+        session = %session,
+        working_dir = %working_dir,
+        project_name = %project_name,
+        window_count = windows_before.len(),
+        windows = ?windows_before,
+        "SPAWN_LEAD: called to spawn lead window"
+    );
+
     // Kill ALL existing lead windows to prevent duplicates.
     // Using kill_all_windows_by_name instead of kill_window because tmux's
     // `kill-window -t session:name` only targets the first match when
@@ -1693,11 +1825,19 @@ pub fn spawn_lead(
     // races during restart create extras.
     match kill_all_windows_by_name(session, "lead") {
         Ok(n) if n > 0 => {
-            tracing::warn!("Killed {} existing lead window(s) before respawn", n);
+            tracing::warn!(
+                "SPAWN_LEAD: Killed {} existing lead window(s) before respawn",
+                n
+            );
         }
-        Ok(_) => {}
+        Ok(_) => {
+            tracing::info!("SPAWN_LEAD: No existing lead windows to kill");
+        }
         Err(e) => {
-            tracing::warn!("Failed to clean up existing lead windows: {}", e);
+            tracing::warn!(
+                "SPAWN_LEAD: Failed to clean up existing lead windows: {}",
+                e
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- When killing a window would leave the session with 0 windows, the session terminates
- If it's the only session, the tmux server dies completely
- This adds a guard in `kill_window` and `kill_window_by_target` that refuses to kill when `window_count <= 1`, logging a warning instead

## Root cause investigation
The daemon was crashing the tmux server around 5 minutes after startup. We suspect the daemon incorrectly tries to kill the Lead window (possibly through stuck detection or duplicate detection), and since it's the only window, this kills the entire tmux server.

## Test plan
- [x] Build passes
- [x] Clippy passes
- [ ] Run daemon and verify it doesn't crash after 5 minutes
- [ ] Verify log shows "Refusing to kill window" if this scenario occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)