### PR TITLE
feat: Adopt !N for tasks and #N for PRs as reference syntax [Midtown !926]

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -127,11 +127,11 @@ This notifies the lead to create a task. Another coworker can work on it in para
 - Commit frequently with clear messages
 - When done, push and create a PR
 
-**Always include the task number in the PR title** using `[Midtown #XXX]` at the end. This makes it easy to trace PRs back to tasks.
+**Always include the task number in the PR title** using `[Midtown !XXX]` at the end. This makes it easy to trace PRs back to tasks.
 
 Example PR creation:
 ```bash
-gh pr create --title "feat: Add auth endpoint [Midtown #42]" --body "$(cat <<'EOF'
+gh pr create --title "feat: Add auth endpoint [Midtown !42]" --body "$(cat <<'EOF'
 <!-- midtown: {name} -->
 
 ## Summary

--- a/agents/lead.md
+++ b/agents/lead.md
@@ -204,7 +204,7 @@ If the user sends a general message without @mentions, you'll still receive it a
 When the human makes a suggestion or provides feedback related to an in-progress task but does NOT @mention the coworker directly, post it to the channel using @mentions so the relevant coworker sees it:
 
 ```bash
-# User suggests something about task #3 that park is working on:
+# User suggests something about task !3 that park is working on:
 midtown channel post "@park User feedback: <their suggestion>"
 ```
 
@@ -235,10 +235,10 @@ Keep the summary concise - coworkers need context, not the full response. Focus 
 Example:
 ```bash
 # User asked about project status
-midtown channel post "Replied to user: Gave status update on auth feature - 2 tasks remaining, park is on task #5"
+midtown channel post "Replied to user: Gave status update on auth feature - 2 tasks remaining, park is on task !5"
 
 # User requested a new feature
-midtown channel post "Replied to user: Created task #12 for dashboard export feature"
+midtown channel post "Replied to user: Created task !12 for dashboard export feature"
 ```
 
 ## Reminders
@@ -300,7 +300,7 @@ When you update a task that a coworker is actively working on, always @mention t
 ```bash
 # After updating task description/requirements:
 midtown task update 714 --description "Updated root cause..."
-midtown channel post "@vernon Updated task #714 description — root cause changed, see updated task for details."
+midtown channel post "@vernon Updated task !714 description — root cause changed, see updated task for details."
 ```
 
 ## Grouping Related Tasks

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -9,7 +9,7 @@ CHANNEL MESSAGE DISCIPLINE: Only post to the channel at these moments:
 Do NOT post task creation, task claims, or intermediate progress to the channel. The channel is for coordination, not a task log. Keep it clean.
 
 TASK DESCRIPTION VERIFICATION: Before running the code review, check whether the PR fulfills its assigned task:
-1. Find the task ID from the PR title — it uses the format `[Midtown #XX]`
+1. Find the task ID from the PR title — it uses the format `[Midtown !XX]`
 2. Run `midtown task view <id>` to read the full, current task description
 3. Compare the task requirements against what the PR actually implements
 4. If any requirements from the task description are missing from the PR, flag them in your review comment as "Missing from task description" items — these are separate from code quality issues

--- a/notification-audit.md
+++ b/notification-audit.md
@@ -120,12 +120,12 @@ for channel messages, and share a `format_review_comment_nudge()` helper for nud
 
 **`daemon_messages.rs:77-88`** — `called_in_pending_task()` does NOT accept a subject:
 ```rust
-"🚀 Called in coworker {name} for pending task #{task}"
+"🚀 Called in coworker {name} for pending task !{task}"
 ```
 
 **`daemon_messages.rs:91-108`** — `called_in_assigned_task()` DOES accept a subject:
 ```rust
-"🚀 Called in coworker {name} for assigned task #{task}: {subject}"
+"🚀 Called in coworker {name} for assigned task !{task}: {subject}"
 ```
 
 **Impact**: When the daemon spawns a coworker for a pending task with an existing
@@ -147,10 +147,10 @@ from the team-visible channel message:
 
 | Path | Coworker prompt | Channel message |
 |------|----------------|-----------------|
-| Orphan recovery (`dispatch.rs:76-78`) | `"task #{id}: {subject}"` | `"♻️ Recovered coworker {name} for orphaned task #{id}"` (line 106-108) |
-| Discovered coworker (`dispatch.rs:187-189`) | `"Resume task #{id}: {subject}"` | `"♻️ Nudged discovered coworker {name} to resume task #{id}"` (line 204-206) |
-| Stuck restart (`health.rs:442-444`) | `"task #{id}: {subject}"` | `"🔄 Restarted stuck coworker {name} ... resuming task #{id}"` (line 462-465) |
-| Pending task spawn (`dispatch.rs:679-681`) | `"task #{id}: {subject}"` | `called_in_pending_task(name, id)` — no subject (line 699-702) |
+| Orphan recovery (`dispatch.rs:76-78`) | `"task !{id}: {subject}"` | `"♻️ Recovered coworker {name} for orphaned task !{id}"` (line 106-108) |
+| Discovered coworker (`dispatch.rs:187-189`) | `"Resume task !{id}: {subject}"` | `"♻️ Nudged discovered coworker {name} to resume task !{id}"` (line 204-206) |
+| Stuck restart (`health.rs:442-444`) | `"task !{id}: {subject}"` | `"🔄 Restarted stuck coworker {name} ... resuming task !{id}"` (line 462-465) |
+| Pending task spawn (`dispatch.rs:679-681`) | `"task !{id}: {subject}"` | `called_in_pending_task(name, id)` — no subject (line 699-702) |
 
 **Recommendation**: Include `{subject}` in all recovery/restart channel messages
 for consistency with `called_in_assigned_task()`.

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -378,7 +378,7 @@ mod tests {
         assert!(prompt.contains("Coordination"));
         assert!(prompt.contains("Read the Channel"));
         assert!(prompt.contains("midtown channel read"));
-        assert!(prompt.contains("[Midtown #"));
+        assert!(prompt.contains("[Midtown !"));
     }
 
     #[test]

--- a/src/bin/midtown/cli/hooks.rs
+++ b/src/bin/midtown/cli/hooks.rs
@@ -752,7 +752,7 @@ fn ensure_lead_task_persistence(
 ///
 /// Claude Code's tool_result for TaskCreate may be:
 /// - A JSON object with an "id" field
-/// - A string containing "task N" or "task #N"
+/// - A string containing "task N" or "task !N"
 /// - A string containing "id: N" or "id N"
 fn extract_internal_task_id(context: &serde_json::Value) -> Option<String> {
     let result = &context["tool_result"];
@@ -767,7 +767,7 @@ fn extract_internal_task_id(context: &serde_json::Value) -> Option<String> {
 
     // Try as string containing a task ID pattern
     if let Some(s) = result.as_str() {
-        // Look for patterns like "task 1", "task #1", "Task #1:", "id: 1"
+        // Look for patterns like "task 1", "task !1", "Task !1:", "id: 1"
         let lower = s.to_lowercase();
         if let Some(pos) = lower.find("task") {
             let rest = &s[pos + 4..];
@@ -1184,7 +1184,7 @@ Second insight
     #[test]
     fn test_extract_internal_task_id_string_task_hash() {
         let context = serde_json::json!({
-            "tool_result": "Task #42 created successfully"
+            "tool_result": "Task !42 created successfully"
         });
         assert_eq!(extract_internal_task_id(&context), Some("42".to_string()));
     }

--- a/src/bin/midtown/cli/task.rs
+++ b/src/bin/midtown/cli/task.rs
@@ -116,7 +116,7 @@ fn handle_list(show_all: bool) -> Result<Response, String> {
                 || t.status == midtown::tasks::TaskStatus::InProgress
         })
         .map(|t| TaskInfo {
-            id: format!("#{}", t.id),
+            id: format!("!{}", t.id),
             subject: t.subject,
             status: match t.status {
                 midtown::tasks::TaskStatus::Pending => "pending".to_string(),
@@ -136,12 +136,15 @@ fn handle_list(show_all: bool) -> Result<Response, String> {
 /// (e.g., "midtown task view 777") reference the shared list, so this always reads
 /// from the correct location regardless of the caller's task isolation mode.
 fn handle_view(id: &str) -> Result<Response, String> {
-    let id = id.strip_prefix('#').unwrap_or(id);
+    let id = id
+        .strip_prefix('#')
+        .or_else(|| id.strip_prefix('!'))
+        .unwrap_or(id);
     let tasks = midtown::tasks::read_tasks();
     let task = tasks
         .iter()
         .find(|t| t.id == id)
-        .ok_or_else(|| format!("Task #{} not found", id))?;
+        .ok_or_else(|| format!("Task !{} not found", id))?;
 
     let status_str = match task.status {
         midtown::tasks::TaskStatus::Pending => "pending",
@@ -149,7 +152,7 @@ fn handle_view(id: &str) -> Result<Response, String> {
         midtown::tasks::TaskStatus::Completed => "completed",
     };
 
-    let mut output = format!("Task #{}\n", task.id);
+    let mut output = format!("Task !{}\n", task.id);
     output.push_str("─────────────────────────────\n");
     output.push_str(&format!("Subject:  {}\n", task.subject));
     output.push_str(&format!("Status:   {}\n", status_str));

--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -77,7 +77,7 @@ pub(super) fn check_and_recover_orphans(
         let cooldowns = state.cooldowns.lock().unwrap();
         if !cooldowns.check("spawn_failure", &recovery.owner, SPAWN_FAILURE_COOLDOWN) {
             debug!(
-                "Spawn failure cooldown active for {} — skipping orphan recovery for task #{}",
+                "Spawn failure cooldown active for {} — skipping orphan recovery for task !{}",
                 recovery.owner, recovery.task_id
             );
             return vec![];
@@ -85,14 +85,14 @@ pub(super) fn check_and_recover_orphans(
     }
 
     info!(
-        "Detected orphaned task #{} owned by {} - attempting recovery",
+        "Detected orphaned task !{} owned by {} - attempting recovery",
         recovery.task_id, recovery.owner
     );
 
     let prompt = format_task_prompt(
         &recovery.task_id,
         &format!(
-            "You've been assigned task #{}: {}. Your previous session was interrupted but your worktree and branch are still intact. Check your git status and get started!",
+            "You've been assigned task !{}: {}. Your previous session was interrupted but your worktree and branch are still intact. Check your git status and get started!",
             recovery.task_id, recovery.task_subject
         ),
     );
@@ -123,7 +123,7 @@ pub(super) fn check_and_recover_orphans(
             Effect::PostToChannel {
                 sender: "midtown".to_string(),
                 message: format!(
-                    "♻️ Recovered coworker {} for orphaned task #{}",
+                    "♻️ Recovered coworker {} for orphaned task !{}",
                     recovery.owner, recovery.task_id
                 ),
             },
@@ -140,7 +140,7 @@ pub(super) fn check_and_recover_orphans(
             Effect::PostToChannel {
                 sender: "midtown".to_string(),
                 message: format!(
-                    "🔄 Task #{} reset to pending - {} could not be respawned (backing off for {}s)",
+                    "🔄 Task !{} reset to pending - {} could not be respawned (backing off for {}s)",
                     recovery.task_id,
                     recovery.owner,
                     SPAWN_FAILURE_COOLDOWN.as_secs()
@@ -220,13 +220,13 @@ fn decide_discovered_coworker_nudges(
             let prompt = format_task_prompt(
                 task_id,
                 &format!(
-                    "Resume task #{}: {}. The daemon was restarted and discovered you still running. Check your git status and continue where you left off.",
+                    "Resume task !{}: {}. The daemon was restarted and discovered you still running. Check your git status and continue where you left off.",
                     task_id, task_subject
                 ),
             );
 
             info!(
-                "Nudging discovered coworker {} to resume task #{}",
+                "Nudging discovered coworker {} to resume task !{}",
                 name, task_id
             );
 
@@ -237,7 +237,7 @@ fn decide_discovered_coworker_nudges(
             effects.push(Effect::PostToChannel {
                 sender: "midtown".to_string(),
                 message: format!(
-                    "♻️ Nudged discovered coworker {} to resume task #{}",
+                    "♻️ Nudged discovered coworker {} to resume task !{}",
                     name, task_id
                 ),
             });
@@ -319,7 +319,7 @@ pub(super) fn check_for_duplicate_task_workers(
             .unwrap_or("unknown");
 
         info!(
-            "Detected {} duplicate workers on task #{} ({}): {:?}",
+            "Detected {} duplicate workers on task !{} ({}): {:?}",
             workers.len(),
             task_id,
             task_subject,
@@ -348,13 +348,13 @@ pub(super) fn check_for_duplicate_task_workers(
         // Keep the first (earliest) worker, kill the rest
         let (keeper, keeper_time) = workers_with_times[0].clone();
         info!(
-            "Keeping {} (started {:?}) for task #{}",
+            "Keeping {} (started {:?}) for task !{}",
             keeper, keeper_time, task_id
         );
 
         for (duplicate, dup_time) in workers_with_times.into_iter().skip(1) {
             warn!(
-                "Killing duplicate worker {} (started {:?}) for task #{} - {} is already working on it",
+                "Killing duplicate worker {} (started {:?}) for task !{} - {} is already working on it",
                 duplicate, dup_time, task_id, keeper
             );
 
@@ -370,7 +370,7 @@ pub(super) fn check_for_duplicate_task_workers(
             effects.push(Effect::PostToChannel {
                 sender: "midtown".to_string(),
                 message: format!(
-                    "🔪 Killed duplicate worker {} on task #{} ({}) - {} started earlier",
+                    "🔪 Killed duplicate worker {} on task !{} ({}) - {} started earlier",
                     duplicate, task_id, task_subject, keeper
                 ),
             });
@@ -753,7 +753,7 @@ pub(super) fn spawn_for_pending_tasks(
             && snap.merged_pr_numbers.contains(&pr_num)
         {
             info!(
-                "Auto-completing stale task #{}: PR #{} has been merged",
+                "Auto-completing stale task !{}: PR #{} has been merged",
                 task_id, pr_num
             );
             effects.push(Effect::CompleteTask {
@@ -803,14 +803,14 @@ pub(super) fn spawn_for_pending_tasks(
             } => {
                 let nudge_msg = format_task_prompt(
                     tid,
-                    &format!("You have pending task #{}: {}. Get started!", tid, subj),
+                    &format!("You have pending task !{}: {}. Get started!", tid, subj),
                 );
                 // Deliver via mailbox (non-urgent task assignment to idle coworker).
                 // Also send via tmux as fallback in case mailbox isn't polled.
                 effects.push(Effect::DeliverMailboxMessage {
                     name: o.clone(),
                     message: nudge_msg.clone(),
-                    summary: Some(format!("Task #{} assignment", tid)),
+                    summary: Some(format!("Task !{} assignment", tid)),
                 });
                 effects.push(Effect::NudgeCoworkerWithCallbacks {
                     name: o.clone(),
@@ -827,12 +827,12 @@ pub(super) fn spawn_for_pending_tasks(
                 task_subject: ref subj,
             } => {
                 info!(
-                    "Pending task #{} is assigned to {} but coworker not running - spawning",
+                    "Pending task !{} is assigned to {} but coworker not running - spawning",
                     tid, o
                 );
                 let prompt = format_task_prompt(
                     tid,
-                    &format!("You've been assigned task #{}: {}. Get started!", tid, subj),
+                    &format!("You've been assigned task !{}: {}. Get started!", tid, subj),
                 );
                 let config = crate::launch::LaunchConfig::coworker(
                     o.clone(),
@@ -912,7 +912,7 @@ pub(super) fn spawn_for_pending_tasks(
         // Check dev coworkers limit before spawning (reserve slots for reviewers)
         if snap.is_at_dev_limit {
             debug!(
-                "Dev coworkers limit reached, deferring unowned task #{}",
+                "Dev coworkers limit reached, deferring unowned task !{}",
                 task.id
             );
             break;
@@ -923,7 +923,7 @@ pub(super) fn spawn_for_pending_tasks(
         // before the previous tick's AssignAndSpawn effect has completed its disk write.
         if state.is_task_spawn_in_flight(&task.id) {
             debug!(
-                "Task #{} already has in-flight spawn, skipping duplicate",
+                "Task !{} already has in-flight spawn, skipping duplicate",
                 task.id
             );
             continue;
@@ -935,7 +935,7 @@ pub(super) fn spawn_for_pending_tasks(
             && snap.merged_pr_numbers.contains(&pr_num)
         {
             info!(
-                "Auto-completing stale task #{}: PR #{} has been merged",
+                "Auto-completing stale task !{}: PR #{} has been merged",
                 task.id, pr_num
             );
             effects.push(Effect::CompleteTask {
@@ -958,7 +958,7 @@ pub(super) fn spawn_for_pending_tasks(
                 // Check in-memory map first (handles same-tick assignments)
                 if let Some(name) = pr_coworker_map.get(&pr_num) {
                     info!(
-                        "Task #{} references PR #{} - assigning to in-memory owner {}",
+                        "Task !{} references PR #{} - assigning to in-memory owner {}",
                         task.id, pr_num, name
                     );
                     break 'resolve Some(name.clone());
@@ -968,7 +968,7 @@ pub(super) fn spawn_for_pending_tasks(
                     crate::tasks::find_pr_owner_in_tasks(&pr_num, all_tasks)
                 {
                     info!(
-                        "Task #{} references PR #{} - assigning to existing owner {}",
+                        "Task !{} references PR #{} - assigning to existing owner {}",
                         task.id, pr_num, existing_owner
                     );
                     break 'resolve Some(existing_owner);
@@ -980,7 +980,7 @@ pub(super) fn spawn_for_pending_tasks(
             for blocked_by_id in &task.blocked_by {
                 if let Some(name) = task_coworker_map.get(blocked_by_id) {
                     info!(
-                        "Task #{} blocked by #{} - assigning to same owner {}",
+                        "Task !{} blocked by #{} - assigning to same owner {}",
                         task.id, blocked_by_id, name
                     );
                     break 'resolve Some(name.clone());
@@ -989,7 +989,7 @@ pub(super) fn spawn_for_pending_tasks(
             // Check disk for blockedBy owners
             if let Some(owner) = crate::tasks::find_owner_via_blocked_by(task, all_tasks) {
                 info!(
-                    "Task #{} blocked by owned task - assigning to {}",
+                    "Task !{} blocked by owned task - assigning to {}",
                     task.id, owner
                 );
                 break 'resolve Some(owner);
@@ -1007,10 +1007,10 @@ pub(super) fn spawn_for_pending_tasks(
             name
         } else {
             let Some(name) = state.coworkers.next_available_name() else {
-                debug!("No available coworker slots for unowned task #{}", task.id);
+                debug!("No available coworker slots for unowned task !{}", task.id);
                 break;
             };
-            debug!("Task #{}: allocated fresh coworker name {}", task.id, name,);
+            debug!("Task !{}: allocated fresh coworker name {}", task.id, name,);
             name
         };
 
@@ -1040,7 +1040,7 @@ pub(super) fn spawn_for_pending_tasks(
                 || (is_busy_from_snapshot && !was_grouped))
         {
             debug!(
-                "Task #{}: skipping coworker {} (busy_snapshot={}, assigned_tick={}, reviewer={}, grouped={})",
+                "Task !{}: skipping coworker {} (busy_snapshot={}, assigned_tick={}, reviewer={}, grouped={})",
                 task.id,
                 coworker_name,
                 is_busy_from_snapshot,
@@ -1055,14 +1055,14 @@ pub(super) fn spawn_for_pending_tasks(
         // to the same not-yet-spawned coworker within the same tick.
         if !already_running && (assigned_this_tick || is_busy_from_snapshot) && !was_grouped {
             debug!(
-                "Task #{}: skipping {} (already assigned this tick)",
+                "Task !{}: skipping {} (already assigned this tick)",
                 task.id, coworker_name
             );
             continue;
         }
 
         info!(
-            "Proposing task #{} for {} (already_running={})",
+            "Proposing task !{} for {} (already_running={})",
             task.id, coworker_name, already_running
         );
 
@@ -1080,7 +1080,7 @@ pub(super) fn spawn_for_pending_tasks(
             format_task_prompt(
                 &task.id,
                 &format!(
-                    "You've been assigned task #{}: {}. Run `midtown task claim {}` to claim it, then get started!",
+                    "You've been assigned task !{}: {}. Run `midtown task claim {}` to claim it, then get started!",
                     task.id, task.subject, task.id
                 ),
             )
@@ -1088,7 +1088,7 @@ pub(super) fn spawn_for_pending_tasks(
             format_task_prompt(
                 &task.id,
                 &format!(
-                    "You've been assigned task #{}: {}. Get started!",
+                    "You've been assigned task !{}: {}. Get started!",
                     task.id, task.subject
                 ),
             )
@@ -1191,7 +1191,7 @@ pub(super) fn build_task_completion_effects(
         Effect::PostToChannel {
             sender: "midtown".to_string(),
             message: format!(
-                "✅ Auto-completed task #{} (PR #{} opened)",
+                "✅ Auto-completed task !{} (PR #{} opened)",
                 task_id, pr_number
             ),
         },
@@ -1665,7 +1665,7 @@ mod tests {
         match &effects[0] {
             Effect::NudgeCoworker { name, message } => {
                 assert_eq!(name, "lexington");
-                assert!(message.contains("Resume task #42"));
+                assert!(message.contains("Resume task !42"));
             }
             _ => panic!("Expected NudgeCoworker"),
         }
@@ -1673,7 +1673,7 @@ mod tests {
             Effect::PostToChannel { sender, message } => {
                 assert_eq!(sender, "midtown");
                 assert!(message.contains("lexington"));
-                assert!(message.contains("task #42"));
+                assert!(message.contains("task !42"));
             }
             _ => panic!("Expected PostToChannel"),
         }
@@ -1756,7 +1756,7 @@ mod tests {
         // Should nudge about the task, not the review
         match &effects[0] {
             Effect::NudgeCoworker { message, .. } => {
-                assert!(message.contains("Resume task #42"));
+                assert!(message.contains("Resume task !42"));
             }
             _ => panic!("Expected NudgeCoworker"),
         }

--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -480,7 +480,7 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
             }
             Effect::ResetTaskToPending { task_id, repo_name } => {
                 if let Err(e) = crate::tasks::reset_task_to_pending_for_repo(&task_id, &repo_name) {
-                    warn!("Failed to reset task #{} to pending: {}", task_id, e);
+                    warn!("Failed to reset task !{} to pending: {}", task_id, e);
                 }
                 // Clear task assignment tracking (task is no longer assigned)
                 state.clear_task_assignment_by_task(&task_id);
@@ -561,7 +561,7 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                         // Set task owner on disk so status and owner are consistent
                         if let Err(e) = crate::tasks::update_task_owner(&task_id, &owner) {
                             warn!(
-                                "Failed to set task #{} owner to {} after spawn: {}",
+                                "Failed to set task !{} owner to {} after spawn: {}",
                                 task_id, owner, e
                             );
                         }
@@ -570,7 +570,7 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                             crate::tasks::set_task_in_progress_for_repo(&task_id, &repo_name)
                         {
                             warn!(
-                                "Failed to set task #{} to in_progress after spawn: {}",
+                                "Failed to set task !{} to in_progress after spawn: {}",
                                 task_id, e
                             );
                         }
@@ -696,9 +696,9 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
             }
             Effect::CompleteTask { task_id, repo_name } => {
                 if let Err(e) = crate::tasks::complete_task_for_repo(&task_id, &repo_name) {
-                    warn!("Failed to complete task #{}: {}", task_id, e);
+                    warn!("Failed to complete task !{}: {}", task_id, e);
                 } else {
-                    info!("Auto-completed task #{}", task_id);
+                    info!("Auto-completed task !{}", task_id);
                     // Clear task assignment tracking (coworker is now free)
                     state.clear_task_assignment_by_task(&task_id);
                 }
@@ -711,12 +711,12 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                     crate::tasks::clear_blocked_by_for_repo(&completed_task_id, &repo_name)
                 {
                     warn!(
-                        "Failed to clear blockedBy for task #{}: {}",
+                        "Failed to clear blockedBy for task !{}: {}",
                         completed_task_id, e
                     );
                 } else {
                     info!(
-                        "Cleared blockedBy references to completed task #{}",
+                        "Cleared blockedBy references to completed task !{}",
                         completed_task_id
                     );
                 }
@@ -751,7 +751,7 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                     ) {
                         Ok(task_id) => {
                             info!(
-                                "Created review feedback task #{} for {} (PR #{})",
+                                "Created review feedback task !{} for {} (PR #{})",
                                 task_id, owner, pr_number
                             );
                         }

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -403,7 +403,7 @@ pub(super) async fn check_and_restart_stuck_coworkers(
     let mut effects = Vec::new();
     for restart in restarts {
         info!(
-            "Coworker {} no events for {}s — restarting for task #{}",
+            "Coworker {} no events for {}s — restarting for task !{}",
             restart.name,
             COWORKER_STUCK_DURATION.as_secs(),
             restart.task_id
@@ -412,7 +412,7 @@ pub(super) async fn check_and_restart_stuck_coworkers(
         let prompt = format_task_prompt(
             &restart.task_id,
             &format!(
-                "You've been assigned task #{}: {}. Your previous session appeared stuck so you were restarted. Check your git status and continue where you left off.",
+                "You've been assigned task !{}: {}. Your previous session appeared stuck so you were restarted. Check your git status and continue where you left off.",
                 restart.task_id, restart.task_subject
             ),
         );
@@ -432,7 +432,7 @@ pub(super) async fn check_and_restart_stuck_coworkers(
         effects.push(Effect::PostToChannel {
             sender: "midtown".to_string(),
             message: format!(
-                "🔄 Restarted stuck coworker {} (no events for {}s) — resuming task #{}",
+                "🔄 Restarted stuck coworker {} (no events for {}s) — resuming task !{}",
                 restart.name,
                 COWORKER_STUCK_DURATION.as_secs(),
                 restart.task_id
@@ -662,14 +662,14 @@ pub(super) async fn check_and_respawn_dead_processes(
 
         let exit_code = health.exit_code.unwrap_or(-1);
         warn!(
-            "Coworker {} process died (exit code {}) — restarting for task #{}",
+            "Coworker {} process died (exit code {}) — restarting for task !{}",
             name, exit_code, task_id
         );
 
         let prompt = format_task_prompt(
             task_id,
             &format!(
-                "You've been assigned task #{}: {}. Your previous session crashed (exit code {}). Check your git status and continue where you left off.",
+                "You've been assigned task !{}: {}. Your previous session crashed (exit code {}). Check your git status and continue where you left off.",
                 task_id, task_subject, exit_code
             ),
         );
@@ -693,7 +693,7 @@ pub(super) async fn check_and_respawn_dead_processes(
         effects.push(Effect::PostToChannel {
             sender: "midtown".to_string(),
             message: format!(
-                "💀 Coworker {} process died (exit {}) — restarting for task #{}",
+                "💀 Coworker {} process died (exit {}) — restarting for task !{}",
                 name, exit_code, task_id
             ),
         });

--- a/src/daemon/helpers.rs
+++ b/src/daemon/helpers.rs
@@ -1020,11 +1020,11 @@ mod tests {
     fn format_task_prompt_appends_footer() {
         let result = format_task_prompt(
             "42",
-            "You've been assigned task #42: Fix auth bug. Get started!",
+            "You've been assigned task !42: Fix auth bug. Get started!",
         );
         assert_eq!(
             result,
-            "You've been assigned task #42: Fix auth bug. Get started!\n\nRun `midtown task view 42` for full details."
+            "You've been assigned task !42: Fix auth bug. Get started!\n\nRun `midtown task view 42` for full details."
         );
     }
 
@@ -1032,9 +1032,9 @@ mod tests {
     fn format_task_prompt_works_with_recovery_context() {
         let result = format_task_prompt(
             "99",
-            "Resume task #99: Add tests. The daemon was restarted and discovered you still running. Check your git status and continue where you left off.",
+            "Resume task !99: Add tests. The daemon was restarted and discovered you still running. Check your git status and continue where you left off.",
         );
-        assert!(result.starts_with("Resume task #99:"));
+        assert!(result.starts_with("Resume task !99:"));
         assert!(result.ends_with("Run `midtown task view 99` for full details."));
     }
 
@@ -1042,9 +1042,9 @@ mod tests {
     fn format_task_prompt_works_with_nudge_context() {
         let result = format_task_prompt(
             "7",
-            "You have pending task #7: Deploy service. Get started!",
+            "You have pending task !7: Deploy service. Get started!",
         );
-        assert!(result.contains("pending task #7"));
+        assert!(result.contains("pending task !7"));
         assert!(result.contains("midtown task view 7"));
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -878,13 +878,13 @@ impl DaemonState {
             match effect {
                 effects::Effect::AssignAndSpawn { task_id, .. } => {
                     self.mark_task_spawn_in_flight(task_id);
-                    debug!("Marked task #{} as in-flight spawn", task_id);
+                    debug!("Marked task !{} as in-flight spawn", task_id);
                 }
                 effects::Effect::NudgeCoworkerWithCallbacks { on_success, .. } => {
                     for sub_effect in on_success {
                         if let effects::Effect::RecordTaskAssignment { task_id, .. } = sub_effect {
                             self.mark_task_spawn_in_flight(task_id);
-                            debug!("Marked task #{} as in-flight nudge assignment", task_id);
+                            debug!("Marked task !{} as in-flight nudge assignment", task_id);
                         }
                     }
                 }

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -1010,7 +1010,7 @@ async fn collect_stuck_condition_effects(
                         .into_iter()
                         .find(|(_, _, owner)| owner.eq_ignore_ascii_case(name))
                         .map(|(id, subject, _)| {
-                            format!("task #{} ({})", id, truncate_str(&subject, 30))
+                            format!("task !{} ({})", id, truncate_str(&subject, 30))
                         })
                         .unwrap_or_else(|| "their task".to_string());
 
@@ -1131,7 +1131,7 @@ fn stuck_nudge_effects(message: &str) -> Vec<Effect> {
 /// For each coworker-owned PR:
 /// 1. Count non-owner comments (excludes PR author and coworker's own comments)
 /// 2. If count increased since last poll, nudge/spawn the owner AND create a review
-///    feedback task for consistent "task #X" formatting
+///    feedback task for consistent "task !X" formatting
 ///
 /// This enables the polling path to fill the gap identified in graceful degradation:
 /// webhooks handle real-time notifications, polling handles the fallback case.
@@ -1235,7 +1235,7 @@ async fn collect_comment_notification_effects(
 
         effects.extend(comment_action_to_effects(action, pr_number, title, state));
 
-        // Also create a review feedback task for consistent "task #X" formatting.
+        // Also create a review feedback task for consistent "task !X" formatting.
         // Skip if a creation is already in flight (nudged to Lead, awaiting confirmation).
         let key = super::DaemonState::task_creation_key(pr_number, &owner);
         if !state.is_task_creation_pending(&key) {
@@ -2166,7 +2166,7 @@ pub(super) async fn handle_pr_comment_nudge(
             ) {
                 Ok(task_id) => {
                     info!(
-                        "Created review feedback task #{} for {} (PR #{}) via webhook",
+                        "Created review feedback task !{} for {} (PR #{}) via webhook",
                         task_id, owner, pr_number
                     );
                 }

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -1253,12 +1253,12 @@ async fn handle_task_create(
                 warn!("Failed to post task creation to channel: {}", e);
             }
 
-            info!("Created task #{}: {}", task_id, subject);
+            info!("Created task !{}: {}", task_id, subject);
             Response::success(
                 id,
                 serde_json::json!({
                     "type": "message",
-                    "message": format!("Task #{} created: {}", task_id, subject),
+                    "message": format!("Task !{} created: {}", task_id, subject),
                 }),
             )
         }
@@ -1359,12 +1359,12 @@ fn handle_task_update(
         state.clear_task_assignment_by_task(task_id);
     }
 
-    info!("Updated task #{}", task_id);
+    info!("Updated task !{}", task_id);
     Response::success(
         id,
         serde_json::json!({
             "type": "message",
-            "message": format!("Task #{} updated", task_id),
+            "message": format!("Task !{} updated", task_id),
         }),
     )
 }
@@ -1385,15 +1385,15 @@ fn handle_task_done(id: RequestId, task_id: &str, state: &DaemonState) -> Respon
 
     // Unblock dependent tasks
     if let Err(e) = crate::tasks::clear_blocked_by_for_repo(task_id, &repo_name) {
-        warn!("Failed to clear blockedBy for task #{}: {}", task_id, e);
+        warn!("Failed to clear blockedBy for task !{}: {}", task_id, e);
     }
 
-    info!("Completed task #{}", task_id);
+    info!("Completed task !{}", task_id);
     Response::success(
         id,
         serde_json::json!({
             "type": "message",
-            "message": format!("Task #{} completed", task_id),
+            "message": format!("Task !{} completed", task_id),
         }),
     )
 }
@@ -1409,7 +1409,7 @@ fn handle_task_claim(id: RequestId, task_id: &str, from: &str, state: &DaemonSta
     let Some(task) = task else {
         return Response::error(
             id,
-            RpcError::new(-32602, format!("Task #{} not found", task_id)),
+            RpcError::new(-32602, format!("Task !{} not found", task_id)),
         );
     };
 
@@ -1419,7 +1419,7 @@ fn handle_task_claim(id: RequestId, task_id: &str, from: &str, state: &DaemonSta
             RpcError::new(
                 -32602,
                 format!(
-                    "Task #{} is not pending (status: {:?})",
+                    "Task !{} is not pending (status: {:?})",
                     task_id, task.status
                 ),
             ),
@@ -1448,7 +1448,7 @@ fn handle_task_claim(id: RequestId, task_id: &str, from: &str, state: &DaemonSta
             }
             Err(e) => {
                 warn!(
-                    "Task claim disk write attempt {} failed for task #{}: {}",
+                    "Task claim disk write attempt {} failed for task !{}: {}",
                     attempt + 1,
                     task_id,
                     e
@@ -1469,13 +1469,13 @@ fn handle_task_claim(id: RequestId, task_id: &str, from: &str, state: &DaemonSta
     // Record in-memory assignment for busy tracking (only after disk write succeeds)
     state.record_task_assignment(from, task_id);
 
-    info!("Task claim: {} claimed task #{} directly", from, task_id);
+    info!("Task claim: {} claimed task !{} directly", from, task_id);
 
     Response::success(
         id,
         serde_json::json!({
             "success": true,
-            "message": format!("Claimed task #{}", task_id),
+            "message": format!("Claimed task !{}", task_id),
         }),
     )
 }
@@ -2513,7 +2513,7 @@ fn resolve_attach_target(target: &str, state: &DaemonState) -> Result<String, St
                     return Ok(coworker.clone());
                 }
             }
-            Err(format!("No coworker is assigned to task #{}", id))
+            Err(format!("No coworker is assigned to task !{}", id))
         }
         AttachTarget::Pr(pr_num) => {
             // Check reviewer assignments

--- a/src/daemon/state.rs
+++ b/src/daemon/state.rs
@@ -29,7 +29,7 @@ pub struct HeadlessSessionInfo {
     pub session_id: String,
     /// Last time this session was active (event received or message sent).
     pub last_active: DateTime<Utc>,
-    /// Human-readable purpose (e.g., "task #5: Add auth endpoint", "reviewer for PR #42").
+    /// Human-readable purpose (e.g., "task !5: Add auth endpoint", "reviewer for PR #42").
     pub purpose: String,
 }
 
@@ -238,12 +238,12 @@ mod tests {
         let info = HeadlessSessionInfo {
             session_id: "abc-123-def".to_string(),
             last_active: Utc::now(),
-            purpose: "task #5: Add auth endpoint".to_string(),
+            purpose: "task !5: Add auth endpoint".to_string(),
         };
         let json = serde_json::to_string(&info).unwrap();
         let parsed: HeadlessSessionInfo = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.session_id, "abc-123-def");
-        assert_eq!(parsed.purpose, "task #5: Add auth endpoint");
+        assert_eq!(parsed.purpose, "task !5: Add auth endpoint");
     }
 
     #[test]
@@ -254,7 +254,7 @@ mod tests {
             HeadlessSessionInfo {
                 session_id: "session-42".to_string(),
                 last_active: Utc::now(),
-                purpose: "task #3: Fix login bug".to_string(),
+                purpose: "task !3: Fix login bug".to_string(),
             },
         );
 
@@ -263,7 +263,7 @@ mod tests {
         assert_eq!(loaded.headless_sessions.len(), 1);
         let park = loaded.headless_sessions.get("park").unwrap();
         assert_eq!(park.session_id, "session-42");
-        assert_eq!(park.purpose, "task #3: Fix login bug");
+        assert_eq!(park.purpose, "task !3: Fix login bug");
     }
 
     #[test]

--- a/src/daemon_messages.rs
+++ b/src/daemon_messages.rs
@@ -73,21 +73,21 @@ pub fn called_in_reviewer(name: &str, pr_number: u64, personality: Personality) 
         .replace("{pr}", &pr_number.to_string())
 }
 
-/// Called in coworker {name} for pending task #{task_id}.
+/// Called in coworker {name} for pending task !{task_id}.
 pub fn called_in_pending_task(name: &str, task_id: &str, personality: Personality) -> String {
     let templates: &[&str] = &[
-        "🚀 Called in coworker {name} for pending task #{task}",
-        "📞 Paging {name} — task #{task} is waiting",
-        "🏃 {name} is on the way for task #{task}",
-        "👋 {name} just walked in for task #{task}",
-        "🎯 Tapped {name} for task #{task}",
+        "🚀 Called in coworker {name} for pending task !{task}",
+        "📞 Paging {name} — task !{task} is waiting",
+        "🏃 {name} is on the way for task !{task}",
+        "👋 {name} just walked in for task !{task}",
+        "🎯 Tapped {name} for task !{task}",
     ];
     pick(templates, personality)
         .replace("{name}", name)
         .replace("{task}", task_id)
 }
 
-/// Called in coworker {name} for assigned task #{task_id}: {subject}.
+/// Called in coworker {name} for assigned task !{task_id}: {subject}.
 pub fn called_in_assigned_task(
     name: &str,
     task_id: &str,
@@ -95,11 +95,11 @@ pub fn called_in_assigned_task(
     personality: Personality,
 ) -> String {
     let templates: &[&str] = &[
-        "🚀 Called in coworker {name} for assigned task #{task}: {subject}",
-        "📞 Paging {name} — task #{task}: {subject}",
-        "🏃 {name} is on the way for task #{task}: {subject}",
-        "👋 {name} just walked in for task #{task}: {subject}",
-        "🎯 Tapped {name} for task #{task}: {subject}",
+        "🚀 Called in coworker {name} for assigned task !{task}: {subject}",
+        "📞 Paging {name} — task !{task}: {subject}",
+        "🏃 {name} is on the way for task !{task}: {subject}",
+        "👋 {name} just walked in for task !{task}: {subject}",
+        "🎯 Tapped {name} for task !{task}: {subject}",
     ];
     pick(templates, personality)
         .replace("{name}", name)
@@ -217,7 +217,7 @@ mod tests {
             );
             assert_eq!(
                 called_in_assigned_task("eve", "5", "Fix bug", Personality::Normal),
-                "🚀 Called in coworker eve for assigned task #5: Fix bug"
+                "🚀 Called in coworker eve for assigned task !5: Fix bug"
             );
             assert_eq!(idle_waiting(Personality::Normal), "waiting for input");
         }

--- a/src/message.rs
+++ b/src/message.rs
@@ -55,7 +55,7 @@ pub enum MessageType {
 /// assert_eq!(sys.message_type, MessageType::System);
 ///
 /// // Status update
-/// let status = Message::status("agent2", "Working on task #42");
+/// let status = Message::status("agent2", "Working on task !42");
 /// assert_eq!(status.message_type, MessageType::Status);
 /// ```
 ///

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1114,7 +1114,7 @@ pub(crate) fn decide_pending_task_action(
     // Skip empty or lead-owned tasks
     if owner.is_empty() || owner.eq_ignore_ascii_case("lead") {
         return PendingTaskAction::Skip {
-            reason: format!("task #{} owner is lead or empty", task_id),
+            reason: format!("task !{} owner is lead or empty", task_id),
         };
     }
 
@@ -1122,7 +1122,7 @@ pub(crate) fn decide_pending_task_action(
     if !crate::coworker::is_coworker_name(&owner.to_lowercase()) {
         return PendingTaskAction::Skip {
             reason: format!(
-                "task #{} owner '{}' is not a valid coworker name",
+                "task !{} owner '{}' is not a valid coworker name",
                 task_id, owner
             ),
         };
@@ -1135,7 +1135,7 @@ pub(crate) fn decide_pending_task_action(
     if has_in_progress_task {
         return PendingTaskAction::Skip {
             reason: format!(
-                "task #{} owner '{}' already has an in_progress task",
+                "task !{} owner '{}' already has an in_progress task",
                 task_id, owner
             ),
         };
@@ -1146,7 +1146,7 @@ pub(crate) fn decide_pending_task_action(
     if is_owner_reviewer {
         return PendingTaskAction::Skip {
             reason: format!(
-                "task #{} owner '{}' is an active reviewer (has review assignment)",
+                "task !{} owner '{}' is an active reviewer (has review assignment)",
                 task_id, owner
             ),
         };
@@ -1156,7 +1156,7 @@ pub(crate) fn decide_pending_task_action(
     if active_names.contains(&owner.to_lowercase()) {
         if on_nudge_cooldown {
             return PendingTaskAction::Skip {
-                reason: format!("task #{} nudge on cooldown for {}", task_id, owner),
+                reason: format!("task !{} nudge on cooldown for {}", task_id, owner),
             };
         }
         return PendingTaskAction::NudgeOwner {
@@ -1170,7 +1170,7 @@ pub(crate) fn decide_pending_task_action(
     if at_dev_limit {
         return PendingTaskAction::Skip {
             reason: format!(
-                "dev limit reached, deferring spawn for task #{} owned by {}",
+                "dev limit reached, deferring spawn for task !{} owned by {}",
                 task_id, owner
             ),
         };
@@ -2939,7 +2939,7 @@ mod tests {
         // (only populated by PR poll). The skip check fails because it requires
         // BOTH has_open_pr AND ci_passed, creating a recovery loop.
         //
-        // This is the root cause of the lexington recovery loop (task #810):
+        // This is the root cause of the lexington recovery loop (task !810):
         // - lexington opened PR #682, went idle, shut down
         // - orphan check fires every 10s, PR poll every 30s
         // - In the window before PR poll caches CI status, recovery fires
@@ -3091,7 +3091,7 @@ mod tests {
     #[test]
     fn orphan_recovery_skips_coworker_that_just_reported_idle() {
         // Scenario: madison reports idle via RPC. She still has in_progress
-        // task #861 (task completion is async). The RPC handler shuts her down
+        // task !861 (task completion is async). The RPC handler shuts her down
         // and records her stop time. On the next TaskDispatchTick, orphan
         // recovery must skip her because she's in recently_stopped.
         let tasks = vec![(
@@ -3945,7 +3945,7 @@ Now implementing the fix.
         // Active reviewers should NOT be nudged about main task list updates.
         let active_names: HashSet<String> = ["madison".to_string()].into_iter().collect();
 
-        // Main task #6 has owner="madison", but madison is an active reviewer
+        // Main task !6 has owner="madison", but madison is an active reviewer
         let action = decide_pending_task_action(
             "6",
             "Prevent coworkers from checking out default branch",

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -2073,7 +2073,7 @@ mod tests {
         assert_eq!(parsed["activeForm"], "Working on it");
     }
 
-    // --- Tests for Lead task persistence mirroring (task #808) ---
+    // --- Tests for Lead task persistence mirroring (task !808) ---
 
     #[test]
     fn test_ensure_task_in_shared_dir_creates_when_missing() {

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -48,16 +48,16 @@ fn load_settings(role_settings: &str) -> serde_json::Value {
 /// Extracts status keywords and task numbers to create concise tab names.
 ///
 /// # Examples
-/// - "claiming task #1" → "claim#1"
-/// - "developing task #1" → "dev#1"
+/// - "claiming task !1" → "claim#1"
+/// - "developing task !1" → "dev#1"
 /// - "running tests" → "test"
-/// - "opening PR for task #1" → "PR#1"
+/// - "opening PR for task !1" → "PR#1"
 /// - "waiting for review" → "idle"
 /// - "investigating the auth bug" → "investigating the au..."
 pub fn parse_status(status: &str) -> String {
     let status_lower = status.to_lowercase();
 
-    // Extract task number if present (matches "#1", "task 1", "task #1", etc.)
+    // Extract task number if present (matches "#1", "task 1", "task !1", etc.)
     let task_num = extract_task_number(status);
 
     // Match status keywords and map to abbreviations
@@ -107,9 +107,18 @@ pub fn parse_status(status: &str) -> String {
 
 /// Extract task number from status text.
 ///
-/// Matches patterns like "#1", "task 1", "task #1", "#42"
+/// Matches patterns like "!1", "#1", "task 1", "task !1", "#42"
 fn extract_task_number(status: &str) -> Option<u32> {
-    // Try to find "#N" pattern first
+    // Try to find "!N" pattern first (new convention)
+    if let Some(pos) = status.find('!') {
+        let rest = &status[pos + 1..];
+        let num_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if let Ok(num) = num_str.parse::<u32>() {
+            return Some(num);
+        }
+    }
+
+    // Try to find "#N" pattern (backward compatibility)
     if let Some(pos) = status.find('#') {
         let rest = &status[pos + 1..];
         let num_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
@@ -122,8 +131,11 @@ fn extract_task_number(status: &str) -> Option<u32> {
     let lower = status.to_lowercase();
     if let Some(pos) = lower.find("task ") {
         let rest = &status[pos + 5..];
-        // Skip optional '#' after "task "
-        let rest = rest.strip_prefix('#').unwrap_or(rest);
+        // Skip optional '!' or '#' after "task "
+        let rest = rest
+            .strip_prefix('!')
+            .or_else(|| rest.strip_prefix('#'))
+            .unwrap_or(rest);
         let num_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
         if let Ok(num) = num_str.parse::<u32>() {
             return Some(num);
@@ -2290,15 +2302,15 @@ mod tests {
 
     #[test]
     fn test_parse_status_claiming() {
-        assert_eq!(parse_status("claiming task #1"), "claim#1");
+        assert_eq!(parse_status("claiming task !1"), "claim#1");
         assert_eq!(parse_status("Claiming task 5"), "claim#5");
         assert_eq!(parse_status("just claimed #3"), "claim#3");
     }
 
     #[test]
     fn test_parse_status_developing() {
-        assert_eq!(parse_status("developing task #1"), "dev#1");
-        assert_eq!(parse_status("working on task #2"), "dev#2");
+        assert_eq!(parse_status("developing task !1"), "dev#1");
+        assert_eq!(parse_status("working on task !2"), "dev#2");
         assert_eq!(parse_status("coding the feature"), "dev");
         assert_eq!(parse_status("implementing auth #5"), "dev#5");
     }
@@ -2312,7 +2324,7 @@ mod tests {
 
     #[test]
     fn test_parse_status_pr() {
-        assert_eq!(parse_status("opening PR for task #1"), "PR#1");
+        assert_eq!(parse_status("opening PR for task !1"), "PR#1");
         assert_eq!(parse_status("PR ready"), "PR");
         assert_eq!(parse_status("creating pull request #4"), "PR#4");
         assert_eq!(parse_status("requesting review #2"), "PR#2");
@@ -2335,12 +2347,12 @@ mod tests {
     fn test_parse_status_idle() {
         assert_eq!(parse_status("idle"), "idle");
         assert_eq!(parse_status("waiting for review"), "idle");
-        assert_eq!(parse_status("blocked on task #3"), "idle#3");
+        assert_eq!(parse_status("blocked on task !3"), "idle#3");
     }
 
     #[test]
     fn test_parse_status_done() {
-        assert_eq!(parse_status("completed task #1"), "done#1");
+        assert_eq!(parse_status("completed task !1"), "done#1");
         assert_eq!(parse_status("finished implementation"), "done");
     }
 
@@ -2355,7 +2367,7 @@ mod tests {
 
     #[test]
     fn test_extract_task_number_hash_format() {
-        assert_eq!(extract_task_number("task #1"), Some(1));
+        assert_eq!(extract_task_number("task !1"), Some(1));
         assert_eq!(extract_task_number("#42 is the answer"), Some(42));
         assert_eq!(extract_task_number("working on #5"), Some(5));
     }
@@ -2410,20 +2422,20 @@ mod tests {
         let pane_content = r#"
 Some previous output
 More output
-❯ You've been assigned task #36: Chat TUI still showing...
+❯ You've been assigned task !36: Chat TUI still showing...
 "#;
-        let nudge_text = "You've been assigned task #36: Chat TUI still showing old messages";
+        let nudge_text = "You've been assigned task !36: Chat TUI still showing old messages";
         assert!(is_nudge_stuck(pane_content, nudge_text));
     }
 
     #[test]
     fn test_is_nudge_stuck_no_match_when_submitted() {
         let pane_content = r#"
-You've been assigned task #36: Chat TUI still showing...
+You've been assigned task !36: Chat TUI still showing...
 Claude is now processing the request
 ❯
 "#;
-        let nudge_text = "You've been assigned task #36: Chat TUI still showing old messages";
+        let nudge_text = "You've been assigned task !36: Chat TUI still showing old messages";
         // The nudge text appears earlier but NOT after the prompt
         assert!(!is_nudge_stuck(pane_content, nudge_text));
     }
@@ -2446,7 +2458,7 @@ Claude is now processing the request
     fn test_is_nudge_stuck_partial_match() {
         // Tests that we match on first 20 chars of long messages
         let pane_content = "❯ You've been assigned";
-        let nudge_text = "You've been assigned task #36: Chat TUI still showing old messages";
+        let nudge_text = "You've been assigned task !36: Chat TUI still showing old messages";
         assert!(is_nudge_stuck(pane_content, nudge_text));
     }
 

--- a/tests/daemon_e2e.rs
+++ b/tests/daemon_e2e.rs
@@ -2410,7 +2410,7 @@ fn test_daemon_rpc_channel_post_me_action() {
 
     let params = serde_json::json!({
         "from": "york",
-        "message": "/me is working on task #42"
+        "message": "/me is working on task !42"
     });
 
     let response = fixture.rpc_call("channel.post", Some(params));

--- a/tests/dispatch_e2e.rs
+++ b/tests/dispatch_e2e.rs
@@ -379,7 +379,7 @@ fn lead_owned_tasks_skipped() {
     for (task_id, subject, owner) in &snap.pending_tasks_with_owners {
         assert!(
             owner.to_lowercase() != "lead",
-            "pending_tasks_with_owners should not include lead-owned task #{}: {}",
+            "pending_tasks_with_owners should not include lead-owned task !{}: {}",
             task_id,
             subject
         );
@@ -438,7 +438,7 @@ fn orphan_detection_finds_inactive_owners() {
     } else {
         for (task_id, subject, owner) in orphans {
             println!(
-                "Orphan detected: Task #{} ({}) owned by inactive {}",
+                "Orphan detected: Task !{} ({}) owned by inactive {}",
                 task_id, subject, owner
             );
         }
@@ -462,7 +462,7 @@ fn active_owners_not_orphaned() {
             .collect();
 
         for (task_id, _, _) in york_tasks {
-            println!("Task #{} owned by active york - NOT orphaned", task_id);
+            println!("Task !{} owned by active york - NOT orphaned", task_id);
         }
     }
 }
@@ -560,7 +560,7 @@ fn blocked_tasks_excluded_from_pending_unowned() {
         let blocked = is_task_blocked(task, &snap.all_tasks);
         assert!(
             !blocked,
-            "pending_tasks_without_owners should not include blocked task #{}: {}",
+            "pending_tasks_without_owners should not include blocked task !{}: {}",
             task.id, task.subject
         );
     }
@@ -735,7 +735,7 @@ fn duplicate_task_detection_data_available() {
     for (task_id, owners) in &task_owners {
         if owners.len() > 1 {
             println!(
-                "Duplicate detected: Task #{} has {} owners: {:?}",
+                "Duplicate detected: Task !{} has {} owners: {:?}",
                 task_id,
                 owners.len(),
                 owners
@@ -852,7 +852,7 @@ fn pending_unowned_tasks_are_unblocked() {
                 if let Some(b) = blocker {
                     assert_eq!(
                         b.status, "completed",
-                        "pending_tasks_without_owners task #{} is blocked by incomplete #{} ({})",
+                        "pending_tasks_without_owners task !{} is blocked by incomplete #{} ({})",
                         task.id, b.id, b.status
                     );
                 }
@@ -875,7 +875,7 @@ fn task_owner_validation() {
             let is_valid = owner_lower == "lead" || is_valid_coworker_name(&owner_lower);
             assert!(
                 is_valid,
-                "Task #{} has invalid owner '{}' - must be an avenue name or 'lead'",
+                "Task !{} has invalid owner '{}' - must be an avenue name or 'lead'",
                 task.id, owner
             );
         }
@@ -917,7 +917,7 @@ fn dispatch_scenario_analysis() {
         let is_active = snap.active_names.contains(&owner_lower);
         let action = if is_active { "nudge" } else { "spawn" };
         println!(
-            "Task #{} ({}) owned by {} -> would {}",
+            "Task !{} ({}) owned by {} -> would {}",
             task_id, task_subject, owner, action
         );
     }
@@ -1225,13 +1225,13 @@ fn dispatch_not_deferred_when_all_prs_have_reviewers() {
 ///
 /// Captured snapshot shows:
 /// - Tasks #873 and #875 are both pending+unowned, both reference PR #708
-/// - Pleasant is the PR #708 owner (has pending task #872 for that PR)
+/// - Pleasant is the PR #708 owner (has pending task !872 for that PR)
 /// - PR grouping logic assigns both #873 and #875 to pleasant
 /// - Without the fix, each tick re-generates nudges for both tasks because:
 ///   (a) grouped tasks bypassed the `assigned_this_tick` guard (within-tick)
 ///   (b) `NudgeCoworkerWithCallbacks` effects weren't tracked as in-flight (cross-tick)
 ///
-/// The daemon logs showed 4+ pairs of "Called in pleasant for task #873/#875"
+/// The daemon logs showed 4+ pairs of "Called in pleasant for task !873/#875"
 /// — the same two assignments repeated across consecutive ticks.
 #[test]
 fn no_duplicate_spawn_notifications_for_same_coworker_and_task() {
@@ -1257,11 +1257,11 @@ fn no_duplicate_spawn_notifications_for_same_coworker_and_task() {
         .collect();
     assert!(
         unowned_ids.contains(&"873"),
-        "task #873 should be pending without owner"
+        "task !873 should be pending without owner"
     );
     assert!(
         unowned_ids.contains(&"875"),
-        "task #875 should be pending without owner"
+        "task !875 should be pending without owner"
     );
 
     // Precondition: pleasant already has a pending owned task (#872) for PR #708
@@ -1326,7 +1326,7 @@ fn no_duplicate_spawn_notifications_for_same_coworker_and_task() {
 ///
 /// Before the fix, nudge effects were not tracked, so the next tick would
 /// re-evaluate the same task and produce another nudge — causing the repeated
-/// "Called in pleasant for task #875" channel messages seen in the snapshot.
+/// "Called in pleasant for task !875" channel messages seen in the snapshot.
 #[test]
 fn no_cross_tick_duplicate_spawn_for_in_flight_task() {
     let fixture =
@@ -1404,7 +1404,7 @@ fn no_cross_tick_duplicate_spawn_for_in_flight_task() {
     for (task_id, _) in &tick2_assignments {
         assert!(
             !in_flight_tasks.contains(*task_id),
-            "tick 2 should not re-assign in-flight task #{} — \
+            "tick 2 should not re-assign in-flight task !{} — \
              this was the cross-tick duplicate bug",
             task_id
         );
@@ -1523,7 +1523,7 @@ fn active_coworker_gets_nudge_not_spawn_for_pr_notifications() {
 
 /// Regression test: tasks referencing a merged PR should be skipped by dispatch.
 ///
-/// Bug: The daemon kept nudging york for task #3 ("Address review feedback on
+/// Bug: The daemon kept nudging york for task !3 ("Address review feedback on
 /// PR #709") even though PR #709 was merged hours ago. The dispatch logic
 /// never checked whether a task's referenced PR was already merged.
 ///
@@ -1578,20 +1578,20 @@ fn tasks_referencing_merged_pr_are_skipped() {
         skipped_tasks
             .iter()
             .any(|(id, pr)| *id == "3" && *pr == 709),
-        "task #3 (PR #709) should be skipped"
+        "task !3 (PR #709) should be skipped"
     );
     assert!(
         skipped_tasks
             .iter()
             .any(|(id, pr)| *id == "7" && *pr == 714),
-        "task #7 (PR #714) should be skipped"
+        "task !7 (PR #714) should be skipped"
     );
 
     // Task without PR reference should proceed normally
     assert_eq!(
         dispatched_tasks,
         vec!["5"],
-        "task #5 (no PR reference) should be dispatched"
+        "task !5 (no PR reference) should be dispatched"
     );
 }
 

--- a/tests/health_e2e.rs
+++ b/tests/health_e2e.rs
@@ -207,7 +207,7 @@ fn pane_has_queued_input(pane_content: &str) -> bool {
 /// Test idle coworker conditions in snapshot-20260203-152121.
 ///
 /// Expected behavior:
-/// - York is busy (has task #27) → NOT eligible for idle shutdown
+/// - York is busy (has task !27) → NOT eligible for idle shutdown
 /// - Lexington is idle (completed task, at prompt) → eligible for idle shutdown
 /// - Coworkers with open PRs → NOT eligible for idle shutdown
 /// - Broadway is active reviewer → NOT eligible for idle shutdown
@@ -216,17 +216,17 @@ fn fixture_idle_detection_snapshot_152121() {
     let fixture = include_str!("fixtures/snapshot/snapshot-20260203-152121.json");
     let snap = load_health_snapshot(fixture);
 
-    // ─── York: Busy with task #27, should NOT be sent on break ───
+    // ─── York: Busy with task !27, should NOT be sent on break ───
     assert!(
         snap.busy_coworkers.contains("york"),
-        "York should be busy with task #27"
+        "York should be busy with task !27"
     );
 
     // Verify york's pane shows active work (not idle)
     let york_pane = snap.pane_contents.get("york").expect("york pane exists");
     assert!(
         york_pane.contains("Fixing false idle detection"),
-        "York should be working on task #27"
+        "York should be working on task !27"
     );
 
     // ─── Lexington: Idle, should be sent on break ───
@@ -358,7 +358,7 @@ fn usage_limit_detection_in_pane_content() {
     );
 
     // Normal pane
-    let normal_pane = "⏺ Working on task #42\n\n❯ ";
+    let normal_pane = "⏺ Working on task !42\n\n❯ ";
     assert!(
         !pane_shows_usage_limit(normal_pane),
         "Should not detect usage limit in normal pane"
@@ -479,12 +479,12 @@ fn busy_coworker_identification() {
         );
     }
 
-    // York has task #27
+    // York has task !27
     assert!(
         snap.in_progress_tasks
             .iter()
             .any(|(id, _, owner)| id == "27" && owner == "york"),
-        "York should own in-progress task #27"
+        "York should own in-progress task !27"
     );
 }
 

--- a/tests/idle_break_e2e.rs
+++ b/tests/idle_break_e2e.rs
@@ -120,7 +120,7 @@ struct SnapshotData {
 
 /// Test that lexington should be sent on break in the captured snapshot.
 ///
-/// Snapshot context: lexington completed task #22, posted idle status, and has
+/// Snapshot context: lexington completed task !22, posted idle status, and has
 /// been at the prompt for >2 minutes. The daemon should detect this and return
 /// a shutdown decision.
 #[test]
@@ -207,13 +207,13 @@ fn coworker_with_open_pr_not_sent_on_break() {
     }
 }
 
-/// Test that busy coworkers (york with task #27) are not sent on break.
+/// Test that busy coworkers (york with task !27) are not sent on break.
 #[test]
 fn busy_coworker_not_sent_on_break() {
     let fixture = include_str!("fixtures/snapshot/snapshot-20260203-152121.json");
     let (coworkers, data) = load_snapshot(fixture);
 
-    // York is busy with task #27 in this snapshot
+    // York is busy with task !27 in this snapshot
     assert!(data.busy_coworkers.contains("york"), "york should be busy");
 
     let _york = coworkers.iter().find(|c| c.name == "york").unwrap();
@@ -222,7 +222,7 @@ fn busy_coworker_not_sent_on_break() {
     let pane = data.pane_contents.get("york").unwrap();
     assert!(
         pane.contains("Fixing false idle detection"),
-        "york should be actively working on task #27"
+        "york should be actively working on task !27"
     );
 }
 

--- a/tests/mailbox_e2e.rs
+++ b/tests/mailbox_e2e.rs
@@ -640,11 +640,11 @@ fn test_mailbox_write_creates_valid_inbox_file() {
 
     // Write a message
     let msg = midtown::mailbox::MailboxMessage::new(
-        "You have pending task #42: Fix auth bug. Get started!",
+        "You have pending task !42: Fix auth bug. Get started!",
         "midtown",
     )
     .with_color("yellow")
-    .with_summary("Task #42 assignment");
+    .with_summary("Task !42 assignment");
 
     midtown::mailbox::write_to_inbox(&team_name, agent_name, msg)
         .expect("write_to_inbox should succeed");
@@ -660,11 +660,11 @@ fn test_mailbox_write_creates_valid_inbox_file() {
     assert_eq!(messages.len(), 1, "Should have exactly one message");
     assert_eq!(
         messages[0].text,
-        "You have pending task #42: Fix auth bug. Get started!"
+        "You have pending task !42: Fix auth bug. Get started!"
     );
     assert_eq!(messages[0].from, "midtown");
     assert_eq!(messages[0].color.as_deref(), Some("yellow"));
-    assert_eq!(messages[0].summary.as_deref(), Some("Task #42 assignment"));
+    assert_eq!(messages[0].summary.as_deref(), Some("Task !42 assignment"));
     assert!(!messages[0].read, "New messages should be unread");
     assert!(!messages[0].timestamp.is_empty(), "Timestamp should be set");
 

--- a/tests/spawn_race_test.rs
+++ b/tests/spawn_race_test.rs
@@ -11,8 +11,8 @@
 //! ```text
 //! 17:13:00.938629Z  INFO Spawned coworker madison (isolated=true, session_mode=Fresh)
 //! 17:13:00.938875Z  INFO Spawned coworker madison successfully
-//! 17:13:05.921367Z  INFO Proposing task #739 for madison (already_running=false)
-//! 17:13:05.941025Z  INFO Assigned task #739 to madison on disk
+//! 17:13:05.921367Z  INFO Proposing task !739 for madison (already_running=false)
+//! 17:13:05.941025Z  INFO Assigned task !739 to madison on disk
 //! 17:13:10.035109Z  INFO Channel post from madison: /me reviewing PR #496
 //! 17:13:11.625229Z  INFO Spawned coworker madison (isolated=false, session_mode=Fresh)
 //! 17:13:11.625257Z  INFO Spawned coworker madison successfully

--- a/tests/task_dispatch_e2e.rs
+++ b/tests/task_dispatch_e2e.rs
@@ -263,7 +263,7 @@ fn in_progress_tasks_have_owners() {
         let owner = task.owner.as_deref().unwrap_or("");
         assert!(
             !owner.is_empty(),
-            "in_progress task #{} should have an owner, found empty",
+            "in_progress task !{} should have an owner, found empty",
             task.id
         );
     }
@@ -325,7 +325,7 @@ fn blocked_tasks_identified() {
                 if blocker.status != "completed" {
                     assert!(
                         is_task_blocked(task, &data.all_tasks),
-                        "task #{} with incomplete blocker #{} should be blocked",
+                        "task !{} with incomplete blocker #{} should be blocked",
                         task.id,
                         blocker_id
                     );
@@ -390,7 +390,7 @@ fn pending_task_with_active_owner_gets_nudge() {
         if is_active {
             // Owner is active - they should be nudged, not spawned
             println!(
-                "Pending task #{} has active owner {} - nudge expected",
+                "Pending task !{} has active owner {} - nudge expected",
                 task.id, owner
             );
         }
@@ -559,11 +559,11 @@ fn blocked_task_not_assigned() {
                         .iter()
                         .any(|t| t.id == *b_id && t.status != "completed")
                 }),
-            "blocked task #{} should not be available for dispatch",
+            "blocked task !{} should not be available for dispatch",
             task.id
         );
         println!(
-            "Blocked task #{} ({}) correctly excluded - blocked by {:?}",
+            "Blocked task !{} ({}) correctly excluded - blocked by {:?}",
             task.id, task.subject, task.blocked_by
         );
     }
@@ -659,7 +659,7 @@ fn snapshot_data_integrity_for_dispatch() {
             let is_valid = valid_avenues.iter().any(|a| *a == owner_lower);
             assert!(
                 is_valid,
-                "task #{} has invalid owner name: {}",
+                "task !{} has invalid owner name: {}",
                 task.id, owner
             );
         }
@@ -705,7 +705,7 @@ fn busy_coworker_not_assigned_additional_tasks() {
     let should_skip = already_running && (is_reviewer || (is_busy && !was_grouped));
     assert!(
         should_skip,
-        "Task #{} should NOT be assigned to busy coworker {} (busy={}, grouped={})",
+        "Task !{} should NOT be assigned to busy coworker {} (busy={}, grouped={})",
         task.id, coworker_name, is_busy, was_grouped
     );
 }

--- a/tests/tmux_e2e.rs
+++ b/tests/tmux_e2e.rs
@@ -1175,7 +1175,7 @@ fn test_channel_write_read_roundtrip() {
         ))
         .unwrap();
     channel
-        .send(&midtown::Message::text("lexington", "working on task #42"))
+        .send(&midtown::Message::text("lexington", "working on task !42"))
         .unwrap();
     channel
         .send(&midtown::Message::text(


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
Convention change to disambiguate task and PR references in channel messages and CLI output:
- **Tasks**: `!123` (midtown-specific)
- **PRs**: `#123` (matches GitHub)

This makes it easier to distinguish task references from PR references in logs, channel messages, and status displays.

## Changes
1. **Agent prompts** (lead.md, coworker.md, reviewer.md) — updated examples and PR title format from `[Midtown #XX]` to `[Midtown !XX]`
2. **CLI output** (task.rs) — task IDs now display with `!` prefix (`!926` instead of `#926`)
3. **Daemon messages** (dispatch.rs, effects.rs, health.rs, etc.) — all task references updated to use `!` sigil
4. **Status parsing** (tmux.rs) — `extract_task_number()` now prioritizes `!` but supports `#` for backward compatibility
5. **Tests** — updated assertions to match new convention
6. **Documentation** (notification-audit.md) — updated task references

## Backward Compatibility
- CLI accepts both `!N` and `#N` for task view/update commands
- Status parsing handles both sigils (prioritizes `!`, falls back to `#`)

## Test plan
- [x] All unit tests pass (918 tests)
- [x] Clippy passes with -D warnings
- [x] Code formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)