### PR TITLE
feat: Add CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS env to shared settings [Midtown #826]

### DIFF
--- a/agents/common-settings.json
+++ b/agents/common-settings.json
@@ -1,3 +1,6 @@
 {
-  "autoUpdates": false
+  "autoUpdates": false,
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
 }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -2388,6 +2388,7 @@ mod tests {
 
         // Verify common settings are merged in
         assert_eq!(settings["autoUpdates"], false);
+        assert_eq!(settings["env"]["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"], "1");
 
         // Verify coworker-specific settings
         assert_eq!(settings["editorMode"], "normal");
@@ -2451,6 +2452,7 @@ mod tests {
 
         // Verify common settings are merged in
         assert_eq!(settings["autoUpdates"], false);
+        assert_eq!(settings["env"]["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"], "1");
 
         // Verify lead-specific hooks
         let stop_hooks = &settings["hooks"]["Stop"];


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Added `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` to `agents/common-settings.json` so both Lead and coworker sessions have the agent teams feature enabled
- Updated tests in `tmux.rs` to verify the new env key is present in both coworker and lead settings

## Test plan
- [x] `cargo test settings_json_is_valid` passes (both coworker and lead)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)