### PR TITLE
fix: Improve diagram viewer tap-to-expand and pinch-to-zoom [Midtown !991]

### DIFF
--- a/web-app/src/lib/MermaidModal.svelte
+++ b/web-app/src/lib/MermaidModal.svelte
@@ -138,6 +138,11 @@
         // So: new_translate = viewport_point - diagram_point * new_scale
         translateX = viewportPinchX - diagramPinchX * newScale
         translateY = viewportPinchY - diagramPinchY * newScale
+
+        // Track finger movement during pinch (panning while zooming)
+        translateX += (midX - lastPinchMidX)
+        translateY += (midY - lastPinchMidY)
+
         scale = newScale
       }
 
@@ -192,17 +197,21 @@
     if (!svg) return
 
     const containerRect = containerEl.getBoundingClientRect()
-    const svgRect = svg.getBoundingClientRect()
+
+    // Get intrinsic SVG dimensions (not affected by current transform)
+    const bbox = svg.getBBox()
+    const intrinsicWidth = bbox.width
+    const intrinsicHeight = bbox.height
 
     // Calculate scale to fit full width with 5% padding
     const targetWidth = containerRect.width * 0.95
-    const initialScale = targetWidth / svgRect.width
+    const initialScale = targetWidth / intrinsicWidth
 
     scale = clampScale(initialScale)
 
-    // Center the diagram
-    const scaledWidth = svgRect.width * scale
-    const scaledHeight = svgRect.height * scale
+    // Center the diagram using intrinsic dimensions
+    const scaledWidth = intrinsicWidth * scale
+    const scaledHeight = intrinsicHeight * scale
     translateX = (containerRect.width - scaledWidth) / 2
     translateY = (containerRect.height - scaledHeight) / 2
   }


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
Fixes two UX issues with the diagram viewer modal in the web UI:

1. **Tap-to-expand now fits full width**: When tapping a diagram to expand it, the modal calculates an initial scale to fit the diagram width to 95% of the viewport width (centered). Previously it used `scale=1`, which often made diagrams overflow or appear too small.

2. **Pinch-to-zoom centers correctly**: Pinch-to-zoom now zooms from the midpoint between your fingers. The fix converts the pinch center from viewport coordinates to diagram space (accounting for the current transform), applies the zoom, then converts back. This keeps the point under your fingers fixed during zoom.

## Implementation Details

**Fit-to-width initialization:**
- Added `initialized` state flag and `fitToWidth()` function
- On modal mount, measures SVG dimensions and calculates scale to fit 95% of viewport width
- Centers the diagram horizontally and vertically
- Reset button now returns to fit-to-width instead of `scale=1`

**Pinch-to-zoom fix:**
- Convert pinch center from viewport to diagram space using inverse transform: `(viewport - translate) / scale`
- Apply zoom in diagram space
- Calculate new translate to keep the diagram point under the pinch center: `translate = viewport - diagram_point * new_scale`

## Test plan
- [x] Web app builds successfully
- [ ] Manual testing: tap diagram → should fill viewport width
- [ ] Manual testing: pinch-to-zoom → should zoom from finger midpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)