### PR TITLE
test: Add WorldSnapshot fixtures for debugging daemon issues [Midtown #38]

### DIFF
--- a/tests/fixtures/snapshot/snapshot-20260204-144326.json
+++ b/tests/fixtures/snapshot/snapshot-20260204-144326.json
@@ -1,0 +1,232 @@
+{
+  "active_coworkers": [
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "riverside",
+      "session_id": "56441fe8-4e88-4fb9-b00b-a14aec223fea",
+      "started_at": "2026-02-04T14:40:45.312977Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/riverside"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "york",
+      "session_id": "75c5978f-b037-42bb-83d8-c38ddcc72096",
+      "started_at": "2026-02-04T14:39:47.352648Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/york"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "amsterdam",
+      "session_id": "",
+      "started_at": "2026-02-04T14:41:16.698284Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/amsterdam"
+    }
+  ],
+  "active_names": [
+    "york",
+    "riverside",
+    "amsterdam"
+  ],
+  "active_reviewers": [],
+  "all_tasks": [
+    {
+      "blocked_by": [],
+      "description": "Bug: `is_auto_mergeable()` in src/daemon/helpers.rs only accepts formal GitHub APPROVED reviewDecision. It should also recognize positive review comments (e.g., \"No issues found\") as approval for auto-merge purposes.\n\nCurrent behavior (line 153):\n```rust\nif review_decision != \"APPROVED\" {\n    return false;\n}\n```\n\nExpected behavior:\n- Keep APPROVED as valid\n- Also check PR comments for positive review indicators from coworkers (look for midtown markers and \"No issues found\" or similar patterns)\n\nContext: We use comment-based reviews because the same GitHub account (btucker) authors PRs and runs coworkers, making formal self-approval impossible.",
+      "id": "3",
+      "owner": "park",
+      "status": "completed",
+      "subject": "Update auto-merge to recognize comment-based reviews"
+    },
+    {
+      "blocked_by": [],
+      "description": "Feature: The daemon should track typical CI check durations and handle stuck/missing checks intelligently.\n\n**Scenarios to handle:**\n\n1. **Stuck check** (pending > 4x typical duration): Re-run the specific check\n2. **Missing/new check** (required check not in PR's CI run): The PR predates the CI workflow change. Daemon should rebase the PR on main to pick up the new workflow, then CI will include the new check.\n\n**Implementation:**\n1. Track historical completion times per CI check name (e.g., \"E2E - idle_break_e2e\" typically takes 2m)\n2. Store rolling average or median of recent runs\n3. For stuck checks: If pending > 4x typical duration, trigger re-run\n4. For missing checks: If a required check never appears in the PR's status checks but exists in main's CI workflow, rebase the PR on main\n5. Add cooldowns to prevent spam\n\n**Key points:**\n- NOT overly aggressive - only at 4x typical time for stuck checks\n- Data-driven based on actual historical times\n- Detect \"new\" required checks that the PR doesn't have and auto-rebase\n\nUse case: PRs #566 and #570 were blocked by missing \"E2E - idle_break_e2e\" - they predated the workflow change. Daemon should have detected this and rebased automatically.",
+      "id": "4",
+      "owner": "broadway",
+      "status": "completed",
+      "subject": "Add daemon auto-retry for stale/missing CI checks"
+    },
+    {
+      "blocked_by": [],
+      "description": "Instead of the daemon parsing review comments to auto-merge, the author coworker should handle merge decisions themselves.\n\nWhen a PR receives a comment or review:\n1. If the author coworker is idle/shutdown, call them in\n2. Nudge the author coworker about the new comment/review\n3. Author reads the feedback and decides whether to merge, address feedback, or take other action\n\nThis is simpler than daemon comment parsing and keeps the merge decision with the agent who has full context of the PR.\n\nReplaces the approach in closed PR #571.\n\nPR #573 is ready - removes auto-merge, author-driven approach. Clean commit without state.json.",
+      "id": "5",
+      "owner": "park",
+      "status": "completed",
+      "subject": "Call-in and nudge PR authors on comments/reviews"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: Park had main checked out in their worktree. Coworkers should NEVER checkout the default branch (main/master).\n\nThis can cause issues:\n1. Multiple worktrees can't share the same branch\n2. Coworkers might accidentally commit directly to main\n3. Blocks other worktrees from using main\n\nFix needed:\n- Add validation when spawning coworkers to ensure they're on a feature branch\n- Add validation in coworker prompts/hooks to prevent `git checkout main`\n- If a coworker somehow ends up on main, detect and fix it (checkout a new feature branch)\n\nCheck how park ended up on main and prevent it from happening.",
+      "id": "6",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Prevent coworkers from checking out default branch"
+    },
+    {
+      "blocked_by": [
+        "8"
+      ],
+      "description": "The `midtown chat` TUI should check every 30 seconds whether it's at the end of the channel. If it got stuck further up (e.g., user scrolled up and forgot), it should auto-scroll back to the end.\n\nThis prevents the chat from appearing frozen/stuck when it's actually just scrolled up in history.",
+      "id": "7",
+      "owner": "vernon",
+      "status": "completed",
+      "subject": "Chat TUI should auto-scroll to end every 30 seconds"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The `midtown chat` TUI spontaneously scrolled to the beginning of the channel on its own. This should never happen.\n\nThis is a higher priority than the auto-scroll-to-end feature (task #7) - we need to fix this regression/bug first.\n\nInvestigate what's causing unexpected scroll position changes in the chat TUI. Could be:\n- A render loop resetting scroll state\n- File watcher event causing re-render from top\n- State management issue with scroll position\n- Race condition in the async event handling\n\nThe chat should maintain its scroll position unless the user explicitly scrolls or it auto-scrolls to follow new messages at the bottom.",
+      "id": "8",
+      "owner": "york",
+      "status": "completed",
+      "subject": "Fix chat TUI unexpectedly scrolling to beginning"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The daemon is warning \"Reviewer pleasant is idle but hasn't posted review for PR #572 yet\" but pleasant DID post a review comment (visible via `gh pr view 572 --json comments`).\n\nThe daemon's review detection is not recognizing that the review comment was posted. It should:\n1. Check PR comments for review signatures from the assigned reviewer\n2. Once a review comment is detected, stop warning about missing reviews\n3. Clear the reviewer assignment from the \"pending\" state\n\nThis might be related to how the daemon checks for reviews - it may be looking for formal GitHub reviews instead of comment-based reviews.",
+      "id": "9",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Fix daemon not detecting posted review comments"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The daemon incorrectly detected that riverside was \"stuck compaction\" and sent Escape to interrupt them (\"Interrupted stuck compaction for riverside (sent Escape)\").\n\nThe user reports this was a false positive - riverside was not actually stuck in compaction.\n\nThis could cause:\n- Unnecessary interruptions to coworkers doing valid work\n- Lost work if the coworker was mid-task\n\nNeed to investigate the compaction detection logic and make it more accurate. May need to:\n- Increase the threshold for \"stuck\" detection\n- Better differentiate compaction from other states\n- Check for actual user input/output before concluding stuck",
+      "id": "10",
+      "owner": "york",
+      "status": "in_progress",
+      "subject": "Fix false positive stuck compaction detection"
+    },
+    {
+      "blocked_by": [],
+      "description": "UX Bug: Nudges inject text via tmux send-keys while the user is trying to type, disrupting their input.\n\n**New nudge behavior:**\n\n1. Before nudging, check if the input box is empty\n2. If empty → safe to nudge immediately\n3. If not empty, check if the content is mostly from the daemon's last nudge\n   - If yes → safe to nudge (can overwrite stale nudge text)\n   - If no → user is typing something, DON'T nudge yet\n4. When user content detected:\n   - Wait 10 seconds, check again\n   - If input has changed → user still typing, wait another 10 seconds\n   - Repeat this process\n5. Only append onto unrecognized input content if it hasn't changed for 20 seconds\n\nThis prevents nudges from:\n- Interrupting users mid-sentence\n- Corrupting user's typed input\n- Creating frustrating UX when daemon is active\n\nThe daemon should track:\n- Last nudge content sent to each coworker/lead\n- Input box state before nudging\n- Timestamps of input changes\n\n**IMPORTANT: Create an E2E test for this using real Claude to verify the behavior works correctly in practice.**",
+      "id": "11",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Make nudges respect user input in progress"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: York received a nudge about PR #577 but that PR was authored by btucker, not york.\n\nThe daemon is sending PR-related nudges to the wrong coworkers. It should:\n1. Correctly identify the PR author (the coworker who created the PR)\n2. Only nudge that author about review feedback, CI status, etc.\n3. Not confuse GitHub username (btucker) with coworker names\n\nThis may be related to the author-driven merge changes (PR #573/task #5) - need to verify the author identification logic is correct.",
+      "id": "12",
+      "owner": "amsterdam",
+      "status": "completed",
+      "subject": "Fix misdirected PR nudges to wrong coworkers"
+    }
+  ],
+  "blank_pane_coworkers": [],
+  "busy_coworkers": [
+    "york"
+  ],
+  "ci_passed_pr_coworkers": [
+    "york",
+    "riverside",
+    "amsterdam"
+  ],
+  "coworker_snapshots": [
+    {
+      "isolated_tasks": false,
+      "name": "riverside",
+      "started_at": "2026-02-04T14:40:45.312977Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "york",
+      "started_at": "2026-02-04T14:39:47.352648Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "amsterdam",
+      "started_at": "2026-02-04T14:41:16.698284Z"
+    }
+  ],
+  "coworker_start_times": {
+    "amsterdam": "2026-02-04T14:41:16.698284Z",
+    "riverside": "2026-02-04T14:40:45.312977Z",
+    "york": "2026-02-04T14:39:47.352648Z"
+  },
+  "coworker_stop_times": {
+    "amsterdam": "2026-02-04T14:39:43.515439Z",
+    "broadway": "2026-02-04T14:26:41.726172Z",
+    "columbus": "2026-02-04T14:36:13.303382Z",
+    "lexington": "2026-02-04T14:14:42.092338Z",
+    "madison": "2026-02-04T14:30:41.726892Z",
+    "park": "2026-02-04T14:37:41.742654Z",
+    "pleasant": "2026-02-04T14:20:47.035314Z",
+    "riverside": "2026-02-04T14:40:41.710567Z",
+    "vernon": "2026-02-04T14:20:47.260622Z",
+    "york": "2026-02-04T14:39:43.735640Z"
+  },
+  "coworkers_with_merged_prs": [
+    "lexington",
+    "vernon",
+    "riverside",
+    "park",
+    "york",
+    "amsterdam",
+    "madison",
+    "broadway",
+    "pleasant"
+  ],
+  "coworkers_with_open_prs": [
+    "amsterdam",
+    "riverside",
+    "york"
+  ],
+  "coworkers_with_running_subagents": [],
+  "coworkers_with_unblocked_deps": [],
+  "in_progress_tasks": [
+    [
+      "10",
+      "Fix false positive stuck compaction detection",
+      "york"
+    ]
+  ],
+  "is_at_dev_limit": false,
+  "now_utc": "2026-02-04T14:43:26.817318Z",
+  "pane_contents": {
+    "amsterdam": "  ⎿  amsterdam → idle\n     Message posted to channel\n\n⏺ PR #579 merged successfully. Task #12 complete - the misdirected PR nudges bug is now fixed on main.\n\n  Summary of the fix:\n  - Changed collect_green_with_feedback_effects() to use coworker_from_branch() instead of raw split('/').next()\n  - This validates branch prefixes against known coworker names (lexington, park, madison, etc.)\n  - PRs with non-coworker branch prefixes (like btucker/fix-something) are now correctly skipped instead of potentially nudging the wrong coworker\n\n  I'm now idle and ready for the next task.\n\n✻ Crunched for 50s\n\n❯ PR #570 (fix: Validate coworker names from bra...) - merge conflict: please rebase\n\n⏺ Let me check PR #570 to understand the conflict.\n\n⏺ Bash(gh pr view 570 --json title,author,headRefName,state,mergeable 2>&1)\n  ⎿  {\n       \"author\": {\n         \"id\": \"MDQ6VXNlcjYxODE=\",\n     … +9 lines (ctrl+o to expand)\n\n⏺ Bash(gh pr diff 570 2>&1 | head -60)\n  ⎿  diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml\n     index 84228d3..6ebc04c 100644\n     --- a/.github/workflows/ci.yml\n     … +57 lines (ctrl+o to expand)\n\n⏺ Bash(gh pr diff 570 2>&1 | grep -A 30 \"src/daemon/pr.rs\")\n  ⎿  diff --git a/src/daemon/pr.rs b/src/daemon/pr.rs\n     index 6a2b3e9..8c42a98 100644\n     --- a/src/daemon/pr.rs\n     … +31 lines (ctrl+o to expand)\n\n⏺ I see - PR #570 has the same core fix I just merged in PR #579. The pr.rs changes are identical. PR #570 also includes:\n  1. CI workflow changes (health_e2e, workflow_e2e tests)\n  2. Additional tests in helpers.rs\n\n  Since PR #579 already merged the core fix, PR #570 is now partially redundant and has conflicts on the same lines. Let me check if PR #570 should be closed as superseded.\n\n⏺ Bash(gh pr view 570 --json createdAt,body --jq '.createdAt + \"\\n\\n\" + .body' 2>&1 | head -30)\n  ⎿  2026-02-04T06:03:24Z\n\n     <!-- midtown: amsterdam -->\n     … +12 lines (ctrl+o to expand)\n\n⏺ PR #570 was an earlier attempt at the same fix that PR #579 just merged. Since the core fix is now on main, PR #570 is superseded. Let me close it.\n\n⏺ Bash(gh pr close 570 --comment \"Closing as superseded by PR #579 which merged the same core fix (using coworker_from_branch() instead of split('/').next() in collect…)\n  ⎿  ✓ Closed pull request btucker/midtown#570 (fix: Validate coworker names from branch prefixes in GreenWithFeedback handler [Midtown #2])\n\n⏺ Bash(midtown channel post \"closed PR #570 as superseded by PR #579 - both fixed the same coworker validation bug\")\n  ⎿  Message posted to channel\n\n⏺ Done. Closed PR #570 as superseded - it was an earlier version of the same fix that PR #579 already merged.\n\n  ★ Insight ─────────────────────────────────────\n  Duplicate PR Detection: When fixing bugs, check if similar PRs already exist. PR #570 and #579 both fixed the same coworker_from_branch validation issue. This can happen when:\n  - A coworker restarts and doesn't see their previous work\n  - Multiple coworkers tackle the same issue independently\n  - Branch management gets out of sync\n\n  The resolution: close the older/superseded PR with a note linking to the merged one.\n  ─────────────────────────────────────────────────\n\n✻ Brewed for 56s\n\n  Tasks (9 done, 1 in progress, 0 open) · ctrl+t to hide tasks\n  ◼ #10 Fix false positive stuck compaction detection (york)\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n  ✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n  ✔ #9 Fix daemon not detecting posted review comments (riverside)\n  ✔ #11 Make nudges respect user input in progress (riverside)\n  ✔ #12 Fix misdirected PR nudges to wrong coworkers (amsterdam)\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle) · 1 file +1 -1\n\n",
+    "riverside": "\n⏺ PR #578 merged successfully. Let me mark my task as completed and update my status.\n✔ Task #11 updated: status → completed\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ Bash(gh pr view 578 --json headRefName -q .headRefName && gh api -X DELETE repos/btucker/midtown/git/refs/heads/riverside/nudge-respect-user-input 2>/dev/null || ech…)\n  ⎿  riverside/nudge-respect-user-input\n     {\"message\":\"Reference does not exist\",\"documentation_url\":\"https://docs.github.com/rest/git/refs#delete-a-reference\",\"status\":\"422\"}Branch already deleted\n\n❯ Your PR #576 (fix: Make review comment detection ca...) has a completed review — please address any feedback and merge if appropriate.\n\n❯ Your PR #574 (fix: Prevent coworkers from checking ...) has a completed review — please address any feedback and merge if appropriate.\n\n❯ PR #576 (fix: Make review comment detection ca...) - CI green with feedback: CI is green — please address review feedback and merge\n\n❯ PR #574 (fix: Prevent coworkers from checking ...) - CI green with feedback: CI is green — please address review feedback and merge\n\n⏺ Let me update my status and check if those older PRs are still relevant.\n\n⏺ Bash(midtown state completed --task 11)\n  ⎿  riverside → done#11\n\n⏺ Bash(gh pr view 576 --json state,merged -q '.state + \" merged:\" + (.merged | tostring)' 2>/dev/null || echo \"PR not found\")\n  ⎿  PR not found\n\n⏺ Bash(gh pr view 574 --json state,merged -q '.state + \" merged:\" + (.merged | tostring)' 2>/dev/null || echo \"PR not found\")\n  ⎿  PR not found\n\n⏺ Those older PRs no longer exist (likely already merged). Let me announce completion and check for any new work.\n\n⏺ Bash(midtown channel post \"/me merged PR #578 for task 11 - the audience applauds as the curtain falls on user input protection\")\n  ⎿  Message posted to channel\n10 tasks (9 done, 1 in progress, 0 open)\n\n✔ #6 Prevent coworkers from checking out default branch (riverside)\n✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n◼ #10 Fix false positive stuck compaction detection (york)\n✔ #11 Make nudges respect user input in progress (riverside)\n✔ #12 Fix misdirected PR nudges to wrong coworkers (amsterdam)\n✔ #3 Update auto-merge to recognize comment-based reviews (park)\n✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n✔ #9 Fix daemon not detecting posted review comments (riverside)\n\n⏺ Task #11 complete. The only remaining active task (#10) is being worked on by york. Let me transition to idle.\n\n⏺ Bash(midtown state idle)\n  ⎿  riverside → idle\n\n⏺ Bash(midtown channel post \"/me the stage is quiet now, waiting for the next scene to unfold\")\n  ⎿  Message posted to channel\n\n⏺ ★ Insight ─────────────────────────────────────\n  Task #11 Completion Summary\n\n  PR #578 added user input protection to the nudge system. The key implementation:\n\n  1. Pane snapshot (src/snapshot.rs) - Added has_user_input_text field that detects >  prompt prefix indicating an active input field\n  2. Rules engine (src/rules.rs) - Checks this flag before emitting nudge effects, suppressing interrupts when users are actively typing\n  3. E2E test - Verifies the behavior by simulating typing during the stuck detection timeout\n\n  This follows the architecture principle of pure decision logic in rules.rs - pane parsing happens during snapshot collection, and the nudge suppression is a simple boolean check on immutable data.\n  ─────────────────────────────────────────────────\n\n  Completed task #11 and merged PR #578. Now idle, awaiting the next act.\n\n✻ Brewed for 1m 15s\n\n  Tasks (9 done, 1 in progress, 0 open) · ctrl+t to hide tasks\n  ◼ #10 Fix false positive stuck compaction detection (york)\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n  ✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n  ✔ #9 Fix daemon not detecting posted review comments (riverside)\n  ✔ #11 Make nudges respect user input in progress (riverside)\n  ✔ #12 Fix misdirected PR nudges to wrong coworkers (amsterdam)\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n",
+    "york": "     index 7a756f7..7a941a1 100644\n     --- a/src/rules.rs\n     … +220 lines (ctrl+o to expand)\n\n⏺ I see I have substantial work done already. The channel shows I was incorrectly detected as stuck during normal work (ironic given that's the bug I'm fixing). Let me update my state and verify my changes work.\n\n⏺ Bash(midtown state developing --task 10)\n  ⎿  york → dev#10\n\n⏺ Bash(midtown channel post \"/me back on the case for task 10 - the third act begins\")\n  ⎿  Message posted to channel\n\n⏺ Bash(cargo test compaction --release -- --nocapture 2>&1)\n  ⎿     Compiling libc v0.2.180\n        Compiling proc-macro2 v1.0.106\n        Compiling quote v1.0.44\n     … +402 lines (ctrl+o to expand)\n\n⏺ All compaction tests pass, including the new false positive test case. Let me run the full test suite and clippy to ensure no regressions.\n\n⏺ Bash(cargo clippy -- -D warnings 2>&1)\n  ⎿      Checking midtown v0.4.2 (/Users/btucker/.midtown/coworkers/midtown/york)\n         Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.21s\n\n⏺ Bash(cargo test --release 2>&1 | tail -50) timeout: 3m 0s\n  ⎿  test webhook::tests::test_truncate_comment ... ok\n     test webhook::tests::test_verify_signature ... ok\n     test webserver::tests::test_default_webserver_port ... ok\n     … +47 lines (ctrl+o to expand)\n\n⏺ One failing test. Let me investigate combined_recovery_returns_both_types to see what it expects.\n\n⏺ Search(pattern: \"fn combined_recovery_returns_both_types\", path: \"src/rules.rs\", output_mode: \"content\")\n  ⎿  Found 61 lines (ctrl+o to expand)\n\n⏺ ★ Insight ─────────────────────────────────────\n  The test uses the old two-line compaction format where the verb and duration are on separate lines. My fix requires them on the same line to prevent cross-contamination from displayed code. This is the correct behavior - the test fixture\n  needs updating, not the fix.\n  ─────────────────────────────────────────────────\n\n  I need to update this test fixture to use the single-line format that matches real Claude Code.\n\n⏺ Read(src/rules.rs)\n  ⎿  Read 55 lines\n\n⏺ Update(src/rules.rs)\n  ⎿  Added 2 lines, removed 3 lines\n      2646      fn combined_recovery_returns_both_types() {\n      2647          let mut panes = HashMap::new();\n      2648          // One coworker stuck in compaction (10 min — well above threshold)\n      2649 -        // Must include actual compaction verb (Whirlpooling) to be detected\n      2649 +        // Single-line format matches real Claude Code compaction status\n      2650          panes.insert(\n      2651              \"york\".to_string(),\n      2652 -            \"  Whirlpooling your conversation…\\n  (esc to interrupt · 10m 00s · ↓ 0 tokens)\\n\"\n      2653 -                .to_string(),\n      2652 +            \"✶ Whirlpooling… (esc to interrupt · 10m 00s · ↓ 0 tokens)\\n\".to_string(),\n      2653          );\n      2654          // Another coworker with queued nudges (proper TUI structure)\n      2655          let amsterdam_tui = \"\\\n\n⏺ Bash(cargo test combined_recovery_returns_both_types --release -- --nocapture 2>&1)\n  ⎿  Interrupted · What should Claude do instead?\n\n  Tasks (9 done, 1 in progress, 0 open) · ctrl+t to hide tasks\n  ◼ #10 Fix false positive stuck compaction detection (york)\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n  ✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n  ✔ #9 Fix daemon not detecting posted review comments (riverside)\n  ✔ #11 Make nudges respect user input in progress (riverside)\n  ✔ #12 Fix misdirected PR nudges to wrong coworkers (amsterdam)\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ Your PR #577 (fix: Prevent chat TUI from unexpected...) has a completed review — please address any feedback and merge if appropriate.\n  PR #577 (fix: Prevent chat TUI from unexpected...) - CI green with feedback: CI is green — please address review feedback and merge\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle) · 2 files +91 -33\n\n\n\n\n\n"
+  },
+  "pending_tasks_with_owners": [],
+  "pending_tasks_without_owners": [],
+  "repo_name": "midtown",
+  "reviewed_prs": [],
+  "reviewer_pr_assignments": {},
+  "running_coworkers": [
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "riverside",
+      "session_id": "56441fe8-4e88-4fb9-b00b-a14aec223fea",
+      "started_at": "2026-02-04T14:40:45.312977Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/riverside"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "york",
+      "session_id": "75c5978f-b037-42bb-83d8-c38ddcc72096",
+      "started_at": "2026-02-04T14:39:47.352648Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/york"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "amsterdam",
+      "session_id": "",
+      "started_at": "2026-02-04T14:41:16.698284Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/amsterdam"
+    }
+  ],
+  "session_name": "midtown-midtown",
+  "usage_limit_nudge_scheduled": false
+}

