### PR TITLE
fix: Add direct lead nudges for orphan warnings and PR merges [Midtown #14]

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -530,14 +530,30 @@ pub(super) async fn cleanup_orphaned_worktrees(state: &DaemonState) -> Vec<Effec
 
     // Notify @lead about orphaned worktrees with unmerged commits
     let names_list = due_for_warning.join(", ");
-    let msg = Message::system(format!(
+    let nudge_text = format!(
         "⚠️ @lead Orphaned worktrees with unmerged commits: {}. \
          Please investigate and decide whether to merge or delete these branches.",
         names_list
-    ));
+    );
+    let msg = Message::system(nudge_text.clone());
     if let Err(e) = state.send_and_broadcast(&msg) {
         warn!("Failed to send orphan flag message: {}", e);
     }
+
+    // Directly nudge the lead (don't rely solely on chat monitor).
+    // This matches the pattern used for CI failures on the default branch.
+    if let Err(e) = state.coworkers.nudge_lead(&nudge_text) {
+        warn!("Failed to nudge lead for orphaned worktrees: {}", e);
+    } else {
+        info!("Nudged lead about orphaned worktrees with unmerged commits");
+    }
+
+    // Send push notification for mobile alerts
+    state.send_push_notification(
+        "Orphaned worktrees need attention",
+        &nudge_text,
+        "orphan_warning",
+    );
 
     effects
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1260,15 +1260,19 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
 
                 // Nudge lead to pull main when a PR merges
                 if let Some(pr_number) = webhook_event.merged_pr {
-                    let nudge_msg = Message::text(
-                        "system",
-                        format!(
-                            "@lead PR #{} merged into {}. Run `git pull` to stay current.",
-                            pr_number, state.default_branch
-                        ),
+                    let nudge_text = format!(
+                        "@lead PR #{} merged into {}. Run `git pull` to stay current.",
+                        pr_number, state.default_branch
                     );
+                    let nudge_msg = Message::text("system", nudge_text.clone());
                     if let Err(e) = state.send_and_broadcast(&nudge_msg) {
                         warn!("Failed to post merge nudge for PR #{}: {}", pr_number, e);
+                    }
+                    // Directly nudge the lead (don't rely solely on chat monitor)
+                    if let Err(e) = state.coworkers.nudge_lead(&nudge_text) {
+                        warn!("Failed to nudge lead for PR #{} merge: {}", pr_number, e);
+                    } else {
+                        info!("Nudged lead about PR #{} merge", pr_number);
                     }
                     chat::route_mentions(&state, &nudge_msg).await;
                 }


### PR DESCRIPTION
<!-- midtown: Lead -->

## Summary
- Adds direct `nudge_lead()` calls when warning about orphaned worktrees with unmerged commits
- Adds direct `nudge_lead()` call when a PR merges into the default branch
- Adds push notification for orphan warnings

Previously, @lead mentions in system messages relied on the chat monitor to trigger nudges. This was unreliable.

## Test plan
- [ ] Merge a PR and verify lead gets a direct nudge
- [ ] Create an orphaned worktree with unmerged commits and verify lead gets warned

🤖 Generated with [Claude Code](https://claude.com/claude-code)