### PR TITLE
fix: Add safe area insets to mobile sidebar [Midtown !992]

### DIFF
--- a/web-app/src/App.svelte
+++ b/web-app/src/App.svelte
@@ -410,7 +410,7 @@
     .mobile-close {
       display: block;
       position: absolute;
-      top: 12px;
+      top: calc(env(safe-area-inset-top) + 12px);
       right: 12px;
       width: 32px;
       height: 32px;
@@ -427,6 +427,8 @@
       left: 0;
       top: 0;
       bottom: 0;
+      padding-top: env(safe-area-inset-top);
+      padding-bottom: env(safe-area-inset-bottom);
       z-index: 100;
       transform: translateX(-100%);
       transition: transform 0.3s ease;


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Fixed sidebar top getting cut off in mobile PWA by adding `env(safe-area-inset-top)` padding
- Adjusted close button position to account for the safe area inset
- Also added `env(safe-area-inset-bottom)` for consistency

## Test plan
- [x] Build passes
- [ ] Test on iOS device with notch/status bar
- [ ] Verify sidebar content is fully visible when opened
- [ ] Verify close button is positioned correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)