### PR TITLE
fix: Handle already-gone coworkers gracefully in coworker break [Midtown #1]

### DIFF
--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -1665,7 +1665,7 @@ mod tests {
     }
 
     #[test]
-    fn test_shutdown_cleans_up_even_on_tmux_failure() {
+    fn test_shutdown_succeeds_when_window_missing() {
         let (manager, _temp_dir) = test_manager();
 
         // Insert a coworker into the HashMap
@@ -1687,11 +1687,29 @@ mod tests {
 
         assert_eq!(manager.count(), 1);
 
-        // shutdown() will fail because there's no real tmux session,
-        // but it should still remove the coworker from the HashMap
-        let _ = manager.shutdown("lexington");
+        // shutdown() should succeed even when tmux window doesn't exist
+        // (idempotent behavior - the window is already "gone")
+        let result = manager.shutdown("lexington");
+        assert!(
+            result.is_ok(),
+            "shutdown should succeed when window is already gone"
+        );
 
-        // The coworker should be removed from tracking regardless of tmux failure
+        // The coworker should be removed from tracking
         assert_eq!(manager.count(), 0);
+    }
+
+    #[test]
+    fn test_shutdown_coworker_not_tracked() {
+        let (manager, _temp_dir) = test_manager();
+
+        // Try to shutdown a coworker that was never tracked
+        let result = manager.shutdown("nonexistent");
+
+        // Should return an error since the coworker isn't tracked
+        assert!(
+            result.is_err(),
+            "shutdown should error for untracked coworker"
+        );
     }
 }

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -379,6 +379,18 @@ fn handle_coworker_spawn(
 
 /// Handle coworker.break RPC method.
 fn handle_coworker_break(id: RequestId, name: &str, state: &DaemonState) -> Response {
+    // Check if the coworker is tracked - if not, they're already "on break"
+    if state.coworkers.get(name).is_none() {
+        info!("Coworker {} is already on break (not tracked)", name);
+        return Response::success(
+            id,
+            serde_json::json!({
+                "success": true,
+                "message": format!("{} is already on break", name),
+            }),
+        );
+    }
+
     state.broadcast_coworker_update(name, "stopped", None);
     match state.coworkers.shutdown(name) {
         Ok(()) => {

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -379,6 +379,12 @@ pub fn create_window(
 /// SAFETY: Refuses to kill the last window in a session, as that would
 /// terminate the session (and potentially the tmux server if it's the only session).
 pub fn kill_window(session: &str, name: &str) -> crate::Result<()> {
+    // Idempotent: if window doesn't exist, it's already "killed"
+    if !window_exists(session, name).unwrap_or(false) {
+        tracing::debug!("Window {}:{} doesn't exist, nothing to kill", session, name);
+        return Ok(());
+    }
+
     // Safety check: don't kill the last window in the session
     let window_count = count_session_windows(session);
     if window_count <= 1 {


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Make `kill_window()` idempotent: returns Ok when window doesn't exist since the goal is already achieved
- Check if coworker is tracked before shutdown: returns friendly "already on break" message for untracked coworkers
- Update tests to verify the new idempotent behavior

Before this fix, running `midtown coworker break broadway` when broadway's tmux window was already gone would error:
```
Error: RPC error: Failed to kill tmux window: midtown-midtown:broadway (code: -32603)
```

Now it returns success with an informative message.

## Test plan
- [x] Unit tests added for both scenarios:
  - `test_shutdown_succeeds_when_window_missing` - verifies shutdown returns Ok when window is gone
  - `test_shutdown_coworker_not_tracked` - verifies shutdown errors for untracked coworkers (RPC handler catches this case)
- [x] All existing tests pass
- [x] Clippy passes with no warnings