### PR TITLE
fix: Prevent infinite loop in wrap_line when width is 0 [Midtown !1049]

### DIFF
--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -1461,6 +1461,9 @@ fn parse_markdown(text: &str, base_style: Style) -> Vec<Span<'static>> {
 /// Uses word boundaries when possible, falls back to character wrapping.
 /// Handles UTF-8 multi-byte characters correctly by using character indices.
 fn wrap_line(text: &str, width: usize) -> Vec<&str> {
+    // Clamp width to minimum 1 to prevent infinite loop
+    let width = width.max(1);
+
     if text.is_empty() {
         return vec![""];
     }
@@ -1716,6 +1719,14 @@ mod tests {
         for line in &wrapped {
             assert!(line.chars().count() <= 40);
         }
+    }
+
+    #[test]
+    fn test_wrap_line_zero_width() {
+        // Zero width should not cause infinite loop - clamp to minimum 1
+        let wrapped = wrap_line("hello", 0);
+        // Should produce single-character chunks
+        assert_eq!(wrapped, vec!["h", "e", "l", "l", "o"]);
     }
 
     #[test]


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Fixed infinite loop in `wrap_line()` when width parameter is 0
- Added test case `test_wrap_line_zero_width` to prevent regression
- Clamped width to minimum of 1 at function start

## Context
Pre-existing bug discovered during PR #849 review. The function would hang if called with width=0 because the split operation produces an empty first part, leaving remaining text unchanged and creating an infinite loop.

The fix is simple: clamp width to `max(1)` at the start of the function.

## Test plan
- [x] New test `test_wrap_line_zero_width` passes (would hang before fix)
- [x] All existing `wrap_line` tests still pass
- [x] Full test suite passes
- [x] Clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)