### PR TITLE
docs: Use Midtown branding in GitHub content [Midtown !1037]

### DIFF
--- a/agents/common.md
+++ b/agents/common.md
@@ -55,6 +55,11 @@ or add the HTML comment anywhere in your comment:
 
 **Reviews are comment-based, not formal GitHub reviews.** All coworkers share the same GitHub user, so `gh pr review --approve` is meaningless. Post reviews as PR comments using `gh pr comment`. Authors merge their own PRs after review feedback is addressed.
 
+**GitHub footer**: When posting to GitHub (PR descriptions, PR comments, review comments), include this footer instead of the default Claude Code footer:
+```
+🌃 Co-built with [Midtown](https://github.com/btucker/midtown)
+```
+
 **CRITICAL: NEVER use @mentions in GitHub** (PR descriptions, comments, reviews). GitHub interprets `@name` as real GitHub usernames and sends unwanted notifications to strangers. This has already caused incidents. Use coworker names without the `@` prefix in all GitHub content. @mentions are ONLY for the IRC channel where the daemon routes them.
 
 - ❌ GitHub: "@park Addressed both issues" — this pings a real GitHub user named "park"

--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -137,6 +137,8 @@ gh pr create --title "feat: Add auth endpoint [Midtown !42]" --body "$(cat <<'EO
 
 ## Test plan
 - [x] Unit tests pass
+
+🌃 Co-built with [Midtown](https://github.com/btucker/midtown)
 EOF
 )"
 ```


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Updated agent documentation to replace default Claude Code footer with Midtown-specific branding
- Modified `agents/common.md` to include GitHub footer guidance
- Updated `agents/coworker.md` PR creation example to include the new footer

## Changes
- **agents/common.md**: Added "GitHub footer" section instructing agents to use "🌃 Co-built with [Midtown](https://github.com/btucker/midtown)" instead of default Claude Code footer
- **agents/coworker.md**: Updated PR creation example to include the Midtown footer in the body template

## Rationale
This ensures all GitHub content (PR descriptions, PR comments, review comments) created by Midtown agents carries consistent Midtown branding, helping attribute the work correctly and promoting the project.

## Test plan
- [x] Reviewed changes to agent documentation
- [x] Verified footer format matches Midtown repository URL
- [x] Confirmed instructions are clear for both PR bodies and comments

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)