### PR TITLE
fix: Add checkout step to coverage upload job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,8 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- The `coverage` CI job uploads lcov reports to Codecov but was missing `actions/checkout@v4`
- Codecov needs the source tree to correlate lcov file paths (`SF:src/auth.rs`) with actual source files
- Without it, every report is rejected as "unusable" due to source code unavailability

## Test plan
- [ ] CI passes and Codecov receives a valid coverage report
- [ ] PR coverage comment appears with diff data

🤖 Generated with [Claude Code](https://claude.com/claude-code)