### PR TITLE
fix: Wire drain_events into daemon event loop for headless sessions [Midtown #916]

### DIFF
--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -1102,7 +1102,10 @@ impl CoworkerManager {
     /// The second case handles coworkers that were missed during startup discovery
     /// (e.g., due to timing issues or transient tmux failures). Without this,
     /// orphan cleanup would incorrectly delete worktrees for running coworkers.
-    pub fn sync_with_tmux(&self) -> crate::Result<()> {
+    pub fn sync_with_tmux(
+        &self,
+        headless_names: &std::collections::HashSet<String>,
+    ) -> crate::Result<()> {
         let active_windows = tmux::list_windows(&self.session_name)?;
 
         // Get all known coworker names for validation
@@ -1114,8 +1117,9 @@ impl CoworkerManager {
 
         let mut coworkers = self.coworkers.write().unwrap();
 
-        // Remove coworkers whose windows are gone
-        coworkers.retain(|name, _| active_windows.contains(name));
+        // Remove coworkers whose windows are gone, but preserve headless sessions
+        // (they don't have tmux windows but are still alive)
+        coworkers.retain(|name, _| active_windows.contains(name) || headless_names.contains(name));
 
         // Add coworkers whose windows exist but aren't tracked.
         // This prevents orphan cleanup from deleting worktrees for coworkers

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1768,8 +1768,12 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
 
             // Periodically monitor coworker sessions: idle shutdown, nudges, stuck detection
             _ = idle_check_interval.tick() => {
-                // Sync internal state with actual tmux windows first
-                if let Err(e) = state.coworkers.sync_with_tmux() {
+                // Sync internal state with actual tmux windows first.
+                // Preserve headless session names so they don't get removed
+                // (headless coworkers have no tmux windows).
+                let headless_names: std::collections::HashSet<String> =
+                    state.session_manager.list_names().await.into_iter().collect();
+                if let Err(e) = state.coworkers.sync_with_tmux(&headless_names) {
                     warn!("Failed to sync coworker state with tmux: {}", e);
                 }
                 run_tick(&events::DaemonEvent::SessionMonitorTick, &state).await;


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary

This PR fixes a critical issue where headless coworker processes hang and die silently due to stdout pipe buffer overflow.

**Two commits:**

1. **Wire drain_events into daemon event loop** - Adds a 2-second timer to drain headless session stdout and detect process exits
2. **Preserve headless coworkers in sync_with_tmux** - Prevents headless sessions from being removed as "orphans" (they have no tmux windows)

## Root Cause

Headless sessions write stdout to a pipe with a 64KB buffer. Without draining:
- Buffer fills up → process blocks on write → silent hang
- Process eventually dies with no diagnostic output
- Daemon thinks coworker is alive but it's actually stuck

## Changes

### 1. Event Draining (`daemon/mod.rs`)
- Added `session_drain_interval` (2 seconds) to prevent buffer overflow
- Drains stdout events and updates `headless_health` for snapshot
- Detects stopped sessions and posts exit notifications to channel
- Cleans up coworker records and session manager state

### 2. Sync Fix (`coworker.rs`)
- `sync_with_tmux()` now takes `headless_names` parameter
- Preserves headless sessions in the `retain()` filter
- Without this, headless coworkers are incorrectly removed as "orphans"

## Test Plan

- [x] Unit tests pass (`cargo test --lib`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [ ] CI E2E tests pass
- [ ] Manual verification: headless coworkers no longer hang or get orphaned

This fixes task #915.