### PR TITLE
fix: Use immediate nudge for web UI lead messages [Midtown !979]

### DIFF
--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -753,6 +753,29 @@ impl CoworkerManager {
             })
     }
 
+    /// Send an immediate nudge to the lead, bypassing the wait-for-empty queue.
+    ///
+    /// Unlike `nudge_lead()`, this sends the nudge immediately via tmux send-keys
+    /// without waiting for the lead's input prompt to be empty. This is intended
+    /// for user-initiated nudges from the web UI where immediate delivery is expected.
+    ///
+    /// The daemon's automatic nudges should use `nudge_lead()` to avoid interrupting
+    /// the user mid-typing.
+    pub fn nudge_lead_immediate(&self, message: &str) -> crate::Result<()> {
+        // Check if lead window exists
+        if !tmux::window_exists(&self.session_name, "lead")? {
+            return Err(crate::Error::Rpc {
+                code: -32602,
+                message: "Lead session not found".to_string(),
+            });
+        }
+
+        // Send keys to the lead's Claude Code pane (pane .0), NOT the chat pane (.1).
+        tmux::send_keys(&self.session_name, "lead.0", message)?;
+
+        Ok(())
+    }
+
     /// Send a special key (like Escape) to a coworker or the lead.
     ///
     /// Unlike nudge, this sends a raw key without text, useful for canceling

--- a/src/web.rs
+++ b/src/web.rs
@@ -1288,11 +1288,12 @@ async fn handle_client_message(
                 .as_ref()
                 .ok_or_else(|| "Coworker manager not available".to_string())?;
 
+            // Use immediate nudge for web UI - user expects instant delivery
             coworkers
-                .nudge_lead(&message)
+                .nudge_lead_immediate(&message)
                 .map_err(|e| format!("Failed to nudge lead: {}", e))?;
 
-            info!("Nudge sent to {} via web UI: {}", target, message);
+            info!("Immediate nudge sent to {} via web UI: {}", target, message);
         }
         ClientMessage::SendKey { target, key } => {
             // Validate target name


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Added `nudge_lead_immediate()` method that bypasses the 90s wait-for-empty queue
- Updated web UI nudge handler to use immediate delivery
- Daemon-initiated nudges still use queued delivery to avoid interrupting user typing

## Problem
The web UI nudge path was using `nudge_lead()`, which queues nudges and waits up to 90 seconds for the lead's input prompt to be empty before delivering. This caused poor UX when sending messages from the web UI (e.g., mobile device) - users expect immediate delivery, not a 90-second delay.

## Solution
Created `nudge_lead_immediate()` that sends nudges directly via `tmux::send_keys`, bypassing the wait-for-empty queue. This is appropriate for user-initiated web UI nudges where the user is explicitly triggering the action.

The daemon's automatic nudges still use the queued `nudge_lead()` path to respect user typing in the terminal.

## Test plan
- [x] Code compiles
- [x] Clippy passes
- [ ] Manual test: Send nudge from web UI, verify immediate delivery

Fixes task !979.

🤖 Generated with [Claude Code](https://claude.com/claude-code)