### PR TITLE
fix: Remove redundant channel heading from Board tab [Midtown !985]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -174,9 +174,6 @@
 </script>
 
 <div class="channel-container">
-  <div class="channel-header">
-    <h2>#{$activeChannel}</h2>
-  </div>
   <div class="messages" bind:this={messagesContainer} onscroll={handleScroll}>
     {#if channelMessages.length === 0}
       <div class="empty-state">
@@ -294,19 +291,6 @@
     flex-direction: column;
     height: 100%;
     position: relative;
-  }
-
-  .channel-header {
-    padding: 12px 16px;
-    background: #262626;
-    border-bottom: 1px solid #3a3a3a;
-  }
-
-  .channel-header h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: #5fafaf;
-    margin: 0;
   }
 
   .messages {


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Removed the redundant `<h2>#{$activeChannel}</h2>` header from the Board tab's Channel component
- Reclaimed vertical space that was pushing chat UI off the bottom of the screen
- The channel name is already visible in the ChannelList sidebar, making this header unnecessary

## Implementation Details
**Removed from `Channel.svelte`:**
- The `<div class="channel-header">` container with channel name heading
- Associated CSS styles for `.channel-header` and `.channel-header h2`

**Why this is redundant:**
- The active channel is already displayed in the ChannelList sidebar (highlighted)
- Users already know they're on the Board tab (active tab indicator)
- The heading was consuming ~45px of vertical space (padding + border + content)

## Test plan
- [x] Code builds without errors
- [x] Pre-commit hooks pass (clippy + fmt)
- [ ] Manual testing: verify chat UI has more vertical space
- [ ] Manual testing: verify channel switching still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)