### PR TITLE
fix: Address session survival safety issues from PR #846 review [Midtown !1048]

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -34,7 +34,6 @@ pub enum Effect {
     ///
     /// Uses `SessionManager::spawn` with `SessionMode::ResumeSession` to
     /// restart a coworker from a previously saved session ID.
-    #[allow(dead_code)]
     ResumeCoworker {
         name: String,
         session_id: String,


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary

Vernon's code review of PR #846 identified 4 issues. PR #846 was already merged to main and addressed issues #1-3. This PR addresses the remaining issue #4.

## Changes

**Issue #4: Unnecessary `#[allow(dead_code)]` on actively used code**

Removed `#[allow(dead_code)]` from `Effect::ResumeCoworker`. This effect is actively used:
- Generated in `startup.rs::recover_headless_sessions()` 
- Executed in `effects.rs::execute_effects()`

The attribute suppresses useful compiler warnings and incorrectly signals the code is unused.

## Issues Already Fixed in Main (PR #846)

**Issue #1: `/proc` filesystem is Linux-only**
- Main now uses `ps` commands which work cross-platform

**Issue #2: Incomplete reviewer metadata tracking**
- Main's `persist_sessions_for_restart()` properly tracks reviewers using `isolated_tasks` and looks up PR numbers from persistent state

**Issue #3: Missing PPID=1 check**  
- Main's `kill_zombie_claude_processes()` filters to only PPID=1 processes

## Test Plan
- [x] Clippy clean with `-D warnings`
- [x] Verified ResumeCoworker is used in startup.rs and effects.rs
- [x] All 990 tests pass

## Related
- Addresses remaining issue from Vernon's review of PR #846
- Closes task !1048

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)