### PR TITLE
fix: Propagate --setting-sources to headless coworkers [Midtown !1092]

### DIFF
--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -497,6 +497,7 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
                         agent_id: None,
                         agent_name: None,
                         settings_path: None,
+                        setting_sources: None,
                         env: std::collections::HashMap::new(),
                     };
                     handle_headless_execute(request.id, prompt, &config).await

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -71,6 +71,10 @@ pub struct HeadlessConfig {
     /// Path to a Claude Code settings JSON file. When set, adds `--settings` flag.
     #[serde(default)]
     pub settings_path: Option<String>,
+    /// Setting sources to use. When set, adds `--setting-sources` CLI flag.
+    /// Common value: "project,local" to exclude user-level settings.
+    #[serde(default)]
+    pub setting_sources: Option<String>,
     /// Additional environment variables to set on the child process.
     ///
     /// Applied after the default env_remove call (MIDTOWN_AGENT), so values here
@@ -231,6 +235,11 @@ impl HeadlessSession {
         // Settings file
         if let Some(ref settings) = config.settings_path {
             cmd.arg("--settings").arg(settings);
+        }
+
+        // Setting sources
+        if let Some(ref sources) = config.setting_sources {
+            cmd.arg("--setting-sources").arg(sources);
         }
 
         if let Some(ref cwd) = config.cwd {
@@ -591,6 +600,7 @@ mod tests {
             agent_id: None,
             agent_name: None,
             settings_path: None,
+            setting_sources: None,
             env: std::collections::HashMap::new(),
         }
     }
@@ -686,6 +696,17 @@ mod tests {
     }
 
     #[test]
+    fn test_headless_config_setting_sources_roundtrip() {
+        let config = HeadlessConfig {
+            setting_sources: Some("project,local".to_string()),
+            ..test_config()
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: HeadlessConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.setting_sources, Some("project,local".to_string()));
+    }
+
+    #[test]
     fn test_headless_config_backward_compat_missing_new_fields() {
         // Existing configs without new fields should deserialize with defaults
         let json = r#"{
@@ -704,6 +725,7 @@ mod tests {
         assert!(config.agent_id.is_none());
         assert!(config.agent_name.is_none());
         assert!(config.settings_path.is_none());
+        assert!(config.setting_sources.is_none());
     }
 
     #[test]

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -236,6 +236,11 @@ impl LaunchConfig {
             agent_id,
             agent_name,
             settings_path: None, // Set by caller
+            setting_sources: if self.restrict_setting_sources {
+                Some("project,local".to_string())
+            } else {
+                None
+            },
             env,
         }
     }
@@ -403,6 +408,30 @@ mod tests {
         let config = LaunchConfig::reviewer("york", 42);
         let headless = config.to_headless_config();
         assert!(headless.allow_tools);
+    }
+
+    #[test]
+    fn test_to_headless_config_includes_setting_sources() {
+        let config = LaunchConfig::coworker("park", "myrepo", SessionMode::Fresh, None);
+        let headless = config.to_headless_config();
+
+        assert_eq!(
+            headless.setting_sources,
+            Some("project,local".to_string()),
+            "Coworkers must restrict setting sources to avoid duplicate plugin loading"
+        );
+    }
+
+    #[test]
+    fn test_to_headless_config_reviewer_includes_setting_sources() {
+        let config = LaunchConfig::reviewer("york", 42);
+        let headless = config.to_headless_config();
+
+        assert_eq!(
+            headless.setting_sources,
+            Some("project,local".to_string()),
+            "Reviewers must restrict setting sources to avoid duplicate plugin loading"
+        );
     }
 
     #[test]

--- a/src/specialized.rs
+++ b/src/specialized.rs
@@ -249,6 +249,7 @@ impl SpecializedCoworker {
             agent_id: None,
             agent_name: None,
             settings_path: None,
+            setting_sources: None,
             env: std::collections::HashMap::new(),
         };
 


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Fixed duplicate tool loading in headless coworkers by propagating `--setting-sources project,local`
- Added `setting_sources` field to `HeadlessConfig` with CLI flag support in `HeadlessSession::spawn()`
- Updated `LaunchConfig::to_headless_config()` to propagate `restrict_setting_sources` field

## Root Cause
Headless coworkers loaded plugins from both:
1. Auth profile settings.json (user-level) — 8 plugins
2. coworker-settings.json (project-level) — 15 plugins (includes the same 8)

This caused double-initialization. The session worked initially (deduplication handled it), but after idle→resume when the system prompt regenerated, the tool list broke and the API returned 400 'Tool names must be unique' (44 tools with duplicates).

The tmux path avoided this with `--setting-sources project,local` but the headless path didn't propagate this restriction.

## Test plan
- [x] `cargo test --lib includes_setting_sources` — verifies coworkers and reviewers get the flag
- [x] `cargo test --lib setting_sources_roundtrip` — verifies serde roundtrip
- [x] `cargo test --lib headless` — all 28 headless tests pass
- [x] `cargo test --lib launch` — all 28 launch tests pass
- [x] `cargo clippy -- -D warnings` — no warnings

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)