### PR TITLE
feat: Show account email in Usage heading [Midtown #816]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -393,7 +393,8 @@ impl App {
             let (tx, rx) = mpsc::channel();
             self.usage_receiver = Some(rx);
             thread::spawn(move || {
-                let result = usage::get_oauth_token().and_then(|token| usage::fetch_usage(&token));
+                let result = usage::get_oauth_credentials()
+                    .and_then(|creds| usage::fetch_usage(&creds.token, creds.email));
                 let _ = tx.send(result);
             });
         }

--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -1371,8 +1371,13 @@ fn draw_usage_bars(f: &mut Frame, app: &App, area: Rect) {
         None => return,
     };
 
+    let title = match &usage.account_email {
+        Some(email) => format!(" Usage ({}) ", email),
+        None => " Usage ".to_string(),
+    };
+
     let block = Block::default()
-        .title(" Usage ")
+        .title(title)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::DarkGray));
 

--- a/src/bin/midtown/cli/chat/usage.rs
+++ b/src/bin/midtown/cli/chat/usage.rs
@@ -17,6 +17,8 @@ pub struct UsageData {
     pub week_util: f64,
     /// When the weekly window resets
     pub week_resets: DateTime<Utc>,
+    /// Account email from OAuth credentials (if available)
+    pub account_email: Option<String>,
 }
 
 /// Raw API response shape.
@@ -32,12 +34,20 @@ struct UsageWindow {
     resets_at: String,
 }
 
-/// Fetch the OAuth access token from macOS Keychain for the current midtown auth profile.
+/// OAuth credentials extracted from macOS Keychain.
+pub struct OAuthCredentials {
+    /// The OAuth access token
+    pub token: String,
+    /// The account email (if present in the credential)
+    pub email: Option<String>,
+}
+
+/// Fetch OAuth credentials from macOS Keychain for the current midtown auth profile.
 ///
 /// The keychain entry name is `Claude Code-credentials-{hash}` where `{hash}` is the
 /// first 8 hex characters of SHA256(CLAUDE_CONFIG_DIR path).
 #[cfg(target_os = "macos")]
-pub fn get_oauth_token() -> Option<String> {
+pub fn get_oauth_credentials() -> Option<OAuthCredentials> {
     use sha2::{Digest, Sha256};
 
     let config_dir = midtown::auth::current_profile_dir();
@@ -67,19 +77,28 @@ pub fn get_oauth_token() -> Option<String> {
     let cred_json = String::from_utf8(output.stdout).ok()?;
     let cred: serde_json::Value = serde_json::from_str(cred_json.trim()).ok()?;
 
-    cred.get("claudeAiOauth")
-        .and_then(|oauth| oauth.get("accessToken"))
+    let oauth = cred.get("claudeAiOauth")?;
+
+    let token = oauth
+        .get("accessToken")
         .and_then(|t| t.as_str())
-        .map(|s| s.to_string())
+        .map(|s| s.to_string())?;
+
+    let email = oauth
+        .get("email")
+        .and_then(|e| e.as_str())
+        .map(|s| s.to_string());
+
+    Some(OAuthCredentials { token, email })
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn get_oauth_token() -> Option<String> {
+pub fn get_oauth_credentials() -> Option<OAuthCredentials> {
     None
 }
 
 /// Fetch usage data from the Anthropic API.
-pub fn fetch_usage(token: &str) -> Option<UsageData> {
+pub fn fetch_usage(token: &str, account_email: Option<String>) -> Option<UsageData> {
     // Use blocking reqwest since we run this on a background thread
     let client = reqwest::blocking::Client::new();
     let resp = client
@@ -113,6 +132,7 @@ pub fn fetch_usage(token: &str) -> Option<UsageData> {
         session_resets,
         week_util: seven_day.utilization,
         week_resets,
+        account_email,
     })
 }
 


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Extract account email from OAuth credentials stored in macOS Keychain (`claudeAiOauth.email`)
- Display email in the Usage panel title as `Usage (user@example.com)` when available
- Falls back to plain `Usage` title when email is not present in credentials

## Changes
- `usage.rs`: Renamed `get_oauth_token()` to `get_oauth_credentials()` returning an `OAuthCredentials` struct with both token and email
- `usage.rs`: Added `account_email: Option<String>` to `UsageData` struct, threaded through `fetch_usage()`
- `app.rs`: Updated background thread to use new credentials API
- `ui.rs`: Updated `draw_usage_bars()` to include email in the block title

## Test plan
- [x] All 843 unit tests pass
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt --check` clean
- [ ] Manual verification: run `midtown chat` and confirm email appears in Usage heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)