### PR TITLE
feat: Update selkie-rs to v0.3.0 [Midtown #4]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "selkie-rs"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb1837992502ab6115416ea15458fb3996ca5da8570d8bb23da6fe9d40fad06"
+checksum = "7e4dbea3faa448acb0485c6b63cca7dbfa102b177eacdcb870b31296eb82716d"
 dependencies = [
  "chrono",
  "fontdue",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ ratatui = "0.29"
 crossterm = { version = "0.29", features = ["event-stream"] }
 
 # Mermaid diagram rendering
-selkie-rs = { version = "0.2", default-features = false }
+selkie-rs = { version = "0.3", default-features = false }
 
 # Async file tailing for instant message updates
 tailf = "0.1"

--- a/src/bin/midtown/cli/chat/mermaid.rs
+++ b/src/bin/midtown/cli/chat/mermaid.rs
@@ -243,40 +243,11 @@ fn render_mermaid_diagram(source: &str) -> Option<RenderedDiagram> {
     // Render SVG (works for all diagram types)
     let svg = selkie::render::render_text(&dark_source).ok()?;
 
-    // Try TUI rendering for flowcharts (the only type selkie supports as ASCII)
-    let ascii_art = render_ascii_art(source).unwrap_or_else(|| {
-        // For non-flowchart types, extract a simple text representation from the source
-        format_source_as_ascii(source)
-    });
+    // Render ASCII art (selkie v0.3 supports all diagram types)
+    let ascii_art =
+        selkie::render::render_text_ascii(source).unwrap_or_else(|_| source.to_string());
 
     Some(RenderedDiagram { ascii_art, svg })
-}
-
-/// Attempt to render a flowchart as ASCII art using selkie's TUI renderer
-fn render_ascii_art(source: &str) -> Option<String> {
-    use selkie::diagrams::{detect_type, remove_directives};
-    use selkie::layout::ToLayoutGraph;
-
-    let clean = remove_directives(source);
-    let diagram_type = detect_type(&clean).ok()?;
-
-    // Parse and check if it's a flowchart
-    let diagram = selkie::diagrams::parse(diagram_type, &clean).ok()?;
-    match diagram {
-        selkie::diagrams::Diagram::Flowchart(ref db) => {
-            let estimator = selkie::layout::CharacterSizeEstimator::default();
-            let graph = db.to_layout_graph(&estimator).ok()?;
-            let graph = selkie::layout::layout(graph).ok()?;
-            selkie::render::tui::render_flowchart_tui(db, &graph).ok()
-        }
-        _ => None,
-    }
-}
-
-/// Format mermaid source as a readable ASCII representation for non-flowchart types.
-/// Shows the source lines indented, which is more useful than a single placeholder line.
-fn format_source_as_ascii(source: &str) -> String {
-    source.to_string()
 }
 
 #[cfg(test)]
@@ -405,10 +376,9 @@ mod tests {
         let diagram = result.unwrap();
         assert!(!diagram.svg.is_empty(), "SVG should not be empty");
         assert!(diagram.svg.contains("<svg"), "SVG should contain <svg tag");
-        // Non-flowchart types get source as ASCII fallback
         assert!(
             diagram.ascii_art.contains("Alice"),
-            "ASCII fallback should contain source content"
+            "ASCII art should contain participant names"
         );
     }
 
@@ -420,25 +390,24 @@ mod tests {
     }
 
     #[test]
-    fn test_render_ascii_art_flowchart() {
-        let result = render_ascii_art("graph TD\n  A[Hello]-->B[World]");
-        assert!(result.is_some(), "Flowchart should produce ASCII art");
-        let art = result.unwrap();
+    fn test_render_mermaid_diagram_flowchart_ascii() {
+        let result = render_mermaid_diagram("graph TD\n  A[Hello]-->B[World]");
+        assert!(result.is_some(), "Flowchart should render");
+        let diagram = result.unwrap();
         assert!(
-            art.contains("Hello"),
+            diagram.ascii_art.contains("Hello"),
             "ASCII art should contain node labels"
         );
-        // "World" renders as "Wor▼d" because the edge arrow overlays a character,
-        // so check for the partial label instead.
-        assert!(art.contains("Wor"), "ASCII art should contain node labels");
     }
 
     #[test]
-    fn test_render_ascii_art_non_flowchart_returns_none() {
-        let result = render_ascii_art("sequenceDiagram\n    Alice->>Bob: Hello");
+    fn test_render_mermaid_diagram_sequence_ascii() {
+        let result = render_mermaid_diagram("sequenceDiagram\n    Alice->>Bob: Hello");
+        assert!(result.is_some(), "Sequence diagram should render");
+        let diagram = result.unwrap();
         assert!(
-            result.is_none(),
-            "Non-flowchart should return None for ASCII art"
+            diagram.ascii_art.contains("Alice"),
+            "ASCII art should contain participant names"
         );
     }
 }


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Updates selkie-rs dependency from v0.2 to v0.3.0
- Replaces the manual flowchart-only ASCII rendering pipeline (`detect_type` → `parse` → `layout` → `render_flowchart_tui`) with a single `render_text_ascii()` call that supports **all** diagram types
- Removes the `render_ascii_art` and `format_source_as_ascii` helper functions (31 lines removed)
- Updates tests to verify ASCII rendering works for both flowcharts and sequence diagrams

## Breaking changes in selkie v0.3.0
- `render::tui` module renamed to `render::ascii`
- `render_flowchart_tui()` → `render_flowchart_ascii()`
- New `render_text_ascii()` convenience function handles all diagram types

## Test plan
- [x] All 18 mermaid tests pass
- [x] Full test suite passes (932+ unit tests, 0 failures)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean