### PR TITLE
docs: Add channel etiquette guidelines to avoid pointless back-and-forth [Midtown #27]

### DIFF
--- a/agents/common.md
+++ b/agents/common.md
@@ -1,6 +1,8 @@
 ## Channel Etiquette
 
-Keep channel messages purposeful. Avoid pointless back-and-forth:
+Keep channel messages purposeful. Avoid pointless back-and-forth.
+
+**Note:** Role-specific guidelines (e.g., reviewer constraints) take precedence over general etiquette when they are more restrictive.
 
 - **Asking questions or sharing info**: Send one @mention with your question/info
 - **Receiving @mentions**: Reply with a brief acknowledgment if needed, then stop


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Adds channel etiquette section to `agents/common.md`
- Provides guidelines to prevent unnecessary thank-you chains and back-and-forth
- Includes good/bad examples showing expected vs excessive exchanges

## Context
Coworkers sometimes engage in pointless acknowledgment chains in the channel (thanks! → no problem! → 👍). This wastes context window space and clutters the channel. These guidelines set expectations for concise, purposeful communication.

## Test plan
- [x] Documentation-only change, no tests needed
- [x] Guidelines will be included in coworker system prompts via common.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)