### PR TITLE
fix: Remove dispatch deadlock that blocks all task assignment when PRs need review [Midtown #932]

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -869,10 +869,11 @@ pub(super) fn spawn_for_pending_tasks(
     // Case 2: Pending tasks without owners - assign ownership atomically, then spawn
     let pending_unowned = &snap.pending_tasks_without_owners;
 
-    // Prioritize PR reviews over new task pickup: if there are PRs waiting for review
-    // that don't already have an assigned reviewer, and we have capacity to spawn
-    // reviewers, defer new task assignment. This ensures PRs don't wait while coworkers
-    // pick up new work — but doesn't block task dispatch when all PRs are already covered.
+    // Log PR review priority state for diagnostics, but never block task dispatch.
+    // Previously this did `return effects` which created a deadlock: idle coworkers
+    // sat with no work while the daemon waited for a reviewer to be spawned.
+    // Reviewer spawning is handled independently in pr.rs — it doesn't need task
+    // dispatch to be deferred.
     let active_review_count = snap.active_reviewers.len();
     let prs_with_reviewers = snap
         .reviewer_pr_assignments
@@ -880,19 +881,15 @@ pub(super) fn spawn_for_pending_tasks(
         .collect::<HashSet<_>>()
         .len();
     let unserved_prs = snap.prs_needing_review.saturating_sub(prs_with_reviewers);
-    if unserved_prs > 0
-        && active_review_count < MAX_CONCURRENT_REVIEWS
-        && !snap.is_at_coworker_limit
-    {
+    if unserved_prs > 0 {
         debug!(
-            "Deferring unowned task pickup: {} unserved PR(s) need review ({} total, {} already have reviewers), {}/{} active reviewers",
+            "PR review state: {} unserved PR(s) need review ({} total, {} already have reviewers), {}/{} active reviewers — task dispatch proceeds independently",
             unserved_prs,
             snap.prs_needing_review,
             prs_with_reviewers,
             active_review_count,
             MAX_CONCURRENT_REVIEWS
         );
-        return effects;
     }
 
     // All tasks from snapshot for relationship lookups (blockedBy, PR owner search)


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

Fixes a critical deadlock in task dispatch logic where the presence of unserved PRs (PRs needing review without assigned reviewers) would **completely block** all unowned task assignment to idle coworkers.

### The Problem

Previously in `spawn_for_pending_tasks()`, when PRs needed review and we had capacity for reviewers, the function would return early with an empty effects list. This created a deadlock scenario:

1. PR needs review, no reviewer assigned
2. Idle coworkers available, pending tasks exist
3. Dispatch logic sees "unserved PRs exist" → returns early, blocks task assignment
4. Idle coworkers sit with no work while tasks wait
5. Reviewer spawning (handled in `pr.rs`) happens independently but can't proceed until the next tick
6. Meanwhile, task dispatch remains blocked indefinitely

### The Solution

This PR removes the early return, converting it to a diagnostic log. Now:

- PR review needs are logged for visibility
- Task dispatch proceeds independently
- Reviewer spawning (already handled separately in `pr.rs`) continues working in parallel
- Idle coworkers get assigned pending tasks without waiting for reviewer spawning

The key insight: **reviewer spawning and task dispatch are independent concerns**. There's no reason to defer one while waiting for the other.

### Testing

- Unit tests pass (all 29 dispatch tests)
- Fix was deployed to production, daemon restarted, and immediately assigned pending tasks to idle coworkers (verified via snapshot-idle-coworkers-pending-tasks-20260208-015535.json)

## Related

This fix was discovered when the daemon was observed leaving idle coworkers unassigned while pending tasks existed.