### PR TITLE
fix: Don't nudge isolated reviewers about main task list updates [Midtown #49]

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -582,6 +582,14 @@ pub(super) fn spawn_for_pending_tasks(
             !cooldowns.check("task_nudge", &task_key, Duration::from_secs(300))
         };
 
+        // Check if the owner is an isolated reviewer (has their own task namespace)
+        let is_owner_isolated = snap
+            .coworker_snapshots
+            .iter()
+            .find(|cw| cw.name.eq_ignore_ascii_case(owner))
+            .map(|cw| cw.isolated_tasks)
+            .unwrap_or(false);
+
         // Decide action using pure decision function
         let action = crate::rules::decide_pending_task_action(
             task_id,
@@ -590,6 +598,7 @@ pub(super) fn spawn_for_pending_tasks(
             &snap.active_names,
             snap.is_at_dev_limit,
             on_nudge_cooldown,
+            is_owner_isolated,
         );
 
         match action {
@@ -748,6 +757,23 @@ pub(super) fn spawn_for_pending_tasks(
 
         // Check if this coworker is already running (grouped to an active coworker)
         let already_running = snap.active_names.contains(&coworker_name.to_lowercase());
+
+        // Check if this coworker is an isolated reviewer (has their own task namespace)
+        let is_coworker_isolated = snap
+            .coworker_snapshots
+            .iter()
+            .find(|cw| cw.name.eq_ignore_ascii_case(&coworker_name))
+            .map(|cw| cw.isolated_tasks)
+            .unwrap_or(false);
+
+        // Skip assigning main task list tasks to isolated reviewers
+        if already_running && is_coworker_isolated {
+            debug!(
+                "Task #{}: skipping isolated reviewer {} (separate task namespace)",
+                task.id, coworker_name
+            );
+            continue;
+        }
 
         info!(
             "Proposing task #{} for {} (already_running={})",

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1405,6 +1405,10 @@ pub(crate) enum PendingTaskAction {
 ///
 /// Pure function: determines whether to nudge an active owner, spawn an
 /// inactive one, or skip.
+///
+/// # Arguments
+/// * `is_owner_isolated` - If true, the owner is an isolated reviewer with their own
+///   task namespace. Main task list updates should not nudge isolated reviewers.
 pub(crate) fn decide_pending_task_action(
     task_id: &str,
     task_subject: &str,
@@ -1412,6 +1416,7 @@ pub(crate) fn decide_pending_task_action(
     active_names: &HashSet<String>,
     at_dev_limit: bool,
     on_nudge_cooldown: bool,
+    is_owner_isolated: bool,
 ) -> PendingTaskAction {
     // Skip empty or lead-owned tasks
     if owner.is_empty() || owner.eq_ignore_ascii_case("lead") {
@@ -1425,6 +1430,17 @@ pub(crate) fn decide_pending_task_action(
         return PendingTaskAction::Skip {
             reason: format!(
                 "task #{} owner '{}' is not a valid coworker name",
+                task_id, owner
+            ),
+        };
+    }
+
+    // Skip isolated reviewers — they have their own task namespace and should
+    // not be nudged about main task list updates (task ID collision issue).
+    if is_owner_isolated {
+        return PendingTaskAction::Skip {
+            reason: format!(
+                "task #{} owner '{}' is an isolated reviewer (separate task namespace)",
                 task_id, owner
             ),
         };
@@ -2337,21 +2353,24 @@ mod tests {
     #[test]
     fn pending_task_nudges_active_owner() {
         let names = set(&["york"]);
-        let action = decide_pending_task_action("42", "Fix bug", "york", &names, false, false);
+        let action =
+            decide_pending_task_action("42", "Fix bug", "york", &names, false, false, false);
         assert!(matches!(action, PendingTaskAction::NudgeOwner { .. }));
     }
 
     #[test]
     fn pending_task_skips_nudge_on_cooldown() {
         let names = set(&["york"]);
-        let action = decide_pending_task_action("42", "Fix bug", "york", &names, false, true);
+        let action =
+            decide_pending_task_action("42", "Fix bug", "york", &names, false, true, false);
         assert!(matches!(action, PendingTaskAction::Skip { .. }));
     }
 
     #[test]
     fn pending_task_spawns_inactive_owner() {
         let names = set(&["amsterdam"]);
-        let action = decide_pending_task_action("42", "Fix bug", "york", &names, false, false);
+        let action =
+            decide_pending_task_action("42", "Fix bug", "york", &names, false, false, false);
         assert_eq!(
             action,
             PendingTaskAction::SpawnOwner {
@@ -2365,21 +2384,23 @@ mod tests {
     #[test]
     fn pending_task_skips_at_dev_limit() {
         let names = set(&["amsterdam"]);
-        let action = decide_pending_task_action("42", "Fix bug", "york", &names, true, false);
+        let action =
+            decide_pending_task_action("42", "Fix bug", "york", &names, true, false, false);
         assert!(matches!(action, PendingTaskAction::Skip { .. }));
     }
 
     #[test]
     fn pending_task_skips_lead_owner() {
         let names = set(&["york"]);
-        let action = decide_pending_task_action("42", "Fix bug", "lead", &names, false, false);
+        let action =
+            decide_pending_task_action("42", "Fix bug", "lead", &names, false, false, false);
         assert!(matches!(action, PendingTaskAction::Skip { .. }));
     }
 
     #[test]
     fn pending_task_skips_empty_owner() {
         let names = set(&["york"]);
-        let action = decide_pending_task_action("42", "Fix bug", "", &names, false, false);
+        let action = decide_pending_task_action("42", "Fix bug", "", &names, false, false, false);
         assert!(matches!(action, PendingTaskAction::Skip { .. }));
     }
 
@@ -2387,7 +2408,8 @@ mod tests {
     fn pending_task_skips_invalid_coworker_name() {
         // "fix" is not a valid coworker name (not an avenue name)
         let names = set(&["york"]);
-        let action = decide_pending_task_action("42", "Fix bug", "fix", &names, false, false);
+        let action =
+            decide_pending_task_action("42", "Fix bug", "fix", &names, false, false, false);
         assert!(matches!(action, PendingTaskAction::Skip { .. }));
     }
 
@@ -4299,6 +4321,87 @@ Now implementing the fix.
         assert!(
             !has_usage_limit_pattern(recovered_with_real_output),
             "real activity after usage limit should indicate recovery"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // decide_pending_task_action tests (isolated namespace handling)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pending_task_action_skips_isolated_reviewer() {
+        // Bug: Task ID collision between reviewer's isolated namespace and main task list.
+        // Isolated reviewers should NOT be nudged about main task list updates.
+        let active_names: HashSet<String> = ["madison".to_string()].into_iter().collect();
+
+        // Main task #6 has owner="madison", but madison is an isolated reviewer
+        let action = decide_pending_task_action(
+            "6",
+            "Prevent coworkers from checking out default branch",
+            "madison",
+            &active_names,
+            false, // not at dev limit
+            false, // not on cooldown
+            true,  // IS isolated reviewer
+        );
+
+        assert!(
+            matches!(action, PendingTaskAction::Skip { .. }),
+            "isolated reviewer should be skipped for main task list updates, got: {:?}",
+            action
+        );
+
+        // Verify the skip reason mentions isolation
+        if let PendingTaskAction::Skip { reason } = action {
+            assert!(
+                reason.contains("isolated"),
+                "skip reason should mention isolation: {}",
+                reason
+            );
+        }
+    }
+
+    #[test]
+    fn pending_task_action_nudges_non_isolated_coworker() {
+        // Non-isolated coworkers SHOULD be nudged about their pending tasks
+        let active_names: HashSet<String> = ["york".to_string()].into_iter().collect();
+
+        let action = decide_pending_task_action(
+            "6",
+            "Prevent coworkers from checking out default branch",
+            "york",
+            &active_names,
+            false, // not at dev limit
+            false, // not on cooldown
+            false, // NOT isolated
+        );
+
+        assert!(
+            matches!(action, PendingTaskAction::NudgeOwner { .. }),
+            "non-isolated coworker should be nudged, got: {:?}",
+            action
+        );
+    }
+
+    #[test]
+    fn pending_task_action_spawns_non_isolated_inactive_owner() {
+        // Inactive non-isolated owners should be spawned
+        let active_names: HashSet<String> = HashSet::new(); // york is not active
+
+        let action = decide_pending_task_action(
+            "6",
+            "Prevent coworkers from checking out default branch",
+            "york",
+            &active_names,
+            false, // not at dev limit
+            false, // not on cooldown
+            false, // NOT isolated
+        );
+
+        assert!(
+            matches!(action, PendingTaskAction::SpawnOwner { .. }),
+            "inactive non-isolated owner should be spawned, got: {:?}",
+            action
         );
     }
 }


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Adds `is_owner_isolated` parameter to `decide_pending_task_action()` to skip nudging isolated reviewers
- Skips assigning unowned main tasks to running isolated reviewers in `spawn_for_pending_tasks()`  
- Adds unit tests verifying isolated namespace handling

## Problem
Task ID collision between reviewer's isolated namespace and main task list caused spurious nudges:

1. **Reviewers getting main task nudges**: Reviewer has their own tasks #1-6 in their isolated session. Main task #6 updates, reviewer gets spurious nudge about "Prevent coworkers from checking out default branch" - wrong namespace.

2. **Main coworkers getting reviewer task nudges**: Developer working on main tasks could get nudged about a reviewer's task #3 "Get PR summary" - also wrong namespace.

## Solution
Check `isolated_tasks` flag before sending task nudges:
- Case 1 (pending tasks with owners): Skip nudging if owner is isolated reviewer  
- Case 2 (unowned tasks): Skip assigning to already-running isolated reviewers

Isolated reviewers only handle tasks in their own namespace (reviewer sub-tasks like "Get PR summary", "Run code review agents", etc.).

## Test plan
- [x] Unit tests for `decide_pending_task_action()` with isolated reviewer  
- [x] Existing pending task tests updated with new parameter
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)