### PR TITLE
feat: Auto-complete tasks when coworker opens PR [Midtown !1019]

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -1332,6 +1332,44 @@ pub(super) fn build_task_completion_effects(
     ]
 }
 
+/// Build effects to auto-complete a task when its PR is opened.
+///
+/// This is a pure function that extracts the task ID from a PR title
+/// (looking for `[Midtown !XX]`) and returns the effects needed to:
+/// 1. Mark the task as completed
+/// 2. Clear the task from other tasks' `blockedBy` arrays
+/// 3. Post a notification to the channel
+///
+/// Returns an empty vector if no task ID is found in the title.
+pub(super) fn build_task_completion_effects_for_opened(
+    pr_title: &str,
+    pr_number: u64,
+    repo_name: &str,
+) -> Vec<Effect> {
+    let Some(task_id) = crate::tasks::extract_task_id_from_pr_title(pr_title) else {
+        return vec![];
+    };
+
+    let task_id_str = task_id.to_string();
+    vec![
+        Effect::CompleteTask {
+            task_id: task_id_str.clone(),
+            repo_name: repo_name.to_string(),
+        },
+        Effect::ClearBlockedBy {
+            completed_task_id: task_id_str.clone(),
+            repo_name: repo_name.to_string(),
+        },
+        Effect::PostToChannel {
+            sender: "midtown".to_string(),
+            message: format!(
+                "✅ Auto-completed task !{} (PR #{} opened)",
+                task_id, pr_number
+            ),
+        },
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1648,6 +1686,69 @@ mod tests {
             }
             _ => panic!("Third effect should be PostToChannel"),
         }
+    }
+
+    #[test]
+    fn test_build_task_completion_effects_for_opened_with_task_id() {
+        let effects = build_task_completion_effects_for_opened(
+            "feat: Add auth endpoint [Midtown !42]",
+            123,
+            "myrepo",
+        );
+
+        assert_eq!(effects.len(), 3, "Should return 3 effects");
+
+        // Verify CompleteTask effect
+        match &effects[0] {
+            Effect::CompleteTask { task_id, repo_name } => {
+                assert_eq!(task_id, "42");
+                assert_eq!(repo_name, "myrepo");
+            }
+            _ => panic!("First effect should be CompleteTask"),
+        }
+
+        // Verify ClearBlockedBy effect
+        match &effects[1] {
+            Effect::ClearBlockedBy {
+                completed_task_id,
+                repo_name,
+            } => {
+                assert_eq!(completed_task_id, "42");
+                assert_eq!(repo_name, "myrepo");
+            }
+            _ => panic!("Second effect should be ClearBlockedBy"),
+        }
+
+        // Verify PostToChannel effect says "opened"
+        match &effects[2] {
+            Effect::PostToChannel { sender, message } => {
+                assert_eq!(sender, "midtown");
+                assert!(
+                    message.contains("opened"),
+                    "Message should say 'opened', got: {}",
+                    message
+                );
+                assert!(
+                    !message.contains("merged"),
+                    "Message should not say 'merged', got: {}",
+                    message
+                );
+                assert!(message.contains("42"));
+                assert!(message.contains("123"));
+            }
+            _ => panic!("Third effect should be PostToChannel"),
+        }
+    }
+
+    #[test]
+    fn test_build_task_completion_effects_for_opened_without_task_id() {
+        let effects =
+            build_task_completion_effects_for_opened("feat: Add auth endpoint", 123, "myrepo");
+
+        assert!(
+            effects.is_empty(),
+            "Should return empty vec when no task ID in title"
+        );
     }
 
     // ======================================================================

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1581,8 +1581,15 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                         }
                     }
 
-                    // NOTE: Task auto-completion has been moved to the PR merged handler
-                    // to avoid completing tasks before review feedback is addressed and CI passes.
+                    // Auto-complete task when PR is opened (task !XXX in title)
+                    // This prevents orphan recovery from incorrectly trying to reassign work
+                    // that's already complete and under review.
+                    let completion_effects = dispatch::build_task_completion_effects_for_opened(
+                        &pr_opened.title,
+                        pr_opened.pr_number,
+                        &state.repo_name,
+                    );
+                    pr_effects.extend(completion_effects);
 
                     if !pr_effects.is_empty() {
                         effects::execute_effects(pr_effects, &state).await;

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -608,8 +608,22 @@ pub fn reset_task_to_pending_for_repo(task_id: &str, repo_name: &str) -> Result<
     Ok(())
 }
 
