### PR TITLE
test: Add action message mermaid placeholder indent test [Midtown #1]

### DIFF
--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -3083,9 +3083,10 @@ mod tests {
             "Normal message should have {} chars indent",
             TIMESTAMP_GUTTER_WIDTH
         );
-        assert!(
-            placeholder_text.len() > normal_placeholder.len(),
-            "Action message placeholder should be wider than normal due to extra indent"
+        assert_eq!(
+            placeholder_text.len(),
+            normal_placeholder.len() + 2,
+            "Action message placeholder should be exactly 2 chars wider than normal due to extra indent"
         );
     }
 }


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Adds test for `MessageType::Action` mermaid placeholder indentation (wider by 2 chars due to `* ` prefix)
- Cross-validates action vs normal text message indent to catch regressions
- Addresses review feedback from PR #718 noting missing action message test coverage

## Test plan
- [x] New test passes (`cargo test --bin midtown -- test_action_message_mermaid`)
- [x] Full test suite passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean