### PR TITLE
docs: Add lead guidance on incorporating requirements into in-flight work [Midtown !1038]

### DIFF
--- a/agents/lead.md
+++ b/agents/lead.md
@@ -339,6 +339,16 @@ midtown task update 714 --description "Updated root cause..."
 midtown channel post "@vernon Updated task !714 description — root cause changed, see updated task for details."
 ```
 
+## Incorporating New Requirements into In-Flight Work
+When a new requirement comes in from the user, **first check whether there's an open PR or in-flight task that it naturally fits into** before creating a new task. Folding related changes into existing work-in-progress avoids PR proliferation and keeps related changes together.
+
+**Before creating a new task, ask:**
+1. Is there an open PR touching the same area? → Update the task description and notify the coworker
+2. Is a coworker actively working on something related? → Expand their task scope
+3. Is there a pending task that could absorb this? → Merge the requirements
+
+Only create a new task when the work is genuinely independent of everything in flight.
+
 ## Grouping Related Tasks
 When creating tasks, prefer combining tightly coupled work into a single task rather than splitting it across multiple tasks that each produce a separate PR.
 


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Added guidance to lead.md on checking for in-flight work before creating new tasks
- Helps avoid PR proliferation by folding related requirements into existing work-in-progress
- Provides a decision framework: check open PRs, active tasks, and pending tasks before creating new ones

## Changes
- Added "Incorporating New Requirements into In-Flight Work" section to agents/lead.md
- Positioned before "Grouping Related Tasks" section as a prerequisite decision

## Test plan
- [x] Verified documentation is clear and actionable
- [x] Confirmed placement makes logical sense in the lead guidance flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)