### PR TITLE
fix: Reap spawned browser processes to prevent zombies [Midtown #1]

### DIFF
--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -210,13 +210,19 @@ fn open_diagram_in_browser(app: &App, idx: usize) {
         return;
     }
 
-    // Open in browser using platform-appropriate command
+    // Open in browser using platform-appropriate command.
+    // Spawn a thread to wait on the child process so it doesn't become a zombie.
     #[cfg(target_os = "macos")]
-    let _ = std::process::Command::new("open").arg(&svg_path).spawn();
+    let child = std::process::Command::new("open").arg(&svg_path).spawn();
     #[cfg(target_os = "linux")]
-    let _ = std::process::Command::new("xdg-open")
+    let child = std::process::Command::new("xdg-open")
         .arg(&svg_path)
         .spawn();
+    if let Ok(mut child) = child {
+        std::thread::spawn(move || {
+            let _ = child.wait();
+        });
+    }
 }
 
 /// Render hyperlinks using OSC 8 escape sequences


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Spawn a reaper thread to `wait()` on child processes from `open`/`xdg-open` browser launches
- Prevents zombie process accumulation in long-running TUI sessions
- Addresses park's review feedback (issue #3) on PR #723

Issues #1 (UTF-8 truncation) and #2 (stale README) from park's review were already fixed before #723 was merged.

## Test plan
- [x] All 96 chat module tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)