### PR TITLE
docs: Clarify that Lead creates tasks from plans, not subagent execution [Midtown #7]

### DIFF
--- a/agents/lead.md
+++ b/agents/lead.md
@@ -236,3 +236,4 @@ When creating tasks, prefer combining tightly coupled work into a single task ra
 - Always save plans to `~/.claude/plans/`
 - Use descriptive filenames: `YYYY-MM-DD-<topic>.md`
 - Plans persist across sessions and are shared with coworkers
+- **After writing a plan, create tasks from it** — don't offer "subagent execution" or "parallel session" options. In midtown, work is delegated to coworkers via tasks, not executed via subagents in the Lead's session.


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Added guidance to the Lead system prompt (agents/lead.md) clarifying that after writing a plan, the Lead should create tasks from it rather than offering "subagent execution" or "parallel session" options
- In midtown, work is delegated to coworkers via tasks, not executed via subagents in the Lead's session

## Changes
- `agents/lead.md`: Added one line to the Plans section with this guidance

## Test plan
- [x] No code changes, only documentation
- [x] Verified the change is clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)