### PR TITLE
docs: Fix task claiming conflict guidance - later claimer should yield [Midtown #60]

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -125,7 +125,8 @@ midtown channel read
 ```
 
 If you see another coworker also claimed the same task:
-- **First to notice** should post: `@{other} you continue with task #X, I'll abandon and find another`
+- Check the timestamps of the claim messages in the channel
+- **The later claimer** should post: `@{other} you claimed first, I'll find another task`
 - Then pick a different task from the list
 
 This prevents wasted effort from duplicate work.


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Fixed incorrect guidance that said "first to notice" should yield
- Changed to: the later claimer (by timestamp) should yield to the first claimer
- This makes the behavior intuitive: first to claim keeps the task

## Test plan
- [x] Documentation change only - no code changes
- [x] Read through the updated section for clarity

🤖 Generated with [Claude Code](https://claude.ai/code)