--- a/tests/fixtures/snapshot/snapshot-api-errors-20260204-164204.json
+++ b/tests/fixtures/snapshot/snapshot-api-errors-20260204-164204.json
@@ -1,0 +1,373 @@
+{
+  "active_coworkers": [
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "vernon",
+      "session_id": "09d2fae2-6435-434b-b895-6eaa5cfae190",
+      "started_at": "2026-02-04T16:39:09.896490Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/vernon"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "columbus",
+      "session_id": "41bd9fe6-0b27-4e6a-84e5-95c597167d07",
+      "started_at": "2026-02-04T16:40:09.206746Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/columbus"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "madison",
+      "session_id": "87ccabb2-6f2a-402a-99f0-bfafe2ed95b0",
+      "started_at": "2026-02-04T16:36:09.539774Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/madison"
+    }
+  ],
+  "active_names": [
+    "madison",
+    "vernon",
+    "columbus"
+  ],
+  "active_reviewers": [],
+  "all_tasks": [
+    {
+      "blocked_by": [],
+      "description": "Bug: `is_auto_mergeable()` in src/daemon/helpers.rs only accepts formal GitHub APPROVED reviewDecision. It should also recognize positive review comments (e.g., \"No issues found\") as approval for auto-merge purposes.\n\nCurrent behavior (line 153):\n```rust\nif review_decision != \"APPROVED\" {\n    return false;\n}\n```\n\nExpected behavior:\n- Keep APPROVED as valid\n- Also check PR comments for positive review indicators from coworkers (look for midtown markers and \"No issues found\" or similar patterns)\n\nContext: We use comment-based reviews because the same GitHub account (btucker) authors PRs and runs coworkers, making formal self-approval impossible.",
+      "id": "3",
+      "owner": "park",
+      "status": "completed",
+      "subject": "Update auto-merge to recognize comment-based reviews"
+    },
+    {
+      "blocked_by": [],
+      "description": "Feature: The daemon should track typical CI check durations and handle stuck/missing checks intelligently.\n\n**Scenarios to handle:**\n\n1. **Stuck check** (pending > 4x typical duration): Re-run the specific check\n2. **Missing/new check** (required check not in PR's CI run): The PR predates the CI workflow change. Daemon should rebase the PR on main to pick up the new workflow, then CI will include the new check.\n\n**Implementation:**\n1. Track historical completion times per CI check name (e.g., \"E2E - idle_break_e2e\" typically takes 2m)\n2. Store rolling average or median of recent runs\n3. For stuck checks: If pending > 4x typical duration, trigger re-run\n4. For missing checks: If a required check never appears in the PR's status checks but exists in main's CI workflow, rebase the PR on main\n5. Add cooldowns to prevent spam\n\n**Key points:**\n- NOT overly aggressive - only at 4x typical time for stuck checks\n- Data-driven based on actual historical times\n- Detect \"new\" required checks that the PR doesn't have and auto-rebase\n\nUse case: PRs #566 and #570 were blocked by missing \"E2E - idle_break_e2e\" - they predated the workflow change. Daemon should have detected this and rebased automatically.",
+      "id": "4",
+      "owner": "broadway",
+      "status": "completed",
+      "subject": "Add daemon auto-retry for stale/missing CI checks"
+    },
+    {
+      "blocked_by": [],
+      "description": "Instead of the daemon parsing review comments to auto-merge, the author coworker should handle merge decisions themselves.\n\nWhen a PR receives a comment or review:\n1. If the author coworker is idle/shutdown, call them in\n2. Nudge the author coworker about the new comment/review\n3. Author reads the feedback and decides whether to merge, address feedback, or take other action\n\nThis is simpler than daemon comment parsing and keeps the merge decision with the agent who has full context of the PR.\n\nReplaces the approach in closed PR #571.\n\nPR #573 is ready - removes auto-merge, author-driven approach. Clean commit without state.json.",
+      "id": "5",
+      "owner": "park",
+      "status": "completed",
+      "subject": "Call-in and nudge PR authors on comments/reviews"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: Park had main checked out in their worktree. Coworkers should NEVER checkout the default branch (main/master).\n\nThis can cause issues:\n1. Multiple worktrees can't share the same branch\n2. Coworkers might accidentally commit directly to main\n3. Blocks other worktrees from using main\n\nFix needed:\n- Add validation when spawning coworkers to ensure they're on a feature branch\n- Add validation in coworker prompts/hooks to prevent `git checkout main`\n- If a coworker somehow ends up on main, detect and fix it (checkout a new feature branch)\n\nCheck how park ended up on main and prevent it from happening.",
+      "id": "6",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Prevent coworkers from checking out default branch"
+    },
+    {
+      "blocked_by": [
+        "8"
+      ],
+      "description": "The `midtown chat` TUI should check every 30 seconds whether it's at the end of the channel. If it got stuck further up (e.g., user scrolled up and forgot), it should auto-scroll back to the end.\n\nThis prevents the chat from appearing frozen/stuck when it's actually just scrolled up in history.",
+      "id": "7",
+      "owner": "vernon",
+      "status": "completed",
+      "subject": "Chat TUI should auto-scroll to end every 30 seconds"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The `midtown chat` TUI spontaneously scrolled to the beginning of the channel on its own. This should never happen.\n\nThis is a higher priority than the auto-scroll-to-end feature (task #7) - we need to fix this regression/bug first.\n\nInvestigate what's causing unexpected scroll position changes in the chat TUI. Could be:\n- A render loop resetting scroll state\n- File watcher event causing re-render from top\n- State management issue with scroll position\n- Race condition in the async event handling\n\nThe chat should maintain its scroll position unless the user explicitly scrolls or it auto-scrolls to follow new messages at the bottom.",
+      "id": "8",
+      "owner": "york",
+      "status": "completed",
+      "subject": "Fix chat TUI unexpectedly scrolling to beginning"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The daemon is warning \"Reviewer pleasant is idle but hasn't posted review for PR #572 yet\" but pleasant DID post a review comment (visible via `gh pr view 572 --json comments`).\n\nThe daemon's review detection is not recognizing that the review comment was posted. It should:\n1. Check PR comments for review signatures from the assigned reviewer\n2. Once a review comment is detected, stop warning about missing reviews\n3. Clear the reviewer assignment from the \"pending\" state\n\nThis might be related to how the daemon checks for reviews - it may be looking for formal GitHub reviews instead of comment-based reviews.",
+      "id": "9",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Fix daemon not detecting posted review comments"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The daemon incorrectly detects coworkers as \"stuck compacting\" when they're not.\n\n**Test cases captured:**\n1. `snapshot-false-positive-bugs-20260204-135417.json` - riverside false positive\n2. `snapshot-20260204-144326.json` - york detected as \"stuck compacting\" but actually had a backlog of nudges in its input box\n\n**Two types of nudge backlogs to distinguish:**\n1. **In the input box** - nudges stacked up IN the input box → needs Enter to process\n2. **Above the input box** - nudges stacked up ABOVE the input box (permission dialogs, etc.) → needs Escape to dismiss\n\n**Root cause:** The daemon may be misinterpreting these nudge backlog states as stuck compaction.\n\n**Fix needed:**\n- Detect and differentiate between:\n  - Actual stuck compaction\n  - Nudge backlog in input box (Enter needed)\n  - Nudge backlog above input box (Escape needed)\n- Don't treat nudge backlogs as stuck state\n- May need different remediation for each backlog type\n- Coordinate with task #11 (smart nudge timing) to prevent backlogs in the first place",
+      "id": "10",
+      "owner": "york",
+      "status": "completed",
+      "subject": "Fix false positive stuck compaction detection"
+    },
+    {
+      "blocked_by": [],
+      "description": "UX Bug: Nudges inject text via tmux send-keys while the user is trying to type, disrupting their input.\n\n**Two types of nudge backlogs to prevent:**\n1. **In the input box** - nudges stacking up IN the input box → needs Enter to clear\n2. **Above the input box** - nudges stacking up ABOVE the input box (permission dialogs, etc.) → needs Escape to dismiss\n\n**New nudge behavior:**\n\n1. Before nudging, check if the input box is empty\n2. If empty → safe to nudge immediately\n3. If not empty, check if the content is mostly from the daemon's last nudge\n   - If yes → safe to nudge (can overwrite stale nudge text)\n   - If no → user is typing something, DON'T nudge yet\n4. When user content detected:\n   - Wait 10 seconds, check again\n   - If input has changed → user still typing, wait another 10 seconds\n   - Repeat this process\n5. Only append onto unrecognized input content if it hasn't changed for 20 seconds\n\nAlso consider:\n- Detecting and handling existing backlog before adding more nudges\n- Different handling for \"above input\" backlog vs \"in input\" backlog\n\nThe daemon should track:\n- Last nudge content sent to each coworker/lead\n- Input box state before nudging\n- Timestamps of input changes\n\n**IMPORTANT: Create an E2E test for this using real Claude to verify the behavior works correctly in practice.**",
+      "id": "11",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Make nudges respect user input in progress"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: York received a nudge about PR #577 but that PR was authored by btucker, not york.\n\nThe daemon is sending PR-related nudges to the wrong coworkers. It should:\n1. Correctly identify the PR author (the coworker who created the PR)\n2. Only nudge that author about review feedback, CI status, etc.\n3. Not confuse GitHub username (btucker) with coworker names\n\nThis may be related to the author-driven merge changes (PR #573/task #5) - need to verify the author identification logic is correct.",
+      "id": "12",
+      "owner": "amsterdam",
+      "status": "completed",
+      "subject": "Fix misdirected PR nudges to wrong coworkers"
+    },
+    {
+      "blocked_by": [],
+      "description": "The GitHub CI check notifications in the channel are noisy when many checks complete around the same time:\n\n```\n08:47 Check 'Clippy' passed on main\n08:48 Check 'E2E - idle_break_e2e' passed on main\n08:48 Check 'Test' passed on main\n08:48 Check 'E2E - tailf_integration' passed on main\n08:48 Check 'E2E - spawn_race_test' passed on main\n```\n\n**Improvement:** Batch these into a single message when multiple checks complete within a short window (e.g., 30-60 seconds):\n\n```\n08:48 5 checks passed on main: Clippy, Test, E2E - idle_break_e2e, E2E - tailf_integration, E2E - spawn_race_test\n```\n\nOr even more condensed:\n```\n08:48 All CI checks passed on main\n```\n\n**Implementation ideas:**\n- Buffer CI check events for a short window before posting to channel\n- If multiple checks for the same ref/PR complete, batch them\n- Keep important events (PR opened, failures) as individual messages\n- Only batch \"passed\" checks, always show failures immediately\n\n**IMPORTANT:** This is purely a channel display change. The underlying webhook/event handling and PR author nudging logic should NOT be affected. The daemon should still process each CI event individually for nudge decisions - only the channel message posting gets batched.",
+      "id": "13",
+      "owner": "broadway",
+      "status": "completed",
+      "subject": "Batch repetitive GitHub CI notifications in channel"
+    },
+    {
+      "blocked_by": [],
+      "description": "Fixed: Added direct nudge_lead() calls in dispatch.rs and mod.rs. PR #584 opened.",
+      "id": "14",
+      "owner": "vernon",
+      "status": "completed",
+      "subject": "Investigate broken lead nudges for @lead mentions"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/effects.rs at 0%\n\nAdd E2E tests that exercise the effect execution layer:\n- Effect::SpawnCoworker - test coworker spawning via real daemon\n- Effect::ShutdownCoworker - test coworker shutdown\n- Effect::NudgeCoworker / Effect::NudgeLead - test nudge delivery\n- Effect::PostChannelMessage - test channel posting\n- Effect::AutoMergePr - test PR merge triggering\n\nUse the containerized E2E approach with real Claude where needed. Tests should verify effects actually execute (tmux windows created, messages posted, etc.).",
+      "id": "15",
+      "owner": "lexington",
+      "status": "completed",
+      "subject": "E2E tests for daemon effects execution"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/pr.rs at 0.94%\n\nAdd E2E tests for PR management flows:\n- PR polling and state detection\n- CI status tracking and stale check detection\n- Review comment detection\n- PR author identification and nudging\n- Auto-merge eligibility checking\n- Merge conflict detection\n\nUse real GitHub PRs in test repo or mock webhook events to exercise the PR handling code paths.",
+      "id": "16",
+      "owner": "columbus",
+      "status": "completed",
+      "subject": "E2E tests for daemon PR management"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/health.rs at 8.89%\n\nAdd E2E tests for coworker health monitoring:\n- Stuck detection (various stuck states)\n- Idle detection\n- Compaction detection (avoiding false positives - see task #10)\n- Usage limit detection\n- Orphan worktree detection\n- Session crash detection\n\nUse captured snapshots as test fixtures and verify health decisions match expected behavior.",
+      "id": "17",
+      "owner": "amsterdam",
+      "status": "completed",
+      "subject": "E2E tests for daemon health checks"
+    },
+    {
+      "blocked_by": [],
+      "description": "**COMPLETED - PR #590 OPEN**\n\nAdded 17 new E2E tests for daemon RPC handlers:\n- coworker.report-state: phase validation (3 tests)\n- coworker.asking: channel posting (2 tests)\n- daemon.check-pending: response structure (1 test)\n- task.updated: params, task not found, list mismatch (3 tests)\n- channel.post: /me actions, shell unescaping (2 tests)\n- channel.read: all parameter (1 test)\n- coworker.nudge: valid params (1 test)\n- reminder.create: invalid trigger (1 test)\n- reminder.cancel: not found (1 test)\n- plus 2 additional edge case tests\n\nAll tests pass. PR at https://github.com/btucker/midtown/pull/590",
+      "id": "18",
+      "owner": "york",
+      "status": "completed",
+      "subject": "E2E tests for daemon RPC handlers"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/dispatch.rs at 23.42%\n\nAdd E2E tests for task dispatch and coworker assignment:\n- Task assignment to idle coworkers\n- Task priority handling\n- Blocked task detection (blockedBy dependencies)\n- Orphan task recovery\n- Reviewer spawning for PRs\n- Max coworker limit enforcement\n\nVerify the daemon correctly assigns work and manages coworker lifecycle.",
+      "id": "19",
+      "owner": "park",
+      "status": "completed",
+      "subject": "E2E tests for daemon dispatch logic"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/webhook_fwd.rs at 0%, daemon/events.rs at 0%\n\nAdd E2E tests for GitHub webhook processing:\n- PR opened/closed/merged events\n- Review submitted events\n- Check run completed events\n- Push events\n- Webhook signature verification\n- Event deduplication\n\nUse mock webhook payloads or test against real GitHub webhooks in test environment.",
+      "id": "20",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "E2E tests for webhook handling"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: web.rs at 31.19%, webserver.rs at 30.63%\n\nAdd E2E tests for the web interface:\n- WebSocket connection and message streaming\n- Chat message display\n- Coworker status updates\n- Kanban board data\n- Static file serving\n- Multi-project routing\n\nCould use Playwright (already have MCP tools) or headless browser testing.",
+      "id": "21",
+      "owner": "vernon",
+      "status": "completed",
+      "subject": "E2E tests for web UI and WebSocket"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: tmux.rs at 41.57%\n\nAdd E2E tests for tmux interactions:\n- Window creation and naming\n- Pane capture and parsing\n- Send-keys for nudges\n- Session management\n- Status bar updates\n- Window killing safety checks\n\nThese tests need real tmux sessions - use the existing tmux_e2e test pattern.",
+      "id": "22",
+      "owner": "pleasant",
+      "status": "completed",
+      "subject": "E2E tests for tmux operations"
+    },
+    {
+      "blocked_by": [],
+      "description": "Vernon's worktree was missing while the daemon still showed them as active. Their Claude Code session was running but couldn't access files or run commands because ~/.midtown/coworkers/midtown/vernon/ didn't exist.\n\nInvestigation needed:\n1. Check daemon logs for any orphan cleanup that might have removed vernon's worktree incorrectly\n2. Check if there's a race condition between worktree creation and coworker startup\n3. Verify the orphan detection logic doesn't incorrectly flag active coworkers\n4. Add safeguards to prevent coworkers from running without valid worktrees\n\nRecent changes to watch:\n- PR #568 merged \"fix: Exclude tmux window orphans from worktree cleanup\"\n- The orphan cleanup logic in tmux.rs\n\nEvidence: Vernon was able to mark task #14 as completed but their bash commands (git, midtown) all failed with \"command not found\" or exit code 1.",
+      "id": "23",
+      "owner": "madison",
+      "status": "completed",
+      "subject": "Investigate and fix coworker worktree corruption (vernon incident)"
+    },
+    {
+      "blocked_by": [],
+      "description": "Madison's review of PR #581 identified that WebhookEvent has grown to 8 optional fields, requiring repetitive `field: None` in every constructor (5 places currently).\n\nRecommended fix:\n1. Derive Default for WebhookEvent\n2. Or use a builder pattern\n\nThis will reduce boilerplate and make adding new optional fields cleaner.\n\nSource: PR #581 review comment",
+      "id": "24",
+      "owner": "columbus",
+      "status": "completed",
+      "subject": "Refactor WebhookEvent to use Default or builder pattern"
+    },
+    {
+      "blocked_by": [],
+      "description": "The daemon is not assigning pending tasks to idle coworkers or spawning reviewers for green PRs.\n\nSymptoms:\n- 7 coworkers showing as idle\n- 4 pending tasks available\n- 7 green PRs without reviewer assignments\n- Daemon repeatedly restarts but doesn't dispatch work\n\nExpected behavior:\n- Idle coworkers should be assigned pending tasks\n- Green PRs should get reviewer coworkers spawned\n\nThis appears to be a bug in the task dispatch or reviewer spawning logic in rules.rs or effects.rs.",
+      "id": "25",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Fix daemon task dispatch - not assigning pending tasks to idle coworkers"
+    },
+    {
+      "blocked_by": [],
+      "description": "**Problem**: When coworkers hit their Claude usage limit, the daemon doesn't recognize this state and continues:\n- Warning about \"idle reviewers who haven't posted review\"\n- Restarting \"stuck\" coworkers (pane unchanged for 180s)\n- Sending nudges that can't be acted upon\n\n**Expected behavior**: The daemon should:\n1. Detect the usage limit message in pane content: \"You've hit your limit · resets Xam/pm (timezone)\"\n2. Parse the reset time from the message\n3. Mark these coworkers as \"usage_limited\" (not idle, not stuck)\n4. Stop nudging/restarting them until the reset time passes\n5. Optionally post to channel once when usage limit is detected\n\n**Test fixture available**: `tests/fixtures/snapshot/snapshot-hit-usage-limit-20260204-154619.json` contains real pane content showing the usage limit state.\n\n**Implementation hints**:\n- Pane parsing likely in `src/tmux.rs` or `src/pane.rs`\n- Decision logic in `src/rules.rs` \n- WorldSnapshot already has `usage_limit_nudge_scheduled` field - may need expansion\n- Follow the pure decision / effect execution pattern\n\n**Acceptance criteria**:\n- [ ] Unit test using the captured fixture verifies correct detection\n- [ ] Daemon stops nudging/restarting usage-limited coworkers\n- [ ] Coworkers resume normal handling after reset time",
+      "id": "26",
+      "owner": "columbus",
+      "status": "in_progress",
+      "subject": "Detect usage limit state and pause daemon actions for affected coworkers"
+    },
+    {
+      "blocked_by": [],
+      "description": "Lead committed changes on branch lead/channel-etiquette. Open a PR, get it reviewed, and merge.\n\nThe change adds channel etiquette guidelines to agents/common.md to avoid pointless back-and-forth conversation (no thank-you chains, brief acknowledgments only).",
+      "id": "27",
+      "owner": "vernon",
+      "status": "in_progress",
+      "subject": "Open PR for lead/channel-etiquette branch"
+    },
+    {
+      "blocked_by": [],
+      "description": "Multiple coworkers have accumulated stale local branches with unmerged commits: park, riverside, amsterdam, broadway, and likely others.\n\n**Task**: Audit and clean up these branches:\n1. List all local branches for each coworker namespace (park/, riverside/, amsterdam/, etc.)\n2. For each branch with unmerged commits, check if the work was merged via a different branch name (common pattern)\n3. Delete branches that are clearly stale (correspond to completed tasks, superseded by other work)\n4. For any with potentially useful unmerged work, note them for review\n\n**Safety**: Don't delete branches that might have unique unmerged work without confirming it's obsolete.\n\n**Commands to audit**:\n```bash\ngit branch | grep '<coworker>/' | while read branch; do\n  commits=$(git rev-list --count main..$branch 2>/dev/null || echo \"0\")\n  if [ \"$commits\" != \"0\" ]; then\n    echo \"$branch: $commits unmerged\"\n  fi\ndone\n```",
+      "id": "28",
+      "owner": "madison",
+      "status": "in_progress",
+      "subject": "Clean up stale coworker branches across all worktrees"
+    }
+  ],
+  "blank_pane_coworkers": [],
+  "busy_coworkers": [
+    "vernon",
+    "madison",
+    "columbus"
+  ],
+  "ci_passed_pr_coworkers": [
+    "vernon",
+    "columbus",
+    "riverside"
+  ],
+  "coworker_snapshots": [
+    {
+      "isolated_tasks": false,
+      "name": "vernon",
+      "started_at": "2026-02-04T16:39:09.896490Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "columbus",
+      "started_at": "2026-02-04T16:40:09.206746Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "madison",
+      "started_at": "2026-02-04T16:36:09.539774Z"
+    }
+  ],
+  "coworker_start_times": {
+    "columbus": "2026-02-04T16:40:09.206746Z",
+    "madison": "2026-02-04T16:36:09.539774Z",
+    "vernon": "2026-02-04T16:39:09.896490Z"
+  },
+  "coworker_stop_times": {
+    "amsterdam": "2026-02-04T16:28:37.244245Z",
+    "broadway": "2026-02-04T16:28:37.468329Z",
+    "columbus": "2026-02-04T16:40:05.596391Z",
+    "lexington": "2026-02-04T16:28:37.017401Z",
+    "madison": "2026-02-04T16:36:05.928298Z",
+    "park": "2026-02-04T16:32:37.941066Z",
+    "pleasant": "2026-02-04T16:28:37.925438Z",
+    "riverside": "2026-02-04T16:39:06.075748Z",
+    "vernon": "2026-02-04T16:39:06.293166Z",
+    "york": "2026-02-04T16:28:36.790738Z"
+  },
+  "coworkers_with_merged_prs": [
+    "pleasant",
+    "madison",
+    "york",
+    "broadway",
+    "riverside",
+    "vernon",
+    "lexington",
+    "amsterdam",
+    "park",
+    "columbus"
+  ],
+  "coworkers_with_open_prs": [
+    "columbus",
+    "vernon",
+    "riverside"
+  ],
+  "coworkers_with_running_subagents": [],
+  "coworkers_with_unblocked_deps": [],
+  "in_progress_tasks": [
+    [
+      "26",
+      "Detect usage limit state and pause daemon actions for affected coworkers",
+      "columbus"
+    ],
+    [
+      "27",
+      "Open PR for lead/channel-etiquette branch",
+      "vernon"
+    ],
+    [
+      "28",
+      "Clean up stale coworker branches across all worktrees",
+      "madison"
+    ]
+  ],
+  "is_at_dev_limit": false,
+  "now_utc": "2026-02-04T16:42:04.982001Z",
+  "pane_contents": {
+    "columbus": "\n⏺ Bash(midtown channel read)\n  ⎿  [2026-02-04T16:31:38.775817+00:00] madison: taking the stage on task 28 — time to sweep these dusty branches off the set\n     [2026-02-04T16:32:23.211125+00:00] columbus: waiting for input\n     [2026-02-04T16:32:37.719094+00:00] system: ☕ Letting park take a break (work's all merged)\n     … +30 lines (ctrl+o to expand)\n\n⏺ Bash(git status && git log --oneline -5)\n  ⎿  On branch columbus/usage-limit-detection\n     Your branch is up to date with 'origin/columbus/usage-limit-detection'.\n     … +11 lines (ctrl+o to expand)\n\n❯ continue\n\n⏺ I can see I was restarted, and my commit 7b7862d feat: Pause daemon actions for usage-limited coworkers is already pushed. Let me check the PR status and task state.\n\n⏺ Bash(gh pr view 594 --json state,reviews,mergeable,statusCheckRollup)\n  ⎿  {\n       \"mergeable\": \"MERGEABLE\",\n       \"reviews\": [],\n     … +144 lines (ctrl+o to expand)\n\n⏺ PR #594 is open with all CI checks passing and it's mergeable. Just waiting for a reviewer. Let me update my state and post to the channel.\n\n⏺ Bash(midtown state pull-request --task 26)\n  ⎿  columbus → PR#26\n\n⏺ Bash(midtown channel post \"/me back from the restart - PR #594 is still waiting for its debut, all CI green and ready for review\")\n  ⎿  Message posted to channel\n\n⏺ ★ Insight ─────────────────────────────────────\n  The daemon's restart mechanism worked correctly here - it detected my session was stuck (pane unchanged for 180s) and restarted me. This is exactly the kind of scenario my PR #594 addresses: detecting when coworkers are stuck due to usage\n  limits vs genuinely stuck.\n  ─────────────────────────────────────────────────\n\n  PR #594 is ready for review. The daemon will automatically assign a reviewer. Let me check if there are any unblocked tasks I can pick up while waiting.\n26 tasks (23 done, 3 in progress, 0 open)\n\n✔ #20 E2E tests for webhook handling (riverside)\n✔ #16 E2E tests for daemon PR management (columbus)\n✔ #6 Prevent coworkers from checking out default branch (riverside)\n✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n✔ #17 E2E tests for daemon health checks (amsterdam)\n✔ #21 E2E tests for web UI and WebSocket (vernon)\n✔ #10 Fix false positive stuck compaction detection (york)\n◼ #26 Detect usage limit state and pause daemon actions for affected coworkers (columbus)\n◼ #27 Open PR for lead/channel-etiquette branch (vernon)\n✔ #11 Make nudges respect user input in progress (riverside)\n◼ #28 Clean up stale coworker branches across all worktrees (madison)\n✔ #12 Fix misdirected PR nudges to wrong coworkers (amsterdam)\n✔ #24 Refactor WebhookEvent to use Default or builder pattern (columbus)\n✔ #25 Fix daemon task dispatch - not assigning pending tasks to idle coworkers (riverside)\n✔ #13 Batch repetitive GitHub CI notifications in channel (broadway)\n✔ #3 Update auto-merge to recognize comment-based reviews (park)\n✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n✔ #22 E2E tests for tmux operations (pleasant)\n✔ #18 E2E tests for daemon RPC handlers (york)\n✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n✔ #14 Investigate broken lead nudges for @lead mentions (vernon)\n✔ #15 E2E tests for daemon effects execution (lexington)\n✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n✔ #19 E2E tests for daemon dispatch logic (park)\n✔ #23 Investigate and fix coworker worktree corruption (vernon incident) (madison)\n✔ #9 Fix daemon not detecting posted review comments (riverside)\n  ⎿  API Error: 500 {\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"Internal server error\"},\"request_id\":\"req_011CXoMs5j26kAfesVvXxcT2\"}\n\n✻ Churned for 33s\n\n  Tasks (23 done, 3 in progress, 0 open) · ctrl+t to hide tasks\n  ◼ #26 Detect usage limit state and pause daemon actions for affected coworkers (columbus)\n  ◼ #27 Open PR for lead/channel-etiquette branch (vernon)\n  ◼ #28 Clean up stale coworker branches across all worktrees (madison)\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n  ✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n  ✔ #9 Fix daemon not detecting posted review comments (riverside)\n   … +16 completed\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n",
+    "madison": "     Your branch is up to date with 'origin/madison/worktree-corruption-fix'.\n     … +6 lines (ctrl+o to expand)\n\n⏺ I was restarted after getting stuck. Let me get back on track - I'll report my state and continue the branch cleanup work.\n\n⏺ Bash(midtown state developing --task 28)\n  ⎿  madison → dev#28\n\n⏺ Bash(midtown channel post \"/me back on stage after a brief intermission — resuming the branch cleanup for task 28\")\n  ⎿  Message posted to channel\n\n⏺ Bash(git restore state.json 2>/dev/null || true)\n  ⎿  (No content)\n\n⏺ Now let me audit all the coworker branches to see what needs cleanup.\n\n⏺ Bash(git fetch origin main && git branch -a | grep -E '^\\s*(park|riverside|amsterdam|broadway|lexington|madison|columbus|vernon|york|pleasant)/' | head -50)\n  ⎿    amsterdam/add-in-progress-duration\n       amsterdam/allow-awaiting-review-as-reviewer\n       amsterdam/auto-shutdown-idle-coworkers\n     … +49 lines (ctrl+o to expand)\n\n⏺ That's a lot of branches. Let me get a comprehensive audit of which branches have unmerged commits.\n\n⏺ Bash(echo \"=== Coworker branches with unmerged commits ===\" && for coworker in amsterdam broadway columbus lexington madison park pleasant riverside vernon york; do…)\n  ⎿  === Coworker branches with unmerged commits ===\n\n     --- amsterdam ---\n     … +311 lines (ctrl+o to expand)\n\n⏺ ★ Insight ─────────────────────────────────────\n  This is a common problem in multi-contributor repos with worktrees. When PRs are merged via squash or rebase, the original branch commits don't become ancestors of main, so git rev-list main..branch still shows \"unmerged\" even though the\n  work is integrated. The solution is to check if each branch's changes are already in main, regardless of commit ancestry.\n  ─────────────────────────────────────────────────\n\n  That's a substantial cleanup needed — over 200 branches with apparent unmerged commits. Let me check which branches are truly stale by seeing if their changes are already in main (merged via squash/rebase).\n\n⏺ Bash(echo \"=== Checking for truly unmerged branches (changes not in main) ===\" && for branch in $(git branch | grep -E '^\\s*(amsterdam|broadway|columbus|lexington|ma…)\n  ⎿  === Checking for truly unmerged branches (changes not in main) ===\n     amsterdam/allow-awaiting-review-as-reviewer:  1 file changed, 20 insertions(+), 6 deletions(-) (last commit: 2026-01-28)\n     amsterdam/auto-shutdown-idle-coworkers:  2 files changed, 144 insertions(+), 72 deletions(-) (last commit: 2026-01-27)\n     … +58 lines (ctrl+o to expand)\n\n❯ continue\n\n⏺ Let me take a smarter approach — check which branches have had their remote deleted (indicating the PR was merged/closed) and are safe to clean up.\n\n⏺ Bash(echo \"=== Branches with deleted remotes (safe to cleanup) ===\" && git fetch --prune origin 2>&1 && for branch in $(git branch | grep -E '^\\s*(amsterdam|broadway…)\n  ⎿  === Branches with deleted remotes (safe to cleanup) ===\n     From github.com:btucker/midtown\n      - [deleted]         (none)     -> origin/amsterdam/e2e-health-checks\n     … +28 lines (ctrl+o to expand)\n\n⏺ Good — git fetch --prune cleaned up the remote tracking refs. Now let me properly identify which local branches have no corresponding remote.\n\n⏺ Bash(# Get all local coworker branches and check if they have a remote\n      echo \"=== Local branches with no remote (merged/closed PRs) ===\" && for branch in $(git branch…)\n  ⎿  === Local branches with no remote (merged/closed PRs) ===\n\n⏺ Let me check if there are open PRs for any of these branches — branches without open PRs are candidates for cleanup.\n\n⏺ Bash(gh pr list --state all --limit 500 --json headRefName,state,mergedAt,closedAt | jq -r '.[] | select(.state != \"OPEN\") | .headRefName' | grep -E '^(amsterdam|bro…)\n  ⎿         0 /tmp/closed_pr_branches.txt\n     === Sample closed PR branches ===\n     jq: error: syntax error, unexpected INVALID_CHARACTER, expecting ';' or ')' (Unix shell quoting issues?) at <top-level>, line 1:\n     … +2 lines (ctrl+o to expand)\n\n✳ Implementing usage limit detection… (Esc to interrupt · ctrl+t to hide tasks · 5m 56s · ↓ 3.5k tokens)\n  ⎿  ◼ #26 Detect usage limit state and pause daemon actions for affected coworkers (columbus)\n     ◼ #27 Open PR for lead/channel-etiquette branch (vernon)\n     ◼ #28 Clean up stale coworker branches across all worktrees (madison)\n     ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n     ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n     ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n     ✔ #6 Prevent coworkers from checking out default branch (riverside)\n     ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n     ✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n     ✔ #9 Fix daemon not detecting posted review comments (riverside)\n      … +16 completed\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n\n",
+    "vernon": "  ⎿  [2026-02-04T16:31:19.734264+00:00] midtown: 🚀 Called in coworker madison for assigned task #28: Clean up stale coworker branches across all worktrees\n     [2026-02-04T16:31:32.122361+00:00] madison: claimed task 28\n     [2026-02-04T16:31:38.775817+00:00] madison: taking the stage on task 28 — time to sweep these dusty branches off the set\n     … +30 lines (ctrl+o to expand)\n\n⏺ Bash(git status)\n  ⎿  On branch vernon/web-e2e-tests\n     Your branch is up to date with 'origin/vernon/web-e2e-tests'.\n     … +6 lines (ctrl+o to expand)\n26 tasks (23 done, 3 in progress, 0 open)\n\n✔ #20 E2E tests for webhook handling (riverside)\n✔ #16 E2E tests for daemon PR management (columbus)\n✔ #6 Prevent coworkers from checking out default branch (riverside)\n✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n✔ #17 E2E tests for daemon health checks (amsterdam)\n✔ #21 E2E tests for web UI and WebSocket (vernon)\n✔ #10 Fix false positive stuck compaction detection (york)\n◼ #26 Detect usage limit state and pause daemon actions for affected coworkers (columbus)\n◼ #27 Open PR for lead/channel-etiquette branch (vernon)\n✔ #11 Make nudges respect user input in progress (riverside)\n◼ #28 Clean up stale coworker branches across all worktrees (madison)\n✔ #12 Fix misdirected PR nudges to wrong coworkers (amsterdam)\n✔ #24 Refactor WebhookEvent to use Default or builder pattern (columbus)\n✔ #25 Fix daemon task dispatch - not assigning pending tasks to idle coworkers (riverside)\n✔ #13 Batch repetitive GitHub CI notifications in channel (broadway)\n✔ #3 Update auto-merge to recognize comment-based reviews (park)\n✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n✔ #22 E2E tests for tmux operations (pleasant)\n✔ #18 E2E tests for daemon RPC handlers (york)\n✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n✔ #14 Investigate broken lead nudges for @lead mentions (vernon)\n✔ #15 E2E tests for daemon effects execution (lexington)\n✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n✔ #19 E2E tests for daemon dispatch logic (park)\n✔ #23 Investigate and fix coworker worktree corruption (vernon incident) (madison)\n✔ #9 Fix daemon not detecting posted review comments (riverside)\n\n⏺ Bash(git fetch origin && git branch -r | grep channel-etiquette)\n  ⎿    origin/lead/channel-etiquette\n\n❯ continue\n\n⏺ Let me update my state and switch to the correct branch.\n\n⏺ Bash(midtown state developing --task 27)\n  ⎿  vernon → dev#27\n\n⏺ Bash(midtown channel post \"/me back from intermission, picking up task 27 - opening PR for channel etiquette guidelines\")\n  ⎿  Message posted to channel\n\n⏺ Bash(git checkout lead/channel-etiquette)\n  ⎿  M  state.json\n     Your branch is up to date with 'origin/lead/channel-etiquette'.\n     Switched to branch 'lead/channel-etiquette'\n\n⏺ Bash(git log origin/main..HEAD --oneline)\n  ⎿  0368984 docs: Add channel etiquette guidelines to avoid pointless back-and-forth\n\n⏺ Bash(git diff origin/main..HEAD --stat)\n  ⎿   agents/common.md    |  26 +++\n      agents/lead.md      |  36 +--\n      src/coworker.rs     |  62 +-----\n     … +2 lines (ctrl+o to expand)\n  ⎿  API Error: 500 {\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"Internal server error\"},\"request_id\":\"req_011CXoMrRYbsPHFYh5nhSRPv\"}\n\n✻ Sautéed for 1m 23s\n\n  Tasks (23 done, 3 in progress, 0 open) · ctrl+t to hide tasks\n  ◼ #26 Detect usage limit state and pause daemon actions for affected coworkers (columbus)\n  ◼ #27 Open PR for lead/channel-etiquette branch (vernon)\n  ◼ #28 Clean up stale coworker branches across all worktrees (madison)\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n  ✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n  ✔ #9 Fix daemon not detecting posted review comments (riverside)\n   … +16 completed\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n"
+  },
+  "pending_tasks_with_owners": [],
+  "pending_tasks_without_owners": [],
+  "repo_name": "midtown",
+  "reviewed_prs": [],
+  "reviewer_pr_assignments": {},
+  "running_coworkers": [
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "vernon",
+      "session_id": "09d2fae2-6435-434b-b895-6eaa5cfae190",
+      "started_at": "2026-02-04T16:39:09.896490Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/vernon"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "columbus",
+      "session_id": "41bd9fe6-0b27-4e6a-84e5-95c597167d07",
+      "started_at": "2026-02-04T16:40:09.206746Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/columbus"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "madison",
+      "session_id": "87ccabb2-6f2a-402a-99f0-bfafe2ed95b0",
+      "started_at": "2026-02-04T16:36:09.539774Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/madison"
+    }
+  ],
+  "session_name": "midtown-midtown",
+  "usage_limit_nudge_scheduled": false
+}

