### PR TITLE
test: Add E2E tests for tmux operations [Midtown #22]

### DIFF
--- a/tests/tmux_e2e.rs
+++ b/tests/tmux_e2e.rs
@@ -2079,7 +2079,9 @@ fn test_kill_window_refuses_to_kill_last_window() {
 
     let session = test_session_name();
     assert!(create_test_session(&session));
-    // NOTE: No SessionCleanup here - we're testing that the session survives
+    let _cleanup = SessionCleanup {
+        session: session.clone(),
+    };
 
     // Rename the default window to "only_window"
     let default_target = format!("{}:0", session);
@@ -2106,9 +2108,6 @@ fn test_kill_window_refuses_to_kill_last_window() {
         still_exists,
         "Last window should NOT have been killed - safety check failed"
     );
-
-    // Clean up
-    kill_test_session(&session);
 }
 
 /// `kill_window_by_target` also refuses to kill the last window.
@@ -2123,6 +2122,9 @@ fn test_kill_window_by_target_refuses_last_window() {
 
     let session = test_session_name();
     assert!(create_test_session(&session));
+    let _cleanup = SessionCleanup {
+        session: session.clone(),
+    };
 
     // Rename the default window
     let default_target = format!("{}:0", session);
@@ -2143,9 +2145,6 @@ fn test_kill_window_by_target_refuses_last_window() {
         still_exists,
         "Last window should NOT have been killed via kill_window_by_target"
     );
-
-    // Clean up
-    kill_test_session(&session);
 }
 
 /// `kill_window` works when there are multiple windows.


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Adds 17 new E2E tests expanding tmux module coverage from 41.57%
- Tests cover send-keys operations for nudge delivery
- Tests session management functions (session_exists, list_sessions)
- Tests status bar hook setup with idempotency verification
- Tests window killing safety checks (refuse to kill last window)
- Tests pane capture, window resize, and count/kill by name functions

## Test plan
- [x] All 45 tmux E2E tests pass (`cargo test --test tmux_e2e -- --ignored`)
- [x] Unit tests pass
- [x] Clippy passes with no warnings
- [x] Formatting verified via cargo fmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)