### PR TITLE
fix: Prevent recovery-registration race in headless coworker recovery [Midtown !983]

### DIFF
--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -2088,7 +2088,7 @@ mod tests {
         assert_eq!(manager.count(), 1);
         let entry = manager.get("lexington").unwrap();
         assert_eq!(entry.name, "lexington");
-        assert_eq!(entry.isolated_tasks, false); // hardcoded by recovery
+        assert!(!entry.isolated_tasks); // hardcoded by recovery
 
         // The spawn flow now tries to register. This should NOT fail.
         // In the current buggy code, this will return an error because
@@ -2108,8 +2108,8 @@ mod tests {
 
         // Verify the entry was updated with the correct isolated_tasks value
         let entry = manager.get("lexington").unwrap();
-        assert_eq!(
-            entry.isolated_tasks, true,
+        assert!(
+            entry.isolated_tasks,
             "isolated_tasks should be updated to true (from register call)"
         );
         assert_eq!(


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Fixed race condition where `sync_with_tmux` recovery blocks legitimate `register()` calls
- Fixed `isolated_tasks` bug where recovered reviewer coworkers get wrong task isolation
- Added headless recovery loop to `sync_with_tmux` (from PR #789)
- `register()` now updates provisional recovery entries instead of failing

## Problem
From PR #790 review (york):

> Headless recovery in `sync_with_tmux()` can insert a Coworker entry that blocks the legitimate `register()` RPC call from the coworker session. When this happens, the daemon sees a duplicate registration and may kill the healthy session.

The race sequence:
1. `SessionManager::spawn()` adds session to SessionManager
2. `sync_with_tmux()` runs before `register()` completes
3. Recovery loop finds the session in SessionManager but not in CoworkerManager
4. Recovery creates a Coworker entry with `isolated_tasks: false`
5. `register()` fails with "already registered" → spawn flow kills the session
6. Recovered reviewer coworkers have wrong `isolated_tasks` value

## Solution
Use **provisional entries** - recovery creates entries with `session_id: None` as a signal. The updated `register()` function:
- Accepts existing entries if `session_id: None` (provisional)
- Rejects existing entries if `session_id: Some(id)` (real concurrent spawn)
- Updates provisional entries with authoritative values from the spawn flow

This allows:
- Recovery to prevent orphan worktree deletion (original goal)
- Registration to complete successfully (fixes the race)
- Correct `isolated_tasks` values for reviewer coworkers (fixes the second bug)

## Test plan
- [x] Added `test_recovery_doesnt_block_register` - verifies register() succeeds after recovery
- [x] All 941 unit tests pass
- [x] Clippy clean (`-D warnings`)
- [x] Format clean

🤖 Generated with [Claude Code](https://claude.ai/code)