### PR TITLE
feat: Enable Kitty graphics passthrough in tmux session [Midtown #819]

### DIFF
--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -579,6 +579,11 @@ pub fn handle_start(
             return Err(format!("Failed to create session '{}'", session));
         }
 
+        // Enable Kitty graphics protocol passthrough for terminals that support it (e.g., Ghostty)
+        let _ = Command::new("tmux")
+            .args(["set-option", "-t", &session, "allow-passthrough", "on"])
+            .status();
+
         // Configure status bar with dark gray background and yellow foreground (Lead's color)
         let _ = Command::new("tmux")
             .args([


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Adds `allow-passthrough on` to the tmux session options when creating the midtown session
- Enables Kitty graphics protocol APC sequences to pass through tmux to the outer terminal (e.g., Ghostty)
- Without this, inline images (such as mermaid diagrams from the architect pipeline) appear as blank space in tmux

## Test plan
- [x] Verified the change is a single `set-option` call placed after session creation, following the existing pattern
- [ ] Manual verification: start midtown in a Kitty-protocol-capable terminal (Ghostty) and confirm mermaid diagram images render correctly through tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)