### PR TITLE
feat: Use unicode chevron prompt and block cursor in TUI [Midtown !1088]

### DIFF
--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -1058,10 +1058,10 @@ fn draw_input_bar(f: &mut Frame, app: &App, area: Rect) {
     let inner = block.inner(area);
 
     // Show input text with cursor
-    let prompt = "> ";
+    let prompt = "› ";
     let char_count = app.input_text.chars().count();
     let text_with_cursor = if is_focused && app.input_cursor == char_count {
-        format!("{}{}_", prompt, app.input_text)
+        format!("{}{}█", prompt, app.input_text)
     } else if is_focused {
         // Convert character index to byte index for split_at
         let byte_idx = app
@@ -1071,7 +1071,7 @@ fn draw_input_bar(f: &mut Frame, app: &App, area: Rect) {
             .map(|(idx, _)| idx)
             .unwrap_or(app.input_text.len());
         let (before, after) = app.input_text.split_at(byte_idx);
-        format!("{}{}_{}", prompt, before, after)
+        format!("{}{}█{}", prompt, before, after)
     } else {
         format!("{}{}", prompt, app.input_text)
     };


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Changed TUI input prompt from `>` to unicode right chevron `›`
- Changed cursor from underscore `_` to full block character `█`

This provides a more polished visual appearance in the terminal UI.

## Test plan
- [x] Code compiles
- [x] Clippy passes
- [x] Manual testing needed for visual verification

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)