### PR TITLE
test: Add missing test for inactive isolated owner [Midtown #49]

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -4667,4 +4667,36 @@ Now implementing the fix.
             action
         );
     }
+
+    #[test]
+    fn pending_task_action_skips_isolated_inactive_owner() {
+        // Regression test from PR #614 review: isolation check fires before active check.
+        // An inactive isolated owner should still be skipped, not spawned.
+        let active_names: HashSet<String> = HashSet::new(); // madison is NOT active
+
+        let action = decide_pending_task_action(
+            "6",
+            "Prevent coworkers from checking out default branch",
+            "madison",
+            &active_names,
+            false, // not at dev limit
+            false, // not on cooldown
+            true,  // IS isolated (even though inactive)
+        );
+
+        assert!(
+            matches!(action, PendingTaskAction::Skip { .. }),
+            "inactive isolated owner should still be skipped, got: {:?}",
+            action
+        );
+
+        // Verify the skip reason mentions isolation
+        if let PendingTaskAction::Skip { reason } = action {
+            assert!(
+                reason.contains("isolated"),
+                "skip reason should mention isolation: {}",
+                reason
+            );
+        }
+    }
 }


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary

Addresses review feedback from madison on PR #614: the test matrix was missing the `(inactive, isolated)` → `Skip` case.

While the code correctly handles this (the isolation check fires before the active/inactive check), this test prevents regressions from future refactors that might reorder the checks.

**Note**: The core PR #614 changes were already merged via PR #623 (channel post timeouts fix). This PR just adds the missing test from the review feedback.

## Test plan

- [x] New test passes locally
- [x] Completes the test matrix for `decide_pending_task_action` isolation handling

🤖 Generated with [Claude Code](https://claude.ai/code)