### PR TITLE
fix: Skip pane capture for non-running coworkers [Midtown #2]

### DIFF
--- a/src/daemon/snapshot.rs
+++ b/src/daemon/snapshot.rs
@@ -609,7 +609,7 @@ mod tests {
         use crate::coworker::{Coworker, CoworkerStatus};
 
         // Simulate a mix of coworker statuses
-        let all_coworkers = vec![
+        let all_coworkers = [
             Coworker {
                 name: "lexington".to_string(),
                 status: CoworkerStatus::Running,


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Changed pane capture loop in `collect_world_snapshot` to iterate over `running_coworkers` instead of `active_coworkers`
- Coworkers in Stopping/Starting states have no tmux windows, so `tmux capture-pane` would fail with "can't find window" errors on every daemon tick
- With 6 on-break coworkers, this produced hundreds of errors in daemon.err

## Test plan
- [x] Added regression test `test_pane_capture_only_for_running_coworkers` verifying only Running status coworkers are candidates for pane capture
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)