### PR TITLE
Fix task completion timing: keep coworker sessions alive through PR review cycle [Midtown !1090]

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -195,15 +195,18 @@ pub enum Effect {
     ///
     /// When a coworker opens a PR, we store their session ID so any other
     /// coworker can later resume work on that PR with full context preserved.
+    /// Also extracts and stores the task ID from the PR title.
     StorePrAuthorSession {
         pr_number: u64,
         session_id: String,
         branch: String,
         author: String,
+        title: String,
     },
-    /// Mark a task as completed (e.g., when its PR is opened).
+    /// Mark a task as completed.
     ///
-    /// Called when a PR is opened with `[Midtown #XX]` in the title.
+    /// Called when a PR is merged with `[Midtown !XX]` in the title (dispatch.rs),
+    /// or for non-PR tasks when the coworker reports completion (rpc.rs).
     CompleteTask { task_id: String, repo_name: String },
     /// Clear a completed task ID from all dependent tasks' `blockedBy` arrays.
     ///
@@ -802,10 +805,11 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 session_id,
                 branch,
                 author,
+                title,
             } => {
                 let mut ps = state.persistent_state.lock().await;
                 ps.github
-                    .store_pr_author_session(pr_number, &session_id, &branch, &author);
+                    .store_pr_author_session(pr_number, &session_id, &branch, &author, &title);
                 // Link the PR to the worktree by matching branch name.
                 // Use get_by_branch instead of get_by_coworker because coworkers can have
                 // multiple worktrees (one per task), and we need to match the exact branch.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1784,6 +1784,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                                 session_id,
                                 branch: pr_opened.branch.clone(),
                                 author: author.clone(),
+                                title: pr_opened.title.clone(),
                             });
                         } else {
                             debug!(

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -21,6 +21,38 @@ use super::helpers::*;
 use super::{DaemonState, effects, snapshot};
 
 // ============================================================================
+// Helper functions
+// ============================================================================
+
+/// Check if a task has an associated open PR.
+///
+/// Returns true if any open PR has this task_id stored in its PrAuthorSession.
+/// This mapping is established when a coworker opens a PR - the daemon extracts
+/// the task ID from the PR title's "[Midtown !XXX]" marker and stores it in
+/// persistent state.
+///
+/// Used to decide whether to auto-complete a task when a coworker reports
+/// WorkflowPhase::Completed. Tasks with open PRs should complete on merge,
+/// not on phase transition.
+async fn task_has_open_pr(task_id: &str, state: &DaemonState) -> bool {
+    let ps = state.persistent_state.lock().await;
+
+    // Check all PR author sessions to see if any have this task_id
+    for (_pr_number, session) in ps.github.pr_author_sessions.iter() {
+        if let Some(ref stored_task_id) = session.task_id
+            && stored_task_id == task_id
+        {
+            // Found a PR associated with this task
+            // The PR is still in pr_author_sessions, which means it's open
+            // (closed PRs are cleaned up by cleanup_closed_pr_state)
+            return true;
+        }
+    }
+
+    false
+}
+
+// ============================================================================
 // Connection handling
 // ============================================================================
 
@@ -1232,6 +1264,11 @@ async fn handle_coworker_report_state(
     // not the shared list the daemon reads. This closes the loop by updating the
     // shared list when a coworker reports completion via RPC.
     //
+    // IMPORTANT: Tasks that produce PRs complete on MERGE, not on coworker phase
+    // transition. Only auto-complete tasks that DON'T have associated open PRs.
+    // This keeps coworkers alive through the review cycle so feedback can be
+    // delivered to the same session (tier 1 routing).
+    //
     // Uses the existing Effect::CompleteTask and Effect::ClearBlockedBy variants
     // to stay consistent with the effect-based architecture and avoid duplicating
     // cleanup logic (e.g., clear_task_assignment_by_task is handled by the effect
@@ -1247,17 +1284,29 @@ async fn handle_coworker_report_state(
         });
 
         if let Some(ref tid) = effective_task_id {
-            let completion_effects = vec![
-                effects::Effect::CompleteTask {
-                    task_id: tid.clone(),
-                    repo_name: state.repo_name.clone(),
-                },
-                effects::Effect::ClearBlockedBy {
-                    completed_task_id: tid.clone(),
-                    repo_name: state.repo_name.clone(),
-                },
-            ];
-            effects::execute_effects(completion_effects, state).await;
+            // Check if the task has an associated open PR. If it does, defer
+            // completion to the PR merge path (dispatch.rs).
+            let has_open_pr = task_has_open_pr(tid, state).await;
+
+            if has_open_pr {
+                debug!(
+                    "Task !{} has open PR, deferring completion to merge path",
+                    tid
+                );
+            } else {
+                // No open PR (review task, investigation, etc.) - complete immediately
+                let completion_effects = vec![
+                    effects::Effect::CompleteTask {
+                        task_id: tid.clone(),
+                        repo_name: state.repo_name.clone(),
+                    },
+                    effects::Effect::ClearBlockedBy {
+                        completed_task_id: tid.clone(),
+                        repo_name: state.repo_name.clone(),
+                    },
+                ];
+                effects::execute_effects(completion_effects, state).await;
+            }
         }
 
         // Always clear the coworker's assignment (they're done regardless)

--- a/src/github_state.rs
+++ b/src/github_state.rs
@@ -130,10 +130,33 @@ pub struct PrAuthorSession {
     pub original_author: String,
     /// When this session was recorded.
     pub stored_at: DateTime<Utc>,
+    /// The task ID associated with this PR (extracted from [Midtown !XXX] in PR title).
+    /// Used to prevent auto-completion of tasks until the PR merges.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
 }
 
 fn default_assignment_source() -> AssignmentSource {
     AssignmentSource::PollingFallback
+}
+
+/// Extract task ID from a PR title in the format "[Midtown !XXX]".
+///
+/// Returns the task ID as a string (e.g., "42") if found, otherwise None.
+fn extract_task_id_from_title(title: &str) -> Option<String> {
+    // Look for pattern "[Midtown !NNN]" - case insensitive
+    let lower = title.to_lowercase();
+    if let Some(start) = lower.find("[midtown !") {
+        let after_marker = &title[start + 10..]; // Skip "[midtown !"
+        if let Some(end) = after_marker.find(']') {
+            let num_str = after_marker[..end].trim();
+            // Validate it's all digits
+            if !num_str.is_empty() && num_str.chars().all(|c| c.is_ascii_digit()) {
+                return Some(num_str.to_string());
+            }
+        }
+    }
+    None
 }
 
 impl GitHubState {
@@ -549,17 +572,20 @@ impl GitHubState {
     /// Store the Claude session ID for a PR author.
     ///
     /// Called when a coworker opens a PR, so that any other coworker can later
-    /// resume work on that PR with the original session context.
+    /// resume work on that PR with the original session context. Also extracts
+    /// the task ID from the PR title if present (format: "[Midtown !XXX]").
     pub fn store_pr_author_session(
         &mut self,
         pr_number: u64,
         session_id: &str,
         branch: &str,
         author: &str,
+        title: &str,
     ) {
+        let task_id = extract_task_id_from_title(title);
         debug!(
-            "Storing author session for PR #{}: session={}, branch={}, author={}",
-            pr_number, session_id, branch, author
+            "Storing author session for PR #{}: session={}, branch={}, author={}, task_id={:?}",
+            pr_number, session_id, branch, author, task_id
         );
         self.pr_author_sessions.insert(
             pr_number,
@@ -568,6 +594,7 @@ impl GitHubState {
                 branch: branch.to_string(),
                 original_author: author.to_string(),
                 stored_at: Utc::now(),
+                task_id,
             },
         );
     }
@@ -1190,12 +1217,19 @@ mod tests {
     #[test]
     fn test_store_pr_author_session() {
         let mut state = GitHubState::default();
-        state.store_pr_author_session(42, "session-abc-123", "lexington/feature", "lexington");
+        state.store_pr_author_session(
+            42,
+            "session-abc-123",
+            "lexington/feature",
+            "lexington",
+            "feat: Add feature [Midtown !42]",
+        );
 
         let session = state.get_pr_author_session(42).unwrap();
         assert_eq!(session.session_id, "session-abc-123");
         assert_eq!(session.branch, "lexington/feature");
         assert_eq!(session.original_author, "lexington");
+        assert_eq!(session.task_id, Some("42".to_string()));
     }
 
     #[test]
@@ -1207,7 +1241,13 @@ mod tests {
     #[test]
     fn test_remove_pr_author_session() {
         let mut state = GitHubState::default();
-        state.store_pr_author_session(42, "session-abc-123", "lexington/feature", "lexington");
+        state.store_pr_author_session(
+            42,
+            "session-abc-123",
+            "lexington/feature",
+            "lexington",
+            "feat: Add feature",
+        );
 
         let removed = state.remove_pr_author_session(42);
         assert!(removed.is_some());
@@ -1218,9 +1258,15 @@ mod tests {
     #[test]
     fn test_cleanup_closed_prs_removes_author_sessions() {
         let mut state = GitHubState::default();
-        state.store_pr_author_session(42, "session-1", "lexington/feature", "lexington");
-        state.store_pr_author_session(43, "session-2", "park/feature", "park");
-        state.store_pr_author_session(44, "session-3", "york/feature", "york");
+        state.store_pr_author_session(
+            42,
+            "session-1",
+            "lexington/feature",
+            "lexington",
+            "feat: Feature 1",
+        );
+        state.store_pr_author_session(43, "session-2", "park/feature", "park", "feat: Feature 2");
+        state.store_pr_author_session(44, "session-3", "york/feature", "york", "feat: Feature 3");
 
         // Only PR 42 and 44 are still open
         state.cleanup_closed_prs(&[42, 44]);
@@ -1236,7 +1282,13 @@ mod tests {
         let path = dir.path().join("github-state.json");
 
         let mut state = GitHubState::default();
-        state.store_pr_author_session(42, "session-abc", "lexington/feature", "lexington");
+        state.store_pr_author_session(
+            42,
+            "session-abc",
+            "lexington/feature",
+            "lexington",
+            "feat: Add auth [Midtown !123]",
+        );
         state.save(&path).unwrap();
 
         let loaded = GitHubState::load(&path).unwrap();
@@ -1244,5 +1296,25 @@ mod tests {
         assert_eq!(session.session_id, "session-abc");
         assert_eq!(session.branch, "lexington/feature");
         assert_eq!(session.original_author, "lexington");
+        assert_eq!(session.task_id, Some("123".to_string()));
+    }
+
+    #[test]
+    fn test_extract_task_id_from_title() {
+        assert_eq!(
+            extract_task_id_from_title("feat: Add auth [Midtown !42]"),
+            Some("42".to_string())
+        );
+        assert_eq!(
+            extract_task_id_from_title("fix: Bug [MIDTOWN !123]"),
+            Some("123".to_string())
+        );
+        assert_eq!(
+            extract_task_id_from_title("feat: Thing [midtown !7]"),
+            Some("7".to_string())
+        );
+        assert_eq!(extract_task_id_from_title("No task marker"), None);
+        assert_eq!(extract_task_id_from_title("[Midtown !]"), None);
+        assert_eq!(extract_task_id_from_title("[Midtown !abc]"), None);
     }
 }


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Modified WorkflowPhase::Completed handler to check for open PRs before auto-completing tasks
- Added task_id field to PrAuthorSession for persistent task→PR mapping
- Tasks with open PRs now defer completion to the PR merge path, keeping coworker sessions alive through the review cycle

## Implementation Details

### Task→PR Mapping Storage
- Added `task_id: Option<String>` field to `PrAuthorSession` struct in `github_state.rs`
- Extract task ID from PR title `[Midtown !XXX]` marker when `StorePrAuthorSession` effect executes
- Persistent disk-backed storage survives daemon restarts

### Conditional Auto-Completion
- New `task_has_open_pr()` helper in `rpc.rs` queries persistent `pr_author_sessions` map
- Modified `handle_coworker_state` to skip auto-completion for tasks with open PRs
- Tasks without PRs (reviews, investigations) complete immediately as before

### Updated Comments
- Fixed stale comment in `effects.rs` that said tasks complete "when PR is opened"
- Clarified that CompleteTask is called on PR merge (dispatch.rs) or for non-PR tasks (rpc.rs)

## Test plan
- [x] Unit tests pass (`cargo test --lib`)
- [x] Clippy passes (`cargo clippy -- -D warnings`)
- [x] Formatting passes (`cargo fmt -- --check`)
- [x] Added test for `extract_task_id_from_title()` helper
- [x] Updated existing tests to pass `title` parameter to `store_pr_author_session()`

## User Impact
Review feedback will now be delivered to the same coworker session that opened the PR (tier 1 routing), preserving full context. No more HandoffToCoworker or fragile SpawnOwner fallbacks during the review cycle.

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)