### PR TITLE
fix: Read .highwatermark file to prevent task ID reset [Midtown #1]

### DIFF
--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -2284,6 +2284,56 @@ mod tests {
     }
 
     #[test]
+    fn test_concurrent_task_creation_with_highwatermark() {
+        // Verify that concurrent task creation with a pre-existing .highwatermark
+        // produces unique IDs that all exceed the watermark value.
+        let temp_dir = TempDir::new().unwrap();
+        let tasks_dir = temp_dir.path().to_path_buf();
+
+        // Pre-populate with a highwatermark (simulating purged tasks)
+        std::fs::write(tasks_dir.join(".highwatermark"), "100").unwrap();
+
+        let mut handles = Vec::new();
+        for i in 0..10 {
+            let dir = tasks_dir.clone();
+            handles.push(std::thread::spawn(move || {
+                create_task_in_dir(
+                    &dir,
+                    &format!("Concurrent task {}", i),
+                    &format!("Description {}", i),
+                    &format!("Working on task {}", i),
+                    &format!("worker-{}", i),
+                )
+                .unwrap()
+            }));
+        }
+
+        let ids: Vec<String> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let unique_ids: std::collections::HashSet<&String> = ids.iter().collect();
+
+        // All 10 tasks should have unique IDs
+        assert_eq!(
+            unique_ids.len(),
+            10,
+            "all concurrent tasks should get unique IDs"
+        );
+
+        // All IDs should be > 100 (the highwatermark value)
+        for id in &ids {
+            let num: u64 = id.parse().unwrap();
+            assert!(num > 100, "task ID {} should be > 100 (highwatermark)", num);
+        }
+
+        // Highwatermark should reflect the highest assigned ID
+        let max_id: u64 = ids
+            .iter()
+            .filter_map(|id| id.parse::<u64>().ok())
+            .max()
+            .unwrap();
+        assert_eq!(read_highwatermark(&tasks_dir), max_id);
+    }
+
+    #[test]
     fn test_highwatermark_prevents_id_reset_after_purge() {
         // Reproduces the bug: when all task files are purged, IDs reset to 1.
         // With .highwatermark support, IDs should continue from the watermark.


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Task IDs were resetting to 1 whenever all task JSON files were cleaned up, because `next_id` was calculated as `max(existing_file_ids) + 1`
- Now reads the `.highwatermark` file (written by Claude Code) as a floor value when computing the next ID, and writes it back after assignment
- Fix applied to both `ensure_task_in_shared_dir()` and `create_task_in_dir()` code paths via a shared `next_task_id()` helper

## Test plan
- [x] `test_highwatermark_prevents_id_reset_after_purge` — verifies IDs continue from watermark when directory is empty
- [x] `test_highwatermark_updates_after_task_creation` — verifies watermark is written after each new task
- [x] `test_highwatermark_with_ensure_task_in_shared_dir` — same fix via the `ensure_task_in_shared_dir` path
- [x] `test_highwatermark_max_of_files_and_watermark` — verifies `max(files, watermark)` logic when files have higher IDs
- [x] All 51 existing tasks module tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)