### PR TITLE
feat: Format review notes with markdown in reviewer.md [Midtown #1]

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -27,9 +27,19 @@ NOTIFY LEAD OF SIGNIFICANT FINDINGS: Post to the channel to notify the lead abou
    - "@lead [Verification] Ran containerized E2E tests locally — all 41 tests pass"
    - "@lead [Verification] Tested webhook flow end-to-end — events are routed correctly"
 
-2. **Below-threshold issues** — Consolidate ALL below-threshold issues for the PR into a **single** `@lead [Review Note]` message. Do NOT post separate messages for each issue — group them together with bullet points:
-   - "@lead [Review Note] PR #123: (1) <first issue>. (2) <second issue>. (3) <third issue>. Please determine if any warrant follow-up tasks."
-   - If there is only one below-threshold issue, a single sentence is fine: "@lead [Review Note] PR #123: <brief description>. Please determine if this warrants a follow-up task and create one if so."
+2. **Below-threshold issues** — Consolidate ALL below-threshold issues for the PR into a **single** `@lead [Review Note]` message. Do NOT post separate messages for each issue. Use markdown formatting for readability:
+   - Multiple issues — use bullet points with **bold** key terms and backticks for `code references`:
+     ```
+     @lead [Review Note] PR #123:
+     - **Untested edge case** — `process_event()` in `handler.rs` doesn't check for empty input
+     - **Missing null check** — `get_repo_url()` returns empty string instead of `None`
+
+     Please determine if any warrant follow-up tasks.
+     ```
+   - Single issue — a single sentence with backticks for code references:
+     ```
+     @lead [Review Note] PR #123: **Unvalidated input** — `parse_config()` in `config.rs` accepts negative values without bounds check. Please determine if this warrants a follow-up task.
+     ```
 
 **Do NOT include numeric scores in @lead messages.** Scores are an internal tool for deciding what to include/exclude — the lead should evaluate each issue on its own merit without being anchored by scores. Describe the issue plainly and let the lead judge its importance.
 


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Updated `agents/reviewer.md` review note formatting instructions
- Multi-issue `[Review Note]` messages now use markdown bullet points with **bold** key terms and backtick `code references` instead of inline `(1)...(2)...(3)...` numbering
- Single-issue format updated to use backticks for code references and bold for emphasis
- Preserves `[Review Note]` tag prefix for daemon routing

## Test plan
- [x] Verify `[Review Note]` tag prefix preserved for daemon message routing
- [x] Confirm examples use bullet points, bold, and backticks
- [x] Pre-commit hooks pass (clippy + fmt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)