### PR TITLE
feat: Auto-scroll chat TUI to bottom every 30 seconds [Midtown #7]

### DIFF
--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -169,8 +169,9 @@ async fn run_app_async(
             }
 
             // Auto-scroll back to bottom if user scrolled up and forgot
+            // Skip if in selection mode - user may be copying text
             _ = auto_scroll_interval.tick() => {
-                if app.scroll_offset > 0 {
+                if app.scroll_offset > 0 && !app.selection_mode {
                     app.scroll_to_bottom();
                 }
             }


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Adds a 30-second auto-scroll timer to the chat TUI
- When triggered, scrolls back to the bottom if user has scrolled up
- Prevents the chat from appearing frozen when users forget to scroll back

## Details
The chat TUI uses `tokio::select!` to multiplex events (keyboard, file changes, refresh timer). This PR adds another interval timer that periodically checks if `scroll_offset > 0` and calls `scroll_to_bottom()` to bring users back to the most recent messages.

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo test --release` passes  
- [x] `cargo clippy -- -D warnings` passes
- [ ] Manual testing: scroll up in `midtown chat`, wait 30 seconds, verify it scrolls back to bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)