--- a/tests/fixtures/snapshot/snapshot-double-nudge-pr-merge-20260204-173400.json
+++ b/tests/fixtures/snapshot/snapshot-double-nudge-pr-merge-20260204-173400.json
@@ -1,0 +1,487 @@
+{
+  "active_coworkers": [
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "columbus",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628703Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/columbus"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "park",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628745Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/park"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "vernon",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628751Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/vernon"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "amsterdam",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628754Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/amsterdam"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "madison",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628758Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/madison"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "riverside",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628764Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/riverside"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "lexington",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628761Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/lexington"
+    }
+  ],
+  "active_names": [
+    "lexington",
+    "amsterdam",
+    "columbus",
+    "madison",
+    "riverside",
+    "park",
+    "vernon"
+  ],
+  "active_reviewers": [
+    "lexington"
+  ],
+  "all_tasks": [
+    {
+      "blocked_by": [],
+      "description": "Bug: `is_auto_mergeable()` in src/daemon/helpers.rs only accepts formal GitHub APPROVED reviewDecision. It should also recognize positive review comments (e.g., \"No issues found\") as approval for auto-merge purposes.\n\nCurrent behavior (line 153):\n```rust\nif review_decision != \"APPROVED\" {\n    return false;\n}\n```\n\nExpected behavior:\n- Keep APPROVED as valid\n- Also check PR comments for positive review indicators from coworkers (look for midtown markers and \"No issues found\" or similar patterns)\n\nContext: We use comment-based reviews because the same GitHub account (btucker) authors PRs and runs coworkers, making formal self-approval impossible.",
+      "id": "3",
+      "owner": "park",
+      "status": "completed",
+      "subject": "Update auto-merge to recognize comment-based reviews"
+    },
+    {
+      "blocked_by": [],
+      "description": "Feature: The daemon should track typical CI check durations and handle stuck/missing checks intelligently.\n\n**Scenarios to handle:**\n\n1. **Stuck check** (pending > 4x typical duration): Re-run the specific check\n2. **Missing/new check** (required check not in PR's CI run): The PR predates the CI workflow change. Daemon should rebase the PR on main to pick up the new workflow, then CI will include the new check.\n\n**Implementation:**\n1. Track historical completion times per CI check name (e.g., \"E2E - idle_break_e2e\" typically takes 2m)\n2. Store rolling average or median of recent runs\n3. For stuck checks: If pending > 4x typical duration, trigger re-run\n4. For missing checks: If a required check never appears in the PR's status checks but exists in main's CI workflow, rebase the PR on main\n5. Add cooldowns to prevent spam\n\n**Key points:**\n- NOT overly aggressive - only at 4x typical time for stuck checks\n- Data-driven based on actual historical times\n- Detect \"new\" required checks that the PR doesn't have and auto-rebase\n\nUse case: PRs #566 and #570 were blocked by missing \"E2E - idle_break_e2e\" - they predated the workflow change. Daemon should have detected this and rebased automatically.",
+      "id": "4",
+      "owner": "broadway",
+      "status": "completed",
+      "subject": "Add daemon auto-retry for stale/missing CI checks"
+    },
+    {
+      "blocked_by": [],
+      "description": "Instead of the daemon parsing review comments to auto-merge, the author coworker should handle merge decisions themselves.\n\nWhen a PR receives a comment or review:\n1. If the author coworker is idle/shutdown, call them in\n2. Nudge the author coworker about the new comment/review\n3. Author reads the feedback and decides whether to merge, address feedback, or take other action\n\nThis is simpler than daemon comment parsing and keeps the merge decision with the agent who has full context of the PR.\n\nReplaces the approach in closed PR #571.\n\nPR #573 is ready - removes auto-merge, author-driven approach. Clean commit without state.json.",
+      "id": "5",
+      "owner": "park",
+      "status": "completed",
+      "subject": "Call-in and nudge PR authors on comments/reviews"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: Park had main checked out in their worktree. Coworkers should NEVER checkout the default branch (main/master).\n\nThis can cause issues:\n1. Multiple worktrees can't share the same branch\n2. Coworkers might accidentally commit directly to main\n3. Blocks other worktrees from using main\n\nFix needed:\n- Add validation when spawning coworkers to ensure they're on a feature branch\n- Add validation in coworker prompts/hooks to prevent `git checkout main`\n- If a coworker somehow ends up on main, detect and fix it (checkout a new feature branch)\n\nCheck how park ended up on main and prevent it from happening.",
+      "id": "6",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Prevent coworkers from checking out default branch"
+    },
+    {
+      "blocked_by": [
+        "8"
+      ],
+      "description": "The `midtown chat` TUI should check every 30 seconds whether it's at the end of the channel. If it got stuck further up (e.g., user scrolled up and forgot), it should auto-scroll back to the end.\n\nThis prevents the chat from appearing frozen/stuck when it's actually just scrolled up in history.",
+      "id": "7",
+      "owner": "vernon",
+      "status": "completed",
+      "subject": "Chat TUI should auto-scroll to end every 30 seconds"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The `midtown chat` TUI spontaneously scrolled to the beginning of the channel on its own. This should never happen.\n\nThis is a higher priority than the auto-scroll-to-end feature (task #7) - we need to fix this regression/bug first.\n\nInvestigate what's causing unexpected scroll position changes in the chat TUI. Could be:\n- A render loop resetting scroll state\n- File watcher event causing re-render from top\n- State management issue with scroll position\n- Race condition in the async event handling\n\nThe chat should maintain its scroll position unless the user explicitly scrolls or it auto-scrolls to follow new messages at the bottom.",
+      "id": "8",
+      "owner": "york",
+      "status": "completed",
+      "subject": "Fix chat TUI unexpectedly scrolling to beginning"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The daemon is warning \"Reviewer pleasant is idle but hasn't posted review for PR #572 yet\" but pleasant DID post a review comment (visible via `gh pr view 572 --json comments`).\n\nThe daemon's review detection is not recognizing that the review comment was posted. It should:\n1. Check PR comments for review signatures from the assigned reviewer\n2. Once a review comment is detected, stop warning about missing reviews\n3. Clear the reviewer assignment from the \"pending\" state\n\nThis might be related to how the daemon checks for reviews - it may be looking for formal GitHub reviews instead of comment-based reviews.",
+      "id": "9",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Fix daemon not detecting posted review comments"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The daemon incorrectly detects coworkers as \"stuck compacting\" when they're not.\n\n**Test cases captured:**\n1. `snapshot-false-positive-bugs-20260204-135417.json` - riverside false positive\n2. `snapshot-20260204-144326.json` - york detected as \"stuck compacting\" but actually had a backlog of nudges in its input box\n\n**Two types of nudge backlogs to distinguish:**\n1. **In the input box** - nudges stacked up IN the input box → needs Enter to process\n2. **Above the input box** - nudges stacked up ABOVE the input box (permission dialogs, etc.) → needs Escape to dismiss\n\n**Root cause:** The daemon may be misinterpreting these nudge backlog states as stuck compaction.\n\n**Fix needed:**\n- Detect and differentiate between:\n  - Actual stuck compaction\n  - Nudge backlog in input box (Enter needed)\n  - Nudge backlog above input box (Escape needed)\n- Don't treat nudge backlogs as stuck state\n- May need different remediation for each backlog type\n- Coordinate with task #11 (smart nudge timing) to prevent backlogs in the first place",
+      "id": "10",
+      "owner": "york",
+      "status": "completed",
+      "subject": "Fix false positive stuck compaction detection"
+    },
+    {
+      "blocked_by": [],
+      "description": "UX Bug: Nudges inject text via tmux send-keys while the user is trying to type, disrupting their input.\n\n**Two types of nudge backlogs to prevent:**\n1. **In the input box** - nudges stacking up IN the input box → needs Enter to clear\n2. **Above the input box** - nudges stacking up ABOVE the input box (permission dialogs, etc.) → needs Escape to dismiss\n\n**New nudge behavior:**\n\n1. Before nudging, check if the input box is empty\n2. If empty → safe to nudge immediately\n3. If not empty, check if the content is mostly from the daemon's last nudge\n   - If yes → safe to nudge (can overwrite stale nudge text)\n   - If no → user is typing something, DON'T nudge yet\n4. When user content detected:\n   - Wait 10 seconds, check again\n   - If input has changed → user still typing, wait another 10 seconds\n   - Repeat this process\n5. Only append onto unrecognized input content if it hasn't changed for 20 seconds\n\nAlso consider:\n- Detecting and handling existing backlog before adding more nudges\n- Different handling for \"above input\" backlog vs \"in input\" backlog\n\nThe daemon should track:\n- Last nudge content sent to each coworker/lead\n- Input box state before nudging\n- Timestamps of input changes\n\n**IMPORTANT: Create an E2E test for this using real Claude to verify the behavior works correctly in practice.**",
+      "id": "11",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Make nudges respect user input in progress"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: York received a nudge about PR #577 but that PR was authored by btucker, not york.\n\nThe daemon is sending PR-related nudges to the wrong coworkers. It should:\n1. Correctly identify the PR author (the coworker who created the PR)\n2. Only nudge that author about review feedback, CI status, etc.\n3. Not confuse GitHub username (btucker) with coworker names\n\nThis may be related to the author-driven merge changes (PR #573/task #5) - need to verify the author identification logic is correct.",
+      "id": "12",
+      "owner": "amsterdam",
+      "status": "completed",
+      "subject": "Fix misdirected PR nudges to wrong coworkers"
+    },
+    {
+      "blocked_by": [],
+      "description": "The GitHub CI check notifications in the channel are noisy when many checks complete around the same time:\n\n```\n08:47 Check 'Clippy' passed on main\n08:48 Check 'E2E - idle_break_e2e' passed on main\n08:48 Check 'Test' passed on main\n08:48 Check 'E2E - tailf_integration' passed on main\n08:48 Check 'E2E - spawn_race_test' passed on main\n```\n\n**Improvement:** Batch these into a single message when multiple checks complete within a short window (e.g., 30-60 seconds):\n\n```\n08:48 5 checks passed on main: Clippy, Test, E2E - idle_break_e2e, E2E - tailf_integration, E2E - spawn_race_test\n```\n\nOr even more condensed:\n```\n08:48 All CI checks passed on main\n```\n\n**Implementation ideas:**\n- Buffer CI check events for a short window before posting to channel\n- If multiple checks for the same ref/PR complete, batch them\n- Keep important events (PR opened, failures) as individual messages\n- Only batch \"passed\" checks, always show failures immediately\n\n**IMPORTANT:** This is purely a channel display change. The underlying webhook/event handling and PR author nudging logic should NOT be affected. The daemon should still process each CI event individually for nudge decisions - only the channel message posting gets batched.",
+      "id": "13",
+      "owner": "broadway",
+      "status": "completed",
+      "subject": "Batch repetitive GitHub CI notifications in channel"
+    },
+    {
+      "blocked_by": [],
+      "description": "Fixed: Added direct nudge_lead() calls in dispatch.rs and mod.rs. PR #584 opened.",
+      "id": "14",
+      "owner": "vernon",
+      "status": "completed",
+      "subject": "Investigate broken lead nudges for @lead mentions"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/effects.rs at 0%\n\nAdd E2E tests that exercise the effect execution layer:\n- Effect::SpawnCoworker - test coworker spawning via real daemon\n- Effect::ShutdownCoworker - test coworker shutdown\n- Effect::NudgeCoworker / Effect::NudgeLead - test nudge delivery\n- Effect::PostChannelMessage - test channel posting\n- Effect::AutoMergePr - test PR merge triggering\n\nUse the containerized E2E approach with real Claude where needed. Tests should verify effects actually execute (tmux windows created, messages posted, etc.).",
+      "id": "15",
+      "owner": "lexington",
+      "status": "completed",
+      "subject": "E2E tests for daemon effects execution"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/pr.rs at 0.94%\n\nAdd E2E tests for PR management flows:\n- PR polling and state detection\n- CI status tracking and stale check detection\n- Review comment detection\n- PR author identification and nudging\n- Auto-merge eligibility checking\n- Merge conflict detection\n\nUse real GitHub PRs in test repo or mock webhook events to exercise the PR handling code paths.",
+      "id": "16",
+      "owner": "columbus",
+      "status": "completed",
+      "subject": "E2E tests for daemon PR management"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/health.rs at 8.89%\n\nAdd E2E tests for coworker health monitoring:\n- Stuck detection (various stuck states)\n- Idle detection\n- Compaction detection (avoiding false positives - see task #10)\n- Usage limit detection\n- Orphan worktree detection\n- Session crash detection\n\nUse captured snapshots as test fixtures and verify health decisions match expected behavior.",
+      "id": "17",
+      "owner": "amsterdam",
+      "status": "completed",
+      "subject": "E2E tests for daemon health checks"
+    },
+    {
+      "blocked_by": [],
+      "description": "**COMPLETED - PR #590 OPEN**\n\nAdded 17 new E2E tests for daemon RPC handlers:\n- coworker.report-state: phase validation (3 tests)\n- coworker.asking: channel posting (2 tests)\n- daemon.check-pending: response structure (1 test)\n- task.updated: params, task not found, list mismatch (3 tests)\n- channel.post: /me actions, shell unescaping (2 tests)\n- channel.read: all parameter (1 test)\n- coworker.nudge: valid params (1 test)\n- reminder.create: invalid trigger (1 test)\n- reminder.cancel: not found (1 test)\n- plus 2 additional edge case tests\n\nAll tests pass. PR at https://github.com/btucker/midtown/pull/590",
+      "id": "18",
+      "owner": "york",
+      "status": "completed",
+      "subject": "E2E tests for daemon RPC handlers"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/dispatch.rs at 23.42%\n\nAdd E2E tests for task dispatch and coworker assignment:\n- Task assignment to idle coworkers\n- Task priority handling\n- Blocked task detection (blockedBy dependencies)\n- Orphan task recovery\n- Reviewer spawning for PRs\n- Max coworker limit enforcement\n\nVerify the daemon correctly assigns work and manages coworker lifecycle.",
+      "id": "19",
+      "owner": "park",
+      "status": "completed",
+      "subject": "E2E tests for daemon dispatch logic"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/webhook_fwd.rs at 0%, daemon/events.rs at 0%\n\nAdd E2E tests for GitHub webhook processing:\n- PR opened/closed/merged events\n- Review submitted events\n- Check run completed events\n- Push events\n- Webhook signature verification\n- Event deduplication\n\nUse mock webhook payloads or test against real GitHub webhooks in test environment.",
+      "id": "20",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "E2E tests for webhook handling"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: web.rs at 31.19%, webserver.rs at 30.63%\n\nAdd E2E tests for the web interface:\n- WebSocket connection and message streaming\n- Chat message display\n- Coworker status updates\n- Kanban board data\n- Static file serving\n- Multi-project routing\n\nCould use Playwright (already have MCP tools) or headless browser testing.",
+      "id": "21",
+      "owner": "vernon",
+      "status": "completed",
+      "subject": "E2E tests for web UI and WebSocket"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: tmux.rs at 41.57%\n\nAdd E2E tests for tmux interactions:\n- Window creation and naming\n- Pane capture and parsing\n- Send-keys for nudges\n- Session management\n- Status bar updates\n- Window killing safety checks\n\nThese tests need real tmux sessions - use the existing tmux_e2e test pattern.",
+      "id": "22",
+      "owner": "pleasant",
+      "status": "completed",
+      "subject": "E2E tests for tmux operations"
+    },
+    {
+      "blocked_by": [],
+      "description": "Vernon's worktree was missing while the daemon still showed them as active. Their Claude Code session was running but couldn't access files or run commands because ~/.midtown/coworkers/midtown/vernon/ didn't exist.\n\nInvestigation needed:\n1. Check daemon logs for any orphan cleanup that might have removed vernon's worktree incorrectly\n2. Check if there's a race condition between worktree creation and coworker startup\n3. Verify the orphan detection logic doesn't incorrectly flag active coworkers\n4. Add safeguards to prevent coworkers from running without valid worktrees\n\nRecent changes to watch:\n- PR #568 merged \"fix: Exclude tmux window orphans from worktree cleanup\"\n- The orphan cleanup logic in tmux.rs\n\nEvidence: Vernon was able to mark task #14 as completed but their bash commands (git, midtown) all failed with \"command not found\" or exit code 1.",
+      "id": "23",
+      "owner": "madison",
+      "status": "completed",
+      "subject": "Investigate and fix coworker worktree corruption (vernon incident)"
+    },
+    {
+      "blocked_by": [],
+      "description": "Madison's review of PR #581 identified that WebhookEvent has grown to 8 optional fields, requiring repetitive `field: None` in every constructor (5 places currently).\n\nRecommended fix:\n1. Derive Default for WebhookEvent\n2. Or use a builder pattern\n\nThis will reduce boilerplate and make adding new optional fields cleaner.\n\nSource: PR #581 review comment",
+      "id": "24",
+      "owner": "columbus",
+      "status": "completed",
+      "subject": "Refactor WebhookEvent to use Default or builder pattern"
+    },
+    {
+      "blocked_by": [],
+      "description": "The daemon is not assigning pending tasks to idle coworkers or spawning reviewers for green PRs.\n\nSymptoms:\n- 7 coworkers showing as idle\n- 4 pending tasks available\n- 7 green PRs without reviewer assignments\n- Daemon repeatedly restarts but doesn't dispatch work\n\nExpected behavior:\n- Idle coworkers should be assigned pending tasks\n- Green PRs should get reviewer coworkers spawned\n\nThis appears to be a bug in the task dispatch or reviewer spawning logic in rules.rs or effects.rs.",
+      "id": "25",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Fix daemon task dispatch - not assigning pending tasks to idle coworkers"
+    },
+    {
+      "blocked_by": [],
+      "description": "**Problem**: When coworkers hit their Claude usage limit, the daemon doesn't recognize this state and continues:\n- Warning about \"idle reviewers who haven't posted review\"\n- Restarting \"stuck\" coworkers (pane unchanged for 180s)\n- Sending nudges that can't be acted upon\n\n**Expected behavior**: The daemon should:\n1. Detect the usage limit message in pane content: \"You've hit your limit · resets Xam/pm (timezone)\"\n2. Parse the reset time from the message\n3. Mark these coworkers as \"usage_limited\" (not idle, not stuck)\n4. Stop nudging/restarting them until the reset time passes\n5. Optionally post to channel once when usage limit is detected\n\n**Test fixture available**: `tests/fixtures/snapshot/snapshot-hit-usage-limit-20260204-154619.json` contains real pane content showing the usage limit state.\n\n**Implementation hints**:\n- Pane parsing likely in `src/tmux.rs` or `src/pane.rs`\n- Decision logic in `src/rules.rs` \n- WorldSnapshot already has `usage_limit_nudge_scheduled` field - may need expansion\n- Follow the pure decision / effect execution pattern\n\n**Acceptance criteria**:\n- [ ] Unit test using the captured fixture verifies correct detection\n- [ ] Daemon stops nudging/restarting usage-limited coworkers\n- [ ] Coworkers resume normal handling after reset time",
+      "id": "26",
+      "owner": "columbus",
+      "status": "completed",
+      "subject": "Detect usage limit state and pause daemon actions for affected coworkers"
+    },
+    {
+      "blocked_by": [],
+      "description": "Lead committed changes on branch lead/channel-etiquette. Open a PR, get it reviewed, and merge.\n\nThe change adds channel etiquette guidelines to agents/common.md to avoid pointless back-and-forth conversation (no thank-you chains, brief acknowledgments only).",
+      "id": "27",
+      "owner": "vernon",
+      "status": "completed",
+      "subject": "Open PR for lead/channel-etiquette branch"
+    },
+    {
+      "blocked_by": [],
+      "description": "Multiple coworkers have accumulated stale local branches with unmerged commits: park, riverside, amsterdam, broadway, and likely others.\n\n**Task**: Audit and clean up these branches:\n1. List all local branches for each coworker namespace (park/, riverside/, amsterdam/, etc.)\n2. For each branch with unmerged commits, check if the work was merged via a different branch name (common pattern)\n3. Delete branches that are clearly stale (correspond to completed tasks, superseded by other work)\n4. For any with potentially useful unmerged work, note them for review\n\n**Safety**: Don't delete branches that might have unique unmerged work without confirming it's obsolete.\n\n**Commands to audit**:\n```bash\ngit branch | grep '<coworker>/' | while read branch; do\n  commits=$(git rev-list --count main..$branch 2>/dev/null || echo \"0\")\n  if [ \"$commits\" != \"0\" ]; then\n    echo \"$branch: $commits unmerged\"\n  fi\ndone\n```",
+      "id": "28",
+      "owner": "madison",
+      "status": "completed",
+      "subject": "Clean up stale coworker branches across all worktrees"
+    },
+    {
+      "blocked_by": [
+        "26"
+      ],
+      "description": "**Problem**: When the Claude API throws errors (500 Internal Server Error, etc.), coworkers get stuck waiting. The daemon doesn't recognize this state and may restart them unnecessarily, or not nudge them to retry.\n\n**API error pattern observed**:\n```\nAPI Error: 500 {\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"Internal server error\"},\"request_id\":\"...\"}\n```\n\n**Expected behavior**: The daemon should:\n1. Detect API error messages in pane content\n2. Mark coworkers as \"api_error\" state\n3. **Periodically nudge** to encourage retry (API errors are transient) - e.g., every 60-90 seconds\n4. Do NOT restart coworkers stuck on API errors (restart won't help)\n5. Optionally post to channel when API errors are detected across multiple coworkers\n\n**Key difference from usage limits**: Usage limits have a known reset time and nudging won't help. API errors are transient and a nudge to retry may succeed.\n\n**Test fixture available**: `tests/fixtures/snapshot/snapshot-api-errors-20260204-164204.json` contains real pane content showing API error states.\n\n**Related work**: Similar to task #26 (usage limit detection) in terms of pane content parsing.\n\n**Acceptance criteria**:\n- [ ] Unit test using the captured fixture verifies correct detection\n- [ ] Daemon periodically nudges coworkers with API errors to retry\n- [ ] Daemon does NOT restart coworkers stuck on API errors\n- [ ] Channel notification when widespread API errors detected",
+      "id": "29",
+      "owner": "columbus",
+      "status": "in_progress",
+      "subject": "Detect API errors in pane content and pause daemon actions"
+    },
+    {
+      "blocked_by": [],
+      "description": "**Problem**: Columbus was actively watching amsterdam review their PR instead of going idle. Coworkers should not monitor their own PR reviews - they should go idle and wait for the daemon to notify them when review feedback arrives.\n\n**Change needed**: Update `agents/coworker.md` to add guidance in the workflow section:\n\nAfter opening a PR:\n- Report state as `pull-request` and go idle\n- Do NOT watch or monitor the reviewer\n- The daemon will nudge you when review feedback arrives\n- If no other tasks are available, simply wait idle\n\n**Location**: `agents/coworker.md` - likely in the workflow phases or PR section",
+      "id": "30",
+      "owner": "park",
+      "status": "completed",
+      "subject": "Add coworker guidance: go idle while waiting for PR reviews"
+    },
+    {
+      "blocked_by": [],
+      "description": "Lead committed changes on branch lead/review-item-tasks. Open a PR, get it reviewed, and merge.\n\nThe change adds guidance for handling review notes - Lead must create tasks for items that need follow-up, otherwise they'll be forgotten.",
+      "id": "31",
+      "owner": "vernon",
+      "status": "pending",
+      "subject": "Open PR for lead/review-item-tasks branch"
+    }
+  ],
+  "blank_pane_coworkers": [],
+  "busy_coworkers": [
+    "columbus"
+  ],
+  "ci_passed_pr_coworkers": [],
+  "coworker_snapshots": [
+    {
+      "isolated_tasks": false,
+      "name": "columbus",
+      "started_at": "2026-02-04T17:33:48.628703Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "park",
+      "started_at": "2026-02-04T17:33:48.628745Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "vernon",
+      "started_at": "2026-02-04T17:33:48.628751Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "amsterdam",
+      "started_at": "2026-02-04T17:33:48.628754Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "madison",
+      "started_at": "2026-02-04T17:33:48.628758Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "riverside",
+      "started_at": "2026-02-04T17:33:48.628764Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "lexington",
+      "started_at": "2026-02-04T17:33:48.628761Z"
+    }
+  ],
+  "coworker_start_times": {
+    "amsterdam": "2026-02-04T17:33:48.628754Z",
+    "columbus": "2026-02-04T17:33:48.628703Z",
+    "lexington": "2026-02-04T17:33:48.628761Z",
+    "madison": "2026-02-04T17:33:48.628758Z",
+    "park": "2026-02-04T17:33:48.628745Z",
+    "riverside": "2026-02-04T17:33:48.628764Z",
+    "vernon": "2026-02-04T17:33:48.628751Z"
+  },
+  "coworker_stop_times": {},
+  "coworkers_with_merged_prs": [
+    "vernon",
+    "riverside",
+    "york",
+    "broadway",
+    "pleasant",
+    "amsterdam",
+    "madison",
+    "park",
+    "columbus",
+    "lexington"
+  ],
+  "coworkers_with_open_prs": [
+    "riverside"
+  ],
+  "coworkers_with_running_subagents": [],
+  "coworkers_with_unblocked_deps": [],
+  "in_progress_tasks": [
+    [
+      "29",
+      "Detect API errors in pane content and pause daemon actions",
+      "columbus"
+    ]
+  ],
+  "is_at_dev_limit": false,
+  "now_utc": "2026-02-04T17:34:00.540567Z",
+  "pane_contents": {
+    "amsterdam": "    2. **Daemon-driven coordination**: The daemon monitors PRs and nudges coworkers when action is needed - this eliminates the need for coworkers to poll or watch each other, reducing API rate limit pressure and\n    … +28 lines (ctrl+o to expand)\n\n\n⏺ No tasks currently available. The task list is empty and several coworkers are idle. I'll stand by for new work.\n\n⏺ Bash(midtown channel post \"/me standing by, the spotlight awaits\")\n  ⎿  Message posted to channel\n\n⏺ I'm idle - no tasks in the queue. The daemon will nudge me when new work becomes available or when PR #594 needs attention (the PR I just reviewed has green CI per columbus's update).\n\n❯ Resume reviewing PR #594. The daemon was restarted and discovered you still running. Continue your code review where you left off.\n\n  IMPORTANT: You MUST always post a GitHub comment on the PR, even if no issues are found. If the code-review skill finishes without posting a comment, post a comment yourself using `gh pr comment 594 --body` with\n  the \"no issues found\" format from the skill.\n\n  REFACTOR DETECTION: While reviewing, look for similar changes repeated across multiple locations in the diff. When a PR makes analogous modifications in several places (similar match arms, duplicated logic\n  across functions, parallel struct/enum additions), this may indicate the codebase needs a refactor to consolidate the pattern. If you spot this, mention it in your review comment and post to the channel:\n  `midtown channel post \"@lead PR #594 repeats similar changes in N places (describe pattern). Recommend a refactor task to (suggested approach).\"`\n\n\n⏺ Bash(gh pr view 594 --json comments --jq '.comments[] | select(.body | contains(\"amsterdam\")) | {author: .author.login, url: .url, bodyPreview: (.body | .[0:200])}')\n  ⎿ {\n      \"author\": \"btucker\",\n      \"bodyPreview\": \"## Code Review by amsterdam\\n\\nFound 2 issues:\\n\\n1. **Case-sensitivity inconsistency in `usage_limited_coworkers` handling**\\n\\nThe `usage_limited_coworkers` HashSet is built without normali\n    … +3 lines (ctrl+o to expand)\n\n\n⏺ My review of PR #594 was already completed and posted earlier in this session.\n\n⏺ Bash(midtown channel post \"Posted review on PR #594: https://github.com/btucker/midtown/pull/594#issuecomment-3848738267 (review was completed earlier, daemon restar…)\n  ⎿  Message posted to channel\n\n⏺ Bash(midtown state idle)\n  ⎿  amsterdam → idle\n\n⏺ Bash(midtown channel post \"/me the review curtain already fell - standing by for the next scene\")\n  ⎿  Message posted to channel\n\n⏺ Review of PR #594 was already completed. The comment is live at https://github.com/btucker/midtown/pull/594#issuecomment-3848738267\n\n  Found 2 issues:\n  1. Case-sensitivity inconsistency in usage_limited_coworkers handling (scored 75)\n  2. Missing test coverage for idle shutdown with usage-limited coworkers (scored 78)\n\n  I'm now idle and ready for new work.\n\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n\n\n",
+    "columbus": "     [2026-02-04T17:32:56.685650+00:00] columbus: completed task 26\n     [2026-02-04T17:32:59.320617+00:00] columbus: PR #594 merged - usage limit detection is live! Task #26 complete, claiming #29 as the natural sequel\n     … +7 lines (ctrl+o to expand)\n\n⏺ No collision. Let me set up the branch and explore the task.\n\n⏺ Bash(git fetch origin main && git checkout -b columbus/api-error-detection origin/main)\n  ⎿  M  state.json\n     branch 'columbus/api-error-detection' set up to track 'origin/main'.\n     From github.com:btucker/midtown\n     … +2 lines (ctrl+o to expand)\n\n⏺ Bash(midtown state developing --task 29)\n  ⎿  columbus → dev#29\n\n⏺ Bash(midtown channel post \"/me diving into API error detection - exploring the fixture and existing patterns\")\n  ⎿  Message posted to channel\n\n⏺ Let me examine the test fixture and the usage limit detection code I just merged.\n\n⏺ Read(tests/fixtures/snapshot/snapshot-api-errors-20260204-164204.json)\n  ⎿  Error reading file\n\n⏺ Search(pattern: \"usage.*limit|USAGE_LIMIT\", path: \"src\")\n  ⎿  Found 8 files (ctrl+o to expand)\n\n⏺ Let me find the fixture and look at the usage limit detection pattern.\n\n⏺ Search(pattern: \"tests/fixtures/**/*.json\")\n  ⎿  Found 12 files (ctrl+o to expand)\n\n⏺ Read(src/daemon/snapshot.rs)\n  ⎿  Read 434 lines\n\n✻ Implementing API error detection… (Esc to interrupt · ctrl+t to hide tasks · 4m 12s · ↓ 5.2k tokens)\n  ⎿  ◼ #29 Detect API errors in pane content and pause daemon actions (columbus)\n     ◻ #31 Open PR for lead/review-item-tasks branch (vernon)\n     ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n     ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n     ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n     ✔ #6 Prevent coworkers from checking out default branch (riverside)\n     ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n     ✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n     ✔ #9 Fix daemon not detecting posted review comments (riverside)\n     ✔ #10 Fix false positive stuck compaction detection (york)\n      … +19 completed\n\n\n  ❯ Resume task #29: Detect API errors in pane content and pause daemon actions. The daemon was restarted and discovered you still running. Check your git status and continue where you left off.\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ Press up to edit queued messages\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n",
+    "lexington": "    … +28 lines (ctrl+o to expand)\n\nNo tasks found\n\n⏺ No tasks in the queue. I'm idle and available for the next assignment.\n\n⏺ Bash(midtown channel post \"/me standing by, ready for the next scene\")\n  ⎿  Message posted to channel\n\n⏺ Standing by. The daemon will nudge me when there's a new task or PR to review.\n\n❯ Resume reviewing PR #592. The daemon was restarted and discovered you still running. Continue your code review where you left off.\n\n  IMPORTANT: You MUST always post a GitHub comment on the PR, even if no issues are found. If the code-review skill finishes without posting a comment, post a comment yourself using `gh pr comment 592 --body` with\n  the \"no issues found\" format from the skill.\n\n  REFACTOR DETECTION: While reviewing, look for similar changes repeated across multiple locations in the diff. When a PR makes analogous modifications in several places (similar match arms, duplicated logic\n  across functions, parallel struct/enum additions), this may indicate the codebase needs a refactor to consolidate the pattern. If you spot this, mention it in your review comment and post to the channel:\n  `midtown channel post \"@lead PR #592 repeats similar changes in N places (describe pattern). Recommend a refactor task to (suggested approach).\"`\n\n\n⏺ Bash(gh pr view 592 --json comments --jq '.comments[] | select(.body | contains(\"lexington\")) | .url')\n  ⎿  https://github.com/btucker/midtown/pull/592#issuecomment-3848741639\n\n⏺ Bash(midtown channel post \"/me checking PR #592 review status\")\n  ⎿  Message posted to channel\n\n⏺ The review for PR #592 was already completed. My comment is posted at: https://github.com/btucker/midtown/pull/592#issuecomment-3848741639\n\n⏺ Bash(midtown channel post \"/me PR #592 review already complete - comment posted earlier at https://github.com/btucker/midtown/pull/592#issuecomment-3848741639\")\n  ⎿  Message posted to channel\n\n⏺ Bash(midtown state idle)\n  ⎿  lexington → idle\n\n⏺ Review for PR #592 was already completed before the daemon restart. Found 5 issues (2 at score 75, 3 at score 50). Now idle and ready for new assignments.\n\n❯ Resume reviewing PR #592. The daemon was restarted and discovered you still running. Continue your code review where you left off.\n\n  IMPORTANT: You MUST always post a GitHub comment on the PR, even if no issues are found. If the code-review skill finishes without posting a comment, post a comment yourself using `gh pr comment 592 --body` with\n  the \"no issues found\" format from the skill.\n\n  REFACTOR DETECTION: While reviewing, look for similar changes repeated across multiple locations in the diff. When a PR makes analogous modifications in several places (similar match arms, duplicated logic\n  across functions, parallel struct/enum additions), this may indicate the codebase needs a refactor to consolidate the pattern. If you spot this, mention it in your review comment and post to the channel:\n  `midtown channel post \"@lead PR #592 repeats similar changes in N places (describe pattern). Recommend a refactor task to (suggested approach).\"`\n\n\n· Coalescing… (Esc to interrupt · thinking)\n\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n",
+    "madison": "\n⏺ ★ Insight ─────────────────────────────────────\n  Code Review Scoring Nuance: The scoring rubric explicitly treats \"pre-existing issues\" as score 0 (false positive category). This is important because code reviews should focus on new problems introduced by a PR, not\n   historical technical debt. When Agent #4 found an issue with phrasing that was already established in the file, the correct disposition was to report it to the lead as a potential broader consistency task rather\n  than blocking the current PR.\n  ─────────────────────────────────────────────────\n\n  Review complete for PR #596.\n\n  Summary:\n  - PR adds \"After Opening a PR: Go Idle\" guidance to agents/coworker.md\n  - 5 parallel review agents found no new issues\n  - One potential concern (daemon notification reliability wording) was identified but determined to be a pre-existing pattern already used at line 267 of the same file\n  - Posted review comment: https://github.com/btucker/midtown/pull/596#issuecomment-3848767023\n  - Notified lead about the pre-existing pattern for potential broader consistency cleanup\n\n⏺ Bash(midtown state idle)\n  ⎿  madison → idle\n\n⏺ Bash(midtown channel post \"/me the curtain falls on this review, awaiting the next act\")\n  ⎿  Message posted to channel\n\n✻ Crunched for 6m 35s\n\n❯ continue\n\n⏺ Bash(midtown channel read)\n  ⎿  [2026-02-04T17:28:39.783334+00:00] madison: review complete for PR #596 - documentation guidance looks solid, follows established patterns\n     [2026-02-04T17:28:51.707661+00:00] github: @park merged PR #596: docs: Add 'go idle after opening PR' guidance for coworkers [Midtown #30]\n     [2026-02-04T17:28:51.711671+00:00] system: @lead PR #596 merged into main. Run `git pull` to stay current.\n     … +23 lines (ctrl+o to expand)\nNo tasks found\n\n⏺ No new tasks assigned. PR #596 was merged - the review is complete. I'm standing by for the next assignment.\n\n⏺ Bash(midtown channel post \"/me standing by, script in hand, ready for the next scene\")\n  ⎿  Message posted to channel\n\n⏺ Standing by - the daemon will assign new work when available or spin me down if there's nothing in the queue.\n\n❯ lead said: @madison Pre-existing pattern (scored 60) - no follow-up needed. Consistency with existing wording is fine.\n\n⏺ Bash(midtown channel post \"@lead understood - consistency with established patterns makes sense. No action needed.\")\n  ⎿  Message posted to channel\n\n⏺ Acknowledged. Still standing by for the next assignment.\n\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n\n\n",
+    "park": "✔ #20 E2E tests for webhook handling (riverside)\n✔ #16 E2E tests for daemon PR management (columbus)\n✔ #6 Prevent coworkers from checking out default branch (riverside)\n✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n✔ #17 E2E tests for daemon health checks (amsterdam)\n✔ #21 E2E tests for web UI and WebSocket (vernon)\n✔ #10 Fix false positive stuck compaction detection (york)\n◼ #26 Detect usage limit state and pause daemon actions for affected coworkers (columbus)\n✔ #30 Add coworker guidance: go idle while waiting for PR reviews (park)\n✔ #27 Open PR for lead/channel-etiquette branch (vernon)\n✔ #11 Make nudges respect user input in progress (riverside)\n✔ #28 Clean up stale coworker branches across all worktrees (madison)\n✔ #12 Fix misdirected PR nudges to wrong coworkers (amsterdam)\n✔ #24 Refactor WebhookEvent to use Default or builder pattern (columbus)\n✔ #25 Fix daemon task dispatch - not assigning pending tasks to idle coworkers (riverside)\n✔ #13 Batch repetitive GitHub CI notifications in channel (broadway)\n◼ #29 Detect API errors in pane content and pause daemon actions ⚠ blocked by #26\n✔ #3 Update auto-merge to recognize comment-based reviews (park)\n✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n✔ #22 E2E tests for tmux operations (pleasant)\n✔ #18 E2E tests for daemon RPC handlers (york)\n✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n✔ #14 Investigate broken lead nudges for @lead mentions (vernon)\n✔ #15 E2E tests for daemon effects execution (lexington)\n✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n✔ #19 E2E tests for daemon dispatch logic (park)\n✔ #23 Investigate and fix coworker worktree corruption (vernon incident) (madison)\n✔ #9 Fix daemon not detecting posted review comments (riverside)\n\n⏺ No unblocked tasks available. Task #29 is blocked by #26 (columbus's work). Staying idle.\n\n⏺ Bash(midtown channel post \"/me stage is clear, no unblocked tasks in the queue\")\n  ⎿  Message posted to channel\n\n⏺ Idle with no available work. The daemon will assign me a task or shut me down when appropriate.\n\n  Tasks (27 done, 1 in progress, 1 open) · ctrl+t to hide tasks\n  ◼ #29 Detect API errors in pane content and pause daemon actions (columbus)\n  ◻ #31 Open PR for lead/review-item-tasks branch (vernon)\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n  ✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n  ✔ #9 Fix daemon not detecting posted review comments (riverside)\n  ✔ #10 Fix false positive stuck compaction detection (york)\n   … +19 completed\n\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle) · 1 file +1 -1\n\n",
+    "riverside": "      177 +            .join(\"target\")\n      178 +            .join(\"debug\")\n      179 +            .join(\"midtown\");\n      180\n      181 +        let binary_path = if release_binary.exists() {\n      182 +            release_binary\n      183 +        } else if debug_binary.exists() {\n      184 +            eprintln!(\"Warning: Using debug binary - timing may not match production\");\n      185 +            debug_binary\n      186 +        } else {\n      187 +            eprintln!(\"Skipping: No midtown binary found. Run 'cargo build --release' first.\");\n      188 +            return false;\n      189 +        };\n      190 +\n      191          let _ = fs::remove_file(&self.socket_path);\n      192          let _ = fs::remove_file(&self.pid_path);\n      193\n\n⏺ Bash(cargo fmt -- --check && cargo clippy --all-targets -- -D warnings 2>&1 | tail -20)\n  ⎿      Checking futures-util v0.3.31\n         Checking tungstenite v0.26.2\n         Checking tower v0.5.3\n     … +11 lines (ctrl+o to expand)\n\n⏺ Bash(git add .github/workflows/ci.yml tests/webhook_e2e.rs && git commit -m \"fix: Address review feedback on webhook E2E tests…)\n  ⎿  [riverside/task20-webhook-e2e 7ef49fe] fix: Address review feedback on webhook E2E tests\n      2 files changed, 18 insertions(+), 13 deletions(-)\n     +cargo clippy -- -D warnings\n     … +3 lines (ctrl+o to expand)\n\n⏺ Bash(git push origin riverside/task20-webhook-e2e)\n  ⎿  To github.com:btucker/midtown.git\n        4b49583..7ef49fe  riverside/task20-webhook-e2e -> riverside/task20-webhook-e2e\n\n· Implementing API error detection… (Esc to interrupt · ctrl+t to hide tasks · 1m 51s · ↓ 3.8k tokens)\n  ⎿  ◼ #29 Detect API errors in pane content and pause daemon actions (columbus)\n     ◻ #31 Open PR for lead/review-item-tasks branch (vernon)\n     ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n     ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n     ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n     ✔ #6 Prevent coworkers from checking out default branch (riverside)\n     ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n     ✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n     ✔ #9 Fix daemon not detecting posted review comments (riverside)\n     ✔ #10 Fix false positive stuck compaction detection (york)\n      … +19 completed\n\n\n  ❯ github said: @riverside pushed to PR #592\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ Press up to edit queued messages\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n",
+    "vernon": "\n ▐▛███▜▌   Claude Code v2.1.19\n▝▜█████▛▘  Opus 4.5 · Claude Max\n  ▘▘ ▝▝    ~/.midtown/coworkers/midtown/vernon\n\n❯ You've been assigned task #31: Open PR for lead/review-item-tasks branch. Get started!\n\n⏺ Let me read the channel first to catch up on team activity, then get the task details.\n\n⏺ Bash(midtown channel read)\n  ⎿  [2026-02-04T17:32:28.241838+00:00] github: columbus commented on PR #594: Thanks for the review amsterdam! Both issues were ...\n     [2026-02-04T17:32:32.283878+00:00] madison: waiting for input\n     [2026-02-04T17:32:39.097825+00:00] lexington: waiting for input\n     … +19 lines (ctrl+o to expand)\n\n✻ Implementing API error detection… (Esc to interrupt · ctrl+t to hide tasks · thought for 1s)\n  ⎿  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n     ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n     ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n     ✔ #6 Prevent coworkers from checking out default branch (riverside)\n     ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n     ✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n     ✔ #9 Fix daemon not detecting posted review comments (riverside)\n     ✔ #10 Fix false positive stuck compaction detection (york)\n     ✔ #11 Make nudges respect user input in progress (riverside)\n     ✔ #12 Fix misdirected PR nudges to wrong coworkers (amsterdam)\n      … +1 in progress, 1 pending, 17 completed\n\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ You have pending task #31: Open PR for lead/review-item-tasks branch. Get started!\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"
+  },
+  "pending_tasks_with_owners": [
+    [
+      "31",
+      "Open PR for lead/review-item-tasks branch",
+      "vernon"
+    ]
+  ],
+  "pending_tasks_without_owners": [],
+  "repo_name": "midtown",
+  "reviewed_prs": [
+    592
+  ],
+  "reviewer_pr_assignments": {
+    "lexington": 592
+  },
+  "running_coworkers": [
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "columbus",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628703Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/columbus"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "park",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628745Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/park"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "vernon",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628751Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/vernon"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "amsterdam",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628754Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/amsterdam"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "madison",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628758Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/madison"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "riverside",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628764Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/riverside"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "lexington",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628761Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/lexington"
+    }
+  ],
+  "session_name": "midtown-midtown",
+  "usage_limit_nudge_scheduled": false,
+  "usage_limited_coworkers": []
+}

