### PR TITLE
fix: Export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS as shell env var [Midtown #1]

### DIFF
--- a/agents/common-settings.json
+++ b/agents/common-settings.json
@@ -1,6 +1,3 @@
 {
-  "autoUpdates": false,
-  "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
-  }
+  "autoUpdates": false
 }

--- a/docs/research/agent-teams-mailbox.md
+++ b/docs/research/agent-teams-mailbox.md
@@ -154,7 +154,7 @@ To write to a running Claude Code instance's mailbox from the daemon:
 
 3. **Inbox directory must exist:** `~/.claude/teams/{team-name}/inboxes/`
 
-4. **The `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` env var must be `"1"`** (already set via common-settings.json).
+4. **The `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` env var must be `"1"`** (exported as a shell env var in the tmux launch command — cannot be set via settings.json as it is blocklisted).
 
 5. **Message format must match** the expected inbox JSON schema.
 

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1689,6 +1689,10 @@ impl ClaudeLaunchConfig {
         // Set Claude config directory from the active auth profile
         let config_dir = crate::auth::current_profile_dir();
         env_parts.push(format!("CLAUDE_CONFIG_DIR='{}'", config_dir.display()));
+        // Must be a real shell env var — Claude Code blocklists this from settings.json
+        if self.team_name.is_some() {
+            env_parts.push("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1".to_string());
+        }
         let env_export = format!("export {}", env_parts.join(" "));
 
         // -- Claude CLI arguments (as structured Vec, not format! interpolation) --
@@ -2424,7 +2428,10 @@ mod tests {
 
         // Verify common settings are merged in
         assert_eq!(settings["autoUpdates"], false);
-        assert_eq!(settings["env"]["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"], "1");
+
+        // CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS is blocklisted from settings.json by Claude Code;
+        // it's now exported as a real shell env var in to_shell_command() instead.
+        assert!(settings["env"]["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"].is_null());
 
         // Verify coworker-specific settings
         assert_eq!(settings["editorMode"], "normal");
@@ -2488,7 +2495,10 @@ mod tests {
 
         // Verify common settings are merged in
         assert_eq!(settings["autoUpdates"], false);
-        assert_eq!(settings["env"]["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"], "1");
+
+        // CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS is blocklisted from settings.json by Claude Code;
+        // it's now exported as a real shell env var in to_shell_command() instead.
+        assert!(settings["env"]["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"].is_null());
 
         // Verify lead-specific hooks
         let stop_hooks = &settings["hooks"]["Stop"];
@@ -3233,6 +3243,12 @@ Claude is now processing the request
             result.shell_command.contains("--team-name midtown-myrepo"),
             "must include --team-name flag"
         );
+        assert!(
+            result
+                .shell_command
+                .contains("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1"),
+            "must export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS as shell env var"
+        );
     }
 
     #[test]
@@ -3266,6 +3282,12 @@ Claude is now processing the request
         assert!(
             !result.shell_command.contains("--team-name"),
             "lead must not have --team-name flag"
+        );
+        assert!(
+            !result
+                .shell_command
+                .contains("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"),
+            "lead must not export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"
         );
     }
 


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Export `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` as a real shell env var in the tmux launch command instead of setting it via `common-settings.json`
- Claude Code blocklists this env var from settings.json, so the previous approach was silently ignored — the InboxPoller was never enabled and 0/305 inbox messages were ever read
- Remove the ineffective setting from `agents/common-settings.json`
- Update tests to verify the env var is exported for coworkers but not for the lead

## Test plan
- [x] All 56 tmux unit tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `test_coworker_config_includes_agent_teams_flags` verifies env var is in the export
- [x] `test_lead_config_omits_agent_teams_flags` verifies lead does NOT export the env var
- [x] `test_coworker_settings_json_is_valid` confirms the setting is absent from settings JSON
- [x] `test_lead_settings_json_is_valid` confirms the setting is absent from settings JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)