### PR TITLE
docs: Add PWA safe-area-inset guidance to CLAUDE.md [Midtown !994]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,6 +272,13 @@ When your changes affect anything documented in README.md, update the README as 
 
 The README is the first thing new users and contributors see. If your PR changes user-facing behavior, the README should reflect it.
 
+## Web App (PWA) Guidelines
+
+The web app runs as a PWA on mobile devices. When modifying layout or adding new UI sections:
+
+- **Always account for `safe-area-inset-*`** — iOS PWAs have a status bar/notch that overlaps content. Use `env(safe-area-inset-top)`, `env(safe-area-inset-bottom)`, etc. for any element positioned at the edges of the viewport. Forgetting this causes content to be cut off on mobile.
+- **Test vertical space** — Mobile viewports are constrained. Avoid adding headings, padding, or chrome that pushes primary content (chat, status) off-screen.
+
 ## Pull Requests
 
 - When a PR includes visual changes to the web UI (`web-app/` or `web/`), include before/after screenshots in the PR description.


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Adds a "Web App (PWA) Guidelines" section to CLAUDE.md with two key reminders for coworkers modifying the web UI:
  - Always use `env(safe-area-inset-*)` for edge-positioned elements to avoid iOS notch/status bar overlap
  - Test vertical space on mobile to avoid pushing primary content off-screen

## Context
This codifies lessons learned from PWA mobile layout issues. The guidance ensures coworkers account for iOS safe areas and constrained mobile viewports when working on the web app.

## Test plan
- [x] Documentation-only change — no code modified
- [x] Placement is correct (new section before "Pull Requests" section)

🤖 Generated with [Claude Code](https://claude.ai/code)