### PR TITLE
fix: Fail daemon startup if github_user lacks project access [Midtown #35]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -822,6 +822,39 @@ fn load_additional_worktree_managers(
         .collect()
 }
 
+/// Extract owner/repo from a git remote URL.
+///
+/// Handles both HTTPS and SSH URL formats:
+/// - HTTPS: `https://github.com/owner/repo.git` -> `owner/repo`
+/// - SSH: `git@github.com:owner/repo.git` -> `owner/repo`
+fn extract_repo_name_from_url(url: &str) -> Option<String> {
+    let url = url.trim().trim_end_matches(".git");
+
+    // SSH format: git@github.com:owner/repo
+    // Find the colon after the @ symbol (separates host from path)
+    if let Some(at_pos) = url.find('@')
+        && let Some(colon_pos) = url[at_pos..].find(':')
+    {
+        let path = &url[at_pos + colon_pos + 1..];
+        if path.contains('/') {
+            return Some(path.to_string());
+        }
+    }
+
+    // HTTPS format: https://github.com/owner/repo
+    // Extract the last two path components
+    let parts: Vec<&str> = url.rsplitn(3, '/').collect();
+    if parts.len() >= 2 {
+        let repo = parts[0];
+        let owner = parts[1];
+        if !owner.is_empty() && !repo.is_empty() {
+            return Some(format!("{}/{}", owner, repo));
+        }
+    }
+
+    None
+}
+
 /// Validate that the configured github_user has access to the repository.
 ///
 /// Makes a simple `gh repo view` call to verify the user can access the repo.
@@ -863,19 +896,9 @@ fn validate_github_repo_access(github_user: &str, workdir: &PathBuf) -> crate::R
         .output()
         .ok()
         .filter(|o| o.status.success())
-        .map(|o| {
+        .and_then(|o| {
             let url = String::from_utf8_lossy(&o.stdout).trim().to_string();
-            // Extract owner/repo from various URL formats
-            url.trim_end_matches(".git")
-                .rsplit('/')
-                .take(2)
-                .collect::<Vec<_>>()
-                .into_iter()
-                .rev()
-                .collect::<Vec<_>>()
-                .join("/")
-                .trim_start_matches(':')
-                .to_string()
+            extract_repo_name_from_url(&url)
         })
         .unwrap_or_else(|| "unknown".to_string());
 
@@ -1631,6 +1654,57 @@ mod tests {
         UsageLimitDecision, UsageLimitExpiryDecision, decide_usage_limit_detection,
         decide_usage_limit_expiry,
     };
+
+    // URL parsing tests for extract_repo_name_from_url
+    #[test]
+    fn test_extract_repo_name_https_url() {
+        assert_eq!(
+            extract_repo_name_from_url("https://github.com/owner/repo.git"),
+            Some("owner/repo".to_string())
+        );
+        assert_eq!(
+            extract_repo_name_from_url("https://github.com/owner/repo"),
+            Some("owner/repo".to_string())
+        );
+        assert_eq!(
+            extract_repo_name_from_url("https://github.com/btucker/midtown.git"),
+            Some("btucker/midtown".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_repo_name_ssh_url() {
+        assert_eq!(
+            extract_repo_name_from_url("git@github.com:owner/repo.git"),
+            Some("owner/repo".to_string())
+        );
+        assert_eq!(
+            extract_repo_name_from_url("git@github.com:owner/repo"),
+            Some("owner/repo".to_string())
+        );
+        assert_eq!(
+            extract_repo_name_from_url("git@github.com:btucker/midtown.git"),
+            Some("btucker/midtown".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_repo_name_with_whitespace() {
+        assert_eq!(
+            extract_repo_name_from_url("  https://github.com/owner/repo.git  \n"),
+            Some("owner/repo".to_string())
+        );
+        assert_eq!(
+            extract_repo_name_from_url("git@github.com:owner/repo.git\n"),
+            Some("owner/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_repo_name_invalid() {
+        assert_eq!(extract_repo_name_from_url("not a url"), None);
+        assert_eq!(extract_repo_name_from_url(""), None);
+    }
 
     // Auto-nudge helper tests
     #[test]


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Validates that `github_user` has access to the project's GitHub repo during daemon startup
- Runs `gh repo view` after setting GH_TOKEN to verify access
- Fails fast with a clear error message if access is denied

## Problem
When `github_user` was configured but didn't have access to the repo, the daemon would start successfully but polling would silently fail. This created confusing behavior where some features worked (webhooks from authenticated sessions) but others didn't (polling).

## Solution
Added a validation step in `daemon::run()` that runs `gh repo view` after setting the token. If it fails, the daemon exits with a clear error:

```
github_user 'foo' does not have access to repository 'owner/repo'.
Please check your ~/.midtown/config.toml configuration.
GitHub error: <api error message>
```

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy -- -D warnings` passes  
- [x] `cargo test` passes
- [ ] Manual test: configure a github_user without repo access and verify daemon fails to start

🤖 Generated with [Claude Code](https://claude.com/claude-code)