### PR TITLE
feat: Simplify CI pass notifications and deduplicate checks [Midtown #766]

### DIFF
--- a/src/daemon/trackers.rs
+++ b/src/daemon/trackers.rs
@@ -349,7 +349,7 @@ const CI_BUFFER_FLUSH_DELAY: Duration = Duration::from_secs(15);
 ///
 /// When multiple checks pass on the same target (PR or branch) within a short
 /// window, we batch them into a single message like:
-/// "5 checks passed on PR #42: Clippy, Test, E2E - foo, ..."
+/// "5 checks passed on PR #42"
 #[derive(Debug, Default)]
 pub struct CiNotificationBuffer {
     /// Buffered checks grouped by target (e.g., "main" or "PR #42").
@@ -382,16 +382,16 @@ impl CiNotificationBuffer {
     pub fn add(&mut self, check: CiCheckPassed) {
         let now = Instant::now();
 
-        // Update oldest_entry if this is the first item
-        if self.oldest_entry.is_none() {
-            self.oldest_entry = Some(now);
-        }
-
         let entries = self.pending.entry(check.target).or_default();
 
         // Skip if this check name already exists for this target
         if entries.iter().any(|(name, _, _)| *name == check.check_name) {
             return;
+        }
+
+        // Only set oldest_entry when an entry is actually added
+        if self.oldest_entry.is_none() {
+            self.oldest_entry = Some(now);
         }
 
         entries.push((check.check_name, check.mention_prefix, now));
@@ -1019,5 +1019,34 @@ mod tests {
         assert_eq!(batched[0].check_names.len(), 2);
         assert!(batched[0].check_names.contains(&"Clippy".to_string()));
         assert!(batched[0].check_names.contains(&"Test".to_string()));
+    }
+
+    #[test]
+    fn ci_buffer_oldest_entry_only_set_on_actual_add() {
+        // Defensive: oldest_entry should only be set when an entry is actually
+        // added, not when a duplicate is skipped.
+        let mut buffer = CiNotificationBuffer::new();
+
+        // Add a check — oldest_entry should be set
+        buffer.add(CiCheckPassed {
+            check_name: "Clippy".to_string(),
+            target: "PR #42".to_string(),
+            mention_prefix: "".to_string(),
+        });
+        assert!(buffer.oldest_entry.is_some());
+
+        // Manually clear oldest_entry to simulate an edge case
+        buffer.oldest_entry = None;
+
+        // Add duplicate — oldest_entry should NOT be set since no entry was added
+        buffer.add(CiCheckPassed {
+            check_name: "Clippy".to_string(),
+            target: "PR #42".to_string(),
+            mention_prefix: "".to_string(),
+        });
+        assert!(
+            buffer.oldest_entry.is_none(),
+            "oldest_entry should not be set when duplicate is skipped"
+        );
     }
 }


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Simplified batched CI notification format: multi-check messages now show just the count (e.g., "12 checks passed on PR #42") instead of listing every individual check name
- Added deduplication to CI notification buffer so re-runs of the same check (e.g., Clippy from multiple workflow runs) are only counted once
- Single-check messages still include the check name for context

**Before:** `@madison 24 checks passed on PR #649: E2E - chat_e2e, E2E - nudge_delivery_e2e, E2E - daemon_e2e, Test, E2E - idle_break_e2e, Test, ...`

**After:** `@madison 12 checks passed on PR #649`

## Test plan
- [x] Added test for multi-check format omitting individual names
- [x] Added test for deduplication of check names within same target
- [x] Updated existing format tests for new behavior
- [x] All tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)