### PR TITLE
fix: Reduce font-size for coworker task text in web UI [Midtown !1015]

### DIFF
--- a/web-app/src/lib/Status.svelte
+++ b/web-app/src/lib/Status.svelte
@@ -231,6 +231,7 @@
 
   .task-text {
     color: #a8a8a8;
+    font-size: 0.75rem;
   }
 
   .started-at {


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Fixed visual hierarchy in coworker cards by reducing font-size of task text from inherited size to 0.75rem
- Task description now appears smaller than coworker name, establishing proper primary/secondary information hierarchy

## Test plan
- [x] Pre-commit hooks passed (clippy + fmt)
- [ ] Verify in web UI that task text is visibly smaller than coworker name
- [ ] Check that text remains readable on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)