### PR TITLE
perf: Tune daemon timing constants for faster throughput [Midtown !962]

### DIFF
--- a/src/daemon/constants.rs
+++ b/src/daemon/constants.rs
@@ -27,8 +27,10 @@ pub const DEFAULT_PR_POLL_INTERVAL_SECS: u64 = 30;
 /// Minimum time between nudging the same PR issue (10 minutes)
 pub const PR_NUDGE_COOLDOWN_SECS: u64 = 600;
 
-/// Minimum age in seconds before a PR is eligible for auto-review (60 seconds)
-pub const PR_REVIEW_DELAY_SECS: u64 = 60;
+/// Minimum age in seconds before a PR is eligible for auto-review (30 seconds).
+/// Tradeoff: Faster reviewer spawn (biggest throughput win) vs. potential duplicate
+/// assignment if PR hash bucket changes quickly. Hash bucket dedup should still work.
+pub const PR_REVIEW_DELAY_SECS: u64 = 30;
 
 /// Maximum number of concurrent PR reviews the daemon will run.
 pub const MAX_CONCURRENT_REVIEWS: usize = 4;
@@ -68,33 +70,35 @@ pub(super) const LEAD_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(10);
 /// tries to respawn the lead window before the tmux session is fully settled.
 pub(super) const LEAD_HEALTH_CHECK_STARTUP_GRACE: Duration = Duration::from_secs(30);
 
-/// Interval for orphaned worktree cleanup tick (10 seconds)
-///
-/// Worktree cleanup involves expensive git and gh CLI operations for each
-/// orphaned worktree. To avoid saturating the blocking thread pool and causing
-/// RPC timeouts, we process at most one worktree per tick. With a 10-second
-/// interval, 10 orphaned worktrees take ~100 seconds to fully process.
-pub(super) const ORPHAN_CHECK_INTERVAL_SECS: u64 = 10;
+/// Interval for task dispatch and orphaned worktree cleanup tick (5 seconds).
+/// Tradeoff: Tasks get assigned faster and orphan recovery happens sooner vs. more frequent
+/// snapshot collection (CPU impact). Worktree cleanup is still rate-limited to one worktree
+/// per tick. Testing shows 5s interval has acceptable CPU overhead while significantly
+/// improving task assignment latency. With 5s interval, 10 orphaned worktrees take ~50s.
+pub(super) const ORPHAN_CHECK_INTERVAL_SECS: u64 = 5;
 
 /// Minimum time a coworker must be alive before being sent on a break (5 minutes)
 /// This prevents spawn storms where coworkers are rapidly sent on breaks.
 pub(super) const MINIMUM_COWORKER_LIFETIME: Duration = Duration::from_secs(300);
 
-/// Cooldown between orphan recovery spawns (5 seconds)
-/// Only spawn one coworker per tick, with a minimum gap between spawns.
-pub(super) const ORPHAN_SPAWN_COOLDOWN: Duration = Duration::from_secs(5);
+/// Cooldown between orphan recovery spawns (2 seconds).
+/// Tradeoff: Multiple orphan recoveries happen faster vs. spawn storm risk. At 2s with
+/// ORPHAN_CHECK_INTERVAL_SECS=5s, we can recover multiple tasks quickly without overwhelming
+/// the system. Still enforces one-spawn-per-tick to prevent uncontrolled spawning.
+pub(super) const ORPHAN_SPAWN_COOLDOWN: Duration = Duration::from_secs(2);
 
-/// Grace period after a coworker stops before orphan recovery kicks in (60 seconds).
-/// When a coworker completes work and goes idle → shutdown, the task may not yet
-/// be marked done. This grace period prevents false recovery by giving the system
-/// time to process the task completion (e.g., PR auto-complete, manual status update).
-pub(super) const ORPHAN_RECOVERY_GRACE_PERIOD: Duration = Duration::from_secs(60);
+/// Grace period after a coworker stops before orphan recovery kicks in (20 seconds).
+/// Tradeoff: Faster recovery of abandoned tasks vs. risk of recovering tasks that are
+/// legitimately completing. Most task completions (PR merge, status update) happen within
+/// seconds, so 20s should be sufficient to prevent false recovery while still being aggressive.
+pub(super) const ORPHAN_RECOVERY_GRACE_PERIOD: Duration = Duration::from_secs(20);
 
-/// Cooldown after a coworker spawn failure before retrying (2 minutes).
-/// Prevents infinite respawn loops when a coworker's environment is broken
-/// (missing worktree, bad session, etc.). The task is reset to pending so
-/// other coworkers can pick it up.
-pub(super) const SPAWN_FAILURE_COOLDOWN: Duration = Duration::from_secs(120);
+/// Cooldown after a coworker spawn failure before retrying (60 seconds).
+/// Tradeoff: Failed spawns retry sooner vs. risk of rapid retry loops. Most spawn failures
+/// are transient (system load, network hiccup), so 60s gives the system time to stabilize
+/// while still retrying reasonably fast. The task resets to pending so other coworkers can
+/// claim it during the cooldown, providing an alternative recovery path.
+pub(super) const SPAWN_FAILURE_COOLDOWN: Duration = Duration::from_secs(60);
 
 /// Cooldown between zombie respawn attempts for the same coworker (5 minutes).
 /// Prevents respawn loops if the zombie condition keeps recurring.

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -3354,14 +3354,14 @@ mod tests {
     ///
     /// ## Bug scenario (before fix):
     /// 1. PR #42 is opened at t=0
-    /// 2. Poll at t=30s: PR is too new (within 60s delay), no reviewer spawn
-    /// 3. Poll at t=90s: PR data unchanged → hash unchanged → early return (BUG!)
+    /// 2. Poll at t=15s: PR is too new (within 30s delay), no reviewer spawn
+    /// 3. Poll at t=45s: PR data unchanged → hash unchanged → early return (BUG!)
     ///    - The reviewer spawn eligibility was never re-evaluated
     ///
     /// ## Fixed behavior (after fix):
     /// 1. PR #42 is opened at t=0
-    /// 2. Poll at t=30s: PR is too new, no reviewer spawn, cache hash saved
-    /// 3. Poll at t=90s: time bucket changed (bucket 0→1) → hash changed
+    /// 2. Poll at t=15s: PR is too new, no reviewer spawn, cache hash saved
+    /// 3. Poll at t=45s: time bucket changed (bucket 0→1) → hash changed
     ///    - Poll proceeds, PR age re-evaluated, reviewer spawn triggered
     ///
     /// This test simulates time passing to verify the hash changes at bucket boundaries.
@@ -3369,18 +3369,18 @@ mod tests {
     fn pr_poll_cache_reevaluates_after_time_bucket_change() {
         // Same PR data throughout - the data doesn't change, only time passes
         let pr_data = r#"[{"number": 42, "title": "feat: Add feature", "state": "OPEN"}]"#;
-        let bucket_secs = super::PR_REVIEW_DELAY_SECS; // 60 seconds
+        let bucket_secs = super::PR_REVIEW_DELAY_SECS; // 30 seconds
 
-        // Scenario: PR opened at t=0, first poll at t=30
-        // Bucket boundaries are at multiples of 60: 0, 60, 120, ...
-        let t_first_poll = 30u64; // In bucket 0 (0-59)
+        // Scenario: PR opened at t=0, first poll at t=15
+        // Bucket boundaries are at multiples of 30: 0, 30, 60, ...
+        let t_first_poll = 15u64; // In bucket 0 (0-29)
         let hash_first_poll = super::compute_time_aware_hash_at(pr_data, bucket_secs, t_first_poll);
 
-        // At this point, PR is too new for review (only 30s old).
+        // At this point, PR is too new for review (only 15s old).
         // The daemon would skip reviewer spawn. Hash is cached.
 
-        // Second poll at t=50 (still in bucket 0)
-        let t_second_poll = 50u64; // Still in bucket 0 (0-59)
+        // Second poll at t=25 (still in bucket 0)
+        let t_second_poll = 25u64; // Still in bucket 0 (0-29)
         let hash_second_poll =
             super::compute_time_aware_hash_at(pr_data, bucket_secs, t_second_poll);
 
@@ -3390,9 +3390,9 @@ mod tests {
             "Within same time bucket, hash should be stable for caching"
         );
 
-        // Third poll at t=90 (NEW bucket!)
-        // This is 90s after PR creation, well past the 60s review delay
-        let t_third_poll = 90u64; // In bucket 1 (60-119)
+        // Third poll at t=45 (NEW bucket!)
+        // This is 45s after PR creation, well past the 30s review delay
+        let t_third_poll = 45u64; // In bucket 1 (30-59)
         let hash_third_poll = super::compute_time_aware_hash_at(pr_data, bucket_secs, t_third_poll);
 
         // Hash should be DIFFERENT (new bucket) - triggers re-evaluation
@@ -3427,46 +3427,46 @@ mod tests {
     #[test]
     fn pr_poll_cache_bucket_boundary_precision() {
         let pr_data = r#"[{"number": 99}]"#;
-        let bucket_secs = super::PR_REVIEW_DELAY_SECS; // 60 seconds
+        let bucket_secs = super::PR_REVIEW_DELAY_SECS; // 30 seconds
 
-        // Bucket boundaries: 0-59 (bucket 0), 60-119 (bucket 1), 120-179 (bucket 2)
+        // Bucket boundaries: 0-29 (bucket 0), 30-59 (bucket 1), 60-89 (bucket 2)
         //
-        // t=59 → 59/60 = 0 (bucket 0)
-        // t=60 → 60/60 = 1 (bucket 1)
+        // t=29 → 29/30 = 0 (bucket 0)
+        // t=30 → 30/30 = 1 (bucket 1)
 
-        // Poll at t=59 (end of bucket 0)
-        let t_end_of_bucket = 59u64;
+        // Poll at t=29 (end of bucket 0)
+        let t_end_of_bucket = 29u64;
         let hash_end = super::compute_time_aware_hash_at(pr_data, bucket_secs, t_end_of_bucket);
 
-        // Poll at t=60 (start of bucket 1)
-        let t_start_next_bucket = 60u64;
+        // Poll at t=30 (start of bucket 1)
+        let t_start_next_bucket = 30u64;
         let hash_start =
             super::compute_time_aware_hash_at(pr_data, bucket_secs, t_start_next_bucket);
 
         // One second difference at bucket boundary → different hash
         assert_ne!(
             hash_end, hash_start,
-            "Crossing bucket boundary (59→60) should change hash"
+            "Crossing bucket boundary (29→30) should change hash"
         );
 
         // Verify bucket values
         assert_eq!(
             t_end_of_bucket / bucket_secs,
             0,
-            "t=59 should be in bucket 0"
+            "t=29 should be in bucket 0"
         );
         assert_eq!(
             t_start_next_bucket / bucket_secs,
             1,
-            "t=60 should be in bucket 1"
+            "t=30 should be in bucket 1"
         );
 
-        // Within bucket, 58→59 should be same hash
-        let hash_58 = super::compute_time_aware_hash_at(pr_data, bucket_secs, 58);
-        let hash_59 = super::compute_time_aware_hash_at(pr_data, bucket_secs, 59);
+        // Within bucket, 28→29 should be same hash
+        let hash_28 = super::compute_time_aware_hash_at(pr_data, bucket_secs, 28);
+        let hash_29 = super::compute_time_aware_hash_at(pr_data, bucket_secs, 29);
         assert_eq!(
-            hash_58, hash_59,
-            "Within same bucket (58→59), hash should be stable"
+            hash_28, hash_29,
+            "Within same bucket (28→29), hash should be stable"
         );
     }
 


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary

Adjusted five key daemon timing constants for improved throughput while maintaining system stability:

- **PR_REVIEW_DELAY_SECS: 60s → 30s** — Biggest win: reviewers spawn 30s faster
- **ORPHAN_RECOVERY_GRACE_PERIOD: 60s → 20s** — Dead coworker tasks recovered 3x faster
- **ORPHAN_SPAWN_COOLDOWN: 5s → 2s** — Multiple orphan recoveries happen faster
- **SPAWN_FAILURE_COOLDOWN: 120s → 60s** — Failed spawns retry sooner
- **ORPHAN_CHECK_INTERVAL_SECS: 10s → 5s** — Task assignment latency cut in half

## Changes

1. Updated timing constants in `src/daemon/constants.rs` with explanatory comments about tradeoffs
2. Fixed test assertions in `src/daemon/pr.rs` to match new 30s bucket boundaries

## Test plan

- [x] All unit tests pass (`cargo test`)
- [x] No clippy warnings (`cargo clippy -- -D warnings`)
- [x] PR poll cache tests updated for 30s buckets
- [x] Build succeeds

## Performance impact

The most significant change is **PR_REVIEW_DELAY_SECS: 60s → 30s**, which means reviewers spawn 30 seconds faster after a PR is opened. Hash bucket deduplication still works correctly with the tighter interval.

The **ORPHAN_CHECK_INTERVAL_SECS: 10s → 5s** change doubles the tick frequency for task dispatch, but testing shows acceptable CPU overhead. Worktree cleanup remains rate-limited to one worktree per tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)