--- a/tests/fixtures/snapshot/snapshot-false-positive-bugs-20260204-135417.json
+++ b/tests/fixtures/snapshot/snapshot-false-positive-bugs-20260204-135417.json
@@ -1,0 +1,385 @@
+{
+  "active_coworkers": [
+    {
+      "current_task": null,
+      "isolated_tasks": true,
+      "name": "pleasant",
+      "session_id": "406367e1-6a10-4316-8652-4df15527da55",
+      "started_at": "2026-02-04T13:24:17.035622Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/pleasant"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "riverside",
+      "session_id": "f52988c3-7c40-4beb-b2de-744b7f4762a1",
+      "started_at": "2026-02-04T13:46:17.282998Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/riverside"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "vernon",
+      "session_id": "1d81e998-5e61-4419-ab14-767509b64389",
+      "started_at": "2026-02-04T13:50:16.836775Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/vernon"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "broadway",
+      "session_id": "7add59c0-a114-407c-9ad3-5f18ca85fcb1",
+      "started_at": "2026-02-04T13:36:17.238096Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/broadway"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": true,
+      "name": "lexington",
+      "session_id": "2fc964b2-b521-4ba8-8c82-5204e823171c",
+      "started_at": "2026-02-04T13:53:51.303168Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/lexington"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "york",
+      "session_id": "5ab1d59e-d012-4919-bdaf-b19f2b91ea43",
+      "started_at": "2026-02-04T13:51:49.081592Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/york"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "amsterdam",
+      "session_id": "",
+      "started_at": "2026-02-04T13:52:48.775792Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/amsterdam"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "park",
+      "session_id": "",
+      "started_at": "2026-02-04T13:46:05.843525Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/park"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": true,
+      "name": "madison",
+      "session_id": "36137fa1-5b67-4d45-ab3e-e01855b4646f",
+      "started_at": "2026-02-04T13:53:19.241094Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/madison"
+    }
+  ],
+  "active_names": [
+    "broadway",
+    "amsterdam",
+    "madison",
+    "pleasant",
+    "vernon",
+    "riverside",
+    "york",
+    "lexington",
+    "park"
+  ],
+  "active_reviewers": [
+    "pleasant",
+    "lexington",
+    "madison"
+  ],
+  "all_tasks": [
+    {
+      "blocked_by": [],
+      "description": "Bug: `is_auto_mergeable()` in src/daemon/helpers.rs only accepts formal GitHub APPROVED reviewDecision. It should also recognize positive review comments (e.g., \"No issues found\") as approval for auto-merge purposes.\n\nCurrent behavior (line 153):\n```rust\nif review_decision != \"APPROVED\" {\n    return false;\n}\n```\n\nExpected behavior:\n- Keep APPROVED as valid\n- Also check PR comments for positive review indicators from coworkers (look for midtown markers and \"No issues found\" or similar patterns)\n\nContext: We use comment-based reviews because the same GitHub account (btucker) authors PRs and runs coworkers, making formal self-approval impossible.",
+      "id": "3",
+      "owner": "park",
+      "status": "completed",
+      "subject": "Update auto-merge to recognize comment-based reviews"
+    },
+    {
+      "blocked_by": [],
+      "description": "Feature: The daemon should track typical CI check durations and handle stuck/missing checks intelligently.\n\n**Scenarios to handle:**\n\n1. **Stuck check** (pending > 4x typical duration): Re-run the specific check\n2. **Missing/new check** (required check not in PR's CI run): The PR predates the CI workflow change. Daemon should rebase the PR on main to pick up the new workflow, then CI will include the new check.\n\n**Implementation:**\n1. Track historical completion times per CI check name (e.g., \"E2E - idle_break_e2e\" typically takes 2m)\n2. Store rolling average or median of recent runs\n3. For stuck checks: If pending > 4x typical duration, trigger re-run\n4. For missing checks: If a required check never appears in the PR's status checks but exists in main's CI workflow, rebase the PR on main\n5. Add cooldowns to prevent spam\n\n**Key points:**\n- NOT overly aggressive - only at 4x typical time for stuck checks\n- Data-driven based on actual historical times\n- Detect \"new\" required checks that the PR doesn't have and auto-rebase\n\nUse case: PRs #566 and #570 were blocked by missing \"E2E - idle_break_e2e\" - they predated the workflow change. Daemon should have detected this and rebased automatically.",
+      "id": "4",
+      "owner": "broadway",
+      "status": "in_progress",
+      "subject": "Add daemon auto-retry for stale/missing CI checks"
+    },
+    {
+      "blocked_by": [],
+      "description": "Instead of the daemon parsing review comments to auto-merge, the author coworker should handle merge decisions themselves.\n\nWhen a PR receives a comment or review:\n1. If the author coworker is idle/shutdown, call them in\n2. Nudge the author coworker about the new comment/review\n3. Author reads the feedback and decides whether to merge, address feedback, or take other action\n\nThis is simpler than daemon comment parsing and keeps the merge decision with the agent who has full context of the PR.\n\nReplaces the approach in closed PR #571.\n\nNOTE: Previous attempt by park was invalid (park had main checked out). Needs actual implementation.",
+      "id": "5",
+      "owner": "park",
+      "status": "completed",
+      "subject": "Call-in and nudge PR authors on comments/reviews"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: Park had main checked out in their worktree. Coworkers should NEVER checkout the default branch (main/master).\n\nThis can cause issues:\n1. Multiple worktrees can't share the same branch\n2. Coworkers might accidentally commit directly to main\n3. Blocks other worktrees from using main\n\nFix needed:\n- Add validation when spawning coworkers to ensure they're on a feature branch\n- Add validation in coworker prompts/hooks to prevent `git checkout main`\n- If a coworker somehow ends up on main, detect and fix it (checkout a new feature branch)\n\nCheck how park ended up on main and prevent it from happening.",
+      "id": "6",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Prevent coworkers from checking out default branch"
+    },
+    {
+      "blocked_by": [
+        "8"
+      ],
+      "description": "The `midtown chat` TUI should check every 30 seconds whether it's at the end of the channel. If it got stuck further up (e.g., user scrolled up and forgot), it should auto-scroll back to the end.\n\nThis prevents the chat from appearing frozen/stuck when it's actually just scrolled up in history.",
+      "id": "7",
+      "owner": "vernon",
+      "status": "completed",
+      "subject": "Chat TUI should auto-scroll to end every 30 seconds"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The `midtown chat` TUI spontaneously scrolled to the beginning of the channel on its own. This should never happen.\n\nThis is a higher priority than the auto-scroll-to-end feature (task #7) - we need to fix this regression/bug first.\n\nInvestigate what's causing unexpected scroll position changes in the chat TUI. Could be:\n- A render loop resetting scroll state\n- File watcher event causing re-render from top\n- State management issue with scroll position\n- Race condition in the async event handling\n\nThe chat should maintain its scroll position unless the user explicitly scrolls or it auto-scrolls to follow new messages at the bottom.",
+      "id": "8",
+      "owner": "york",
+      "status": "in_progress",
+      "subject": "Fix chat TUI unexpectedly scrolling to beginning"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The daemon is warning \"Reviewer pleasant is idle but hasn't posted review for PR #572 yet\" but pleasant DID post a review comment (visible via `gh pr view 572 --json comments`).\n\nThe daemon's review detection is not recognizing that the review comment was posted. It should:\n1. Check PR comments for review signatures from the assigned reviewer\n2. Once a review comment is detected, stop warning about missing reviews\n3. Clear the reviewer assignment from the \"pending\" state\n\nThis might be related to how the daemon checks for reviews - it may be looking for formal GitHub reviews instead of comment-based reviews.",
+      "id": "9",
+      "owner": null,
+      "status": "pending",
+      "subject": "Fix daemon not detecting posted review comments"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The daemon incorrectly detected that riverside was \"stuck compaction\" and sent Escape to interrupt them (\"Interrupted stuck compaction for riverside (sent Escape)\").\n\nThe user reports this was a false positive - riverside was not actually stuck in compaction.\n\nThis could cause:\n- Unnecessary interruptions to coworkers doing valid work\n- Lost work if the coworker was mid-task\n\nNeed to investigate the compaction detection logic and make it more accurate. May need to:\n- Increase the threshold for \"stuck\" detection\n- Better differentiate compaction from other states\n- Check for actual user input/output before concluding stuck",
+      "id": "10",
+      "owner": null,
+      "status": "pending",
+      "subject": "Fix false positive stuck compaction detection"
+    }
+  ],
+  "blank_pane_coworkers": [],
+  "busy_coworkers": [
+    "broadway",
+    "york"
+  ],
+  "ci_passed_pr_coworkers": [
+    "broadway",
+    "amsterdam"
+  ],
+  "coworker_snapshots": [
+    {
+      "isolated_tasks": true,
+      "name": "pleasant",
+      "started_at": "2026-02-04T13:24:17.035622Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "riverside",
+      "started_at": "2026-02-04T13:46:17.282998Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "vernon",
+      "started_at": "2026-02-04T13:50:16.836775Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "broadway",
+      "started_at": "2026-02-04T13:36:17.238096Z"
+    },
+    {
+      "isolated_tasks": true,
+      "name": "lexington",
+      "started_at": "2026-02-04T13:53:51.303168Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "york",
+      "started_at": "2026-02-04T13:51:49.081592Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "amsterdam",
+      "started_at": "2026-02-04T13:52:48.775792Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "park",
+      "started_at": "2026-02-04T13:46:05.843525Z"
+    },
+    {
+      "isolated_tasks": true,
+      "name": "madison",
+      "started_at": "2026-02-04T13:53:19.241094Z"
+    }
+  ],
+  "coworker_start_times": {
+    "amsterdam": "2026-02-04T13:52:48.775792Z",
+    "broadway": "2026-02-04T13:36:17.238096Z",
+    "lexington": "2026-02-04T13:53:51.303168Z",
+    "madison": "2026-02-04T13:53:19.241094Z",
+    "park": "2026-02-04T13:46:05.843525Z",
+    "pleasant": "2026-02-04T13:24:17.035622Z",
+    "riverside": "2026-02-04T13:46:17.282998Z",
+    "vernon": "2026-02-04T13:50:16.836775Z",
+    "york": "2026-02-04T13:51:49.081592Z"
+  },
+  "coworker_stop_times": {
+    "amsterdam": "2026-02-04T13:49:13.282144Z",
+    "broadway": "2026-02-04T13:36:13.621452Z",
+    "columbus": "2026-02-04T13:27:44.353571Z",
+    "madison": "2026-02-04T06:26:11.730617Z",
+    "park": "2026-02-04T13:35:42.168218Z",
+    "vernon": "2026-02-04T06:26:12.182293Z"
+  },
+  "coworkers_with_merged_prs": [
+    "lexington",
+    "pleasant",
+    "york",
+    "amsterdam",
+    "riverside",
+    "vernon",
+    "park",
+    "madison"
+  ],
+  "coworkers_with_open_prs": [
+    "park",
+    "riverside",
+    "vernon",
+    "amsterdam",
+    "broadway"
+  ],
+  "coworkers_with_running_subagents": [
+    "madison",
+    "park"
+  ],
+  "coworkers_with_unblocked_deps": [],
+  "in_progress_tasks": [
+    [
+      "4",
+      "Add daemon auto-retry for stale/missing CI checks",
+      "broadway"
+    ],
+    [
+      "8",
+      "Fix chat TUI unexpectedly scrolling to beginning",
+      "york"
+    ]
+  ],
+  "is_at_dev_limit": true,
+  "now_utc": "2026-02-04T13:54:17.685212Z",
+  "pane_contents": {
+    "amsterdam": "\n⏺ Bash(midtown channel read | tail -15)\n  ⎿  [2026-02-04T13:40:43.139473+00:00] system: ⚠️ Reviewer pleasant is idle but hasn't posted review for PR #572 yet\n     [2026-02-04T13:41:11.896555+00:00] system: ⚠️ Reviewer pleasant is idle but hasn't posted review for PR #572 yet\n     [2026-02-04T13:41:41.973885+00:00] system: ⚠️ Reviewer pleasant is idle but hasn't posted review for PR #572 yet\n     … +13 lines (ctrl+o to expand)\n  ⎿  Running PostToolUse hook…\n\n⏺ Bash(midtown channel post \"/me checking in - PRs #566 and #570 both have positive reviews and green CI, just need @user approval to auto-merge\")\n  ⎿  Message posted to channel\n  ⎿  Running PostToolUse hook…\n\n⏺ Bash(midtown state idle)\n  ⎿  amsterdam → idle\n  ⎿  Running PostToolUse hook…\n\n⏺ Both my PRs are ready to merge:\n  - PR #566 (health check E2E tests): CI green ✓, reviewed by lexington ✓\n  - PR #570 (coworker naming fix): CI green ✓, reviewed by broadway ✓\n\n  Just waiting for @user approval to trigger auto-merge. Idle and ready for new work.\n\n❯ Your PR #570 (fix: Validate coworker names from bra...) has a completed review — please address any feedback and merge if appropriate.\n\n⏺ Bash(gh pr view 570 --json state,mergeStateStatus,autoMergeRequest --jq '{state: .state, mergeStatus: .mergeStateStatus, hasAutoMerge: (.autoMergeRequest != null)}')\n  ⎿  Error: Exit code 1\n     failed to parse jq expression (line 1, column 82)\n         {state: .state, mergeStatus: .mergeStateStatus, hasAutoMerge: (.autoMergeRequest \\!= null)}\n                                                                                          ^  unexpected token \"\\\\\"\n\n⏺ Bash(gh pr view 570 --json state,mergeStateStatus)\n  ⎿  {\n       \"mergeStateStatus\": \"BLOCKED\",\n       \"state\": \"OPEN\"\n     }\n\n⏺ Bash(gh pr view 566 --json state,mergeStateStatus)\n  ⎿  {\n       \"mergeStateStatus\": \"BLOCKED\",\n       \"state\": \"OPEN\"\n     }\n\n⏺ Both PRs still blocked waiting for formal approval:\n  - PR #570: Positive review from broadway, CI green ✓\n  - PR #566: Positive review from lexington, CI green ✓\n6 tasks (3 done, 3 in progress, 0 open)\n\n✔ #6 Prevent coworkers from checking out default branch (riverside)\n◼ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon) ⚠ blocked by #8\n✔ #3 Update auto-merge to recognize comment-based reviews (park)\n◼ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n◼ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n\n⏺ No unassigned tasks available. Other coworkers are working on tasks #4, #7, #8. My PRs just need user approval to auto-merge.\n\n⏺ Bash(midtown state idle && midtown channel post \"/me PRs #566 and #570 still waiting for user approval - ready for new work if any comes up\")\n  ⎿  amsterdam → idle\n     Message posted to channel\n\n⏺ ★ Insight ─────────────────────────────────────\n  The file modifications I see from other coworkers' work enhance the daemon's ability to manage reviewer state:\n  - remove_assignment_by_reviewer() in github_state.rs allows clearing assignments by coworker name (not just PR number)\n  - cleanup_orphaned_worktrees() now returns Vec<Effect> including ClearOrphanedReviewerAssignments to free reviewer slots when coworkers crash\n  - This prevents reviewer slots from being \"stuck\" when a coworker session ends unexpectedly\n  ─────────────────────────────────────────────────\n\n  Idle and waiting for user approval on PRs #566 and #570, or new tasks to be assigned.\n\n✻ Sautéed for 44s\n\n  Tasks (4 done, 2 in progress, 2 open) · ctrl+t to hide tasks\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon) › blocked by #8\n  ◼ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ◼ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n  ◻ #9 Fix daemon not detecting posted review comments\n  ◻ #10 Fix false positive stuck compaction detection\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle) · 1 file +1 -1\n\n",
+    "broadway": "     +cargo clippy -- -D warnings\n     … +3 lines (ctrl+o to expand)\n\n⏺ Bash(git push)\n  ⎿  To github.com:btucker/midtown.git\n        4fc4dc7..3ba966d  broadway/daemon-ci-auto-retry -> broadway/daemon-ci-auto-retry\n\n⏺ Bash(midtown state pull-request --task 4)\n  ⎿  broadway → PR#4\n\n⏺ Bash(midtown channel post \"/me addressed all 4 review issues on PR #572 - the show goes on\")\n  ⎿  Message posted to channel\n\n⏺ ★ Insight ─────────────────────────────────────\n  Testing time-dependent code: The original collect_stale_check_effects used Utc::now() directly, making it non-deterministic. By extracting a pure helper that accepts the reference time as a parameter, we get:\n  1. Deterministic tests that don't depend on wall-clock time\n  2. Full control over \"edge\" timestamps in tests\n  3. The async wrapper remains thin - just fetching data and calling the pure logic\n  ─────────────────────────────────────────────────\n\n  I've addressed all 4 review issues on PR #572:\n\n  Changes made:\n  1. Removed dead Effect::RecordCiCheckDuration - The webhook handler's inline duration recording is architecturally appropriate (webhooks operate outside the tick loop)\n  2. Added 9 tests for compute_check_duration - Covers valid/invalid timestamps, edge cases, 24-hour boundary\n  3. Added 8 tests for collect_stale_check_effects - Covers stale detection, threshold logic, missing data, cooldown\n  4. Refactored for testability - Extracted collect_stale_check_effects_with_time pure helper with injectable timestamp\n\n  The PR is updated and pushed. Waiting for CI to run.\n\n✻ Cooked for 5m 55s\n\n❯ github said: @broadway Check 'E2E - full_stack_e2e' passed on PR #572\n\n⏺ Bash(gh pr view 572 --json state,reviewDecision,statusCheckRollup --jq '{state, reviewDecision, checks: [.statusCheckRollup[] | select(.status != \"COMPLETED\") | .nam…)\n  ⎿  Error: Exit code 1\n     failed to parse jq expression (line 1, column 72)\n         {state, reviewDecision, checks: [.statusCheckRollup[] | select(.status \\!= \"COMPLETED\") | .name]}\n                                                                                ^  unexpected token \"\\\\\"\n\n⏺ Bash(gh pr view 572 --json state,reviewDecision,statusCheckRollup | jq '{state, reviewDecision, pending_checks: [.statusCheckRollup[] | select(.status != \"COMPLETED\"…)\n  ⎿  Error: Exit code 3\n     jq: error: syntax error, unexpected INVALID_CHARACTER, expecting ';' or ')' (Unix shell quoting issues?) at <top-level>, line 1:\n     {state, reviewDecision, pending_checks: [.statusCheckRollup[] | select(.status \\!= \"COMPLETED\") | .name]}\n     jq: 1 compile error\n\n⏺ Bash(gh pr checks 572 2>&1 | head -20)\n  ⎿  Clippy     pass    22s     https://github.com/btucker/midtown/actions/runs/21673727315/job/62488121801\n     E2E - chat_e2e     pass    2m58s   https://github.com/btucker/midtown/actions/runs/21673727315/job/62488121952\n     E2E - daemon_e2e   pass    3m4s    https://github.com/btucker/midtown/actions/runs/21673727315/job/62488122030\n     … +11 lines (ctrl+o to expand)\n\n⏺ All CI checks pass (Upload Coverage is just finalizing). PR #572 is ready - waiting for approval and auto-merge.\n\n⏺ Bash(midtown channel post \"/me all checks green on PR #572 - curtain call approaching\")\n  ⎿  Message posted to channel\n\n⏺ PR #572 has all checks passing. The daemon will handle auto-merge once approved.\n\n❯ github said: @broadway Check 'Upload Coverage' passed on PR #572\n\n⏺ All checks green on PR #572. Ready for approval and auto-merge.\n\n❯ Your task #4 (Add daemon auto-retry for stale/missing CI checks) was updated by madison — check the latest changes\n\n⏺ Bash(midtown channel read)\n  ⎿  [2026-02-04T13:53:39.072469+00:00] madison: created task: Check PR #573 eligibility for code review\n     [2026-02-04T13:53:43.286699+00:00] madison: claimed task 1\n     [2026-02-04T13:53:51.303755+00:00] midtown: 🔍 Called in lexington to review PR #574\n     … +17 lines (ctrl+o to expand)\n\n✳ Fixing chat scroll bug… (Esc to interrupt · ctrl+t to hide tasks · thinking)\n  ⎿  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon) › blocked by #8\n     ◼ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n     ◼ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n     ◻ #9 Fix daemon not detecting posted review comments\n     ◻ #10 Fix false positive stuck compaction detection\n     ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n     ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n     ✔ #6 Prevent coworkers from checking out default branch (riverside)\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle) · 1 file +1 -1\n\n",
+    "lexington": "\n ▐▛███▜▌   Claude Code v2.1.19\n▝▜█████▛▘  Opus 4.5 · Claude Max\n  ▘▘ ▝▝    ~/.midtown/coworkers/midtown/lexington\n\n❯ Review PR #574 using /code-review:code-review 574\n\n⏺ Let me read the channel first to catch up, then start the review.\n\n⏺ Bash(midtown channel read)\n  ⎿  [2026-02-04T13:52:48.786282+00:00] midtown: PR #570 (fix: Validate coworker names from bra...) owned by amsterdam - CI green with feedback: CI is green — please address review feedback and merge (call-in failed)\n     [2026-02-04T13:52:48.791189+00:00] midtown: PR #566 (feat: Add health check and workflow E...) owned by amsterdam - CI green with feedback: CI is green — please address review feedback and merge (call-in failed)\n     [2026-02-04T13:52:50.292158+00:00] riverside: the stage is quiet - awaiting the next scene\n     … +23 lines (ctrl+o to expand)\n\n⏺ Bash(midtown state reviewing --task 0 && midtown channel post \"/me reviewing PR #574\")\n  ⎿  lexington → review\n     Message posted to channel\n\n⏺ Skill(code-review:code-review)\n  ⎿  Successfully loaded skill · 7 tools allowed\n\n⏺ I'll create a todo list to track the code review process for PR #574.\n✔ Task #1 created: Check PR #574 eligibility for code review\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n· Improvising… (Esc to interrupt · ctrl+t to hide tasks · thinking)\n  ⎿  ◻ #1 Check PR #574 eligibility for code review\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n",
+    "madison": "\n ▐▛███▜▌   Claude Code v2.1.19\n▝▜█████▛▘  Opus 4.5 · Claude Max\n  ▘▘ ▝▝    ~/.midtown/coworkers/midtown/madison\n\n❯ Review PR #573 using /code-review:code-review 573\n\n⏺ Bash(midtown channel read)\n  ⎿  [2026-02-04T13:51:57.013612+00:00] park: completed task 5\n     [2026-02-04T13:52:00.860760+00:00] york: claimed task 8\n     [2026-02-04T13:52:03.230744+00:00] park: PR #573 ready - switched from daemon auto-merge to author-driven merge decisions\n     … +23 lines (ctrl+o to expand)\n\n⏺ Bash(midtown channel post \"/me reviewing PR #573 - let's see what park has cooked up\")\n  ⎿  Message posted to channel\n\n⏺ Bash(midtown state reviewing --task 0)\n  ⎿  madison → review\n\n⏺ Skill(code-review:code-review)\n  ⎿  Successfully loaded skill · 7 tools allowed\n\n⏺ I'll create a todo list and work through this code review systematically.\n✔ Task #1 created: Check PR #573 eligibility for code review\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #1 updated: owner, status → in progress\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #2 created: Find relevant CLAUDE.md files for PR #573\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #3 created: Get PR #573 summary\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #4 created: Run 5 parallel code review agents on PR #573\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #5 created: Score and filter issues from PR #573 review\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #6 created: Post review comment on PR #573\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #2 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #3 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #4 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #5 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #6 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ Now let me run the eligibility check and CLAUDE.md discovery in parallel:\n\n  Running 2 Task agents… (ctrl+o to expand)\n   ├─ Check PR #573 eligibility · 1 tool use · 19.8k tokens\n   │  ⎿  Bash: Get PR #573 details\n   └─ Find CLAUDE.md files for PR #573 · 1 tool use · 19.9k tokens\n      ⎿  Bash: gh pr view 573 --json files --jq '.files[].path'\n     ctrl+b ctrl+b (twice) to run in background\n\n✶ Checking PR eligibility… (Esc to interrupt · ctrl+t to hide tasks · 58s · ↓ 1.4k tokens · thinking)\n  ⎿  ◼ #1 Check PR #573 eligibility for code review (madison)\n     ◻ #2 Find relevant CLAUDE.md files for PR #573 (madison)\n     ◻ #3 Get PR #573 summary (madison)\n     ◻ #4 Run 5 parallel code review agents on PR #573 (madison)\n     ◻ #5 Score and filter issues from PR #573 review (madison)\n     ◻ #6 Post review comment on PR #573 (madison)\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n",
+    "park": "  ⎿  Found 0 lines\n\n⏺ Search(pattern: \"get_issue_action\"\", path: \"src/daemon\", output_mode: \"content\")\n  ⎿  Found 0 lines\n\n⏺ Search(pattern: \"Approved.*ready\"\", path: \"src\", output_mode: \"content\")\n  ⎿  Found 0 lines\n\n⏺ Search(pattern: \"ready to merge\", path: \"src\", output_mode: \"content\")\n  ⎿  Found 17 lines (ctrl+o to expand)\n\n⏺ ★ Insight ─────────────────────────────────────\n  Message flow for approved PRs:\n  - The get_issue_action(PrIssueType::Approved) returns \"ready to merge!\"\n  - The nudge message format is: \"PR #{} ({}) - {}: {}\"\n  - So authors will receive: \"PR #42 (feat: ...) - Approved: ready to merge!\"\n  - This clearly signals the PR is ready while letting the author decide to merge.\n  ─────────────────────────────────────────────────\n\n⏺ Bash(git diff --stat)\n  ⎿   src/daemon/effects.rs | 56 ---------------------------------------------------\n      src/daemon/pr.rs      | 21 +++----------------\n      state.json            |  2 +-\n      3 files changed, 4 insertions(+), 75 deletions(-)\n\n⏺ Bash(git add src/daemon/effects.rs src/daemon/pr.rs && git commit -m \"feat: Switch from daemon auto-merge to author-driven merge decisions…)\n  ⎿  [park/author-pr-notification d9bce83] feat: Switch from daemon auto-merge to author-driven merge decisions\n      2 files changed, 3 insertions(+), 74 deletions(-)\n     +cargo clippy -- -D warnings\n     … +2 lines (ctrl+o to expand)\n\n⏺ Bash(git push -u origin park/author-pr-notification 2>&1)\n  ⎿  remote:\n     remote: Create a pull request for 'park/author-pr-notification' on GitHub by visiting:\n     remote:      https://github.com/btucker/midtown/pull/new/park/author-pr-notification\n     … +4 lines (ctrl+o to expand)\n\n⏺ Bash(gh pr create --title \"feat: Switch to author-driven merge decisions [Midtown #5]\" --body \"<!-- midtown: park -->…)\n  ⎿  https://github.com/btucker/midtown/pull/573\n     Warning: 1 uncommitted change\n✔ Task #5 updated: status → completed\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ Bash(midtown state pull-request --task 5 && midtown channel post \"/me PR #573 ready - switched from daemon auto-merge to author-driven merge decisions\")\n  ⎿  park → PR#5\n     Message posted to channel\n\n⏺ PR #573 created: https://github.com/btucker/midtown/pull/573\n\n  ★ Insight ─────────────────────────────────────\n  Architectural change summary:\n\n  Before: Daemon auto-merged PRs when reviewDecision == \"APPROVED\" and CI was green. The author had no say.\n\n  After: Daemon notifies the author (\"ready to merge!\") and they decide. This respects the principle that agents with full context make decisions about their work.\n\n  Code impact: Removed 74 lines - the AutoMergePr effect, auto_merge_pr() function, and the special-case branching in poll_prs_for_issues(). The existing decide_pr_issue_action() nudge path now handles all PR issue types uniformly.\n  ─────────────────────────────────────────────────\n\n  Task #5 complete. PR #573 implements author-driven merge decisions - authors are notified when their PRs are ready to merge instead of the daemon auto-merging. Waiting for CI and review.\n\n✻ Cooked for 6m 7s\n\n❯ Your task #3 (Update auto-merge to recognize comment-based reviews) was updated by madison — check the latest changesYour task #5 (Call-in and nudge PR authors on comments/reviews) was updated by madison — check the latest changes\n\n⏺ Bash(midtown channel read | tail -20)\n  ⎿  [2026-02-04T13:53:43.286699+00:00] madison: claimed task 1\n     [2026-02-04T13:53:51.303755+00:00] midtown: 🔍 Called in lexington to review PR #574\n     [2026-02-04T13:53:51.313677+00:00] lead: Bug: daemon not detecting pleasant's posted review on PR #572. Created task #9 to fix review detection - daemon may be looking for formal GitHub reviews instead of comment-based ones.\n     … +17 lines (ctrl+o to expand)\n\n✽ Fixing chat scroll bug… (Esc to interrupt · ctrl+t to hide tasks · thought for 2s)\n  ⎿  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon) › blocked by #8\n     ◼ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n     ◼ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n     ◻ #9 Fix daemon not detecting posted review comments\n     ◻ #10 Fix false positive stuck compaction detection\n     ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n     ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n     ✔ #6 Prevent coworkers from checking out default branch (riverside)\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle) · 1 file +1 -1                                                                                                                                              Context left until auto-compact: 6%\n\n",
+    "pleasant": "   │  ⎿  Done\n   ├─ Score issue 4: missing tests · 24 tool uses · 43.5k tokens\n   │  ⎿  Done\n   └─ Score issue 5: webhook tests · 10 tool uses · 38.8k tokens\n      ⎿  Done\n\n⏺ Excellent. Now I have the scores:\n  ┌─────────────────────────────────────────────────────┬───────┬────────────────┐\n  │                        Issue                        │ Score │ Threshold (40) │\n  ├─────────────────────────────────────────────────────┼───────┼────────────────┤\n  │ Inline CI duration recording bypasses Effect system │ 85    │ ✓ Pass         │\n  ├─────────────────────────────────────────────────────┼───────┼────────────────┤\n  │ Decision logic in pr.rs accesses daemon state       │ 25    │ ✗ Fail         │\n  ├─────────────────────────────────────────────────────┼───────┼────────────────┤\n  │ RecordCiCheckDuration Effect unused                 │ 50    │ ✓ Pass         │\n  ├─────────────────────────────────────────────────────┼───────┼────────────────┤\n  │ Missing tests for collect_stale_check_effects       │ 75    │ ✓ Pass         │\n  ├─────────────────────────────────────────────────────┼───────┼────────────────┤\n  │ Missing tests for compute_check_duration            │ 75    │ ✓ Pass         │\n  └─────────────────────────────────────────────────────┴───────┴────────────────┘\n✔ Task #5 updated: status → completed\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ Let me now re-check PR eligibility and get the full commit SHA for linking, then post the review comment.\n\n⏺ Task(Re-check PR eligibility) Haiku 4.5\n  ⎿  Done (1 tool use · 19.8k tokens · 4s)\n\n⏺ Bash(gh pr view 572 --json headRefOid --jq '.headRefOid')\n  ⎿  4fc4dc7ef685c238cc5a77cc499b30ffd80f0998\n\n⏺ Now let me post the review comment. Based on the threshold of 40, I have 4 issues to report:\n\n  1. Score 85 - Inline CI duration recording bypasses Effect system\n  2. Score 75 - Missing tests for collect_stale_check_effects\n  3. Score 75 - Missing tests for compute_check_duration\n  4. Score 50 - RecordCiCheckDuration Effect unused (dead code)\n\n  I also need to report the below-threshold issue (score 25) to the lead.\n✔ Task #6 updated: status → in progress\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ Bash(gh pr comment 572 --body \"### Code review by pleasant…)\n  ⎿  https://github.com/btucker/midtown/pull/572#issuecomment-3847468226\n✔ Task #6 updated: status → completed\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ Bash(midtown channel post \"Posted review on PR #572: https://github.com/btucker/midtown/pull/572#issuecomment-3847468226\")\n  ⎿  Message posted to channel\n\n⏺ Bash(midtown channel post \"@lead [Review Note] PR #572: Decision logic in pr.rs accesses daemon state directly via async lock instead of being a pure function taking…)\n  ⎿  Message posted to channel\n\n⏺ Bash(midtown state completed --task 0)\n  ⎿  pleasant → done\n\n⏺ Bash(midtown channel post \"/me review complete for PR #572 - found 4 issues around Effect system architecture and test coverage\")\n  ⎿  Message posted to channel\n\n⏺ ★ Insight ─────────────────────────────────────\n  PR #572 Review Summary:\n  - The PR adds stale CI check detection with auto-retry functionality\n  - Main architectural concern: webhook handler performs I/O inline instead of through the Effect system\n  - Test coverage gap: ci_stats.rs has 9 tests but collect_stale_check_effects() and compute_check_duration() lack tests\n  - The Effect-based architecture in midtown keeps decision logic pure and testable - bypassing it creates technical debt\n  ─────────────────────────────────────────────────\n\n  Review complete for PR #572. I found 4 issues above the threshold (40):\n\n  1. Score 85 - CI duration recording bypasses Effect system (inline I/O in webhook handler)\n  2. Score 75 - Missing tests for collect_stale_check_effects integration logic\n  3. Score 75 - Missing tests for compute_check_duration webhook parsing\n  4. Score 50 - Unused RecordCiCheckDuration Effect variant with complete implementation\n\n  Posted review comment: https://github.com/btucker/midtown/pull/572#issuecomment-3847468226\n\n  I also notified the lead about one below-threshold issue (score 25) regarding decision logic in pr.rs accessing daemon state - though this may be a false positive since CLAUDE.md's \"pure function\" principle specifically applies to\n  rules.rs, not domain modules like pr.rs.\n\n✻ Baked for 6m 38s\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n",
+    "riverside": "\n⏺ Bash(git add src/coworker.rs src/worktree.rs)\n  ⎿  (No content)\n\n⏺ Bash(git log --oneline -5)\n  ⎿  5e37332 fix: Clear reviewer assignments when coworker sessions end unexpectedly [Midtown #1] (#569)\n     629fbd3 fix: Exclude tmux from orphan process cleanup (#568)\n     a8a9e5d test: Add effect verification E2E tests [Midtown #4] (#563)\n     … +2 lines (ctrl+o to expand)\n\n⏺ Bash(git commit -m \"fix: Prevent coworkers from checking out default branch [Midtown #6]…)\n  ⎿  [riverside/prevent-default-branch-checkout 60f1763] fix: Prevent coworkers from checking out default branch [Midtown #6]\n      2 files changed, 226 insertions(+)\n     +cargo clippy -- -D warnings\n     … +3 lines (ctrl+o to expand)\n\n⏺ Bash(git push -u origin riverside/prevent-default-branch-checkout 2>&1)\n  ⎿  remote:\n     remote: Create a pull request for 'riverside/prevent-default-branch-checkout' on GitHub by visiting:\n     remote:      https://github.com/btucker/midtown/pull/new/riverside/prevent-default-branch-checkout\n     … +4 lines (ctrl+o to expand)\n\n⏺ Bash(gh pr create --title \"fix: Prevent coworkers from checking out default branch [Midtown #6]\" --body \"<!-- midtown: riverside -->…)\n  ⎿  https://github.com/btucker/midtown/pull/574\n     Warning: 1 uncommitted change\n\n⏺ Bash(midtown channel post \"/me PR #574 ready - the stage is set for review\")\n  ⎿  Message posted to channel\n✔ Task #6 updated: status → completed\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ Bash(midtown state completed --task 6)\n  ⎿  riverside → done#6\n\n⏺ Bash(midtown state idle)\n  ⎿  riverside → idle\n\n⏺ Bash(midtown channel post \"/me the stage is quiet - awaiting the next scene\")\n  ⎿  Message posted to channel\n\n⏺ Task #6 completed. I've created PR #574 which adds validation to prevent coworkers from checking out the default branch:\n\n  Summary of changes:\n  - Added is_on_default_branch() method to detect if a worktree is on main/master\n  - Added checkout_new_branch() method to create a feature branch for recovery\n  - Added validation in spawn_with_name() that auto-creates a <name>/recovery branch when a coworker's worktree is found on the default branch\n\n  PR: https://github.com/btucker/midtown/pull/574\n\n✻ Sautéed for 6m 44s\n\n❯ Your task #6 (Prevent coworkers from checking out default branch) was updated by madison — check the latest changes\n\n⏺ Bash(midtown channel read | tail -30)\n  ⎿  [2026-02-04T13:53:39.072469+00:00] madison: created task: Check PR #573 eligibility for code review\n     [2026-02-04T13:53:43.286699+00:00] madison: claimed task 1\n     [2026-02-04T13:53:51.303755+00:00] midtown: 🔍 Called in lexington to review PR #574\n     … +17 lines (ctrl+o to expand)\n\n⏺ I see the updates - lexington is reviewing my PR #574 and madison appears to have claimed some review sub-tasks. My task #6 is already marked as completed. Let me check if there are any available tasks.\n8 tasks (4 done, 2 in progress, 2 open)\n\n✔ #6 Prevent coworkers from checking out default branch (riverside)\n✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon) ⚠ blocked by #8\n◼ #10 Fix false positive stuck compaction detection\n✔ #3 Update auto-merge to recognize comment-based reviews (park)\n◼ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n◼ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n◼ #9 Fix daemon not detecting posted review comments\n\n✶ Fixing chat scroll bug… (Esc to interrupt · ctrl+t to hide tasks · thought for 3s)\n  ⎿  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon) › blocked by #8\n     ◼ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n     ◼ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n     ◻ #9 Fix daemon not detecting posted review comments\n     ◻ #10 Fix false positive stuck compaction detection\n     ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n     ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n     ✔ #6 Prevent coworkers from checking out default branch (riverside)\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle) · 1 file +1 -1\n\n",
+    "vernon": "⏺ Bash(cargo clippy -- -D warnings 2>&1 | tail -20)\n  ⎿      Checking strum v0.26.3\n         Checking hyper-rustls v0.27.7\n         Checking axum v0.8.8\n     … +17 lines (ctrl+o to expand)\n\n⏺ Clippy passes. Let me view the final changes and prepare the PR.\n\n⏺ Bash(git diff)\n  ⎿  diff --git a/src/bin/midtown/cli/chat/mod.rs b/src/bin/midtown/cli/chat/mod.rs\n     index fceeb0a..be79593 100644\n     --- a/src/bin/midtown/cli/chat/mod.rs\n     … +35 lines (ctrl+o to expand)\n\n⏺ ★ Insight ─────────────────────────────────────\n  The implementation is minimal and clean:\n  - Added a new 30-second interval timer (auto_scroll_interval)\n  - In the tokio::select! event loop, added a handler that resets scroll to bottom when triggered\n  - No changes to the UI logic - we just call the existing scroll_to_bottom() method\n\n  This pattern of adding new timers to tokio::select! is the standard way to add periodic behaviors to async Rust applications.\n  ─────────────────────────────────────────────────\n\n  Now let me create the commit and PR. I'll only commit the actual code change, not the state.json file.\n\n⏺ Bash(midtown state pull-request --task 7)\n  ⎿  vernon → PR#7\n\n⏺ Bash(git checkout -- state.json)\n  ⎿  (No content)\n\n⏺ Bash(git add src/bin/midtown/cli/chat/mod.rs && git commit -m \"feat: Auto-scroll chat TUI to bottom every 30 seconds…)\n  ⎿  [vernon/chat-tui-auto-scroll 787fff1] feat: Auto-scroll chat TUI to bottom every 30 seconds\n      1 file changed, 11 insertions(+)\n     +cargo clippy -- -D warnings\n     … +2 lines (ctrl+o to expand)\n\n⏺ Bash(git push -u origin vernon/chat-tui-auto-scroll 2>&1)\n  ⎿  remote:\n     remote: Create a pull request for 'vernon/chat-tui-auto-scroll' on GitHub by visiting:\n     remote:      https://github.com/btucker/midtown/pull/new/vernon/chat-tui-auto-scroll\n     … +4 lines (ctrl+o to expand)\n\n⏺ Bash(gh pr create --title \"feat: Auto-scroll chat TUI to bottom every 30 seconds [Midtown #7]\" --body \"<!-- midtown: vernon -->…)\n  ⎿  https://github.com/btucker/midtown/pull/575\n\n⏺ Bash(midtown channel post \"/me opened PR #575 for task 7 - chat TUI auto-scroll is ready for review\")\n  ⎿  Message posted to channel\n✔ Task #7 updated: status → completed\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ Bash(midtown state completed --task 7)\n  ⎿  vernon → done#7\n7 tasks (4 done, 2 in progress, 1 open)\n\n✔ #6 Prevent coworkers from checking out default branch (riverside)\n✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon) ⚠ blocked by #8\n✔ #3 Update auto-merge to recognize comment-based reviews (park)\n◼ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n◼ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n◼ #9 Fix daemon not detecting posted review comments\n\n⏺ Task #7 is complete. PR #575 is ready for review: https://github.com/btucker/midtown/pull/575\n\n⏺ Bash(midtown state idle)\n  ⎿  vernon → idle\n\n⏺ Bash(midtown channel post \"/me the show is over for task 7 - standing by for the next act\")\n  ⎿  Message posted to channel\n\n✢ Fixing chat scroll bug… (Esc to interrupt · ctrl+t to hide tasks · 4m 0s · ↓ 6.8k tokens · thought for 5s)\n  ⎿  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon) › blocked by #8\n     ◼ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n     ◼ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n     ◻ #9 Fix daemon not detecting posted review comments\n     ◻ #10 Fix false positive stuck compaction detection\n     ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n     ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n     ✔ #6 Prevent coworkers from checking out default branch (riverside)\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle) · 1 file +1 -1\n\n",
+    "york": "     1. A coworker checks out `main` directly\n     2. An existing worktree from a crashed coworker was left on `main`\n     … +47 lines (ctrl+o to expand)\n\n❯ You have pending task #8: Fix chat TUI unexpectedly scrolling to beginning. Get started!\n\n⏺ I see the bug. The chat TUI is spontaneously scrolling to the beginning when it shouldn't. Let me claim this task and investigate the scroll state management.\n✔ Task #8 updated: status → in progress\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ Bash(midtown state claiming --task 8)\n  ⎿  york → claim#8\n\n⏺ Bash(midtown channel post \"/me claiming task 8 - time to chase down this scroll bug\")\n  ⎿  Message posted to channel\n\n⏺ Bash(sleep 10 && midtown channel read --since 1m)\n  ⎿  Error: Exit code 2\n     error: unexpected argument '--since' found\n\n     Usage: midtown channel read [OPTIONS]\n\n     For more information, try '--help'.\n\n⏺ Bash(midtown channel read | tail -20)\n  ⎿  [2026-02-04T13:51:19.379922+00:00] lead: updated task 8\n     [2026-02-04T13:51:24.841997+00:00] vernon: 💡 The chat TUI uses `tokio::select!` for event multiplexing with three sources:\n     1. Terminal events (keyboard/mouse via EventStream)\n     … +17 lines (ctrl+o to expand)\n\n⏺ No duplicate claims. Let me create a feature branch and start investigating.\n\n⏺ Bash(git checkout -b york/fix-chat-scroll-bug)\n  ⎿  Switched to a new branch 'york/fix-chat-scroll-bug'\n\n⏺ Bash(midtown state developing --task 8)\n  ⎿  york → dev#8\n\n⏺ Bash(midtown channel post \"/me investigating the chat TUI scroll state management\")\n  ⎿  Message posted to channel\n\n⏺ Search(pattern: \"**/chat*.rs\")\n  ⎿  Found 3 files (ctrl+o to expand)\n\n⏺ Search(pattern: \"scroll_offset\")\n  ⎿  Found 4 files (ctrl+o to expand)\n\n⏺ Search(pattern: \"midtown chat\")\n  ⎿  Found 7 files (ctrl+o to expand)\n\n⏺ Found the chat TUI code. Let me examine the scroll state management.\n\n⏺ Read(src/bin/midtown/cli/chat/app.rs)\n  ⎿  Read 1551 lines\n\n⏺ Read(src/bin/midtown/cli/chat/ui.rs)\n  ⎿  Read 2054 lines\n\n⏺ ★ Insight ─────────────────────────────────────\n  The chat TUI uses an inverted scroll system where scroll_offset = 0 means \"at bottom\" (newest messages). The refresh() method at app.rs:235-246 carefully preserves scroll position when new messages arrive - if scrolled up, it adjusts\n  offset to keep viewing the same content.\n  ─────────────────────────────────────────────────\n\n  Let me find the main event loop to understand what might reset scroll state.\n\n⏺ Search(pattern: \"**/cli/chat/*.rs\")\n  ⎿  Found 3 files (ctrl+o to expand)\n\n⏺ Read(src/bin/midtown/cli/chat/mod.rs)\n  ⎿  Read 287 lines\n\n✶ Fixing chat scroll bug… (Esc to interrupt · ctrl+t to hide tasks · 2m 27s · ↓ 4.6k tokens · thinking)\n  ⎿  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon) › blocked by #8\n     ◼ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n     ◼ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n     ◻ #9 Fix daemon not detecting posted review comments\n     ◻ #10 Fix false positive stuck compaction detection\n     ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n     ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n     ✔ #6 Prevent coworkers from checking out default branch (riverside)\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n"
+  },
+  "pending_tasks_with_owners": [],
+  "pending_tasks_without_owners": [],
+  "repo_name": "midtown",
+  "reviewed_prs": [],
+  "reviewer_pr_assignments": {
+    "lexington": 574,
+    "madison": 573,
+    "pleasant": 572
+  },
+  "running_coworkers": [
+    {
+      "current_task": null,
+      "isolated_tasks": true,
+      "name": "pleasant",
+      "session_id": "406367e1-6a10-4316-8652-4df15527da55",
+      "started_at": "2026-02-04T13:24:17.035622Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/pleasant"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "riverside",
+      "session_id": "f52988c3-7c40-4beb-b2de-744b7f4762a1",
+      "started_at": "2026-02-04T13:46:17.282998Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/riverside"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "vernon",
+      "session_id": "1d81e998-5e61-4419-ab14-767509b64389",
+      "started_at": "2026-02-04T13:50:16.836775Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/vernon"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "broadway",
+      "session_id": "7add59c0-a114-407c-9ad3-5f18ca85fcb1",
+      "started_at": "2026-02-04T13:36:17.238096Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/broadway"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": true,
+      "name": "lexington",
+      "session_id": "2fc964b2-b521-4ba8-8c82-5204e823171c",
+      "started_at": "2026-02-04T13:53:51.303168Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/lexington"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "york",
+      "session_id": "5ab1d59e-d012-4919-bdaf-b19f2b91ea43",
+      "started_at": "2026-02-04T13:51:49.081592Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/york"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "amsterdam",
+      "session_id": "",
+      "started_at": "2026-02-04T13:52:48.775792Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/amsterdam"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "park",
+      "session_id": "",
+      "started_at": "2026-02-04T13:46:05.843525Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/park"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": true,
+      "name": "madison",
+      "session_id": "36137fa1-5b67-4d45-ab3e-e01855b4646f",
+      "started_at": "2026-02-04T13:53:19.241094Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/madison"
+    }
+  ],
+  "session_name": "midtown-midtown",
+  "usage_limit_nudge_scheduled": false
+}

--- a/tests/fixtures/snapshot/snapshot-hit-usage-limit-20260204-154619.json
+++ b/tests/fixtures/snapshot/snapshot-hit-usage-limit-20260204-154619.json
@@ -1,0 +1,491 @@
+{
+  "active_coworkers": [
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "riverside",
+      "session_id": "69828d3c-97cc-4f58-bfb6-8529c258867a",
+      "started_at": "2026-02-04T15:43:42.439736Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/riverside"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "columbus",
+      "session_id": "10ad5b70-bfe7-49dc-a746-4f172ab759cc",
+      "started_at": "2026-02-04T15:44:48.919057Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/columbus"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "madison",
+      "session_id": "ed41e48e-9c26-4bca-a342-6f91e1e73322",
+      "started_at": "2026-02-04T15:40:13.601954Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/madison"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "york",
+      "session_id": "e3cada2f-0f70-4e50-9035-d51b0653d34b",
+      "started_at": "2026-02-04T15:43:50.127855Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/york"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": true,
+      "name": "park",
+      "session_id": "c2b52ecc-9c0f-4e13-9740-11a31a215f4f",
+      "started_at": "2026-02-04T15:38:15.920686Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/park"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": true,
+      "name": "lexington",
+      "session_id": "fa8ef3e1-fd15-41d8-9026-4b0c3d48285c",
+      "started_at": "2026-02-04T15:33:46.132557Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/lexington"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": true,
+      "name": "amsterdam",
+      "session_id": "f6becc58-c4ad-47a2-81ce-da7585ad5369",
+      "started_at": "2026-02-04T15:33:14.135039Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/amsterdam"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "vernon",
+      "session_id": "0ed547b0-4aa1-4a3f-a20c-a12e9692fe8b",
+      "started_at": "2026-02-04T15:43:46.277581Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/vernon"
+    }
+  ],
+  "active_names": [
+    "columbus",
+    "riverside",
+    "lexington",
+    "vernon",
+    "madison",
+    "york",
+    "amsterdam",
+    "park"
+  ],
+  "active_reviewers": [
+    "park"
+  ],
+  "all_tasks": [
+    {
+      "blocked_by": [],
+      "description": "Bug: `is_auto_mergeable()` in src/daemon/helpers.rs only accepts formal GitHub APPROVED reviewDecision. It should also recognize positive review comments (e.g., \"No issues found\") as approval for auto-merge purposes.\n\nCurrent behavior (line 153):\n```rust\nif review_decision != \"APPROVED\" {\n    return false;\n}\n```\n\nExpected behavior:\n- Keep APPROVED as valid\n- Also check PR comments for positive review indicators from coworkers (look for midtown markers and \"No issues found\" or similar patterns)\n\nContext: We use comment-based reviews because the same GitHub account (btucker) authors PRs and runs coworkers, making formal self-approval impossible.",
+      "id": "3",
+      "owner": "park",
+      "status": "completed",
+      "subject": "Update auto-merge to recognize comment-based reviews"
+    },
+    {
+      "blocked_by": [],
+      "description": "Feature: The daemon should track typical CI check durations and handle stuck/missing checks intelligently.\n\n**Scenarios to handle:**\n\n1. **Stuck check** (pending > 4x typical duration): Re-run the specific check\n2. **Missing/new check** (required check not in PR's CI run): The PR predates the CI workflow change. Daemon should rebase the PR on main to pick up the new workflow, then CI will include the new check.\n\n**Implementation:**\n1. Track historical completion times per CI check name (e.g., \"E2E - idle_break_e2e\" typically takes 2m)\n2. Store rolling average or median of recent runs\n3. For stuck checks: If pending > 4x typical duration, trigger re-run\n4. For missing checks: If a required check never appears in the PR's status checks but exists in main's CI workflow, rebase the PR on main\n5. Add cooldowns to prevent spam\n\n**Key points:**\n- NOT overly aggressive - only at 4x typical time for stuck checks\n- Data-driven based on actual historical times\n- Detect \"new\" required checks that the PR doesn't have and auto-rebase\n\nUse case: PRs #566 and #570 were blocked by missing \"E2E - idle_break_e2e\" - they predated the workflow change. Daemon should have detected this and rebased automatically.",
+      "id": "4",
+      "owner": "broadway",
+      "status": "completed",
+      "subject": "Add daemon auto-retry for stale/missing CI checks"
+    },
+    {
+      "blocked_by": [],
+      "description": "Instead of the daemon parsing review comments to auto-merge, the author coworker should handle merge decisions themselves.\n\nWhen a PR receives a comment or review:\n1. If the author coworker is idle/shutdown, call them in\n2. Nudge the author coworker about the new comment/review\n3. Author reads the feedback and decides whether to merge, address feedback, or take other action\n\nThis is simpler than daemon comment parsing and keeps the merge decision with the agent who has full context of the PR.\n\nReplaces the approach in closed PR #571.\n\nPR #573 is ready - removes auto-merge, author-driven approach. Clean commit without state.json.",
+      "id": "5",
+      "owner": "park",
+      "status": "completed",
+      "subject": "Call-in and nudge PR authors on comments/reviews"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: Park had main checked out in their worktree. Coworkers should NEVER checkout the default branch (main/master).\n\nThis can cause issues:\n1. Multiple worktrees can't share the same branch\n2. Coworkers might accidentally commit directly to main\n3. Blocks other worktrees from using main\n\nFix needed:\n- Add validation when spawning coworkers to ensure they're on a feature branch\n- Add validation in coworker prompts/hooks to prevent `git checkout main`\n- If a coworker somehow ends up on main, detect and fix it (checkout a new feature branch)\n\nCheck how park ended up on main and prevent it from happening.",
+      "id": "6",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Prevent coworkers from checking out default branch"
+    },
+    {
+      "blocked_by": [
+        "8"
+      ],
+      "description": "The `midtown chat` TUI should check every 30 seconds whether it's at the end of the channel. If it got stuck further up (e.g., user scrolled up and forgot), it should auto-scroll back to the end.\n\nThis prevents the chat from appearing frozen/stuck when it's actually just scrolled up in history.",
+      "id": "7",
+      "owner": "vernon",
+      "status": "completed",
+      "subject": "Chat TUI should auto-scroll to end every 30 seconds"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The `midtown chat` TUI spontaneously scrolled to the beginning of the channel on its own. This should never happen.\n\nThis is a higher priority than the auto-scroll-to-end feature (task #7) - we need to fix this regression/bug first.\n\nInvestigate what's causing unexpected scroll position changes in the chat TUI. Could be:\n- A render loop resetting scroll state\n- File watcher event causing re-render from top\n- State management issue with scroll position\n- Race condition in the async event handling\n\nThe chat should maintain its scroll position unless the user explicitly scrolls or it auto-scrolls to follow new messages at the bottom.",
+      "id": "8",
+      "owner": "york",
+      "status": "completed",
+      "subject": "Fix chat TUI unexpectedly scrolling to beginning"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The daemon is warning \"Reviewer pleasant is idle but hasn't posted review for PR #572 yet\" but pleasant DID post a review comment (visible via `gh pr view 572 --json comments`).\n\nThe daemon's review detection is not recognizing that the review comment was posted. It should:\n1. Check PR comments for review signatures from the assigned reviewer\n2. Once a review comment is detected, stop warning about missing reviews\n3. Clear the reviewer assignment from the \"pending\" state\n\nThis might be related to how the daemon checks for reviews - it may be looking for formal GitHub reviews instead of comment-based reviews.",
+      "id": "9",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Fix daemon not detecting posted review comments"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The daemon incorrectly detects coworkers as \"stuck compacting\" when they're not.\n\n**Test cases captured:**\n1. `snapshot-false-positive-bugs-20260204-135417.json` - riverside false positive\n2. `snapshot-20260204-144326.json` - york detected as \"stuck compacting\" but actually had a backlog of nudges in its input box\n\n**Two types of nudge backlogs to distinguish:**\n1. **In the input box** - nudges stacked up IN the input box → needs Enter to process\n2. **Above the input box** - nudges stacked up ABOVE the input box (permission dialogs, etc.) → needs Escape to dismiss\n\n**Root cause:** The daemon may be misinterpreting these nudge backlog states as stuck compaction.\n\n**Fix needed:**\n- Detect and differentiate between:\n  - Actual stuck compaction\n  - Nudge backlog in input box (Enter needed)\n  - Nudge backlog above input box (Escape needed)\n- Don't treat nudge backlogs as stuck state\n- May need different remediation for each backlog type\n- Coordinate with task #11 (smart nudge timing) to prevent backlogs in the first place",
+      "id": "10",
+      "owner": "york",
+      "status": "completed",
+      "subject": "Fix false positive stuck compaction detection"
+    },
+    {
+      "blocked_by": [],
+      "description": "UX Bug: Nudges inject text via tmux send-keys while the user is trying to type, disrupting their input.\n\n**Two types of nudge backlogs to prevent:**\n1. **In the input box** - nudges stacking up IN the input box → needs Enter to clear\n2. **Above the input box** - nudges stacking up ABOVE the input box (permission dialogs, etc.) → needs Escape to dismiss\n\n**New nudge behavior:**\n\n1. Before nudging, check if the input box is empty\n2. If empty → safe to nudge immediately\n3. If not empty, check if the content is mostly from the daemon's last nudge\n   - If yes → safe to nudge (can overwrite stale nudge text)\n   - If no → user is typing something, DON'T nudge yet\n4. When user content detected:\n   - Wait 10 seconds, check again\n   - If input has changed → user still typing, wait another 10 seconds\n   - Repeat this process\n5. Only append onto unrecognized input content if it hasn't changed for 20 seconds\n\nAlso consider:\n- Detecting and handling existing backlog before adding more nudges\n- Different handling for \"above input\" backlog vs \"in input\" backlog\n\nThe daemon should track:\n- Last nudge content sent to each coworker/lead\n- Input box state before nudging\n- Timestamps of input changes\n\n**IMPORTANT: Create an E2E test for this using real Claude to verify the behavior works correctly in practice.**",
+      "id": "11",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Make nudges respect user input in progress"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: York received a nudge about PR #577 but that PR was authored by btucker, not york.\n\nThe daemon is sending PR-related nudges to the wrong coworkers. It should:\n1. Correctly identify the PR author (the coworker who created the PR)\n2. Only nudge that author about review feedback, CI status, etc.\n3. Not confuse GitHub username (btucker) with coworker names\n\nThis may be related to the author-driven merge changes (PR #573/task #5) - need to verify the author identification logic is correct.",
+      "id": "12",
+      "owner": "amsterdam",
+      "status": "completed",
+      "subject": "Fix misdirected PR nudges to wrong coworkers"
+    },
+    {
+      "blocked_by": [],
+      "description": "The GitHub CI check notifications in the channel are noisy when many checks complete around the same time:\n\n```\n08:47 Check 'Clippy' passed on main\n08:48 Check 'E2E - idle_break_e2e' passed on main\n08:48 Check 'Test' passed on main\n08:48 Check 'E2E - tailf_integration' passed on main\n08:48 Check 'E2E - spawn_race_test' passed on main\n```\n\n**Improvement:** Batch these into a single message when multiple checks complete within a short window (e.g., 30-60 seconds):\n\n```\n08:48 5 checks passed on main: Clippy, Test, E2E - idle_break_e2e, E2E - tailf_integration, E2E - spawn_race_test\n```\n\nOr even more condensed:\n```\n08:48 All CI checks passed on main\n```\n\n**Implementation ideas:**\n- Buffer CI check events for a short window before posting to channel\n- If multiple checks for the same ref/PR complete, batch them\n- Keep important events (PR opened, failures) as individual messages\n- Only batch \"passed\" checks, always show failures immediately\n\n**IMPORTANT:** This is purely a channel display change. The underlying webhook/event handling and PR author nudging logic should NOT be affected. The daemon should still process each CI event individually for nudge decisions - only the channel message posting gets batched.",
+      "id": "13",
+      "owner": "broadway",
+      "status": "completed",
+      "subject": "Batch repetitive GitHub CI notifications in channel"
+    },
+    {
+      "blocked_by": [],
+      "description": "Fixed: Added direct nudge_lead() calls in dispatch.rs and mod.rs. PR #584 opened.",
+      "id": "14",
+      "owner": "vernon",
+      "status": "completed",
+      "subject": "Investigate broken lead nudges for @lead mentions"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/effects.rs at 0%\n\nAdd E2E tests that exercise the effect execution layer:\n- Effect::SpawnCoworker - test coworker spawning via real daemon\n- Effect::ShutdownCoworker - test coworker shutdown\n- Effect::NudgeCoworker / Effect::NudgeLead - test nudge delivery\n- Effect::PostChannelMessage - test channel posting\n- Effect::AutoMergePr - test PR merge triggering\n\nUse the containerized E2E approach with real Claude where needed. Tests should verify effects actually execute (tmux windows created, messages posted, etc.).",
+      "id": "15",
+      "owner": "lexington",
+      "status": "completed",
+      "subject": "E2E tests for daemon effects execution"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/pr.rs at 0.94%\n\nAdd E2E tests for PR management flows:\n- PR polling and state detection\n- CI status tracking and stale check detection\n- Review comment detection\n- PR author identification and nudging\n- Auto-merge eligibility checking\n- Merge conflict detection\n\nUse real GitHub PRs in test repo or mock webhook events to exercise the PR handling code paths.",
+      "id": "16",
+      "owner": "columbus",
+      "status": "completed",
+      "subject": "E2E tests for daemon PR management"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/health.rs at 8.89%\n\nAdd E2E tests for coworker health monitoring:\n- Stuck detection (various stuck states)\n- Idle detection\n- Compaction detection (avoiding false positives - see task #10)\n- Usage limit detection\n- Orphan worktree detection\n- Session crash detection\n\nUse captured snapshots as test fixtures and verify health decisions match expected behavior.",
+      "id": "17",
+      "owner": "amsterdam",
+      "status": "completed",
+      "subject": "E2E tests for daemon health checks"
+    },
+    {
+      "blocked_by": [],
+      "description": "**TESTS WRITTEN** - 19 new E2E tests added to /Users/btucker/projects/midtown/tests/daemon_e2e.rs (lines 2100-2665)\n\nTests cover:\n- coworker.report-state: phase validation (3 tests)\n- coworker.nudge: response structure (1 test)\n- coworker.asking: channel posting (2 tests)\n- task.updated: params and missing task (3 tests)\n- daemon.check-pending: dispatch trigger (1 test)\n- channel.read: all=true parameter (1 test)\n- channel.post: /me actions, shell unescaping, mentions (4 tests)\n- coworker.break: params and nonexistent (2 tests)\n- reminder.cancel/create: validation (2 tests)\n\n**BLOCKER**: Shell environment completely broken (exit code 1 on all commands including `true`). Cannot:\n- Run cargo check to verify compilation\n- Create feature branch\n- Commit changes\n\nNeed: Working shell to complete git workflow",
+      "id": "18",
+      "owner": "york",
+      "status": "in_progress",
+      "subject": "E2E tests for daemon RPC handlers"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/dispatch.rs at 23.42%\n\nAdd E2E tests for task dispatch and coworker assignment:\n- Task assignment to idle coworkers\n- Task priority handling\n- Blocked task detection (blockedBy dependencies)\n- Orphan task recovery\n- Reviewer spawning for PRs\n- Max coworker limit enforcement\n\nVerify the daemon correctly assigns work and manages coworker lifecycle.",
+      "id": "19",
+      "owner": "park",
+      "status": "completed",
+      "subject": "E2E tests for daemon dispatch logic"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/webhook_fwd.rs at 0%, daemon/events.rs at 0%\n\nAdd E2E tests for GitHub webhook processing:\n- PR opened/closed/merged events\n- Review submitted events\n- Check run completed events\n- Push events\n- Webhook signature verification\n- Event deduplication\n\nUse mock webhook payloads or test against real GitHub webhooks in test environment.",
+      "id": "20",
+      "owner": "riverside",
+      "status": "in_progress",
+      "subject": "E2E tests for webhook handling"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: web.rs at 31.19%, webserver.rs at 30.63%\n\nAdd E2E tests for the web interface:\n- WebSocket connection and message streaming\n- Chat message display\n- Coworker status updates\n- Kanban board data\n- Static file serving\n- Multi-project routing\n\nCould use Playwright (already have MCP tools) or headless browser testing.",
+      "id": "21",
+      "owner": "vernon",
+      "status": "in_progress",
+      "subject": "E2E tests for web UI and WebSocket"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: tmux.rs at 41.57%\n\nAdd E2E tests for tmux interactions:\n- Window creation and naming\n- Pane capture and parsing\n- Send-keys for nudges\n- Session management\n- Status bar updates\n- Window killing safety checks\n\nThese tests need real tmux sessions - use the existing tmux_e2e test pattern.",
+      "id": "22",
+      "owner": "pleasant",
+      "status": "completed",
+      "subject": "E2E tests for tmux operations"
+    },
+    {
+      "blocked_by": [],
+      "description": "Vernon's worktree was missing while the daemon still showed them as active. Their Claude Code session was running but couldn't access files or run commands because ~/.midtown/coworkers/midtown/vernon/ didn't exist.\n\nInvestigation needed:\n1. Check daemon logs for any orphan cleanup that might have removed vernon's worktree incorrectly\n2. Check if there's a race condition between worktree creation and coworker startup\n3. Verify the orphan detection logic doesn't incorrectly flag active coworkers\n4. Add safeguards to prevent coworkers from running without valid worktrees\n\nRecent changes to watch:\n- PR #568 merged \"fix: Exclude tmux window orphans from worktree cleanup\"\n- The orphan cleanup logic in tmux.rs\n\nEvidence: Vernon was able to mark task #14 as completed but their bash commands (git, midtown) all failed with \"command not found\" or exit code 1.",
+      "id": "23",
+      "owner": "madison",
+      "status": "pending",
+      "subject": "Investigate and fix coworker worktree corruption (vernon incident)"
+    },
+    {
+      "blocked_by": [],
+      "description": "Madison's review of PR #581 identified that WebhookEvent has grown to 8 optional fields, requiring repetitive `field: None` in every constructor (5 places currently).\n\nRecommended fix:\n1. Derive Default for WebhookEvent\n2. Or use a builder pattern\n\nThis will reduce boilerplate and make adding new optional fields cleaner.\n\nSource: PR #581 review comment",
+      "id": "24",
+      "owner": "columbus",
+      "status": "in_progress",
+      "subject": "Refactor WebhookEvent to use Default or builder pattern"
+    },
+    {
+      "blocked_by": [],
+      "description": "The daemon is not assigning pending tasks to idle coworkers or spawning reviewers for green PRs.\n\nSymptoms:\n- 7 coworkers showing as idle\n- 4 pending tasks available\n- 7 green PRs without reviewer assignments\n- Daemon repeatedly restarts but doesn't dispatch work\n\nExpected behavior:\n- Idle coworkers should be assigned pending tasks\n- Green PRs should get reviewer coworkers spawned\n\nThis appears to be a bug in the task dispatch or reviewer spawning logic in rules.rs or effects.rs.",
+      "id": "25",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Fix daemon task dispatch - not assigning pending tasks to idle coworkers"
+    }
+  ],
+  "blank_pane_coworkers": [],
+  "busy_coworkers": [
+    "riverside",
+    "vernon",
+    "york",
+    "columbus"
+  ],
+  "ci_passed_pr_coworkers": [
+    "columbus"
+  ],
+  "coworker_snapshots": [
+    {
+      "isolated_tasks": false,
+      "name": "riverside",
+      "started_at": "2026-02-04T15:43:42.439736Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "columbus",
+      "started_at": "2026-02-04T15:44:48.919057Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "madison",
+      "started_at": "2026-02-04T15:40:13.601954Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "york",
+      "started_at": "2026-02-04T15:43:50.127855Z"
+    },
+    {
+      "isolated_tasks": true,
+      "name": "park",
+      "started_at": "2026-02-04T15:38:15.920686Z"
+    },
+    {
+      "isolated_tasks": true,
+      "name": "lexington",
+      "started_at": "2026-02-04T15:33:46.132557Z"
+    },
+    {
+      "isolated_tasks": true,
+      "name": "amsterdam",
+      "started_at": "2026-02-04T15:33:14.135039Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "vernon",
+      "started_at": "2026-02-04T15:43:46.277581Z"
+    }
+  ],
+  "coworker_start_times": {
+    "amsterdam": "2026-02-04T15:33:14.135039Z",
+    "columbus": "2026-02-04T15:44:48.919057Z",
+    "lexington": "2026-02-04T15:33:46.132557Z",
+    "madison": "2026-02-04T15:40:13.601954Z",
+    "park": "2026-02-04T15:38:15.920686Z",
+    "riverside": "2026-02-04T15:43:42.439736Z",
+    "vernon": "2026-02-04T15:43:46.277581Z",
+    "york": "2026-02-04T15:43:50.127855Z"
+  },
+  "coworker_stop_times": {
+    "amsterdam": "2026-02-04T15:32:41.419191Z",
+    "broadway": "2026-02-04T15:37:42.328657Z",
+    "columbus": "2026-02-04T15:44:45.298821Z",
+    "lexington": "2026-02-04T15:32:41.192974Z",
+    "madison": "2026-02-04T15:40:08.709940Z",
+    "park": "2026-02-04T15:37:42.102584Z",
+    "pleasant": "2026-02-04T15:40:08.484901Z",
+    "riverside": "2026-02-04T15:43:38.827236Z",
+    "vernon": "2026-02-04T15:43:42.666786Z",
+    "york": "2026-02-04T15:43:46.504447Z"
+  },
+  "coworkers_with_merged_prs": [
+    "park",
+    "amsterdam",
+    "pleasant",
+    "york",
+    "vernon",
+    "broadway",
+    "lexington",
+    "riverside"
+  ],
+  "coworkers_with_open_prs": [
+    "columbus"
+  ],
+  "coworkers_with_running_subagents": [],
+  "coworkers_with_unblocked_deps": [],
+  "in_progress_tasks": [
+    [
+      "18",
+      "E2E tests for daemon RPC handlers",
+      "york"
+    ],
+    [
+      "20",
+      "E2E tests for webhook handling",
+      "riverside"
+    ],
+    [
+      "21",
+      "E2E tests for web UI and WebSocket",
+      "vernon"
+    ],
+    [
+      "24",
+      "Refactor WebhookEvent to use Default or builder pattern",
+      "columbus"
+    ]
+  ],
+  "is_at_dev_limit": true,
+  "now_utc": "2026-02-04T15:46:19.916007Z",
+  "pane_contents": {
+    "amsterdam": "     … +17 lines (ctrl+o to expand)\n\n⏺ Bash(midtown state reviewing --task 0 && midtown channel post \"/me reviewing PR #589\")\n  ⎿  amsterdam → review\n     Message posted to channel\n\n⏺ Skill(code-review:code-review)\n  ⎿  Successfully loaded skill · 7 tools allowed\n\n⏺ I'll create a todo list and work through this code review systematically.\n✔ Task #1 created: Check PR #589 eligibility for review\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #2 created: Find relevant CLAUDE.md files\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #3 created: Get PR #589 summary\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #4 created: Run 5 parallel code review agents\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #5 created: Score and filter issues\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #6 created: Post review comment on PR #589\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #1 updated: owner, status → in progress\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #2 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #3 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #4 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #5 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #6 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ Now let me run the first three tasks in parallel - eligibility check, finding CLAUDE.md files, and getting the PR summary.\n\n⏺ 3 Task agents finished (ctrl+o to expand)\n   ├─ Check PR #589 eligibility · 1 tool use · 19.8k tokens\n   │  ⎿  Done\n   ├─ Find CLAUDE.md files · 2 tool uses · 19.9k tokens\n   │  ⎿  Done\n   └─ Get PR #589 summary · 4 tool uses · 21.2k tokens\n      ⎿  Done\n\n⏺ PR is eligible. Let me update task status and proceed with the 5 parallel code review agents.\n✔ Task #1 updated: status → completed\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #2 updated: status → completed\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #3 updated: status → completed\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #4 updated: status → in progress\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ Now launching 5 parallel Sonnet agents for the code review:\n\n⏺ 5 Task agents finished (ctrl+o to expand)\n   ├─ CLAUDE.md compliance check · 0 tool uses\n   │  ⎿  Done\n   ├─ Shallow bug scan · 0 tool uses\n   │  ⎿  Done\n   ├─ Git history context review · 0 tool uses\n   │  ⎿  Done\n   ├─ Previous PR comments review · 0 tool uses\n   │  ⎿  Done\n   └─ Code comments compliance · 0 tool uses\n      ⎿  Done\n  ⎿  You've hit your limit · resets 11am (America/Chicago)\n     /upgrade to increase your usage limit.\n\n✻ Sautéed for 1m 33s\n\n  Tasks (3 done, 1 in progress, 2 open) · ctrl+t to hide tasks\n  ◼ #4 Run 5 parallel code review agents (amsterdam)\n  ◻ #5 Score and filter issues (amsterdam)\n  ◻ #6 Post review comment on PR #589 (amsterdam)\n  ✔ #1 Check PR #589 eligibility for review (amsterdam)\n  ✔ #2 Find relevant CLAUDE.md files (amsterdam)\n  ✔ #3 Get PR #589 summary (amsterdam)\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n",
+    "columbus": "\n ▐▛███▜▌   Claude Code v2.1.19\n▝▜█████▛▘  Opus 4.5 · Claude Max\n  ▘▘ ▝▝    ~/.midtown/coworkers/midtown/columbus\n\n❯ You've been assigned task #24: Refactor WebhookEvent to use Default or builder pattern. Your previous session appeared stuck so you were restarted. Check your git status and continue where you left off.\n  ⎿  You've hit your limit · resets 10am (America/Chicago)\n     /upgrade to increase your usage limit.\n\n  Tasks (18 done, 4 in progress, 1 open) · ctrl+t to hide tasks\n  ◼ #18 E2E tests for daemon RPC handlers (york)\n  ◼ #20 E2E tests for webhook handling (riverside)\n  ◼ #21 E2E tests for web UI and WebSocket (vernon)\n  ◼ #24 Refactor WebhookEvent to use Default or builder pattern (columbus)\n  ◻ #23 Investigate and fix coworker worktree corruption (vernon incident) (madison)\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n   … +13 completed\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n",
+    "lexington": "\n ▐▛███▜▌   Claude Code v2.1.19\n▝▜█████▛▘  Opus 4.5 · Claude Max\n  ▘▘ ▝▝    ~/.midtown/coworkers/midtown/lexington\n\n❯ Review PR #588 using /code-review:code-review 588\n\n⏺ I'll read the channel first to catch up on team activity, then invoke the code-review skill.\n\n⏺ Bash(midtown channel read)\n  ⎿  [2026-02-04T15:33:24.645158+00:00] amsterdam: reviewing PR #589\n     [2026-02-04T15:33:27.200830+00:00] park: waiting for input\n     [2026-02-04T15:33:35.913732+00:00] riverside: 💡 The `webhook_fwd.rs` module manages the `gh webhook forward` process - a watchdog that:\n     … +27 lines (ctrl+o to expand)\n\n⏺ Bash(midtown channel post \"/me reviewing PR #588\")\n  ⎿  Message posted to channel\n\n⏺ Bash(midtown state reviewing --task 0)\n  ⎿  lexington → review\n\n⏺ Skill(code-review:code-review)\n  ⎿  Successfully loaded skill · 7 tools allowed\n\n⏺ I'll create a todo list and work through the code review systematically.\n✔ Task #1 created: Check PR #588 eligibility for review\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #1 updated: owner, status → in progress\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #2 created: Find relevant CLAUDE.md files\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #3 created: Get PR #588 summary\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #4 created: Run 5 parallel code review agents\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #5 created: Score and filter issues\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #6 created: Post review comment on PR #588\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #2 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #3 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #4 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #5 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #6 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ Now let me run the first three tasks in parallel - eligibility check, finding CLAUDE.md files, and getting PR summary:\n\n⏺ 3 Task agents finished (ctrl+o to expand)\n   ├─ Check PR #588 eligibility · 3 tool uses · 20.2k tokens\n   │  ⎿  Done\n   ├─ Find CLAUDE.md files · 2 tool uses · 19.8k tokens\n   │  ⎿  Done\n   └─ Get PR #588 summary · 2 tool uses · 19.7k tokens\n      ⎿  Done\n\n⏺ The eligibility check flagged this PR because it contains \"Generated with Claude Code\" in the description - but that's the standard PR footer, not an indication it shouldn't be reviewed. Let me verify this more carefully:\n\n⏺ Bash(gh pr view 588 --json state,isDraft,author,title,body,comments)\n  ⎿  {\n       \"author\": {\n         \"id\": \"MDQ6VXNlcjYxODE=\",\n     … +12 lines (ctrl+o to expand)\n  ⎿  You've hit your limit · resets 11am (America/Chicago)\n     /upgrade to increase your usage limit.\n\n✻ Worked for 1m 1s\n\n  Tasks (0 done, 1 in progress, 5 open) · ctrl+t to hide tasks\n  ◼ #1 Check PR #588 eligibility for review (lexington)\n  ◻ #2 Find relevant CLAUDE.md files (lexington)\n  ◻ #3 Get PR #588 summary (lexington)\n  ◻ #4 Run 5 parallel code review agents (lexington)\n  ◻ #5 Score and filter issues (lexington)\n  ◻ #6 Post review comment on PR #588 (lexington)\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n\n",
+    "madison": "\n ▐▛███▜▌   Claude Code v2.1.19\n▝▜█████▛▘  Opus 4.5 · Claude Max\n  ▘▘ ▝▝    ~/.midtown/coworkers/midtown/madison\n\n❯ You've been assigned task #23: Investigate and fix coworker worktree corruption (vernon incident). Get started!\n  ⎿  You've hit your limit · resets 10am (America/Chicago)\n     /upgrade to increase your usage limit.\n\n❯ You have pending task #23: Investigate and fix coworker worktree corruption (vernon incident). Get started!\n  ⎿  You've hit your limit · resets 10am (America/Chicago)\n     /upgrade to increase your usage limit.\n\n❯ You have pending task #23: Investigate and fix coworker worktree corruption (vernon incident). Get started!\n  ⎿  You've hit your limit · resets 10am (America/Chicago)\n     /upgrade to increase your usage limit.\n\n  Tasks (18 done, 4 in progress, 1 open) · ctrl+t to hide tasks\n  ◼ #18 E2E tests for daemon RPC handlers (york)\n  ◼ #20 E2E tests for webhook handling (riverside)\n  ◼ #21 E2E tests for web UI and WebSocket (vernon)\n  ◼ #24 Refactor WebhookEvent to use Default or builder pattern (columbus)\n  ◻ #23 Investigate and fix coworker worktree corruption (vernon incident) (madison)\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n   … +13 completed\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n",
+    "park": "\n ▐▛███▜▌   Claude Code v2.1.19\n▝▜█████▛▘  Opus 4.5 · Claude Max\n  ▘▘ ▝▝    ~/.midtown/coworkers/midtown/park\n\n❯ Review PR #587 using /code-review:code-review 587\n  ⎿  You've hit your limit · resets 10am (America/Chicago)\n     /upgrade to increase your usage limit.\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n",
+    "riverside": "\n ▐▛███▜▌   Claude Code v2.1.19\n▝▜█████▛▘  Opus 4.5 · Claude Max\n  ▘▘ ▝▝    ~/.midtown/coworkers/midtown/riverside\n\n❯ You've been assigned task #20: E2E tests for webhook handling. Your previous session appeared stuck so you were restarted. Check your git status and continue where you left off.\n  ⎿  You've hit your limit · resets 10am (America/Chicago)\n     /upgrade to increase your usage limit.\n\n  Tasks (18 done, 4 in progress, 1 open) · ctrl+t to hide tasks\n  ◼ #18 E2E tests for daemon RPC handlers (york)\n  ◼ #20 E2E tests for webhook handling (riverside)\n  ◼ #21 E2E tests for web UI and WebSocket (vernon)\n  ◼ #24 Refactor WebhookEvent to use Default or builder pattern (columbus)\n  ◻ #23 Investigate and fix coworker worktree corruption (vernon incident) (madison)\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n   … +13 completed\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n",
+    "vernon": "\n ▐▛███▜▌   Claude Code v2.1.19\n▝▜█████▛▘  Opus 4.5 · Claude Max\n  ▘▘ ▝▝    ~/.midtown/coworkers/midtown/vernon\n\n❯ You've been assigned task #21: E2E tests for web UI and WebSocket. Your previous session appeared stuck so you were restarted. Check your git status and continue where you left off.\n  ⎿  You've hit your limit · resets 10am (America/Chicago)\n     /upgrade to increase your usage limit.\n\n  Tasks (18 done, 4 in progress, 1 open) · ctrl+t to hide tasks\n  ◼ #18 E2E tests for daemon RPC handlers (york)\n  ◼ #20 E2E tests for webhook handling (riverside)\n  ◼ #21 E2E tests for web UI and WebSocket (vernon)\n  ◼ #24 Refactor WebhookEvent to use Default or builder pattern (columbus)\n  ◻ #23 Investigate and fix coworker worktree corruption (vernon incident) (madison)\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n   … +13 completed\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n",
+    "york": "\n ▐▛███▜▌   Claude Code v2.1.19\n▝▜█████▛▘  Opus 4.5 · Claude Max\n  ▘▘ ▝▝    ~/.midtown/coworkers/midtown/york\n\n❯ You've been assigned task #18: E2E tests for daemon RPC handlers. Your previous session appeared stuck so you were restarted. Check your git status and continue where you left off.\n  ⎿  You've hit your limit · resets 10am (America/Chicago)\n     /upgrade to increase your usage limit.\n\n  Tasks (18 done, 4 in progress, 1 open) · ctrl+t to hide tasks\n  ◼ #18 E2E tests for daemon RPC handlers (york)\n  ◼ #20 E2E tests for webhook handling (riverside)\n  ◼ #21 E2E tests for web UI and WebSocket (vernon)\n  ◼ #24 Refactor WebhookEvent to use Default or builder pattern (columbus)\n  ◻ #23 Investigate and fix coworker worktree corruption (vernon incident) (madison)\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n   … +13 completed\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"
+  },
+  "pending_tasks_with_owners": [
+    [
+      "23",
+      "Investigate and fix coworker worktree corruption (vernon incident)",
+      "madison"
+    ]
+  ],
+  "pending_tasks_without_owners": [],
+  "repo_name": "midtown",
+  "reviewed_prs": [],
+  "reviewer_pr_assignments": {
+    "amsterdam": 589,
+    "lexington": 588,
+    "park": 587
+  },
+  "running_coworkers": [
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "riverside",
+      "session_id": "69828d3c-97cc-4f58-bfb6-8529c258867a",
+      "started_at": "2026-02-04T15:43:42.439736Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/riverside"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "columbus",
+      "session_id": "10ad5b70-bfe7-49dc-a746-4f172ab759cc",
+      "started_at": "2026-02-04T15:44:48.919057Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/columbus"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "madison",
+      "session_id": "ed41e48e-9c26-4bca-a342-6f91e1e73322",
+      "started_at": "2026-02-04T15:40:13.601954Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/madison"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "york",
+      "session_id": "e3cada2f-0f70-4e50-9035-d51b0653d34b",
+      "started_at": "2026-02-04T15:43:50.127855Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/york"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": true,
+      "name": "park",
+      "session_id": "c2b52ecc-9c0f-4e13-9740-11a31a215f4f",
+      "started_at": "2026-02-04T15:38:15.920686Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/park"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": true,
+      "name": "lexington",
+      "session_id": "fa8ef3e1-fd15-41d8-9026-4b0c3d48285c",
+      "started_at": "2026-02-04T15:33:46.132557Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/lexington"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": true,
+      "name": "amsterdam",
+      "session_id": "f6becc58-c4ad-47a2-81ce-da7585ad5369",
+      "started_at": "2026-02-04T15:33:14.135039Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/amsterdam"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "vernon",
+      "session_id": "0ed547b0-4aa1-4a3f-a20c-a12e9692fe8b",
+      "started_at": "2026-02-04T15:43:46.277581Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/vernon"
+    }
+  ],
+  "session_name": "midtown-midtown",
+  "usage_limit_nudge_scheduled": true
+}

--- a/tests/fixtures/snapshot/snapshot-lead-nudge-not-working-20260204-145321.json
+++ b/tests/fixtures/snapshot/snapshot-lead-nudge-not-working-20260204-145321.json
@@ -1,0 +1,311 @@
+{
+  "active_coworkers": [
+    {
+      "current_task": null,
+      "isolated_tasks": true,
+      "name": "columbus",
+      "session_id": "6251f0de-9af2-4556-8d1a-6d052cbe7eea",
+      "started_at": "2026-02-04T14:49:55.969846Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/columbus"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "riverside",
+      "session_id": "",
+      "started_at": "2026-02-04T14:51:47.825186Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/riverside"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "broadway",
+      "session_id": "434baf55-b65f-4143-8dc3-a70ab34985fa",
+      "started_at": "2026-02-04T14:50:46.017550Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/broadway"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "york",
+      "session_id": "75c5978f-b037-42bb-83d8-c38ddcc72096",
+      "started_at": "2026-02-04T14:39:47.352648Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/york"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "amsterdam",
+      "session_id": "",
+      "started_at": "2026-02-04T14:51:51.438304Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/amsterdam"
+    }
+  ],
+  "active_names": [
+    "columbus",
+    "broadway",
+    "amsterdam",
+    "riverside",
+    "york"
+  ],
+  "active_reviewers": [
+    "columbus"
+  ],
+  "all_tasks": [
+    {
+      "blocked_by": [],
+      "description": "Bug: `is_auto_mergeable()` in src/daemon/helpers.rs only accepts formal GitHub APPROVED reviewDecision. It should also recognize positive review comments (e.g., \"No issues found\") as approval for auto-merge purposes.\n\nCurrent behavior (line 153):\n```rust\nif review_decision != \"APPROVED\" {\n    return false;\n}\n```\n\nExpected behavior:\n- Keep APPROVED as valid\n- Also check PR comments for positive review indicators from coworkers (look for midtown markers and \"No issues found\" or similar patterns)\n\nContext: We use comment-based reviews because the same GitHub account (btucker) authors PRs and runs coworkers, making formal self-approval impossible.",
+      "id": "3",
+      "owner": "park",
+      "status": "completed",
+      "subject": "Update auto-merge to recognize comment-based reviews"
+    },
+    {
+      "blocked_by": [],
+      "description": "Feature: The daemon should track typical CI check durations and handle stuck/missing checks intelligently.\n\n**Scenarios to handle:**\n\n1. **Stuck check** (pending > 4x typical duration): Re-run the specific check\n2. **Missing/new check** (required check not in PR's CI run): The PR predates the CI workflow change. Daemon should rebase the PR on main to pick up the new workflow, then CI will include the new check.\n\n**Implementation:**\n1. Track historical completion times per CI check name (e.g., \"E2E - idle_break_e2e\" typically takes 2m)\n2. Store rolling average or median of recent runs\n3. For stuck checks: If pending > 4x typical duration, trigger re-run\n4. For missing checks: If a required check never appears in the PR's status checks but exists in main's CI workflow, rebase the PR on main\n5. Add cooldowns to prevent spam\n\n**Key points:**\n- NOT overly aggressive - only at 4x typical time for stuck checks\n- Data-driven based on actual historical times\n- Detect \"new\" required checks that the PR doesn't have and auto-rebase\n\nUse case: PRs #566 and #570 were blocked by missing \"E2E - idle_break_e2e\" - they predated the workflow change. Daemon should have detected this and rebased automatically.",
+      "id": "4",
+      "owner": "broadway",
+      "status": "completed",
+      "subject": "Add daemon auto-retry for stale/missing CI checks"
+    },
+    {
+      "blocked_by": [],
+      "description": "Instead of the daemon parsing review comments to auto-merge, the author coworker should handle merge decisions themselves.\n\nWhen a PR receives a comment or review:\n1. If the author coworker is idle/shutdown, call them in\n2. Nudge the author coworker about the new comment/review\n3. Author reads the feedback and decides whether to merge, address feedback, or take other action\n\nThis is simpler than daemon comment parsing and keeps the merge decision with the agent who has full context of the PR.\n\nReplaces the approach in closed PR #571.\n\nPR #573 is ready - removes auto-merge, author-driven approach. Clean commit without state.json.",
+      "id": "5",
+      "owner": "park",
+      "status": "completed",
+      "subject": "Call-in and nudge PR authors on comments/reviews"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: Park had main checked out in their worktree. Coworkers should NEVER checkout the default branch (main/master).\n\nThis can cause issues:\n1. Multiple worktrees can't share the same branch\n2. Coworkers might accidentally commit directly to main\n3. Blocks other worktrees from using main\n\nFix needed:\n- Add validation when spawning coworkers to ensure they're on a feature branch\n- Add validation in coworker prompts/hooks to prevent `git checkout main`\n- If a coworker somehow ends up on main, detect and fix it (checkout a new feature branch)\n\nCheck how park ended up on main and prevent it from happening.",
+      "id": "6",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Prevent coworkers from checking out default branch"
+    },
+    {
+      "blocked_by": [
+        "8"
+      ],
+      "description": "The `midtown chat` TUI should check every 30 seconds whether it's at the end of the channel. If it got stuck further up (e.g., user scrolled up and forgot), it should auto-scroll back to the end.\n\nThis prevents the chat from appearing frozen/stuck when it's actually just scrolled up in history.",
+      "id": "7",
+      "owner": "vernon",
+      "status": "completed",
+      "subject": "Chat TUI should auto-scroll to end every 30 seconds"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The `midtown chat` TUI spontaneously scrolled to the beginning of the channel on its own. This should never happen.\n\nThis is a higher priority than the auto-scroll-to-end feature (task #7) - we need to fix this regression/bug first.\n\nInvestigate what's causing unexpected scroll position changes in the chat TUI. Could be:\n- A render loop resetting scroll state\n- File watcher event causing re-render from top\n- State management issue with scroll position\n- Race condition in the async event handling\n\nThe chat should maintain its scroll position unless the user explicitly scrolls or it auto-scrolls to follow new messages at the bottom.",
+      "id": "8",
+      "owner": "york",
+      "status": "completed",
+      "subject": "Fix chat TUI unexpectedly scrolling to beginning"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The daemon is warning \"Reviewer pleasant is idle but hasn't posted review for PR #572 yet\" but pleasant DID post a review comment (visible via `gh pr view 572 --json comments`).\n\nThe daemon's review detection is not recognizing that the review comment was posted. It should:\n1. Check PR comments for review signatures from the assigned reviewer\n2. Once a review comment is detected, stop warning about missing reviews\n3. Clear the reviewer assignment from the \"pending\" state\n\nThis might be related to how the daemon checks for reviews - it may be looking for formal GitHub reviews instead of comment-based reviews.",
+      "id": "9",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Fix daemon not detecting posted review comments"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The daemon incorrectly detects coworkers as \"stuck compacting\" when they're not.\n\n**Test cases captured:**\n1. `snapshot-false-positive-bugs-20260204-135417.json` - riverside false positive\n2. `snapshot-20260204-144326.json` - york detected as \"stuck compacting\" but actually had a backlog of nudges in its input box\n\n**Two types of nudge backlogs to distinguish:**\n1. **In the input box** - nudges stacked up IN the input box → needs Enter to process\n2. **Above the input box** - nudges stacked up ABOVE the input box (permission dialogs, etc.) → needs Escape to dismiss\n\n**Root cause:** The daemon may be misinterpreting these nudge backlog states as stuck compaction.\n\n**Fix needed:**\n- Detect and differentiate between:\n  - Actual stuck compaction\n  - Nudge backlog in input box (Enter needed)\n  - Nudge backlog above input box (Escape needed)\n- Don't treat nudge backlogs as stuck state\n- May need different remediation for each backlog type\n- Coordinate with task #11 (smart nudge timing) to prevent backlogs in the first place",
+      "id": "10",
+      "owner": "york",
+      "status": "in_progress",
+      "subject": "Fix false positive stuck compaction detection"
+    },
+    {
+      "blocked_by": [],
+      "description": "UX Bug: Nudges inject text via tmux send-keys while the user is trying to type, disrupting their input.\n\n**Two types of nudge backlogs to prevent:**\n1. **In the input box** - nudges stacking up IN the input box → needs Enter to clear\n2. **Above the input box** - nudges stacking up ABOVE the input box (permission dialogs, etc.) → needs Escape to dismiss\n\n**New nudge behavior:**\n\n1. Before nudging, check if the input box is empty\n2. If empty → safe to nudge immediately\n3. If not empty, check if the content is mostly from the daemon's last nudge\n   - If yes → safe to nudge (can overwrite stale nudge text)\n   - If no → user is typing something, DON'T nudge yet\n4. When user content detected:\n   - Wait 10 seconds, check again\n   - If input has changed → user still typing, wait another 10 seconds\n   - Repeat this process\n5. Only append onto unrecognized input content if it hasn't changed for 20 seconds\n\nAlso consider:\n- Detecting and handling existing backlog before adding more nudges\n- Different handling for \"above input\" backlog vs \"in input\" backlog\n\nThe daemon should track:\n- Last nudge content sent to each coworker/lead\n- Input box state before nudging\n- Timestamps of input changes\n\n**IMPORTANT: Create an E2E test for this using real Claude to verify the behavior works correctly in practice.**",
+      "id": "11",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Make nudges respect user input in progress"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: York received a nudge about PR #577 but that PR was authored by btucker, not york.\n\nThe daemon is sending PR-related nudges to the wrong coworkers. It should:\n1. Correctly identify the PR author (the coworker who created the PR)\n2. Only nudge that author about review feedback, CI status, etc.\n3. Not confuse GitHub username (btucker) with coworker names\n\nThis may be related to the author-driven merge changes (PR #573/task #5) - need to verify the author identification logic is correct.",
+      "id": "12",
+      "owner": "amsterdam",
+      "status": "completed",
+      "subject": "Fix misdirected PR nudges to wrong coworkers"
+    },
+    {
+      "blocked_by": [],
+      "description": "The GitHub CI check notifications in the channel are noisy when many checks complete around the same time:\n\n```\n08:47 Check 'Clippy' passed on main\n08:48 Check 'E2E - idle_break_e2e' passed on main\n08:48 Check 'Test' passed on main\n08:48 Check 'E2E - tailf_integration' passed on main\n08:48 Check 'E2E - spawn_race_test' passed on main\n```\n\n**Improvement:** Batch these into a single message when multiple checks complete within a short window (e.g., 30-60 seconds):\n\n```\n08:48 5 checks passed on main: Clippy, Test, E2E - idle_break_e2e, E2E - tailf_integration, E2E - spawn_race_test\n```\n\nOr even more condensed:\n```\n08:48 All CI checks passed on main\n```\n\n**Implementation ideas:**\n- Buffer CI check events for a short window before posting to channel\n- If multiple checks for the same ref/PR complete, batch them\n- Keep important events (PR opened, failures) as individual messages\n- Only batch \"passed\" checks, always show failures immediately\n\n**IMPORTANT:** This is purely a channel display change. The underlying webhook/event handling and PR author nudging logic should NOT be affected. The daemon should still process each CI event individually for nudge decisions - only the channel message posting gets batched.",
+      "id": "13",
+      "owner": "broadway",
+      "status": "in_progress",
+      "subject": "Batch repetitive GitHub CI notifications in channel"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The user isn't receiving nudges when system messages mention @lead (e.g., orphaned worktree warnings).\n\nThe channel shows multiple @lead mentions:\n- \"⚠️ @lead Orphaned worktrees with unmerged commits: madison...\"\n- \"⚠️ @lead Orphaned worktrees with unmerged commits: columbus...\"\n- \"⚠️ @lead Orphaned worktrees with unmerged commits: lexington...\"\n\nBut the user (running as Lead) didn't receive tmux nudges for these.\n\n**Investigate:**\n1. Is the lead nudge queue running?\n2. Are @lead mentions being detected in channel messages?\n3. Is the nudge delivery actually happening via tmux send-keys?\n4. Could this be related to the smart nudge changes (task #11) or other recent PRs?\n\nThis is a critical bug - the Lead needs to be notified of important system events.",
+      "id": "14",
+      "owner": null,
+      "status": "pending",
+      "subject": "Investigate broken lead nudges for @lead mentions"
+    }
+  ],
+  "blank_pane_coworkers": [],
+  "busy_coworkers": [
+    "broadway",
+    "york"
+  ],
+  "ci_passed_pr_coworkers": [
+    "riverside",
+    "amsterdam",
+    "york"
+  ],
+  "coworker_snapshots": [
+    {
+      "isolated_tasks": true,
+      "name": "columbus",
+      "started_at": "2026-02-04T14:49:55.969846Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "riverside",
+      "started_at": "2026-02-04T14:51:47.825186Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "broadway",
+      "started_at": "2026-02-04T14:50:46.017550Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "york",
+      "started_at": "2026-02-04T14:39:47.352648Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "amsterdam",
+      "started_at": "2026-02-04T14:51:51.438304Z"
+    }
+  ],
+  "coworker_start_times": {
+    "amsterdam": "2026-02-04T14:51:51.438304Z",
+    "broadway": "2026-02-04T14:50:46.017550Z",
+    "columbus": "2026-02-04T14:49:55.969846Z",
+    "riverside": "2026-02-04T14:51:47.825186Z",
+    "york": "2026-02-04T14:39:47.352648Z"
+  },
+  "coworker_stop_times": {
+    "amsterdam": "2026-02-04T14:47:13.347755Z",
+    "broadway": "2026-02-04T14:26:41.726172Z",
+    "columbus": "2026-02-04T14:36:13.303382Z",
+    "lexington": "2026-02-04T14:14:42.092338Z",
+    "madison": "2026-02-04T14:30:41.726892Z",
+    "park": "2026-02-04T14:37:41.742654Z",
+    "pleasant": "2026-02-04T14:20:47.035314Z",
+    "riverside": "2026-02-04T14:46:41.832351Z",
+    "vernon": "2026-02-04T14:20:47.260622Z",
+    "york": "2026-02-04T14:39:43.735640Z"
+  },
+  "coworkers_with_merged_prs": [
+    "lexington",
+    "riverside",
+    "vernon",
+    "park",
+    "amsterdam",
+    "york",
+    "madison",
+    "broadway"
+  ],
+  "coworkers_with_open_prs": [
+    "amsterdam",
+    "york",
+    "riverside"
+  ],
+  "coworkers_with_running_subagents": [
+    "columbus"
+  ],
+  "coworkers_with_unblocked_deps": [],
+  "in_progress_tasks": [
+    [
+      "10",
+      "Fix false positive stuck compaction detection",
+      "york"
+    ],
+    [
+      "13",
+      "Batch repetitive GitHub CI notifications in channel",
+      "broadway"
+    ]
+  ],
+  "is_at_dev_limit": false,
+  "now_utc": "2026-02-04T14:53:21.711557Z",
+  "pane_contents": {
+    "amsterdam": "⏺ Bash(gh pr close 570 --comment \"Closing as superseded by PR #579 which merged the same core fix (using coworker_from_branch() instead of split('/').next() in collect…)\n  ⎿  ✓ Closed pull request btucker/midtown#570 (fix: Validate coworker names from branch prefixes in GreenWithFeedback handler [Midtown #2])\n  ⎿  Running PostToolUse hook…\n\n⏺ Bash(midtown channel post \"closed PR #570 as superseded by PR #579 - both fixed the same coworker validation bug\")\n  ⎿  Message posted to channel\n  ⎿  Running PostToolUse hook…\n\n⏺ Done. Closed PR #570 as superseded - it was an earlier version of the same fix that PR #579 already merged.\n\n  ★ Insight ─────────────────────────────────────\n  Duplicate PR Detection: When fixing bugs, check if similar PRs already exist. PR #570 and #579 both fixed the same coworker_from_branch validation issue. This can happen when:\n  - A coworker restarts and doesn't see their previous work\n  - Multiple coworkers tackle the same issue independently\n  - Branch management gets out of sync\n\n  The resolution: close the older/superseded PR with a note linking to the merged one.\n  ─────────────────────────────────────────────────\n\n❯ Your PR #566 (feat: Add health check and workflow E...) has a completed review — please address any feedback and merge if appropriate.\n\n⏺ Let me check PR #566 and its review feedback.\n\n⏺ Bash(gh pr view 566 --json title,author,headRefName,state,mergeable,reviewDecision 2>&1)\n  ⎿  {\n       \"author\": {\n         \"id\": \"MDQ6VXNlcjYxODE=\",\n     … +10 lines (ctrl+o to expand)\n\n⏺ Bash(gh pr view 566 --comments 2>&1 | tail -50)\n  ⎿  author:    btucker\n     association:       owner\n     edited:    false\n     … +17 lines (ctrl+o to expand)\n\n⏺ Lexington's review says \"No issues found\". Let me check CI status and merge.\n\n⏺ Bash(gh pr checks 566 2>&1 | head -20)\n  ⎿  Clippy     pass    26s     https://github.com/btucker/midtown/actions/runs/21672834254/job/62484927697\n     E2E - chat_e2e     pass    2m46s   https://github.com/btucker/midtown/actions/runs/21672834254/job/62484927773\n     E2E - daemon_e2e   pass    3m3s    https://github.com/btucker/midtown/actions/runs/21672834254/job/62484927734\n     … +12 lines (ctrl+o to expand)\n\n⏺ All CI green including the new health_e2e and workflow_e2e tests. Let me merge.\n\n⏺ Bash(gh pr merge 566 --squash 2>&1)\n  ⎿  Error: Exit code 1\n     X Pull request btucker/midtown#566 is not mergeable: the base branch policy prohibits the merge.\n     To have the pull request merged after all the requirements have been met, add the `--auto` flag.\n     To use administrator privileges to immediately merge the pull request, add the `--admin` flag.\n\n⏺ Bash(gh pr merge 566 --squash --auto 2>&1)\n  ⎿  (No content)\n\n⏺ Bash(midtown channel post \"enabled auto-merge on PR #566 (health_e2e and workflow_e2e tests) - clean review from lexington, all CI green\")\n  ⎿  Message posted to channel\n\n⏺ Auto-merge enabled for PR #566. It will merge automatically when branch protection requirements are met.\n\n  ★ Insight ─────────────────────────────────────\n  Branch Protection Policies: GitHub branch protection can prevent direct merges even with passing CI and reviews. The --auto flag enables auto-merge, which:\n  - Queues the PR to merge once all requirements are satisfied\n  - Works with required status checks and review approvals\n  - Useful when formal GitHub reviews (not just comment-based) are required by policy\n  ─────────────────────────────────────────────────\n\n✻ Cooked for 48s\n\n  Tasks (9 done, 2 in progress, 1 open) · ctrl+t to hide tasks\n  ◼ #10 Fix false positive stuck compaction detection (york)\n  ◼ #13 Batch repetitive GitHub CI notifications in channel (broadway)\n  ◻ #14 Investigate broken lead nudges for @lead mentions\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n  ✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n  ✔ #9 Fix daemon not detecting posted review comments (riverside)\n   … +2 completed\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle) · 1 file +0 -1\n\n",
+    "broadway": "\n⏺ Read(src/webhook.rs)\n  ⎿  Read 25 lines\n\n⏺ Now let me update the check_run handler to populate ci_check_passed:\n\n⏺ Update(src/webhook.rs)\n  ⎿  Added 21 lines\n      943          None\n      944      };\n      945\n      946 +    // Produce a batchable CI success for the daemon to aggregate\n      947 +    let ci_check_passed = if event.check_run.conclusion.as_deref() == Some(\"success\") {\n      948 +        // Extract target from pr_info: \"main\", \"PR #42\", etc.\n      949 +        let target = event\n      950 +            .check_run\n      951 +            .check_suite\n      952 +            .as_ref()\n      953 +            .and_then(|cs| cs.pull_requests.first())\n      954 +            .map(|pr| format!(\"PR #{}\", pr.number))\n      955 +            .or_else(|| branch.map(|b| b.to_string()));\n      956 +\n      957 +        target.map(|t| CiCheckPassed {\n      958 +            check_name: event.check_run.name.clone(),\n      959 +            target: t,\n      960 +            mention_prefix: mention.clone(),\n      961 +        })\n      962 +    } else {\n      963 +        None\n      964 +    };\n      965 +\n      966      let content = format!(\"{}{}\", mention, action_text);\n      967      Ok(Some(WebhookEvent {\n      968          message: Message::new(\"github\", content, MessageType::Text),\n     ...\n      973          reviewed_pr: None,\n      974          review_state_change: None,\n      975          pr_ci_failure,\n      976 +        ci_check_passed,\n      977      }))\n      978  }\n      979\n\n❯ Your task #4 (Add daemon auto-retry for stale/missing CI checks) was updated by columbus — check the latest changes\n\n⏺ I need to update all other places where WebhookEvent is constructed. Let me find them:\n\n⏺ Search(pattern: \"Ok\\(Some\\(WebhookEvent\", path: \"src/webhook.rs\", output_mode: \"content\")\n  ⎿  Found 6 lines (ctrl+o to expand)\n\n⏺ Let me update each WebhookEvent construction to include the new field:\n\n⏺ Read(src/webhook.rs)\n  ⎿  Read 30 lines\n\n⏺ Update(src/webhook.rs)\n  ⎿  Added 1 line\n      648          reviewed_pr: None,\n      649          review_state_change: None,\n      650          pr_ci_failure: None,\n      651 +        ci_check_passed: None,\n      652      }))\n      653  }\n      654\n\n⏺ Read(src/webhook.rs)\n  ⎿  Read 30 lines\n\n✢ Fixing false positive compaction detection… (Esc to interrupt · ctrl+t to hide tasks · 2m 36s · ↑ 9.2k tokens · thinking)\n  ⎿  ◼ #10 Fix false positive stuck compaction detection (york)\n     ◼ #13 Batch repetitive GitHub CI notifications in channel (broadway)\n     ◻ #14 Investigate broken lead nudges for @lead mentions\n     ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n     ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n     ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n     ✔ #6 Prevent coworkers from checking out default branch (riverside)\n     ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n     ✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n     ✔ #9 Fix daemon not detecting posted review comments (riverside)\n      … +2 completed\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle) · 2 files +39 -1\n\n",
+    "columbus": "✔ Task #2 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #3 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #4 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #5 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #6 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ Now let me start with the eligibility check:\n\n⏺ Task(Check PR #580 eligibility) Haiku 4.5\n  ⎿  Done (1 tool use · 20.2k tokens · 5s)\n\n⏺ PR is eligible. Let me now run the CLAUDE.md finder and PR summary agents in parallel:\n✔ Task #1 updated: status → completed\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #2 updated: status → in progress\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #3 updated: status → in progress\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ 2 Task agents finished (ctrl+o to expand)\n   ├─ Find CLAUDE.md files for PR · 3 tool uses · 19.9k tokens\n   │  ⎿  Done\n   └─ Get PR #580 summary · 2 tool uses · 19.7k tokens\n      ⎿  Done\n\n⏺ Now I have the context. Let me update tasks and launch the 5 parallel review agents:\n✔ Task #2 updated: status → completed\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #3 updated: status → completed\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #4 updated: status → in progress\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ 5 Task agents finished (ctrl+o to expand)\n   ├─ Review CLAUDE.md compliance · 2 tool uses · 19.8k tokens\n   │  ⎿  Done\n   ├─ Review for obvious bugs · 3 tool uses · 24.6k tokens\n   │  ⎿  Done\n   ├─ Review with git history context · 16 tool uses · 41.7k tokens\n   │  ⎿  Done\n   ├─ Review previous PR comments · 16 tool uses · 34.8k tokens\n   │  ⎿  Done\n   └─ Review code comments compliance · 18 tool uses · 36.3k tokens\n      ⎿  Done\n\n⏺ Excellent! I've gathered findings from all 5 agents. Let me summarize the issues and score them:\n✔ Task #4 updated: status → completed\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #5 updated: status → in progress\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ ★ Insight ─────────────────────────────────────\n  The 5-agent parallel review approach provides complementary perspectives: CLAUDE.md compliance, bug scanning, git history, previous PR patterns, and code comment adherence. This parallelism catches issues that a single reviewer might miss\n  - particularly the git history agent catching the has_compaction_indicator() impact on other callers.\n  ─────────────────────────────────────────────────\n\n  Now let me score each issue with Haiku agents in parallel:\n\n⏺ Running 4 Task agents… (ctrl+o to expand)\n   ├─ Score: Sautéed false positive · 0 tool uses\n   │  ⎿  Initializing…\n   ├─ Score: queued nudge detection · 0 tool uses\n   │  ⎿  Initializing…\n   ├─ Score: TDD workflow issue · 0 tool uses\n   │  ⎿  Initializing…\n   └─ Score: function doc inconsistency · 0 tool uses\n      ⎿  Initializing…\n\n✶ Scoring issues… (Esc to interrupt · ctrl+t to hide tasks · 3m 26s · ↓ 10.7k tokens · thinking)\n  ⎿  ✔ #4 Run 5 parallel code review agents (columbus)\n     ◼ #5 Score and filter issues (columbus)\n     ◻ #6 Post review comment on PR #580 (columbus)\n     ✔ #1 Check PR #580 eligibility for code review (columbus)\n     ✔ #2 Find relevant CLAUDE.md files for PR #580 (columbus)\n     ✔ #3 Get PR #580 summary (columbus)\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n",
+    "riverside": "  ⎿  author:    btucker\n     association:       owner\n     edited:    false\n     … +52 lines (ctrl+o to expand)\n\n⏺ I see the review feedback was about code from PR #574 (which I said I'd rebase once that merged). Let me check if PR #574 has merged.\n\n⏺ Bash(gh pr view 574 --json state,merged 2>/dev/null || echo \"PR not found - likely merged and branch deleted\")\n  ⎿  PR not found - likely merged and branch deleted\n\n⏺ PR #574 was merged. Now I need to rebase PR #576 on main. Let me check what branch PR #576 is on and rebase it.\n\n⏺ Bash(gh pr view 576 --json headRefName -q .headRefName)\n  ⎿  riverside/fix-review-comment-detection\n\n⏺ Bash(git fetch origin && git checkout riverside/fix-review-comment-detection 2>&1 || git checkout -B riverside/fix-review-comment-detection origin/riverside/fix-revi…)\n  ⎿  Error: Exit code 128\n     fatal: 'riverside/fix-review-comment-detection' is already used by worktree at '/Users/btucker/.midtown/coworkers/midtown/columbus'\n\n     fatal: 'riverside/fix-review-comment-detection' is already used by worktree at '/Users/btucker/.midtown/coworkers/midtown/columbus'\n\n⏺ The branch is checked out in columbus's worktree. Let me check the current state - task #9 is marked as completed, so maybe the work is already done.\n\n⏺ Bash(midtown channel read)\n  ⎿  [2026-02-04T14:50:47.612572+00:00] columbus: started task 2\n     [2026-02-04T14:50:47.612583+00:00] columbus: started task 3\n     [2026-02-04T14:50:47.612605+00:00] columbus: completed task 1\n     … +30 lines (ctrl+o to expand)\n\n⏺ Let me check if the changes from PR #576 are already in main (since task #9 is completed).\n\n⏺ Bash(git fetch origin main && git log origin/main --oneline -20 | grep -i \"review\\|comment\\|case\")\n  ⎿  5e37332 fix: Clear reviewer assignments when coworker sessions end unexpectedly [Midtown #1] (#569)\n     1a5394e feat: Add polling nudge for PRs with green CI and review feedback [Midtown #6] (#555)\n     From github.com:btucker/midtown\n      * branch            main       -> FETCH_HEAD\n\n⏺ Bash(gh pr diff 576)\n  ⎿  diff --git a/src/coworker.rs b/src/coworker.rs\n     index 4824b174..1dad0cba 100644\n     --- a/src/coworker.rs\n     … +318 lines (ctrl+o to expand)\n\n⏺ I see. This PR includes both task #9 (review detection) AND task #6 (prevent default branch) code. Let me check what's already in main.\n\n⏺ Bash(git show origin/main:src/daemon/helpers.rs | grep -A20 \"text_has_code_review_header\\|Code Review by\" | head -30)\n  ⎿  /// - The \"## Code Review by\" header (comment-based reviews)\n     pub fn text_contains_review_signature(text: &str) -> bool {\n         text.contains(\"🤖 Reviewed by\")\n     … +27 lines (ctrl+o to expand)\n\n⏺ Bash(git show origin/main:src/worktree.rs | grep -A5 \"is_on_default_branch\\|checkout_new_branch\" | head -20)\n  ⎿  (No content)\n\n⏺ Let me check my commit history and whether PR #574 was actually merged.\n\n⏺ Bash(gh pr list --author btucker --state merged --limit 20 | grep -i \"prevent\\|default\\|574\")\n  ⎿  577        fix: Prevent chat TUI from unexpectedly scrolling to beginning [Midtown #8]     york/fix-chat-scroll-bug        MERGED  2026-02-04T14:00:22Z\n     561        fix: Add safety check to prevent killing last tmux window       lead/prevent-last-window-kill   MERGED  2026-02-04T04:31:24Z\n\n⏺ Bash(gh pr list --author btucker --state all --limit 50 | grep \"574\\|prevent.*default\\|default.*branch\")\n  ⎿  574        fix: Prevent coworkers from checking out default branch [Midtown #6]    riverside/prevent-default-branch-checkout       OPEN    2026-02-04T13:52:28Z\n\n⏺ PR #574 is still open. Let me check its status and merge it first since it's marked as completed.\n\n⏺ Bash(gh pr view 574 --json state,mergeStateStatus,reviewDecision,statusCheckRollup --jq '{state,mergeStateStatus,reviewDecision,checks: [.statusCheckRollup[] | {name…)\n  ⎿  Running…\n\n· Fixing false positive compaction detection… (Esc to interrupt · ctrl+t to hide tasks · 1m 34s · ↓ 3.8k tokens · thought for 2s)\n  ⎿  ◼ #10 Fix false positive stuck compaction detection (york)\n     ◼ #13 Batch repetitive GitHub CI notifications in channel (broadway)\n     ◻ #14 Investigate broken lead nudges for @lead mentions\n     ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n     ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n     ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n     ✔ #6 Prevent coworkers from checking out default branch (riverside)\n     ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n     ✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n     ✔ #9 Fix daemon not detecting posted review comments (riverside)\n      … +2 completed\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n",
+    "york": "  ⎿  Error: Exit code 1\n     From github.com:btucker/midtown\n      * branch            main       -> FETCH_HEAD\n        7685330..17da427  main       -> origin/main\n\n     error: cannot rebase: You have unstaged changes.\n     error: Please commit or stash them.\n\n⏺ Bash(git stash && git rebase origin/main && git stash pop 2>&1)\n  ⎿  Saved working directory and index state WIP on york/fix-false-positive-stuck-compaction: 5e37332 fix: Clear reviewer assignments when coworker sessions end unexpectedly [Midtown #1] (#569)\n     On branch york/fix-false-positive-stuck-compaction\n     Changes not staged for commit:\n     … +8 lines (ctrl+o to expand)\n\n⏺ Bash(git add src/rules.rs && git commit -m \"fix: Prevent false positive stuck compaction from verbs in displayed code…)\n  ⎿  [york/fix-false-positive-stuck-compaction 8f80d94] fix: Prevent false positive stuck compaction from verbs in displayed code\n      1 file changed, 90 insertions(+), 32 deletions(-)\n     +cargo clippy -- -D warnings\n     … +3 lines (ctrl+o to expand)\n\n⏺ Bash(midtown state pull-request --task 10)\n  ⎿  york → PR#10\n\n⏺ Bash(git push -u origin york/fix-false-positive-stuck-compaction 2>&1)\n  ⎿  remote:\n     remote: Create a pull request for 'york/fix-false-positive-stuck-compaction' on GitHub by visiting:\n     remote:      https://github.com/btucker/midtown/pull/new/york/fix-false-positive-stuck-compaction\n     … +4 lines (ctrl+o to expand)\n\n⏺ Bash(gh pr create --title \"fix: Prevent false positive stuck compaction from verbs in displayed code [Midtown #10]\" --body \"<!-- midtown: york -->…)\n  ⎿  https://github.com/btucker/midtown/pull/580\n     Warning: 1 uncommitted change\n\n⏺ Bash(midtown channel post \"/me opened PR #580 for task 10 - the methodical fix for false positive compaction detection awaits review\")\n  ⎿  Message posted to channel\n\n⏺ ★ Insight ─────────────────────────────────────\n  The fix addresses verb contamination (compaction verbs in displayed code). The task also mentions nudge backlog misinterpretation as a separate issue - when queued nudges in the input box are mistaken for stuck state. This may need\n  additional investigation to see if it's still occurring.\n  ─────────────────────────────────────────────────\n\n  Let me check if the nudge backlog issue is still present or if the task description reflects older findings.\n\n⏺ Search(pattern: \"queued.*nudge|nudge.*backlog|input.*box\", path: \"src/rules.rs\", output_mode: \"content\")\n  ⎿  Found 59 lines (ctrl+o to expand)\n\n⏺ Search(pattern: \"decide_stuck_ui_recoveries\", path: \"src/rules.rs\", output_mode: \"content\")\n  ⎿  Found 330 lines (ctrl+o to expand)\n\n⏺ ★ Insight ─────────────────────────────────────\n  The stuck detection has two independent paths:\n  - detect_compaction_stuck() - checks for long-running compaction\n  - detect_queued_prompt_stuck() - checks for queued nudges in input box\n\n  My fix prevents cross-contamination in compaction detection. If a nudge backlog was being reported as \"stuck compaction\", it was likely because a compaction verb in displayed code was being combined with an unrelated duration line. With\n  verb+duration required on the same line, this false positive should be eliminated.\n  ─────────────────────────────────────────────────\n\n⏺ Bash(midtown state idle)\n  ⎿  york → idle\n\n⏺ Bash(midtown channel post \"/me the manuscript is submitted, awaiting the editor's review\")\n  ⎿  Message posted to channel\n\n⏺ PR #580 is open for review at https://github.com/btucker/midtown/pull/580. The fix requires compaction verb AND duration on the same line, preventing false positives from verbs appearing in displayed code. All 627 tests pass.\n\n✻ Cooked for 3m 5s\n\n  Tasks (9 done, 2 in progress, 1 open) · ctrl+t to hide tasks\n  ◼ #10 Fix false positive stuck compaction detection (york)\n  ◼ #13 Batch repetitive GitHub CI notifications in channel (broadway)\n  ◻ #14 Investigate broken lead nudges for @lead mentions\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n  ✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n  ✔ #9 Fix daemon not detecting posted review comments (riverside)\n   … +2 completed\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle) · 1 file +1 -1\n\n"
+  },
+  "pending_tasks_with_owners": [],
+  "pending_tasks_without_owners": [],
+  "repo_name": "midtown",
+  "reviewed_prs": [],
+  "reviewer_pr_assignments": {
+    "columbus": 580
+  },
+  "running_coworkers": [
+    {
+      "current_task": null,
+      "isolated_tasks": true,
+      "name": "columbus",
+      "session_id": "6251f0de-9af2-4556-8d1a-6d052cbe7eea",
+      "started_at": "2026-02-04T14:49:55.969846Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/columbus"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "riverside",
+      "session_id": "",
+      "started_at": "2026-02-04T14:51:47.825186Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/riverside"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "broadway",
+      "session_id": "434baf55-b65f-4143-8dc3-a70ab34985fa",
+      "started_at": "2026-02-04T14:50:46.017550Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/broadway"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "york",
+      "session_id": "75c5978f-b037-42bb-83d8-c38ddcc72096",
+      "started_at": "2026-02-04T14:39:47.352648Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/york"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "amsterdam",
+      "session_id": "",
+      "started_at": "2026-02-04T14:51:51.438304Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/amsterdam"
+    }
+  ],
+  "session_name": "midtown-midtown",
+  "usage_limit_nudge_scheduled": false
+}

--- a/tests/fixtures/snapshot/snapshot-stuck-compaction-false-positive-20260204-174139.json
+++ b/tests/fixtures/snapshot/snapshot-stuck-compaction-false-positive-20260204-174139.json
@@ -1,0 +1,607 @@
+{
+  "active_coworkers": [
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "columbus",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628703Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/columbus"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "vernon",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628751Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/vernon"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "madison",
+      "session_id": "f1ed0f8d-c1e9-4012-bbc5-d049d70ec211",
+      "started_at": "2026-02-04T17:40:05.809565Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/madison"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "lexington",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628761Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/lexington"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "park",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628745Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/park"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "amsterdam",
+      "session_id": "cf4a7d88-81ae-4140-a880-8d54f7f7e5b4",
+      "started_at": "2026-02-04T17:40:02.098393Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/amsterdam"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "york",
+      "session_id": "67735b8b-5b01-46a4-b6af-c41ea74c3145",
+      "started_at": "2026-02-04T17:35:03.398441Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/york"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "riverside",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628764Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/riverside"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": true,
+      "name": "pleasant",
+      "session_id": "27078008-2c7c-43f0-853e-21a396eb4a37",
+      "started_at": "2026-02-04T17:37:06.041097Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/pleasant"
+    }
+  ],
+  "active_names": [
+    "park",
+    "pleasant",
+    "lexington",
+    "vernon",
+    "columbus",
+    "madison",
+    "amsterdam",
+    "york",
+    "riverside"
+  ],
+  "active_reviewers": [
+    "lexington",
+    "pleasant"
+  ],
+  "all_tasks": [
+    {
+      "blocked_by": [],
+      "description": "Bug: `is_auto_mergeable()` in src/daemon/helpers.rs only accepts formal GitHub APPROVED reviewDecision. It should also recognize positive review comments (e.g., \"No issues found\") as approval for auto-merge purposes.\n\nCurrent behavior (line 153):\n```rust\nif review_decision != \"APPROVED\" {\n    return false;\n}\n```\n\nExpected behavior:\n- Keep APPROVED as valid\n- Also check PR comments for positive review indicators from coworkers (look for midtown markers and \"No issues found\" or similar patterns)\n\nContext: We use comment-based reviews because the same GitHub account (btucker) authors PRs and runs coworkers, making formal self-approval impossible.",
+      "id": "3",
+      "owner": "park",
+      "status": "completed",
+      "subject": "Update auto-merge to recognize comment-based reviews"
+    },
+    {
+      "blocked_by": [],
+      "description": "Feature: The daemon should track typical CI check durations and handle stuck/missing checks intelligently.\n\n**Scenarios to handle:**\n\n1. **Stuck check** (pending > 4x typical duration): Re-run the specific check\n2. **Missing/new check** (required check not in PR's CI run): The PR predates the CI workflow change. Daemon should rebase the PR on main to pick up the new workflow, then CI will include the new check.\n\n**Implementation:**\n1. Track historical completion times per CI check name (e.g., \"E2E - idle_break_e2e\" typically takes 2m)\n2. Store rolling average or median of recent runs\n3. For stuck checks: If pending > 4x typical duration, trigger re-run\n4. For missing checks: If a required check never appears in the PR's status checks but exists in main's CI workflow, rebase the PR on main\n5. Add cooldowns to prevent spam\n\n**Key points:**\n- NOT overly aggressive - only at 4x typical time for stuck checks\n- Data-driven based on actual historical times\n- Detect \"new\" required checks that the PR doesn't have and auto-rebase\n\nUse case: PRs #566 and #570 were blocked by missing \"E2E - idle_break_e2e\" - they predated the workflow change. Daemon should have detected this and rebased automatically.",
+      "id": "4",
+      "owner": "broadway",
+      "status": "completed",
+      "subject": "Add daemon auto-retry for stale/missing CI checks"
+    },
+    {
+      "blocked_by": [],
+      "description": "Instead of the daemon parsing review comments to auto-merge, the author coworker should handle merge decisions themselves.\n\nWhen a PR receives a comment or review:\n1. If the author coworker is idle/shutdown, call them in\n2. Nudge the author coworker about the new comment/review\n3. Author reads the feedback and decides whether to merge, address feedback, or take other action\n\nThis is simpler than daemon comment parsing and keeps the merge decision with the agent who has full context of the PR.\n\nReplaces the approach in closed PR #571.\n\nPR #573 is ready - removes auto-merge, author-driven approach. Clean commit without state.json.",
+      "id": "5",
+      "owner": "park",
+      "status": "completed",
+      "subject": "Call-in and nudge PR authors on comments/reviews"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: Park had main checked out in their worktree. Coworkers should NEVER checkout the default branch (main/master).\n\nThis can cause issues:\n1. Multiple worktrees can't share the same branch\n2. Coworkers might accidentally commit directly to main\n3. Blocks other worktrees from using main\n\nFix needed:\n- Add validation when spawning coworkers to ensure they're on a feature branch\n- Add validation in coworker prompts/hooks to prevent `git checkout main`\n- If a coworker somehow ends up on main, detect and fix it (checkout a new feature branch)\n\nCheck how park ended up on main and prevent it from happening.",
+      "id": "6",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Prevent coworkers from checking out default branch"
+    },
+    {
+      "blocked_by": [
+        "8"
+      ],
+      "description": "The `midtown chat` TUI should check every 30 seconds whether it's at the end of the channel. If it got stuck further up (e.g., user scrolled up and forgot), it should auto-scroll back to the end.\n\nThis prevents the chat from appearing frozen/stuck when it's actually just scrolled up in history.",
+      "id": "7",
+      "owner": "vernon",
+      "status": "completed",
+      "subject": "Chat TUI should auto-scroll to end every 30 seconds"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The `midtown chat` TUI spontaneously scrolled to the beginning of the channel on its own. This should never happen.\n\nThis is a higher priority than the auto-scroll-to-end feature (task #7) - we need to fix this regression/bug first.\n\nInvestigate what's causing unexpected scroll position changes in the chat TUI. Could be:\n- A render loop resetting scroll state\n- File watcher event causing re-render from top\n- State management issue with scroll position\n- Race condition in the async event handling\n\nThe chat should maintain its scroll position unless the user explicitly scrolls or it auto-scrolls to follow new messages at the bottom.",
+      "id": "8",
+      "owner": "york",
+      "status": "completed",
+      "subject": "Fix chat TUI unexpectedly scrolling to beginning"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The daemon is warning \"Reviewer pleasant is idle but hasn't posted review for PR #572 yet\" but pleasant DID post a review comment (visible via `gh pr view 572 --json comments`).\n\nThe daemon's review detection is not recognizing that the review comment was posted. It should:\n1. Check PR comments for review signatures from the assigned reviewer\n2. Once a review comment is detected, stop warning about missing reviews\n3. Clear the reviewer assignment from the \"pending\" state\n\nThis might be related to how the daemon checks for reviews - it may be looking for formal GitHub reviews instead of comment-based reviews.",
+      "id": "9",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Fix daemon not detecting posted review comments"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: The daemon incorrectly detects coworkers as \"stuck compacting\" when they're not.\n\n**Test cases captured:**\n1. `snapshot-false-positive-bugs-20260204-135417.json` - riverside false positive\n2. `snapshot-20260204-144326.json` - york detected as \"stuck compacting\" but actually had a backlog of nudges in its input box\n\n**Two types of nudge backlogs to distinguish:**\n1. **In the input box** - nudges stacked up IN the input box → needs Enter to process\n2. **Above the input box** - nudges stacked up ABOVE the input box (permission dialogs, etc.) → needs Escape to dismiss\n\n**Root cause:** The daemon may be misinterpreting these nudge backlog states as stuck compaction.\n\n**Fix needed:**\n- Detect and differentiate between:\n  - Actual stuck compaction\n  - Nudge backlog in input box (Enter needed)\n  - Nudge backlog above input box (Escape needed)\n- Don't treat nudge backlogs as stuck state\n- May need different remediation for each backlog type\n- Coordinate with task #11 (smart nudge timing) to prevent backlogs in the first place",
+      "id": "10",
+      "owner": "york",
+      "status": "completed",
+      "subject": "Fix false positive stuck compaction detection"
+    },
+    {
+      "blocked_by": [],
+      "description": "UX Bug: Nudges inject text via tmux send-keys while the user is trying to type, disrupting their input.\n\n**Two types of nudge backlogs to prevent:**\n1. **In the input box** - nudges stacking up IN the input box → needs Enter to clear\n2. **Above the input box** - nudges stacking up ABOVE the input box (permission dialogs, etc.) → needs Escape to dismiss\n\n**New nudge behavior:**\n\n1. Before nudging, check if the input box is empty\n2. If empty → safe to nudge immediately\n3. If not empty, check if the content is mostly from the daemon's last nudge\n   - If yes → safe to nudge (can overwrite stale nudge text)\n   - If no → user is typing something, DON'T nudge yet\n4. When user content detected:\n   - Wait 10 seconds, check again\n   - If input has changed → user still typing, wait another 10 seconds\n   - Repeat this process\n5. Only append onto unrecognized input content if it hasn't changed for 20 seconds\n\nAlso consider:\n- Detecting and handling existing backlog before adding more nudges\n- Different handling for \"above input\" backlog vs \"in input\" backlog\n\nThe daemon should track:\n- Last nudge content sent to each coworker/lead\n- Input box state before nudging\n- Timestamps of input changes\n\n**IMPORTANT: Create an E2E test for this using real Claude to verify the behavior works correctly in practice.**",
+      "id": "11",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Make nudges respect user input in progress"
+    },
+    {
+      "blocked_by": [],
+      "description": "Bug: York received a nudge about PR #577 but that PR was authored by btucker, not york.\n\nThe daemon is sending PR-related nudges to the wrong coworkers. It should:\n1. Correctly identify the PR author (the coworker who created the PR)\n2. Only nudge that author about review feedback, CI status, etc.\n3. Not confuse GitHub username (btucker) with coworker names\n\nThis may be related to the author-driven merge changes (PR #573/task #5) - need to verify the author identification logic is correct.",
+      "id": "12",
+      "owner": "amsterdam",
+      "status": "completed",
+      "subject": "Fix misdirected PR nudges to wrong coworkers"
+    },
+    {
+      "blocked_by": [],
+      "description": "The GitHub CI check notifications in the channel are noisy when many checks complete around the same time:\n\n```\n08:47 Check 'Clippy' passed on main\n08:48 Check 'E2E - idle_break_e2e' passed on main\n08:48 Check 'Test' passed on main\n08:48 Check 'E2E - tailf_integration' passed on main\n08:48 Check 'E2E - spawn_race_test' passed on main\n```\n\n**Improvement:** Batch these into a single message when multiple checks complete within a short window (e.g., 30-60 seconds):\n\n```\n08:48 5 checks passed on main: Clippy, Test, E2E - idle_break_e2e, E2E - tailf_integration, E2E - spawn_race_test\n```\n\nOr even more condensed:\n```\n08:48 All CI checks passed on main\n```\n\n**Implementation ideas:**\n- Buffer CI check events for a short window before posting to channel\n- If multiple checks for the same ref/PR complete, batch them\n- Keep important events (PR opened, failures) as individual messages\n- Only batch \"passed\" checks, always show failures immediately\n\n**IMPORTANT:** This is purely a channel display change. The underlying webhook/event handling and PR author nudging logic should NOT be affected. The daemon should still process each CI event individually for nudge decisions - only the channel message posting gets batched.",
+      "id": "13",
+      "owner": "broadway",
+      "status": "completed",
+      "subject": "Batch repetitive GitHub CI notifications in channel"
+    },
+    {
+      "blocked_by": [],
+      "description": "Fixed: Added direct nudge_lead() calls in dispatch.rs and mod.rs. PR #584 opened.",
+      "id": "14",
+      "owner": "vernon",
+      "status": "completed",
+      "subject": "Investigate broken lead nudges for @lead mentions"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/effects.rs at 0%\n\nAdd E2E tests that exercise the effect execution layer:\n- Effect::SpawnCoworker - test coworker spawning via real daemon\n- Effect::ShutdownCoworker - test coworker shutdown\n- Effect::NudgeCoworker / Effect::NudgeLead - test nudge delivery\n- Effect::PostChannelMessage - test channel posting\n- Effect::AutoMergePr - test PR merge triggering\n\nUse the containerized E2E approach with real Claude where needed. Tests should verify effects actually execute (tmux windows created, messages posted, etc.).",
+      "id": "15",
+      "owner": "lexington",
+      "status": "completed",
+      "subject": "E2E tests for daemon effects execution"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/pr.rs at 0.94%\n\nAdd E2E tests for PR management flows:\n- PR polling and state detection\n- CI status tracking and stale check detection\n- Review comment detection\n- PR author identification and nudging\n- Auto-merge eligibility checking\n- Merge conflict detection\n\nUse real GitHub PRs in test repo or mock webhook events to exercise the PR handling code paths.",
+      "id": "16",
+      "owner": "columbus",
+      "status": "completed",
+      "subject": "E2E tests for daemon PR management"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/health.rs at 8.89%\n\nAdd E2E tests for coworker health monitoring:\n- Stuck detection (various stuck states)\n- Idle detection\n- Compaction detection (avoiding false positives - see task #10)\n- Usage limit detection\n- Orphan worktree detection\n- Session crash detection\n\nUse captured snapshots as test fixtures and verify health decisions match expected behavior.",
+      "id": "17",
+      "owner": "amsterdam",
+      "status": "completed",
+      "subject": "E2E tests for daemon health checks"
+    },
+    {
+      "blocked_by": [],
+      "description": "**COMPLETED - PR #590 OPEN**\n\nAdded 17 new E2E tests for daemon RPC handlers:\n- coworker.report-state: phase validation (3 tests)\n- coworker.asking: channel posting (2 tests)\n- daemon.check-pending: response structure (1 test)\n- task.updated: params, task not found, list mismatch (3 tests)\n- channel.post: /me actions, shell unescaping (2 tests)\n- channel.read: all parameter (1 test)\n- coworker.nudge: valid params (1 test)\n- reminder.create: invalid trigger (1 test)\n- reminder.cancel: not found (1 test)\n- plus 2 additional edge case tests\n\nAll tests pass. PR at https://github.com/btucker/midtown/pull/590",
+      "id": "18",
+      "owner": "york",
+      "status": "completed",
+      "subject": "E2E tests for daemon RPC handlers"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/dispatch.rs at 23.42%\n\nAdd E2E tests for task dispatch and coworker assignment:\n- Task assignment to idle coworkers\n- Task priority handling\n- Blocked task detection (blockedBy dependencies)\n- Orphan task recovery\n- Reviewer spawning for PRs\n- Max coworker limit enforcement\n\nVerify the daemon correctly assigns work and manages coworker lifecycle.",
+      "id": "19",
+      "owner": "park",
+      "status": "completed",
+      "subject": "E2E tests for daemon dispatch logic"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: daemon/webhook_fwd.rs at 0%, daemon/events.rs at 0%\n\nAdd E2E tests for GitHub webhook processing:\n- PR opened/closed/merged events\n- Review submitted events\n- Check run completed events\n- Push events\n- Webhook signature verification\n- Event deduplication\n\nUse mock webhook payloads or test against real GitHub webhooks in test environment.",
+      "id": "20",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "E2E tests for webhook handling"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: web.rs at 31.19%, webserver.rs at 30.63%\n\nAdd E2E tests for the web interface:\n- WebSocket connection and message streaming\n- Chat message display\n- Coworker status updates\n- Kanban board data\n- Static file serving\n- Multi-project routing\n\nCould use Playwright (already have MCP tools) or headless browser testing.",
+      "id": "21",
+      "owner": "vernon",
+      "status": "completed",
+      "subject": "E2E tests for web UI and WebSocket"
+    },
+    {
+      "blocked_by": [],
+      "description": "Current coverage: tmux.rs at 41.57%\n\nAdd E2E tests for tmux interactions:\n- Window creation and naming\n- Pane capture and parsing\n- Send-keys for nudges\n- Session management\n- Status bar updates\n- Window killing safety checks\n\nThese tests need real tmux sessions - use the existing tmux_e2e test pattern.",
+      "id": "22",
+      "owner": "pleasant",
+      "status": "completed",
+      "subject": "E2E tests for tmux operations"
+    },
+    {
+      "blocked_by": [],
+      "description": "Vernon's worktree was missing while the daemon still showed them as active. Their Claude Code session was running but couldn't access files or run commands because ~/.midtown/coworkers/midtown/vernon/ didn't exist.\n\nInvestigation needed:\n1. Check daemon logs for any orphan cleanup that might have removed vernon's worktree incorrectly\n2. Check if there's a race condition between worktree creation and coworker startup\n3. Verify the orphan detection logic doesn't incorrectly flag active coworkers\n4. Add safeguards to prevent coworkers from running without valid worktrees\n\nRecent changes to watch:\n- PR #568 merged \"fix: Exclude tmux window orphans from worktree cleanup\"\n- The orphan cleanup logic in tmux.rs\n\nEvidence: Vernon was able to mark task #14 as completed but their bash commands (git, midtown) all failed with \"command not found\" or exit code 1.",
+      "id": "23",
+      "owner": "madison",
+      "status": "completed",
+      "subject": "Investigate and fix coworker worktree corruption (vernon incident)"
+    },
+    {
+      "blocked_by": [],
+      "description": "Madison's review of PR #581 identified that WebhookEvent has grown to 8 optional fields, requiring repetitive `field: None` in every constructor (5 places currently).\n\nRecommended fix:\n1. Derive Default for WebhookEvent\n2. Or use a builder pattern\n\nThis will reduce boilerplate and make adding new optional fields cleaner.\n\nSource: PR #581 review comment",
+      "id": "24",
+      "owner": "columbus",
+      "status": "completed",
+      "subject": "Refactor WebhookEvent to use Default or builder pattern"
+    },
+    {
+      "blocked_by": [],
+      "description": "The daemon is not assigning pending tasks to idle coworkers or spawning reviewers for green PRs.\n\nSymptoms:\n- 7 coworkers showing as idle\n- 4 pending tasks available\n- 7 green PRs without reviewer assignments\n- Daemon repeatedly restarts but doesn't dispatch work\n\nExpected behavior:\n- Idle coworkers should be assigned pending tasks\n- Green PRs should get reviewer coworkers spawned\n\nThis appears to be a bug in the task dispatch or reviewer spawning logic in rules.rs or effects.rs.",
+      "id": "25",
+      "owner": "riverside",
+      "status": "completed",
+      "subject": "Fix daemon task dispatch - not assigning pending tasks to idle coworkers"
+    },
+    {
+      "blocked_by": [],
+      "description": "**Problem**: When coworkers hit their Claude usage limit, the daemon doesn't recognize this state and continues:\n- Warning about \"idle reviewers who haven't posted review\"\n- Restarting \"stuck\" coworkers (pane unchanged for 180s)\n- Sending nudges that can't be acted upon\n\n**Expected behavior**: The daemon should:\n1. Detect the usage limit message in pane content: \"You've hit your limit · resets Xam/pm (timezone)\"\n2. Parse the reset time from the message\n3. Mark these coworkers as \"usage_limited\" (not idle, not stuck)\n4. Stop nudging/restarting them until the reset time passes\n5. Optionally post to channel once when usage limit is detected\n\n**Test fixture available**: `tests/fixtures/snapshot/snapshot-hit-usage-limit-20260204-154619.json` contains real pane content showing the usage limit state.\n\n**Implementation hints**:\n- Pane parsing likely in `src/tmux.rs` or `src/pane.rs`\n- Decision logic in `src/rules.rs` \n- WorldSnapshot already has `usage_limit_nudge_scheduled` field - may need expansion\n- Follow the pure decision / effect execution pattern\n\n**Acceptance criteria**:\n- [ ] Unit test using the captured fixture verifies correct detection\n- [ ] Daemon stops nudging/restarting usage-limited coworkers\n- [ ] Coworkers resume normal handling after reset time",
+      "id": "26",
+      "owner": "columbus",
+      "status": "completed",
+      "subject": "Detect usage limit state and pause daemon actions for affected coworkers"
+    },
+    {
+      "blocked_by": [],
+      "description": "Lead committed changes on branch lead/channel-etiquette. Open a PR, get it reviewed, and merge.\n\nThe change adds channel etiquette guidelines to agents/common.md to avoid pointless back-and-forth conversation (no thank-you chains, brief acknowledgments only).",
+      "id": "27",
+      "owner": "vernon",
+      "status": "completed",
+      "subject": "Open PR for lead/channel-etiquette branch"
+    },
+    {
+      "blocked_by": [],
+      "description": "Multiple coworkers have accumulated stale local branches with unmerged commits: park, riverside, amsterdam, broadway, and likely others.\n\n**Task**: Audit and clean up these branches:\n1. List all local branches for each coworker namespace (park/, riverside/, amsterdam/, etc.)\n2. For each branch with unmerged commits, check if the work was merged via a different branch name (common pattern)\n3. Delete branches that are clearly stale (correspond to completed tasks, superseded by other work)\n4. For any with potentially useful unmerged work, note them for review\n\n**Safety**: Don't delete branches that might have unique unmerged work without confirming it's obsolete.\n\n**Commands to audit**:\n```bash\ngit branch | grep '<coworker>/' | while read branch; do\n  commits=$(git rev-list --count main..$branch 2>/dev/null || echo \"0\")\n  if [ \"$commits\" != \"0\" ]; then\n    echo \"$branch: $commits unmerged\"\n  fi\ndone\n```",
+      "id": "28",
+      "owner": "madison",
+      "status": "completed",
+      "subject": "Clean up stale coworker branches across all worktrees"
+    },
+    {
+      "blocked_by": [
+        "26"
+      ],
+      "description": "**Problem**: When the Claude API throws errors (500 Internal Server Error, etc.), coworkers get stuck waiting. The daemon doesn't recognize this state and may restart them unnecessarily, or not nudge them to retry.\n\n**API error pattern observed**:\n```\nAPI Error: 500 {\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"Internal server error\"},\"request_id\":\"...\"}\n```\n\n**Expected behavior**: The daemon should:\n1. Detect API error messages in pane content\n2. Mark coworkers as \"api_error\" state\n3. **Periodically nudge** to encourage retry (API errors are transient) - e.g., every 60-90 seconds\n4. Do NOT restart coworkers stuck on API errors (restart won't help)\n5. Optionally post to channel when API errors are detected across multiple coworkers\n\n**Key difference from usage limits**: Usage limits have a known reset time and nudging won't help. API errors are transient and a nudge to retry may succeed.\n\n**Test fixture available**: `tests/fixtures/snapshot/snapshot-api-errors-20260204-164204.json` contains real pane content showing API error states.\n\n**Related work**: Similar to task #26 (usage limit detection) in terms of pane content parsing.\n\n**Acceptance criteria**:\n- [ ] Unit test using the captured fixture verifies correct detection\n- [ ] Daemon periodically nudges coworkers with API errors to retry\n- [ ] Daemon does NOT restart coworkers stuck on API errors\n- [ ] Channel notification when widespread API errors detected",
+      "id": "29",
+      "owner": "columbus",
+      "status": "in_progress",
+      "subject": "Detect API errors in pane content and pause daemon actions"
+    },
+    {
+      "blocked_by": [],
+      "description": "**Problem**: Columbus was actively watching amsterdam review their PR instead of going idle. Coworkers should not monitor their own PR reviews - they should go idle and wait for the daemon to notify them when review feedback arrives.\n\n**Change needed**: Update `agents/coworker.md` to add guidance in the workflow section:\n\nAfter opening a PR:\n- Report state as `pull-request` and go idle\n- Do NOT watch or monitor the reviewer\n- The daemon will nudge you when review feedback arrives\n- If no other tasks are available, simply wait idle\n\n**Location**: `agents/coworker.md` - likely in the workflow phases or PR section",
+      "id": "30",
+      "owner": "park",
+      "status": "completed",
+      "subject": "Add coworker guidance: go idle while waiting for PR reviews"
+    },
+    {
+      "blocked_by": [],
+      "description": "Lead committed changes on branch lead/review-item-tasks. Open a PR, get it reviewed, and merge.\n\nThe change adds guidance for handling review notes - Lead must create tasks for items that need follow-up, otherwise they'll be forgotten.",
+      "id": "31",
+      "owner": "vernon",
+      "status": "in_progress",
+      "subject": "Open PR for lead/review-item-tasks branch"
+    },
+    {
+      "blocked_by": [],
+      "description": "**Problem**: When a PR is merged, Lead receives two nudges:\n1. One with \"system: \" prefix\n2. One without the prefix\n\nThis appears to be the same event being sent twice with inconsistent formatting.\n\n**Test fixture available**: `tests/fixtures/snapshot/snapshot-double-nudge-pr-merge-20260204-173400.json`\n\n**Investigation needed**:\n- Check where PR merge notifications are generated\n- Look for duplicate event emission paths\n- Ensure consistent \"system:\" prefix usage\n\n**Acceptance criteria**:\n- Single notification on PR merge\n- Consistent formatting",
+      "id": "32",
+      "owner": "york",
+      "status": "in_progress",
+      "subject": "Fix double-nudge on PR merge - duplicate notifications with different prefixes"
+    },
+    {
+      "blocked_by": [],
+      "description": "**Problem**: Two issues with personality system:\n\n1. **\"Normal\" still has casual flair**: With personality=\"normal\", coworkers use casual phrases like \"diving into\", \"time to get\", \"taking the stage\"\n\n2. **All coworkers use identical whimsical language**: When personality IS enabled, everyone uses the same theatrical phrases (\"taking the stage\", \"curtain falls\", \"standing by backstage\"). This isn't personality - it's a shared template. Different coworkers should have distinct voices, not copy the same Broadway-themed language.\n\n**Expected for \"normal\"**: Professional, neutral. \"Starting task #29\", \"Claimed task #31\"\n\n**Expected for personality modes**: Each coworker should have a DISTINCT voice, not share the same theatrical template.\n\n**Changes needed**:\n1. Tighten \"normal\" in `agents/personalities.md` to be strictly professional\n2. Ensure personality variants give each coworker a unique voice, not a shared theme\n3. Consider per-coworker personality seeds or distinct personality descriptions\n\n**Acceptance criteria**:\n- Normal mode: professional, no flair\n- Personality modes: distinct voices per coworker, not identical phrases",
+      "id": "33",
+      "owner": "amsterdam",
+      "status": "in_progress",
+      "subject": "Tighten \"normal\" personality to be more professional/neutral"
+    },
+    {
+      "blocked_by": [],
+      "description": "**Problem**: When `github_user` in config doesn't have access to a project:\n- Polling silently fails (uses github_user credentials)\n- Webhooks still work\n\nThis suggests webhook handling may not be using the `github_user` config, creating inconsistency.\n\n**Investigation needed**:\n- Check how webhooks authenticate/authorize GitHub API calls\n- Compare with how polling authenticates\n- Ensure both use the same `github_user` configuration\n\n**Acceptance criteria**:\n- Webhooks and polling use the same github_user credentials consistently\n- Or document why they differ (if intentional)",
+      "id": "34",
+      "owner": "madison",
+      "status": "in_progress",
+      "subject": "Verify webhook forwarding uses github_user config consistently with polling"
+    },
+    {
+      "blocked_by": [],
+      "description": "**Problem**: If `github_user` in config doesn't have access to the project, midtown starts but polling silently fails. This creates confusing behavior where some features work (webhooks) and others don't (polling).\n\n**Expected behavior**: On daemon startup, validate that `github_user` has access to the project's GitHub repo. If not, fail with a clear error message like:\n\n```\nError: github_user 'foo' does not have access to repository 'owner/repo'.\nPlease check your ~/.midtown/config.toml configuration.\n```\n\n**Implementation hints**:\n- Add startup validation in daemon init\n- Make a simple GitHub API call (e.g., GET /repos/{owner}/{repo}) to verify access\n- Fail fast with actionable error message\n\n**Acceptance criteria**:\n- Daemon fails to start if github_user lacks repo access\n- Error message clearly identifies the problem and config file to check",
+      "id": "35",
+      "owner": null,
+      "status": "pending",
+      "subject": "Fail daemon startup if github_user lacks project access"
+    }
+  ],
+  "blank_pane_coworkers": [],
+  "busy_coworkers": [
+    "amsterdam",
+    "madison",
+    "vernon",
+    "columbus",
+    "york"
+  ],
+  "ci_passed_pr_coworkers": [],
+  "coworker_snapshots": [
+    {
+      "isolated_tasks": false,
+      "name": "columbus",
+      "started_at": "2026-02-04T17:33:48.628703Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "vernon",
+      "started_at": "2026-02-04T17:33:48.628751Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "madison",
+      "started_at": "2026-02-04T17:40:05.809565Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "lexington",
+      "started_at": "2026-02-04T17:33:48.628761Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "park",
+      "started_at": "2026-02-04T17:33:48.628745Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "amsterdam",
+      "started_at": "2026-02-04T17:40:02.098393Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "york",
+      "started_at": "2026-02-04T17:35:03.398441Z"
+    },
+    {
+      "isolated_tasks": false,
+      "name": "riverside",
+      "started_at": "2026-02-04T17:33:48.628764Z"
+    },
+    {
+      "isolated_tasks": true,
+      "name": "pleasant",
+      "started_at": "2026-02-04T17:37:06.041097Z"
+    }
+  ],
+  "coworker_start_times": {
+    "amsterdam": "2026-02-04T17:40:02.098393Z",
+    "columbus": "2026-02-04T17:33:48.628703Z",
+    "lexington": "2026-02-04T17:33:48.628761Z",
+    "madison": "2026-02-04T17:40:05.809565Z",
+    "park": "2026-02-04T17:33:48.628745Z",
+    "pleasant": "2026-02-04T17:37:06.041097Z",
+    "riverside": "2026-02-04T17:33:48.628764Z",
+    "vernon": "2026-02-04T17:33:48.628751Z",
+    "york": "2026-02-04T17:35:03.398441Z"
+  },
+  "coworker_stop_times": {
+    "amsterdam": "2026-02-04T17:39:50.206558Z",
+    "madison": "2026-02-04T17:39:49.980046Z"
+  },
+  "coworkers_with_merged_prs": [
+    "park",
+    "lexington",
+    "columbus",
+    "pleasant",
+    "madison",
+    "york",
+    "amsterdam",
+    "broadway",
+    "vernon",
+    "riverside"
+  ],
+  "coworkers_with_open_prs": [
+    "york",
+    "riverside"
+  ],
+  "coworkers_with_running_subagents": [
+    "amsterdam",
+    "pleasant"
+  ],
+  "coworkers_with_unblocked_deps": [],
+  "in_progress_tasks": [
+    [
+      "29",
+      "Detect API errors in pane content and pause daemon actions",
+      "columbus"
+    ],
+    [
+      "31",
+      "Open PR for lead/review-item-tasks branch",
+      "vernon"
+    ],
+    [
+      "32",
+      "Fix double-nudge on PR merge - duplicate notifications with different prefixes",
+      "york"
+    ],
+    [
+      "33",
+      "Tighten \"normal\" personality to be more professional/neutral",
+      "amsterdam"
+    ],
+    [
+      "34",
+      "Verify webhook forwarding uses github_user config consistently with polling",
+      "madison"
+    ]
+  ],
+  "is_at_dev_limit": true,
+  "now_utc": "2026-02-04T17:41:39.122901Z",
+  "pane_contents": {
+    "amsterdam": "\n⏺ Bash(midtown state developing --task 33)\n  ⎿  amsterdam → dev#33\n\n⏺ Found it. Lines 45-60 and 85-91 in coworker.md contain theatrical examples that are shared across ALL coworkers regardless of personality:\n  - \"the spotlight awaits!\"\n  - \"another scene in the books\"\n  - \"the stage is dark, waiting for the next act\"\n\n  This is why everyone sounds theatrical - these Broadway-themed examples are hardcoded in the template.\n\n  Let me see how personality is injected and look at the rest of the coworker file.\n\n⏺ Read(agents/coworker.md)\n  ⎿  Read 1 line\n\n⏺ Search(pattern: \"personality\", path: \"src\")\n  ⎿  Found 7 files (ctrl+o to expand)\n\n⏺ Read(src/agents.rs)\n  ⎿  Read 675 lines\n\n⏺ ★ Insight ─────────────────────────────────────\n  The architecture here is elegant: agents.rs loads personality descriptions from personalities.md, builds a personality_section() with instructions about voice, and appends it to the system prompt. The issue is that\n  lines 218-223 tell ALL coworkers (including \"normal\" mode) to \"bring your character to life\" and that \"every channel post is a chance\" for personality expression. This instruction overrides the intent of \"normal\"\n  mode.\n  ─────────────────────────────────────────────────\n\n  Now I understand the full picture. I need to make three changes:\n\n  1. coworker.md: Replace theatrical examples with professional/neutral ones\n  2. personalities.md: Tighten \"normal\" variants to be strictly professional\n  3. agents.rs: Make personality_section() behave differently for \"normal\" vs fun/wild\n\n  Let me start with the edits.\n\n✽ Opening PR for review item guidance… (Esc to interrupt · ctrl+t to hide tasks · 1m 36s · ↓ 5.2k tokens)\n  ⎿  ◼ #29 Detect API errors in pane content and pause daemon actions (columbus)\n     ◼ #31 Open PR for lead/review-item-tasks branch (vernon)\n     ◼ #32 Fix double-nudge on PR merge - duplicate notifications with different prefixes (york)\n     ◼ #33 Tighten \"normal\" personality to be more professional/neutral (amsterdam)\n     ◼ #34 Verify webhook forwarding uses github_user config consistently with polling (madison)\n     ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n     ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n     ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n     ✔ #6 Prevent coworkers from checking out default branch (riverside)\n     ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n      … +22 completed\n\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n",
+    "columbus": "      4101      // -----------------------------------------------------------------------\n      4102      // has_running_subagent tests\n      4103      // -----------------------------------------------------------------------\n\n⏺ Let me run the tests to verify everything passes.\n\n⏺ Bash(cargo test 2>&1 | tail -30) timeout: 3m 0s\n  ⎿  test test_web_update_channel_message_format ... ok\n     test test_web_update_lead_typing_format ... ok\n     test test_web_assets_exist ... ok\n     … +27 lines (ctrl+o to expand)\n\n⏺ Let me run clippy to check for any issues.\n\n⏺ Bash(cargo clippy -- -D warnings 2>&1 | tail -30)\n  ⎿      Checking midtown v0.4.2 (/Users/btucker/.midtown/coworkers/midtown/columbus)\n         Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.02s\n\n⏺ ★ Insight ─────────────────────────────────────\n  API Error Detection Implementation:\n  1. Pattern: \"type\":\"api_error\" - specific to Claude API error responses, won't match code comments\n  2. Detection flows through WorldSnapshot.api_error_coworkers HashSet (normalized to lowercase)\n  3. Two key protections: stuck detection skip (restart won't help) and idle shutdown skip\n  4. Key difference from usage limits: API errors are transient and can resolve on retry, while usage limits have fixed reset times\n  ─────────────────────────────────────────────────\n\n  The core detection and protection are implemented. Let me commit and create a PR. The periodic nudging can be a follow-up enhancement.\n\n⏺ Bash(git add -A && git status)\n  ⎿  On branch columbus/api-error-detection\n     Your branch is up to date with 'origin/main'.\n     … +6 lines (ctrl+o to expand)\n\n⏺ Bash(git restore --staged state.json && git checkout -- state.json)\n  ⎿  (No content)\n\n· Opening PR for review item guidance… (Esc to interrupt · ctrl+t to hide tasks · 11m 51s · ↓ 25.5k tokens · thought for 1s)\n  ⎿  ◼ #29 Detect API errors in pane content and pause daemon actions (columbus)\n     ◼ #31 Open PR for lead/review-item-tasks branch (vernon)\n     ◼ #32 Fix double-nudge on PR merge - duplicate notifications with different prefixes (york)\n     ◼ #33 Tighten \"normal\" personality to be more professional/neutral (amsterdam)\n     ◼ #34 Verify webhook forwarding uses github_user config consistently with polling (madison)\n     ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n     ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n     ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n     ✔ #6 Prevent coworkers from checking out default branch (riverside)\n     ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n      … +22 completed\n\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle) · 4 files +217 -4\n\n",
+    "lexington": "  across functions, parallel struct/enum additions), this may indicate the codebase needs a refactor to consolidate the pattern. If you spot this, mention it in your review comment and post to the channel:\n  `midtown channel post \"@lead PR #592 repeats similar changes in N places (describe pattern). Recommend a refactor task to (suggested approach).\"`\n\n\n⏺ Bash(gh pr view 592 --json comments --jq '.comments[] | select(.body | contains(\"lexington\")) | .url')\n  ⎿  https://github.com/btucker/midtown/pull/592#issuecomment-3848741639\n\n⏺ Bash(midtown channel post \"/me checking PR #592 review status\")\n  ⎿  Message posted to channel\n\n⏺ The review for PR #592 was already completed. My comment is posted at: https://github.com/btucker/midtown/pull/592#issuecomment-3848741639\n\n⏺ Bash(midtown channel post \"/me PR #592 review already complete - comment posted earlier at https://github.com/btucker/midtown/pull/592#issuecomment-3848741639\")\n  ⎿  Message posted to channel\n\n⏺ Bash(midtown state idle)\n  ⎿  lexington → idle\n\n⏺ Review for PR #592 was already completed before the daemon restart. Found 5 issues (2 at score 75, 3 at score 50). Now idle and ready for new assignments.\n\n❯ Resume reviewing PR #592. The daemon was restarted and discovered you still running. Continue your code review where you left off.\n\n  IMPORTANT: You MUST always post a GitHub comment on the PR, even if no issues are found. If the code-review skill finishes without posting a comment, post a comment yourself using `gh pr comment 592 --body` with\n  the \"no issues found\" format from the skill.\n\n  REFACTOR DETECTION: While reviewing, look for similar changes repeated across multiple locations in the diff. When a PR makes analogous modifications in several places (similar match arms, duplicated logic\n  across functions, parallel struct/enum additions), this may indicate the codebase needs a refactor to consolidate the pattern. If you spot this, mention it in your review comment and post to the channel:\n  `midtown channel post \"@lead PR #592 repeats similar changes in N places (describe pattern). Recommend a refactor task to (suggested approach).\"`\n\n\n⏺ Bash(gh api repos/btucker/midtown/issues/592/comments --jq '.[] | select(.body | contains(\"lexington\")) | {url: .html_url, created: .created_at}')\n  ⎿  {\n       \"created\": \"2026-02-04T17:22:31Z\",\n       \"url\": \"https://github.com/btucker/midtown/pull/592#issuecomment-3848741639\"\n     }\n\n⏺ The review for PR #592 is already complete. My comment was posted at 17:22:31 UTC:\n  https://github.com/btucker/midtown/pull/592#issuecomment-3848741639\n\n⏺ Bash(midtown channel post \"/me PR #592 review was completed at 17:22 UTC - comment already posted\")\n  ⎿  Message posted to channel\n\n⏺ Bash(midtown state idle)\n  ⎿  lexington → idle\n\n⏺ PR #592 review was already completed. Now idle and available for new work.\n\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ check the task list\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n\n\n",
+    "madison": "\n⏺ Search(pattern: \"get_pr_owner_coworker_async\", path: \"~/.midtown/coworkers/midtown/madison\", glob: \"*.rs\", output_mode: \"content\")\n  ⎿  Found 31 lines (ctrl+o to expand)\n\n⏺ Read(src/daemon/pr.rs)\n  ⎿  Read 50 lines\n\n⏺ Search(pattern: \"poll|fetch.*pr|gh pr\", path: \"src/daemon/pr.rs\", output_mode: \"content\")\n  ⎿  Found 44 lines (ctrl+o to expand)\n\n⏺ ★ Insight ─────────────────────────────────────\n  The daemon uses the GH_TOKEN environment variable pattern instead of gh auth switch. This is a smart design choice: GH_TOKEN is process-local (no global state modification), has no race conditions with other\n  processes using gh, and gets inherited by all child processes spawned by the daemon.\n  ─────────────────────────────────────────────────\n\n  Let me verify the webhook server runs in the same process (inheriting GH_TOKEN).\n\n⏺ Search(pattern: \"start_webhook_server|webhook.*server|WebhookState\", path: \"src\", glob: \"*.rs\", output_mode: \"content\")\n  ⎿  Found 120 lines (ctrl+o to expand)\n\n⏺ Let me look at how the webhook forwarding watchdog works - that's the part that receives webhooks from GitHub.\n\n⏺ Search(pattern: \"forwarder|gh.*webhook\", path: \"src\", glob: \"*.rs\", output_mode: \"content\")\n  ⎿  Found 372 lines (ctrl+o to expand)\n\n⏺ Search(pattern: \"**/forwarder*.rs\", path: \"~/.midtown/coworkers/midtown/madison\")\n  ⎿  Found 0 files\n\n⏺ Read(~/.claude/projects/-Users-btucker--midtown-coworkers-midtown-madison/f1ed0f8d-c1e9-4012-bbc5-d049d70ec211/tool-results/toolu_0183nqG4RY9uZZWS1DRiYNLE.txt)\n  ⎿  Read 200 lines\n\n⏺ Let me read the full webhook_fwd module to see exactly how the forwarder process is spawned.\n\n⏺ Read(src/daemon/webhook_fwd.rs)\n  ⎿  Read 376 lines\n\n✻ Opening PR for review item guidance… (Esc to interrupt · ctrl+t to hide tasks · 1m 34s · ↑ 4.1k tokens · thought for 1s)\n  ⎿  ◼ #29 Detect API errors in pane content and pause daemon actions (columbus)\n     ◼ #31 Open PR for lead/review-item-tasks branch (vernon)\n     ◼ #32 Fix double-nudge on PR merge - duplicate notifications with different prefixes (york)\n     ◼ #33 Tighten \"normal\" personality to be more professional/neutral (amsterdam)\n     ◼ #34 Verify webhook forwarding uses github_user config consistently with polling (madison)\n     ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n     ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n     ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n     ✔ #6 Prevent coworkers from checking out default branch (riverside)\n     ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n      … +22 completed\n\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n",
+    "park": "✔ #12 Fix misdirected PR nudges to wrong coworkers (amsterdam)\n✔ #24 Refactor WebhookEvent to use Default or builder pattern (columbus)\n✔ #25 Fix daemon task dispatch - not assigning pending tasks to idle coworkers (riverside)\n✔ #13 Batch repetitive GitHub CI notifications in channel (broadway)\n◼ #29 Detect API errors in pane content and pause daemon actions ⚠ blocked by #26\n✔ #3 Update auto-merge to recognize comment-based reviews (park)\n✔ #8 Fix chat TUI unexpectedly scrolling to beginning (york)\n✔ #22 E2E tests for tmux operations (pleasant)\n✔ #18 E2E tests for daemon RPC handlers (york)\n✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n✔ #14 Investigate broken lead nudges for @lead mentions (vernon)\n✔ #15 E2E tests for daemon effects execution (lexington)\n✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n✔ #19 E2E tests for daemon dispatch logic (park)\n✔ #23 Investigate and fix coworker worktree corruption (vernon incident) (madison)\n✔ #9 Fix daemon not detecting posted review comments (riverside)\n\n⏺ No unblocked tasks available. Task #29 is blocked by #26 (columbus's work). Staying idle.\n\n⏺ Bash(midtown channel post \"/me stage is clear, no unblocked tasks in the queue\")\n  ⎿  Message posted to channel\n\n⏺ Idle with no available work. The daemon will assign me a task or shut me down when appropriate.\n\n❯ Your task #5 (Call-in and nudge PR authors on comments/reviews) was updated by pleasant — check the latest changes\n\n⏺ Task #5 is already completed - that's just a metadata update by pleasant. Still idle, waiting for new work.\n\n❯ Your task #3 (Update auto-merge to recognize comment-based reviews) was updated by pleasant — check the latest changes\n\n⏺ Task #3 also completed. Still idle.\n\n❯ Your task #3 (Update auto-merge to recognize comment-based reviews) was updated by pleasant — check the latest changes\n\n⏺ Duplicate notification. Remaining idle.\n\n  Tasks (27 done, 5 in progress, 0 open) · ctrl+t to hide tasks\n  ◼ #29 Detect API errors in pane content and pause daemon actions (columbus)\n  ◼ #31 Open PR for lead/review-item-tasks branch (vernon)\n  ◼ #32 Fix double-nudge on PR merge - duplicate notifications with different prefixes (york)\n  ◼ #33 Tighten \"normal\" personality to be more professional/neutral (amsterdam)\n  ◼ #34 Verify webhook forwarding uses github_user config consistently with polling (madison)\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n   … +22 completed\n\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle) · 1 file +1 -1\n\n",
+    "pleasant": "  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #5 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #6 updated: owner\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ Now let me run the first three steps in parallel - eligibility check, CLAUDE.md files, and PR summary:\n\n⏺ 3 Task agents finished (ctrl+o to expand)\n   ├─ Check PR #597 eligibility · 1 tool use · 19.8k tokens\n   │  ⎿  Done\n   ├─ Find relevant CLAUDE.md files · 3 tool uses · 20.0k tokens\n   │  ⎿  Done\n   └─ Get PR #597 summary · 2 tool uses · 19.7k tokens\n      ⎿  Done\n\n⏺ PR #597 is eligible for review. Let me update task 1 and proceed with the parallel code review agents:\n✔ Task #1 updated: status → completed\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #2 updated: status → completed\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #3 updated: status → completed\n  ⎿  Running PostToolUse hooks… (1/2 done)\n✔ Task #4 updated: status → in progress\n  ⎿  Running PostToolUse hooks… (1/2 done)\n\n⏺ Now launching 5 parallel Sonnet agents to review the PR from different angles:\n\n  Running 5 Task agents… (ctrl+o to expand)\n   ├─ Agent 1: CLAUDE.md compliance · 3 tool uses · 19.8k tokens\n   │  ⎿  Done\n   ├─ Agent 2: Bug scan · 5 tool uses · 24.8k tokens\n   │  ⎿  Done\n   ├─ Agent 3: Git history context · 60 tool uses · 55.9k tokens\n   │  ⎿  Bash: Check if fc613bd is in the PR branch\n   ├─ Agent 4: Previous PR comments · 17 tool uses · 32.6k tokens\n   │  ⎿  Done\n   └─ Agent 5: Code comments compliance · 7 tool uses · 25.8k tokens\n      ⎿  Done\n\n✽ Running review agents… (Esc to interrupt · ctrl+t to hide tasks · 4m 31s · ↓ 10.1k tokens · thinking)\n  ⎿  ◼ #4 Run 5 parallel code review agents (pleasant)\n     ◻ #5 Score and filter issues (pleasant)\n     ◻ #6 Post review comment on PR #597 (pleasant)\n     ✔ #1 Check PR #597 eligibility (pleasant)\n     ✔ #2 Find relevant CLAUDE.md files (pleasant)\n     ✔ #3 Get PR #597 summary (pleasant)\n\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n\n",
+    "riverside": "❯ github said: @riverside Check 'E2E - task_sharing' passed on PR #592\n\n⏺ Bash(gh pr checks 592 2>/dev/null | grep -E \"pending|fail\" | head -10)\n  ⎿  E2E - chat_e2e     pending 0       https://github.com/btucker/midtown/actions/runs/21681832591/job/62518184296\n     E2E - daemon_e2e   pending 0       https://github.com/btucker/midtown/actions/runs/21681832591/job/62518184282\n     E2E - full_stack_e2e       pending 0       https://github.com/btucker/midtown/actions/runs/21681832591/job/62518184326\n     … +6 lines (ctrl+o to expand)\n\n❯ github said: @riverside Check 'E2E - idle_break_e2e' passed on PR #592\n\n⏺ 9 checks still running including webhook_e2e. Waiting for results.\n\n❯ github said: @riverside Check 'E2E - tailf_integration' passed on PR #592\n\n⏺ Continuing to wait for webhook_e2e and other E2E checks.\n\n❯ github said: @riverside Check 'Test' passed on PR #592\n\n⏺ Unit tests passed. Waiting for E2E checks.\n\n❯ github said: @riverside Check 'E2E - spawn_race_test' passed on PR #592\n\n⏺ Bash(gh pr checks 592 2>/dev/null | grep -E \"pending|fail\")\n  ⎿  E2E - full_stack_e2e       pending 0       https://github.com/btucker/midtown/actions/runs/21681832591/job/62518184326\n     E2E - chat_e2e     pending 0       https://github.com/btucker/midtown/actions/runs/21681832591/job/62518184296\n     E2E - daemon_e2e   pending 0       https://github.com/btucker/midtown/actions/runs/21681832591/job/62518184282\n     … +3 lines (ctrl+o to expand)\n\n❯ github said: @riverside Check 'E2E - polling_degradation' passed on PR #592\n\n⏺ 6 E2E checks remaining including webhook_e2e. Waiting.\n\n❯ github said: @riverside Check 'E2E - nudge_delivery_e2e' passed on PR #592\n\n⏺ 5 checks left. Waiting for webhook_e2e result.\n\n  Tasks (27 done, 5 in progress, 0 open) · ctrl+t to hide tasks\n  ◼ #29 Detect API errors in pane content and pause daemon actions (columbus)\n  ◼ #31 Open PR for lead/review-item-tasks branch (vernon)\n  ◼ #32 Fix double-nudge on PR merge - duplicate notifications with different prefixes (york)\n  ◼ #33 Tighten \"normal\" personality to be more professional/neutral (amsterdam)\n  ◼ #34 Verify webhook forwarding uses github_user config consistently with polling (madison)\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n   … +22 completed\n\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n",
+    "vernon": "\n⏺ Bash(midtown state pull-request --task 31)\n  ⎿  vernon → PR#31\n\n⏺ Bash(gh pr create --base main --head lead/review-item-tasks --title \"docs: Add Lead guidance for handling review notes [Midtown #31]\" --body \"<!-- midtown: vernon --…)\n  ⎿  https://github.com/btucker/midtown/pull/597\n\n⏺ PR #597 is open. Let me post to the channel and then go idle.\n\n⏺ Bash(midtown channel post \"/me PR #597 is ready for review - rebased the lead's branch onto main so we don't accidentally revert the usage limit feature\")\n  ⎿  Message posted to channel\n\n⏺ Bash(midtown state idle)\n  ⎿  vernon → idle\n\n⏺ Bash(midtown channel post \"/me taking a breather while the team reviews #597\")\n  ⎿  Message posted to channel\n\n⏺ ★ Insight ─────────────────────────────────────\n  Branch rebasing for PRs: When opening a PR for a branch that was created before recent merges to main, you need to rebase it first. Otherwise, the PR diff will show \"changes\" that are actually the absence of new code\n   from main. Here, the lead's branch was missing PR #594's usage limit feature - without rebasing, merging would have reverted it.\n\n  --force-with-lease safety: When force-pushing rebased branches, --force-with-lease is safer than --force - it will refuse to push if someone else has pushed to the branch since you fetched it.\n  ─────────────────────────────────────────────────\n\n  Done! I've:\n  1. Claimed task #31\n  2. Discovered the lead's branch was based on an older main (before PR #594 merged)\n  3. Rebased lead/review-item-tasks onto current main to avoid reverting the usage limit feature\n  4. Opened PR #597: https://github.com/btucker/midtown/pull/597\n  5. Gone idle while waiting for review\n\n  The daemon will nudge me when there's review feedback or the PR is ready to merge.\n\n✻ Sautéed for 2m 23s\n\n  Tasks (27 done, 5 in progress, 0 open) · ctrl+t to hide tasks\n  ◼ #29 Detect API errors in pane content and pause daemon actions (columbus)\n  ◼ #31 Open PR for lead/review-item-tasks branch (vernon)\n  ◼ #32 Fix double-nudge on PR merge - duplicate notifications with different prefixes (york)\n  ◼ #33 Tighten \"normal\" personality to be more professional/neutral (amsterdam)\n  ◼ #34 Verify webhook forwarding uses github_user config consistently with polling (madison)\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n   … +22 completed\n\n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ \n──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on (shift+Tab to cycle)\n\n",
+    "york": "     index df64299..82a9610 100644\n     --- a/src/daemon/mod.rs\n     … +75 lines (ctrl+o to expand)\n\n⏺ The changes look correct. Let me create the commit.\n\n⏺ Bash(git add src/daemon/mod.rs && git commit -m \"fix: Prevent double-nudge on PR merge…)\n  ⎿  [york/fix-double-nudge-pr-merge 2154f24] fix: Prevent double-nudge on PR merge\n      1 file changed, 45 insertions(+), 7 deletions(-)\n     +cargo clippy -- -D warnings\n     … +2 lines (ctrl+o to expand)\n\n⏺ Commit created and pre-commit hooks passed. Let me push and create the PR.\n\n⏺ Bash(midtown state pull-request --task 32)\n  ⎿  york → PR#32\n\n⏺ Bash(git push -u origin york/fix-double-nudge-pr-merge 2>&1)\n  ⎿  remote:\n     remote: Create a pull request for 'york/fix-double-nudge-pr-merge' on GitHub by visiting:\n     remote:      https://github.com/btucker/midtown/pull/new/york/fix-double-nudge-pr-merge\n     … +4 lines (ctrl+o to expand)\n\n⏺ Bash(gh pr create --title \"fix: Prevent double-nudge on PR merge [Midtown #32]\" --body \"<!-- midtown: york -->…)\n  ⎿  https://github.com/btucker/midtown/pull/598\n     Warning: 1 uncommitted change\n\n⏺ Bash(midtown channel post \"PR #598 is ready for review - fixes the double-nudge on PR merge bug\")\n  ⎿  Message posted to channel\n\n⏺ Bash(midtown e2e run coordination --test nudge_delivery_e2e 2>&1 | tail -30) timeout: 5m 0s\n  ⎿  Running in the background (↓ to manage)\n\n⏺ Bash(midtown state idle)\n  ⎿  york → idle\n\n⏺ Bash(midtown channel post \"/me awaiting review on PR #598, standing by for further assignments\")\n  ⎿  Message posted to channel\n\n⏺ ★ Insight ─────────────────────────────────────\n  The Double-Nudge Pattern: This bug illustrates a common problem in event-driven systems - redundant notification paths. The daemon had two independent mechanisms for notifying the lead about PR merges:\n  1. Direct nudge: Explicit call to nudge_lead() for reliability\n  2. Chat monitor: Background watcher that routes @lead mentions from system messages\n\n  When both paths trigger on the same event, you get duplicate notifications with slightly different formatting. The fix preserves both mechanisms but ensures only one triggers per event by removing the @lead marker from the channel message.\n  ─────────────────────────────────────────────────\n\n  Summary\n\n  I've completed the fix for task #32 - Fix double-nudge on PR merge.\n\n  Root Cause: When a PR was merged, the lead received two nudges:\n  1. Direct nudge_lead() call in daemon/mod.rs (no prefix)\n  2. Chat monitor in chat.rs detecting @lead in the posted system message (with \"system: \" prefix)\n\n  Fix: Separated the channel message (informational, no @lead) from the direct nudge (includes actionable instruction):\n  - Channel: \"PR #42 merged into main.\"\n  - Nudge: \"PR #42 merged into main. Run 'git pull' to stay current.\"\n\n  Changes:\n  - src/daemon/mod.rs: Modified the merged_pr handling block and added a unit test\n\n  PR: https://github.com/btucker/midtown/pull/598\n\n  I'm now idle waiting for the PR review. The daemon will notify me when there's feedback or when the PR is approved.\n\n✻ Sautéed for 6m 11s\n\n  Tasks (27 done, 5 in progress, 0 open) · ctrl+t to hide tasks\n  ◼ #29 Detect API errors in pane content and pause daemon actions (columbus)\n  ◼ #31 Open PR for lead/review-item-tasks branch (vernon)\n  ◼ #32 Fix double-nudge on PR merge - duplicate notifications with different prefixes (york)\n  ◼ #33 Tighten \"normal\" personality to be more professional/neutral (amsterdam)\n  ◼ #34 Verify webhook forwarding uses github_user config consistently with polling (madison)\n  ✔ #3 Update auto-merge to recognize comment-based reviews (park)\n  ✔ #4 Add daemon auto-retry for stale/missing CI checks (broadway)\n  ✔ #5 Call-in and nudge PR authors on comments/reviews (park)\n  ✔ #6 Prevent coworkers from checking out default branch (riverside)\n  ✔ #7 Chat TUI should auto-scroll to end every 30 seconds (vernon)\n   … +22 completed\n\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n❯ check on the e2e tests\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────\n  ⏵⏵ bypass permissions on · midtown e2e run coordination --test nud… (running)\n\n"
+  },
+  "pending_tasks_with_owners": [],
+  "pending_tasks_without_owners": [
+    {
+      "blocked_by": [],
+      "description": "**Problem**: If `github_user` in config doesn't have access to the project, midtown starts but polling silently fails. This creates confusing behavior where some features work (webhooks) and others don't (polling).\n\n**Expected behavior**: On daemon startup, validate that `github_user` has access to the project's GitHub repo. If not, fail with a clear error message like:\n\n```\nError: github_user 'foo' does not have access to repository 'owner/repo'.\nPlease check your ~/.midtown/config.toml configuration.\n```\n\n**Implementation hints**:\n- Add startup validation in daemon init\n- Make a simple GitHub API call (e.g., GET /repos/{owner}/{repo}) to verify access\n- Fail fast with actionable error message\n\n**Acceptance criteria**:\n- Daemon fails to start if github_user lacks repo access\n- Error message clearly identifies the problem and config file to check",
+      "id": "35",
+      "owner": null,
+      "status": "pending",
+      "subject": "Fail daemon startup if github_user lacks project access"
+    }
+  ],
+  "repo_name": "midtown",
+  "reviewed_prs": [
+    592
+  ],
+  "reviewer_pr_assignments": {
+    "lexington": 592,
+    "pleasant": 597
+  },
+  "running_coworkers": [
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "columbus",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628703Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/columbus"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "vernon",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628751Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/vernon"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "madison",
+      "session_id": "f1ed0f8d-c1e9-4012-bbc5-d049d70ec211",
+      "started_at": "2026-02-04T17:40:05.809565Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/madison"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "lexington",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628761Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/lexington"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "park",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628745Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/park"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "amsterdam",
+      "session_id": "cf4a7d88-81ae-4140-a880-8d54f7f7e5b4",
+      "started_at": "2026-02-04T17:40:02.098393Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/amsterdam"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "york",
+      "session_id": "67735b8b-5b01-46a4-b6af-c41ea74c3145",
+      "started_at": "2026-02-04T17:35:03.398441Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/york"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": false,
+      "name": "riverside",
+      "session_id": null,
+      "started_at": "2026-02-04T17:33:48.628764Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/riverside"
+    },
+    {
+      "current_task": null,
+      "isolated_tasks": true,
+      "name": "pleasant",
+      "session_id": "27078008-2c7c-43f0-853e-21a396eb4a37",
+      "started_at": "2026-02-04T17:37:06.041097Z",
+      "status": "running",
+      "working_dir": "/Users/btucker/.midtown/coworkers/midtown/pleasant"
+    }
+  ],
+  "session_name": "midtown-midtown",
+  "usage_limit_nudge_scheduled": false,
+  "usage_limited_coworkers": []
+}


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
Adds 7 captured WorldSnapshot fixtures for debugging various daemon behaviors:

- `snapshot-20260204-144326.json` - General baseline
- `snapshot-api-errors-20260204-164204.json` - API error detection scenarios
- `snapshot-double-nudge-pr-merge-20260204-173400.json` - Double-nudge bug reproduction
- `snapshot-false-positive-bugs-20260204-135417.json` - False positive detection issues
- `snapshot-hit-usage-limit-20260204-154619.json` - Usage limit detection state
- `snapshot-lead-nudge-not-working-20260204-145321.json` - Lead nudge debugging
- `snapshot-stuck-compaction-false-positive-20260204-174139.json` - Stuck compaction false positive

These fixtures enable unit tests for daemon decisions without running real Claude Code sessions.

## Test plan
- [x] Fixtures are valid JSON (WorldSnapshot format)
- [x] No sensitive data in captured snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)