### PR TITLE
test: Add E2E tests for daemon dispatch logic [Midtown #19]

### DIFF
--- a/tests/dispatch_e2e.rs
+++ b/tests/dispatch_e2e.rs
@@ -850,16 +850,16 @@ fn task_owner_validation() {
     let snap = load_snapshot(fixture);
 
     for task in &snap.all_tasks {
-        if let Some(owner) = &task.owner {
-            if !owner.is_empty() {
-                let owner_lower = owner.to_lowercase();
-                let is_valid = owner_lower == "lead" || is_valid_coworker_name(&owner_lower);
-                assert!(
-                    is_valid,
-                    "Task #{} has invalid owner '{}' - must be an avenue name or 'lead'",
-                    task.id, owner
-                );
-            }
+        if let Some(owner) = &task.owner
+            && !owner.is_empty()
+        {
+            let owner_lower = owner.to_lowercase();
+            let is_valid = owner_lower == "lead" || is_valid_coworker_name(&owner_lower);
+            assert!(
+                is_valid,
+                "Task #{} has invalid owner '{}' - must be an avenue name or 'lead'",
+                task.id, owner
+            );
         }
     }
 }


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Adds comprehensive E2E tests for daemon dispatch logic using WorldSnapshot fixtures
- Tests validate preconditions for task assignment, orphan recovery, blocked task handling, and reviewer spawning
- 27 tests covering all major dispatch scenarios

## Test Coverage
Tests validate:
- **Pending task assignment**: Conditions for nudge (active owner) vs spawn (inactive owner)
- **Orphan task recovery**: Detection of in_progress tasks with inactive owners
- **Blocked task handling**: blockedBy dependency filtering
- **Duplicate worker detection**: Start time sorting for conflict resolution
- **Reviewer management**: Assignment tracking, idle pool exclusion, isolated task mode
- **Dev limit enforcement**: Spawn blocking conditions
- **Snapshot data integrity**: Consistency across multiple real fixtures

## Design Notes
The pure decision functions (`decide_pending_task_action`, `decide_orphan_recovery`) are `pub(crate)` and tested via unit tests in `rules.rs`. These E2E tests validate the snapshot data and preconditions that feed into those decisions using real captured production state.

## Test plan
- [x] All 27 tests pass locally
- [x] cargo clippy passes
- [x] cargo fmt passes
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)