### PR TITLE
feat: Detect stale PENDING CI checks that never started [Midtown #825]

### DIFF
--- a/src/ci_stats.rs
+++ b/src/ci_stats.rs
@@ -1,8 +1,11 @@
 //! CI check duration statistics for auto-retry of stale checks.
 //!
-//! Tracks historical completion times for CI checks to detect when checks
-//! are running significantly longer than typical (4x threshold). When a check
-//! exceeds this threshold, the daemon can trigger a re-run.
+//! Tracks historical completion times for CI checks to detect two failure modes:
+//! - **Pass 1 (in-progress)**: Checks running significantly longer than typical (4x threshold).
+//! - **Pass 2 (pending)**: Checks stuck in QUEUED/PENDING/WAITING when all siblings completed
+//!   (2x typical duration with a 30-minute minimum floor).
+//!
+//! When a stale check is detected, the daemon can trigger a workflow re-run.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -292,6 +295,44 @@ mod tests {
 
         let invalid = "https://github.com/owner/repo/pull/42";
         assert_eq!(extract_run_id_from_url(invalid), None);
+    }
+
+    #[test]
+    fn test_is_pending_stale() {
+        let mut stats = CiCheckStats::default();
+        // Typical duration: 1200 seconds (20 min) → 2x = 2400s > MIN (1800s)
+        for _ in 0..5 {
+            stats.record_duration("SlowCheck", 1200);
+        }
+
+        // 2x threshold = 2400 seconds (multiplier wins over 1800s floor)
+        assert!(!stats.is_pending_stale("SlowCheck", 2000)); // Below threshold
+        assert!(!stats.is_pending_stale("SlowCheck", 2400)); // At threshold (not stale)
+        assert!(stats.is_pending_stale("SlowCheck", 2401)); // Above threshold
+    }
+
+    #[test]
+    fn test_is_pending_stale_floor_applies() {
+        let mut stats = CiCheckStats::default();
+        // Typical duration: 120 seconds (2 min) → 2x = 240s < MIN (1800s)
+        for _ in 0..5 {
+            stats.record_duration("FastCheck", 120);
+        }
+
+        // Floor of 1800s should apply since 2x (240s) < MIN_PENDING_STALE_SECS
+        assert!(!stats.is_pending_stale("FastCheck", 1000)); // Well below floor
+        assert!(!stats.is_pending_stale("FastCheck", 1800)); // At floor (not stale)
+        assert!(stats.is_pending_stale("FastCheck", 1801)); // Above floor
+    }
+
+    #[test]
+    fn test_is_pending_stale_default_threshold() {
+        let stats = CiCheckStats::default();
+
+        // No samples → default 600s, 2x = 1200s < MIN (1800s), floor applies
+        assert!(!stats.is_pending_stale("Unknown", 1500));
+        assert!(!stats.is_pending_stale("Unknown", 1800)); // At floor
+        assert!(stats.is_pending_stale("Unknown", 1801)); // Above floor
     }
 
     #[test]

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -2692,11 +2692,15 @@ pub(super) async fn handle_webhook_ci_failure(
     }
 }
 
-/// Detect CI checks that are stuck (running > 4x typical duration) and collect re-run effects.
+/// Detect stale CI checks and collect re-run effects.
 ///
-/// This function examines `statusCheckRollup` for each PR to find checks that have been
-/// running for an unusually long time. When detected, it returns effects to re-run the
-/// workflow. Uses historical check durations to determine "typical" time.
+/// Examines `statusCheckRollup` for each PR to find stuck checks in two passes:
+/// - **Pass 1**: IN_PROGRESS checks running > 4x typical duration.
+/// - **Pass 2**: QUEUED/PENDING/WAITING checks that never started when all sibling checks
+///   have completed (2x typical duration with a 30-minute minimum floor).
+///
+/// Returns effects to re-run the affected workflows. Uses historical check durations
+/// from `CiCheckStats` to determine "typical" time.
 async fn collect_stale_check_effects(
     state: &DaemonState,
     prs: &[serde_json::Value],
@@ -3433,6 +3437,46 @@ mod tests {
         assert!(
             effects.is_empty(),
             "should skip pending check re-run when on cooldown"
+        );
+    }
+
+    #[test]
+    fn collect_stale_check_effects_pending_skips_malformed_sibling_timestamps() {
+        use chrono::{DateTime, Utc};
+
+        let ci_stats = test_ci_stats_with_duration("task_sharing", 120);
+        let now: DateTime<Utc> = "2026-02-04T13:00:00Z".parse().unwrap();
+
+        // All siblings COMPLETED but with missing/malformed startedAt
+        let prs = vec![json!({
+            "number": 679,
+            "statusCheckRollup": [
+                {
+                    "name": "Test",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "startedAt": "not-a-date",
+                    "detailsUrl": "https://github.com/owner/repo/actions/runs/111/job/1"
+                },
+                {
+                    "name": "Clippy",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "detailsUrl": "https://github.com/owner/repo/actions/runs/111/job/2"
+                },
+                {
+                    "name": "task_sharing",
+                    "status": "QUEUED",
+                    "startedAt": "",
+                    "detailsUrl": "https://github.com/owner/repo/actions/runs/222/job/3"
+                }
+            ]
+        })];
+
+        let effects = collect_stale_check_effects_with_time(&ci_stats, &prs, now);
+        assert!(
+            effects.is_empty(),
+            "should skip pending check when sibling timestamps are unparseable"
         );
     }
 


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Add Pass 2 to `collect_stale_check_effects_with_time` that detects checks stuck in QUEUED/PENDING/WAITING state when all sibling checks on the same PR have completed
- Uses 2x typical duration threshold with a 30-minute minimum floor to avoid false positives on fresh pushes
- Triggers the existing `RerunWorkflow` effect to re-run stuck workflows, respecting existing rerun cooldowns
- Adds `is_pending_stale()` method to `CiCheckStats` with new constants `PENDING_STALE_MULTIPLIER` (2.0) and `MIN_PENDING_STALE_SECS` (1800)

## Test plan
- [x] 5 unit tests covering: detection when siblings completed, no false positive when siblings still running, threshold behavior, minimum floor enforcement, rerun cooldown respect
- [x] All 848 existing tests pass
- [x] Clippy clean with `-D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)