### PR TITLE
chore: Bump version to v0.4.5 [Midtown #1]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "midtown"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "axum",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midtown"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2024"
 description = "Midtown - a multi-Claude Code workspace manager, inspired by Gastown"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Bumps version from v0.4.4 to v0.4.5 in Cargo.toml
- Updates Cargo.lock accordingly

## Test plan
- [x] `cargo build --release` succeeds
- [x] Pre-commit hooks pass (clippy, fmt)

## Note
After this PR merges, the release tag `v0.4.5` should be created on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)