### PR TITLE
refactor: Extract format_task_prompt helper [Midtown #786]

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -14,6 +14,7 @@ use crate::{config, daemon_messages};
 
 use super::constants::*;
 use super::effects::{self, Effect};
+use super::helpers::format_task_prompt;
 use super::{DaemonState, snapshot};
 
 // ============================================================================
@@ -73,9 +74,12 @@ pub(super) fn check_and_recover_orphans(
         recovery.task_id, recovery.owner
     );
 
-    let prompt = format!(
-        "You've been assigned task #{}: {}. Your previous session was interrupted but your worktree and branch are still intact. Check your git status and get started!\n\nRun `midtown task view {}` for full details.",
-        recovery.task_id, recovery.task_subject, recovery.task_id
+    let prompt = format_task_prompt(
+        &recovery.task_id,
+        &format!(
+            "You've been assigned task #{}: {}. Your previous session was interrupted but your worktree and branch are still intact. Check your git status and get started!",
+            recovery.task_id, recovery.task_subject
+        ),
     );
 
     // Spawn fresh (no --continue) — the coworker keeps the same name so they
@@ -184,9 +188,12 @@ pub(super) async fn nudge_discovered_coworkers(state: &DaemonState) {
 
         // Check for an in_progress task owned by this coworker
         if let Some((task_id, task_subject)) = owner_tasks.get(&name_lower) {
-            let prompt = format!(
-                "Resume task #{}: {}. The daemon was restarted and discovered you still running. Check your git status and continue where you left off.\n\nRun `midtown task view {}` for full details.",
-                task_id, task_subject, task_id
+            let prompt = format_task_prompt(
+                task_id,
+                &format!(
+                    "Resume task #{}: {}. The daemon was restarted and discovered you still running. Check your git status and continue where you left off.",
+                    task_id, task_subject
+                ),
             );
 
             info!(
@@ -654,9 +661,9 @@ pub(super) fn spawn_for_pending_tasks(
                 task_id: ref tid,
                 task_subject: ref subj,
             } => {
-                let nudge_msg = format!(
-                    "You have pending task #{}: {}. Get started!\n\nRun `midtown task view {}` for full details.",
-                    tid, subj, tid
+                let nudge_msg = format_task_prompt(
+                    tid,
+                    &format!("You have pending task #{}: {}. Get started!", tid, subj),
                 );
                 effects.push(Effect::NudgeCoworkerWithCallbacks {
                     name: o.clone(),
@@ -676,9 +683,9 @@ pub(super) fn spawn_for_pending_tasks(
                     "Pending task #{} is assigned to {} but coworker not running - spawning",
                     tid, o
                 );
-                let prompt = format!(
-                    "You've been assigned task #{}: {}. Get started!\n\nRun `midtown task view {}` for full details.",
-                    tid, subj, tid
+                let prompt = format_task_prompt(
+                    tid,
+                    &format!("You've been assigned task #{}: {}. Get started!", tid, subj),
                 );
                 let config = crate::tmux::ClaudeLaunchConfig::coworker(
                     o.clone(),
@@ -891,9 +898,12 @@ pub(super) fn spawn_for_pending_tasks(
         names_assigned_this_tick.insert(coworker_name.to_lowercase());
 
         // Build the prompt message
-        let prompt = format!(
-            "You've been assigned task #{}: {}. Get started!\n\nRun `midtown task view {}` for full details.",
-            task.id, task.subject, task.id
+        let prompt = format_task_prompt(
+            &task.id,
+            &format!(
+                "You've been assigned task #{}: {}. Get started!",
+                task.id, task.subject
+            ),
         );
 
         if already_running {

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -15,6 +15,7 @@ use crate::{config, daemon_messages, web};
 
 use super::constants::*;
 use super::effects::Effect;
+use super::helpers::format_task_prompt;
 use super::{DaemonState, snapshot};
 
 /// Check if the lead's tmux pane has changed and broadcast typing status.
@@ -439,9 +440,12 @@ pub(super) async fn check_and_restart_stuck_coworkers(
             restart.task_id
         );
 
-        let prompt = format!(
-            "You've been assigned task #{}: {}. Your previous session appeared stuck so you were restarted. Check your git status and continue where you left off.\n\nRun `midtown task view {}` for full details.",
-            restart.task_id, restart.task_subject, restart.task_id
+        let prompt = format_task_prompt(
+            &restart.task_id,
+            &format!(
+                "You've been assigned task #{}: {}. Your previous session appeared stuck so you were restarted. Check your git status and continue where you left off.",
+                restart.task_id, restart.task_subject
+            ),
         );
 
         effects.push(Effect::ShutdownCoworker {

--- a/src/daemon/helpers.rs
+++ b/src/daemon/helpers.rs
@@ -393,6 +393,22 @@ pub(super) fn extract_pr_number(content: &str) -> Option<u64> {
 }
 
 // ---------------------------------------------------------------------------
+// Task prompt helpers
+// ---------------------------------------------------------------------------
+
+/// Format a task prompt with the standard `midtown task view` footer.
+///
+/// Appends `\n\nRun midtown task view {id} for full details.` to the given
+/// context message, ensuring consistent formatting across all task assignment
+/// and nudge paths (dispatch, health, recovery).
+pub fn format_task_prompt(task_id: &str, context_message: &str) -> String {
+    format!(
+        "{}\n\nRun `midtown task view {}` for full details.",
+        context_message, task_id
+    )
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -931,5 +947,41 @@ mod tests {
         assert!(!is_gh_auth_error("repository not found"));
         assert!(!is_gh_auth_error("rate limit exceeded"));
         assert!(!is_gh_auth_error(""));
+    }
+
+    // =========================================================================
+    // format_task_prompt tests
+    // =========================================================================
+
+    #[test]
+    fn format_task_prompt_appends_footer() {
+        let result = format_task_prompt(
+            "42",
+            "You've been assigned task #42: Fix auth bug. Get started!",
+        );
+        assert_eq!(
+            result,
+            "You've been assigned task #42: Fix auth bug. Get started!\n\nRun `midtown task view 42` for full details."
+        );
+    }
+
+    #[test]
+    fn format_task_prompt_works_with_recovery_context() {
+        let result = format_task_prompt(
+            "99",
+            "Resume task #99: Add tests. The daemon was restarted and discovered you still running. Check your git status and continue where you left off.",
+        );
+        assert!(result.starts_with("Resume task #99:"));
+        assert!(result.ends_with("Run `midtown task view 99` for full details."));
+    }
+
+    #[test]
+    fn format_task_prompt_works_with_nudge_context() {
+        let result = format_task_prompt(
+            "7",
+            "You have pending task #7: Deploy service. Get started!",
+        );
+        assert!(result.contains("pending task #7"));
+        assert!(result.contains("midtown task view 7"));
     }
 }


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Extracts `format_task_prompt()` helper in `dispatch.rs` that appends the standard `Run midtown task view {id} for full details` footer
- Replaces 6 duplicated format strings across `dispatch.rs` (5) and `health.rs` (1)
- No behavior change — purely mechanical refactor

## Test plan
- [x] All 809 lib tests pass
- [x] Clippy clean, fmt clean
- [x] Verified no remaining hardcoded footer strings in `src/daemon/`