### PR TITLE
feat: Speed up daemon task dispatch on idle coworker [Midtown #15]

### DIFF
--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -520,6 +520,21 @@ async fn handle_coworker_report_state(
                         records.remove(name);
                     }
 
+                    // Immediately trigger task dispatch so pending tasks get picked up
+                    // without waiting for the next TaskDispatchTick (up to 10 seconds).
+                    // This is the same pattern as daemon.check-pending RPC.
+                    let snap = snapshot::collect_world_snapshot(state).await;
+                    let pending_effects = super::dispatch::spawn_for_pending_tasks(&snap, state);
+                    if !pending_effects.is_empty() {
+                        info!(
+                            "Immediate dispatch after {} idle: {} effect(s)",
+                            name,
+                            pending_effects.len()
+                        );
+                        state.mark_in_flight_spawns_from_effects(&pending_effects);
+                        effects::execute_effects(pending_effects, state).await;
+                    }
+
                     info!("Coworker {} went on break after reporting idle", name);
                     return Response::success(
                         id,


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- When a coworker reports idle via RPC, the daemon now immediately triggers task dispatch
- Reduces latency from up to 10 seconds (next TaskDispatchTick) to nearly instant
- Follows same pattern as existing `daemon.check-pending` RPC endpoint

## Changes
Modified `handle_coworker_report_state()` in `src/daemon/rpc.rs` to call `spawn_for_pending_tasks()` after successfully sending a coworker on break.

## Test plan
- [x] Build passes
- [x] All RPC tests pass
- [x] Clippy passes with `-D warnings`
- [ ] E2E coordination tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)