### PR TITLE
fix: Don't block daemon startup on GitHub API rate limit

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1087,6 +1087,18 @@ fn validate_github_repo_access(github_user: &str, workdir: &PathBuf) -> crate::R
         return Ok(());
     }
 
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Rate limit errors are transient — warn but don't block daemon startup.
+    if stderr.contains("rate limit") {
+        warn!(
+            "GitHub API rate limit exceeded — skipping repo access validation for user '{}'. \
+             Access will be validated on the next successful API call.",
+            github_user
+        );
+        return Ok(());
+    }
+
     // Get the repo name for a better error message (even if access check failed)
     let repo_name = std::process::Command::new("git")
         .current_dir(workdir)
@@ -1100,7 +1112,6 @@ fn validate_github_repo_access(github_user: &str, workdir: &PathBuf) -> crate::R
         })
         .unwrap_or_else(|| "unknown".to_string());
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
     Err(crate::Error::Rpc {
         code: -32603,
         message: format!(


### PR DESCRIPTION
## Summary
- When the GitHub GraphQL rate limit is exhausted, `validate_github_repo_access()` was treating the rate-limit error as a permanent "user doesn't have access" failure, making the daemon impossible to start
- Now detects "rate limit" in the `gh repo view` stderr and logs a warning instead of returning a fatal error
- The daemon starts normally and GitHub features resume once the rate limit resets

## Test plan
- [x] Verified fix works with exhausted GraphQL quota (0/5000 remaining) — daemon starts and logs warning
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)