### PR TITLE
chore: Bump version to v0.4.4 [Midtown #65]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "midtown"
-version = "0.4.2"
+version = "0.4.4"
 dependencies = [
  "axum",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midtown"
-version = "0.4.2"
+version = "0.4.4"
 edition = "2024"
 description = "Midtown - a multi-Claude Code workspace manager, inspired by Gastown"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Bumps version from 0.4.2 to 0.4.4 (skipping 0.4.3 which was already tagged)
- Prepares for v0.4.4 release

## Notable changes since v0.4.3

### Features
- Detect API errors in pane content and pause daemon actions (#599)
- Show review#PR in tmux window for reviewer coworkers (#627)
- Batch repetitive GitHub CI notifications in channel (#581)
- Make coworker nudges respect user input in progress (#578)
- Add daemon auto-retry for stale CI checks (#572)
- Switch to author-driven merge decisions (#573)
- Prioritize PR reviews over new task pickup (#615)
- Send idle coworkers on break immediately (#612)
- Detect usage limit recovery when activity resumes (#609)
- Add PR handoff infrastructure for any coworker to resume work (#617)

### Bug fixes
- Improve midtown restart reliability with proper daemon shutdown (#630)
- Move ClearOrphanedReviewerAssignments after pr_poll_initialized check (#629)
- Skip orphan flagging until first PR poll completes (#626)
- Prevent orphan cleanup from deleting worktrees for running coworkers (#591)
- Prevent false positive stuck compaction from verbs in displayed code (#580)
- Make review comment detection case-insensitive (#576)
- Prevent coworkers from checking out default branch (#574)
- Prevent chat TUI from unexpectedly scrolling to beginning (#577)
- Clear reviewer assignments when coworker sessions end unexpectedly (#569)
- Many more stability and reliability improvements

### Tests & Documentation
- Comprehensive E2E test coverage for daemon, effects, health, dispatch, tmux, web UI, webhooks, and RPC
- WorldSnapshot fixture system for debugging daemon issues
- Lead debugging workflow documentation

## Test plan
- [x] Build passes with new version
- [x] Pre-commit hooks (clippy, fmt) pass

After merge: create and push v0.4.4 tag, then create GitHub release.