### PR TITLE
feat: Batch repetitive GitHub CI notifications in channel [Midtown #13]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -355,6 +355,10 @@ pub(crate) struct DaemonState {
     coworker_stop_times: std::sync::RwLock<HashMap<String, chrono::DateTime<chrono::Utc>>>,
     /// Tracks stuck conditions that warrant nudging the lead (no review, unresolved feedback, etc.)
     stuck_tracker: Mutex<StuckConditionTracker>,
+    /// Buffer for batching CI check success notifications.
+    /// Multiple checks passing on the same target within a short window are
+    /// aggregated into a single channel message to reduce noise.
+    ci_notification_buffer: Mutex<trackers::CiNotificationBuffer>,
     /// Cached GitHub repo full names (owner/repo) by repo path.
     /// Repo names never change during a daemon session, so we cache indefinitely.
     repo_name_cache: std::sync::RwLock<HashMap<PathBuf, String>>,
@@ -523,6 +527,7 @@ impl DaemonState {
             pr_break_sessions: std::sync::RwLock::new(HashMap::new()),
             coworker_stop_times: std::sync::RwLock::new(HashMap::new()),
             stuck_tracker: Mutex::new(StuckConditionTracker::new()),
+            ci_notification_buffer: Mutex::new(trackers::CiNotificationBuffer::new()),
             repo_name_cache: std::sync::RwLock::new(HashMap::new()),
             user_display_name,
             last_webhook_event_at: Mutex::new(None),
@@ -1186,6 +1191,12 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
     // Skip the first tick (which fires immediately)
     orphan_process_interval.tick().await;
 
+    // Timer for flushing batched CI notifications (check every 5 seconds).
+    // The actual flush delay is 15 seconds from the oldest buffered item.
+    let mut ci_notification_flush_interval = interval(std::time::Duration::from_secs(5));
+    // Skip the first tick (which fires immediately)
+    ci_notification_flush_interval.tick().await;
+
     // Nudge any coworkers discovered from tmux to continue their tasks.
     // This runs once at startup after the daemon has fully initialized.
     {
@@ -1230,7 +1241,14 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                     *ts = Some(tokio::time::Instant::now());
                 }
 
-                if let Err(e) = state.send_and_broadcast(&webhook_event.message) {
+                // Buffer successful CI checks for batching; post other messages immediately.
+                // When ci_check_passed is set, the webhook's `message` field is ignored in favor
+                // of a later batched message (see WebhookEvent.ci_check_passed doc comment).
+                if let Some(ci_check) = webhook_event.ci_check_passed {
+                    debug!("Buffering CI success for batching: {} on {}", ci_check.check_name, ci_check.target);
+                    let mut buffer = state.ci_notification_buffer.lock().await;
+                    buffer.add(ci_check);
+                } else if let Err(e) = state.send_and_broadcast(&webhook_event.message) {
                     error!("Failed to forward webhook message to channel: {}", e);
                 }
 
@@ -1442,6 +1460,22 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                 let killed = crate::tmux::kill_orphaned_processes(pattern);
                 if killed > 0 {
                     info!("Cleaned up {} orphaned claude process(es)", killed);
+                }
+            }
+
+            // Flush batched CI notifications: aggregate success checks by target
+            // into single messages to reduce channel noise.
+            _ = ci_notification_flush_interval.tick() => {
+                let mut buffer = state.ci_notification_buffer.lock().await;
+                if buffer.should_flush() {
+                    let batched = buffer.flush();
+                    for batch in batched {
+                        let msg = trackers::format_batched_ci_notification(&batch);
+                        let message = Message::text("github", msg);
+                        if let Err(e) = state.send_and_broadcast(&message) {
+                            error!("Failed to post batched CI notification: {}", e);
+                        }
+                    }
                 }
             }
 

--- a/src/daemon/trackers.rs
+++ b/src/daemon/trackers.rs
@@ -322,6 +322,127 @@ impl OrphanTracker {
 }
 
 // ---------------------------------------------------------------------------
+// CiNotificationBuffer
+// ---------------------------------------------------------------------------
+
+use crate::webhook::CiCheckPassed;
+
+/// How long to buffer CI notifications before posting a batched message.
+const CI_BUFFER_FLUSH_DELAY: Duration = Duration::from_secs(15);
+
+/// Buffers successful CI check notifications for batching.
+///
+/// When multiple checks pass on the same target (PR or branch) within a short
+/// window, we batch them into a single message like:
+/// "5 checks passed on PR #42: Clippy, Test, E2E - foo, ..."
+#[derive(Debug, Default)]
+pub struct CiNotificationBuffer {
+    /// Buffered checks grouped by target (e.g., "main" or "PR #42").
+    /// Each entry contains: (check_name, mention_prefix, added_time)
+    pending: HashMap<String, Vec<(String, String, Instant)>>,
+    /// When the oldest item was added (to know when to flush).
+    oldest_entry: Option<Instant>,
+}
+
+/// A batched CI notification message ready to post.
+#[derive(Debug)]
+pub struct BatchedCiNotification {
+    /// The target (e.g., "main" or "PR #42")
+    pub target: String,
+    /// The coworker mention prefix (e.g., "@columbus " or "")
+    pub mention_prefix: String,
+    /// Names of checks that passed
+    pub check_names: Vec<String>,
+}
+
+impl CiNotificationBuffer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a successful CI check to the buffer.
+    pub fn add(&mut self, check: CiCheckPassed) {
+        let now = Instant::now();
+
+        // Update oldest_entry if this is the first item
+        if self.oldest_entry.is_none() {
+            self.oldest_entry = Some(now);
+        }
+
+        self.pending.entry(check.target).or_default().push((
+            check.check_name,
+            check.mention_prefix,
+            now,
+        ));
+    }
+
+    /// Check if we have buffered items ready to flush.
+    pub fn should_flush(&self) -> bool {
+        self.oldest_entry
+            .is_some_and(|t| t.elapsed() >= CI_BUFFER_FLUSH_DELAY)
+    }
+
+    /// Flush all buffered notifications and return batched messages.
+    ///
+    /// Returns a list of batched notifications, one per target.
+    pub fn flush(&mut self) -> Vec<BatchedCiNotification> {
+        let mut results = Vec::new();
+
+        for (target, checks) in self.pending.drain() {
+            if checks.is_empty() {
+                continue;
+            }
+
+            // Use the mention prefix from the first check (they should all be the same)
+            let mention_prefix = checks
+                .first()
+                .map(|(_, m, _)| m.clone())
+                .unwrap_or_default();
+            let check_names: Vec<String> = checks.into_iter().map(|(name, _, _)| name).collect();
+
+            results.push(BatchedCiNotification {
+                target,
+                mention_prefix,
+                check_names,
+            });
+        }
+
+        self.oldest_entry = None;
+        results
+    }
+
+    /// Check if the buffer is empty.
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+}
+
+/// Format a batched CI notification into a channel message.
+///
+/// Examples:
+/// - Single check: "Check 'Clippy' passed on main"
+/// - Multiple checks: "5 checks passed on PR #42: Clippy, Test, E2E - foo, ..."
+pub fn format_batched_ci_notification(batch: &BatchedCiNotification) -> String {
+    let count = batch.check_names.len();
+    let names = batch.check_names.join(", ");
+
+    if count == 1 {
+        // Single check: use original format
+        format!(
+            "{}Check '{}' passed on {}",
+            batch.mention_prefix, batch.check_names[0], batch.target
+        )
+    } else {
+        // Multiple checks: batched format
+        format!(
+            "{}{} checks passed on {}: {}",
+            batch.mention_prefix, count, batch.target, names
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -654,5 +775,154 @@ mod tests {
             !tracker.should_nudge(42, PrIssueType::CiFailed),
             "repeat polling should be blocked after first handled"
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // CiNotificationBuffer — batches CI check notifications
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn ci_buffer_batches_checks_by_target() {
+        let mut buffer = CiNotificationBuffer::new();
+
+        // Add checks for two different targets
+        buffer.add(CiCheckPassed {
+            check_name: "Clippy".to_string(),
+            target: "main".to_string(),
+            mention_prefix: "".to_string(),
+        });
+        buffer.add(CiCheckPassed {
+            check_name: "Test".to_string(),
+            target: "main".to_string(),
+            mention_prefix: "".to_string(),
+        });
+        buffer.add(CiCheckPassed {
+            check_name: "Build".to_string(),
+            target: "PR #42".to_string(),
+            mention_prefix: "@columbus ".to_string(),
+        });
+
+        // Buffer should not flush immediately
+        assert!(
+            !buffer.should_flush(),
+            "buffer should not flush immediately"
+        );
+
+        // Force flush by simulating time passing
+        buffer.oldest_entry = Some(Instant::now() - Duration::from_secs(20));
+
+        assert!(buffer.should_flush(), "buffer should flush after delay");
+
+        let batched = buffer.flush();
+        assert_eq!(
+            batched.len(),
+            2,
+            "should have 2 batched notifications (one per target)"
+        );
+
+        // Find the "main" batch
+        let main_batch = batched.iter().find(|b| b.target == "main").unwrap();
+        assert_eq!(main_batch.check_names.len(), 2);
+        assert!(main_batch.check_names.contains(&"Clippy".to_string()));
+        assert!(main_batch.check_names.contains(&"Test".to_string()));
+        assert_eq!(main_batch.mention_prefix, "");
+
+        // Find the "PR #42" batch
+        let pr_batch = batched.iter().find(|b| b.target == "PR #42").unwrap();
+        assert_eq!(pr_batch.check_names.len(), 1);
+        assert!(pr_batch.check_names.contains(&"Build".to_string()));
+        assert_eq!(pr_batch.mention_prefix, "@columbus ");
+    }
+
+    #[test]
+    fn ci_buffer_clears_after_flush() {
+        let mut buffer = CiNotificationBuffer::new();
+
+        buffer.add(CiCheckPassed {
+            check_name: "Test".to_string(),
+            target: "main".to_string(),
+            mention_prefix: "".to_string(),
+        });
+
+        // Force flush
+        buffer.oldest_entry = Some(Instant::now() - Duration::from_secs(20));
+        let _ = buffer.flush();
+
+        assert!(buffer.is_empty(), "buffer should be empty after flush");
+        assert!(
+            !buffer.should_flush(),
+            "should_flush should be false after flush"
+        );
+    }
+
+    #[test]
+    fn ci_buffer_single_check_returns_single_result() {
+        let mut buffer = CiNotificationBuffer::new();
+
+        buffer.add(CiCheckPassed {
+            check_name: "Clippy".to_string(),
+            target: "main".to_string(),
+            mention_prefix: "".to_string(),
+        });
+
+        // Force flush
+        buffer.oldest_entry = Some(Instant::now() - Duration::from_secs(20));
+        let batched = buffer.flush();
+
+        assert_eq!(batched.len(), 1);
+        assert_eq!(batched[0].check_names.len(), 1);
+        assert_eq!(batched[0].check_names[0], "Clippy");
+    }
+
+    // -------------------------------------------------------------------------
+    // format_batched_ci_notification tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn format_batched_ci_single_check() {
+        let batch = BatchedCiNotification {
+            target: "main".to_string(),
+            mention_prefix: "".to_string(),
+            check_names: vec!["Clippy".to_string()],
+        };
+        let msg = format_batched_ci_notification(&batch);
+        assert_eq!(msg, "Check 'Clippy' passed on main");
+    }
+
+    #[test]
+    fn format_batched_ci_single_check_with_mention() {
+        let batch = BatchedCiNotification {
+            target: "PR #42".to_string(),
+            mention_prefix: "@columbus ".to_string(),
+            check_names: vec!["Build".to_string()],
+        };
+        let msg = format_batched_ci_notification(&batch);
+        assert_eq!(msg, "@columbus Check 'Build' passed on PR #42");
+    }
+
+    #[test]
+    fn format_batched_ci_multiple_checks() {
+        let batch = BatchedCiNotification {
+            target: "main".to_string(),
+            mention_prefix: "".to_string(),
+            check_names: vec![
+                "Clippy".to_string(),
+                "Test".to_string(),
+                "E2E - foo".to_string(),
+            ],
+        };
+        let msg = format_batched_ci_notification(&batch);
+        assert_eq!(msg, "3 checks passed on main: Clippy, Test, E2E - foo");
+    }
+
+    #[test]
+    fn format_batched_ci_multiple_checks_with_mention() {
+        let batch = BatchedCiNotification {
+            target: "PR #99".to_string(),
+            mention_prefix: "@park ".to_string(),
+            check_names: vec!["Build".to_string(), "Test".to_string()],
+        };
+        let msg = format_batched_ci_notification(&batch);
+        assert_eq!(msg, "@park 2 checks passed on PR #99: Build, Test");
     }
 }

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -62,6 +62,10 @@ pub struct WebhookEvent {
     pub pr_ci_failure: Option<PrCiFailure>,
     /// A completed CI check with its duration — used for tracking typical check times.
     pub check_duration: Option<CheckDuration>,
+    /// A successful CI check that can be batched with others for the same target.
+    /// When set, the daemon buffers this notification instead of posting `message`
+    /// immediately — `message` is ignored in favor of a later batched message.
+    pub ci_check_passed: Option<CiCheckPassed>,
 }
 
 /// Structured data about a completed CI check's duration.
@@ -74,6 +78,20 @@ pub struct CheckDuration {
     pub check_name: String,
     /// Duration in seconds
     pub duration_secs: u64,
+}
+
+/// Structured data about a successful CI check that can be batched.
+///
+/// When multiple CI checks pass within a short window on the same target
+/// (PR or branch), the daemon batches them into a single channel message.
+#[derive(Debug, Clone)]
+pub struct CiCheckPassed {
+    /// Name of the check that passed
+    pub check_name: String,
+    /// Target reference: "main", "PR #42", etc.
+    pub target: String,
+    /// Mention prefix for the coworker (e.g., "@columbus ") or empty string
+    pub mention_prefix: String,
 }
 
 /// Structured data about a formal PR review state change (approved or changes requested).
@@ -650,6 +668,7 @@ fn handle_pull_request(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json::
         review_state_change: None,
         pr_ci_failure: None,
         check_duration: None,
+        ci_check_passed: None,
     }))
 }
 