-/// Extract task ID from PR title using the `[Midtown #XX]` format.
+/// Extract task ID from PR title using the `[Midtown !XX]` or `[Midtown #XX]` format.
+///
+/// The `!` format is the current convention, but `#` is supported for backward compatibility.
 pub fn extract_task_id_from_pr_title(title: &str) -> Option<u64> {
+    // Try the current convention first: [Midtown !XX]
+    if let Some(start) = title.find("[Midtown !") {
+        let rest = &title[start + 10..]; // Skip "[Midtown !"
+        if let Some(end) = rest.find(']') {
+            let num_str = &rest[..end];
+            if let Ok(id) = num_str.parse::<u64>() {
+                return Some(id);
+            }
+        }
+    }
+
+    // Fall back to legacy format: [Midtown #XX]
     if let Some(start) = title.find("[Midtown #") {
         let rest = &title[start + 10..]; // Skip "[Midtown #"
         if let Some(end) = rest.find(']') {
@@ -617,6 +631,7 @@ pub fn extract_task_id_from_pr_title(title: &str) -> Option<u64> {
             return num_str.parse::<u64>().ok();
         }
     }
+
     None
 }
 
@@ -1636,6 +1651,21 @@ mod tests {
 
     #[test]
     fn test_extract_task_id_from_pr_title() {
+        // Current convention with !
+        assert_eq!(
+            extract_task_id_from_pr_title("feat: Add auth endpoint [Midtown !42]"),
+            Some(42)
+        );
+        assert_eq!(
+            extract_task_id_from_pr_title("fix: Something [Midtown !7]"),
+            Some(7)
+        );
+        assert_eq!(
+            extract_task_id_from_pr_title("prefix [Midtown !123] suffix"),
+            Some(123)
+        );
+
+        // Legacy format with # (for backward compatibility)
         assert_eq!(
             extract_task_id_from_pr_title("feat: Add auth endpoint [Midtown #42]"),
             Some(42)
@@ -1644,13 +1674,16 @@ mod tests {
             extract_task_id_from_pr_title("fix: Something [Midtown #7]"),
             Some(7)
         );
-        assert_eq!(extract_task_id_from_pr_title("No task id here"), None);
-        assert_eq!(extract_task_id_from_pr_title(""), None);
-        assert_eq!(extract_task_id_from_pr_title("[Midtown #] empty id"), None);
         assert_eq!(
             extract_task_id_from_pr_title("prefix [Midtown #123] suffix"),
             Some(123)
         );
+
+        // No task ID
+        assert_eq!(extract_task_id_from_pr_title("No task id here"), None);
+        assert_eq!(extract_task_id_from_pr_title(""), None);
+        assert_eq!(extract_task_id_from_pr_title("[Midtown !] empty id"), None);
+        assert_eq!(extract_task_id_from_pr_title("[Midtown #] empty id"), None);
     }
 
     #[test]


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Auto-complete tasks when PR is opened, not when merged
- Updated `extract_task_id_from_pr_title()` to support both `!` and `#` formats
- Added `build_task_completion_effects_for_opened()` function

## Problem
Currently tasks stay `in_progress` until PR merge, which can cause false orphan recovery after the grace period when a coworker is idle waiting for review. The orphan recovery system sees an `in_progress` task with no active coworker and tries to reassign it.

## Solution
Auto-complete tasks when the PR is opened instead of when merged. Opening a PR marks the implementation work as complete - the PR review/merge lifecycle is already tracked separately by the daemon's PR monitoring.

This prevents the orphan recovery system from incorrectly trying to reassign work that's already complete and under review.

## Changes
1. **dispatch.rs**: Added `build_task_completion_effects_for_opened()` - pure function that returns effects to complete a task when PR opens
2. **tasks.rs**: Updated `extract_task_id_from_pr_title()` to support both `[Midtown !XX]` (current) and `[Midtown #XX]` (legacy) formats
3. **daemon/mod.rs**: Call task completion effects when `pr_opened` webhook is received
4. **Tests**: Added tests for new function and updated task ID extraction

## Test plan
- [x] Unit tests pass (960 tests)
- [x] Clippy passes with -D warnings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)