### PR TITLE
chore: Bump version to v0.5.0 [Midtown #1]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,7 +1574,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "midtown"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "axum",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midtown"
-version = "0.4.5"
+version = "0.5.0"
 edition = "2024"
 description = "Midtown - a multi-Claude Code workspace manager, inspired by Gastown"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary

Bump version from 0.4.5 to 0.5.0 in Cargo.toml and Cargo.lock.

This is a significant release: **94 commits** and **33 features** since v0.4.5.

### Key highlights

- **Mermaid diagram rendering** — inline ASCII art in terminal, browser SVG with zoom/pan, fullscreen viewer with Enter key
- **Agent teams mailbox** — coworker message delivery via file-based mailbox system
- **Task CLI** — `midtown task create/list/view` for coworker task management
- **Usage progress bars** — time-to-100% estimates in chat TUI
- **Auth multi-account management** — profile switcher for multiple accounts
- **Headless Claude Code executor** — daemon-managed AI subprocess support
- **Task-based worktree registry** — daemon integration for worktree lifecycle
- **Docker support** — production image for containerized deployment
- **Stale CI check detection** — detect and expire stuck CI checks
- **Review notes formatting** — markdown in reviewer.md
- **Numerous daemon stability fixes** — orphan recovery, nudge deduplication, dispatch improvements, UTF-8 safe truncation, temp file cleanup, zombie process reaping

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] `cargo build --release` succeeds with version `midtown v0.5.0`