@@ -720,6 +739,7 @@ fn handle_pull_request_review(body: &[u8]) -> Result<Option<WebhookEvent>, serde
         review_state_change,
         pr_ci_failure: None,
         check_duration: None,
+        ci_check_passed: None,
     }))
 }
 
@@ -772,6 +792,7 @@ fn handle_issue_comment(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json:
         review_state_change: None,
         pr_ci_failure: None,
         check_duration: None,
+        ci_check_passed: None,
     }))
 }
 
@@ -817,6 +838,7 @@ fn handle_review_comment(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json
         review_state_change: None,
         pr_ci_failure: None,
         check_duration: None,
+        ci_check_passed: None,
     }))
 }
 
@@ -863,6 +885,7 @@ fn handle_status(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json::Error>
         review_state_change: None,
         pr_ci_failure: None,
         check_duration: None,
+        ci_check_passed: None,
     }))
 }
 
@@ -960,6 +983,28 @@ fn handle_check_run(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json::Err
         None
     };
 
+    // Produce a batchable CI success for the daemon to aggregate.
+    // Note: We still construct the message above for consistency, but when ci_check_passed
+    // is set, the daemon buffers this check and posts a batched message later instead.
+    let ci_check_passed = if event.check_run.conclusion.as_deref() == Some("success") {
+        // Extract target from pr_info: "main", "PR #42", etc.
+        let target = event
+            .check_run
+            .check_suite
+            .as_ref()
+            .and_then(|cs| cs.pull_requests.first())
+            .map(|pr| format!("PR #{}", pr.number))
+            .or_else(|| branch.map(|b| b.to_string()));
+
+        target.map(|t| CiCheckPassed {
+            check_name: event.check_run.name.clone(),
+            target: t,
+            mention_prefix: mention.clone(),
+        })
+    } else {
+        None
+    };
+
     let content = format!("{}{}", mention, action_text);
     Ok(Some(WebhookEvent {
         message: Message::new("github", content, MessageType::Text),
@@ -971,6 +1016,7 @@ fn handle_check_run(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json::Err
         review_state_change: None,
         pr_ci_failure,
         check_duration,
+        ci_check_passed,
     }))
 }
 


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Batch multiple CI check pass notifications that occur within a 15-second window into a single channel message
- Reduces noise from successive CI check completion events (e.g., Clippy, Test, E2E tests all finishing around the same time)
- Single checks still use original format; batched format shows count and lists check names

**Before:**
```
Check 'Clippy' passed on main
Check 'Test' passed on main
Check 'E2E - idle_break_e2e' passed on main
Check 'E2E - tailf_integration' passed on main
Check 'E2E - spawn_race_test' passed on main
```

**After:**
```
5 checks passed on main: Clippy, Test, E2E - idle_break_e2e, E2E - tailf_integration, E2E - spawn_race_test
```

## Technical Details
- Added `CiCheckPassed` struct to `webhook.rs` for structured CI success data
- Added `CiNotificationBuffer` to `trackers.rs` for buffering with 15-second flush delay
- Daemon webhook handler buffers CI successes; flush interval checks every 5 seconds
- Failures and other events remain unbatched for immediate visibility
- Nudge and event processing logic unchanged - only channel display is affected

## Test plan
- [x] Unit tests for `CiNotificationBuffer` batching logic
- [x] Unit tests for `format_batched_ci_notification` output format
- [x] All existing tests pass
- [x] Clippy and fmt checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)