### PR TITLE
fix: Move RPC listener to dedicated task to prevent timeout under load [Midtown !1097]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1701,25 +1701,41 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
         });
     }
 
-    // Main accept loop
+    // Spawn dedicated RPC listener task so connection acceptance is never
+    // blocked by long-running tick handlers (PR polling, task dispatch, etc.).
+    // Previously, listener.accept() was inside the main tokio::select! loop,
+    // meaning a tick that takes >15s would cause RPC client timeouts.
+    {
+        let rpc_state = Arc::clone(&state);
+        let rpc_shutdown_tx = shutdown_tx.clone();
+        tokio::spawn(async move {
+            let mut shutdown_rx = rpc_shutdown_tx.subscribe();
+            loop {
+                tokio::select! {
+                    result = listener.accept() => {
+                        match result {
+                            Ok((stream, _addr)) => {
+                                debug!("New RPC connection");
+                                let conn_shutdown = rpc_shutdown_tx.subscribe();
+                                let conn_state = Arc::clone(&rpc_state);
+                                tokio::spawn(rpc::handle_connection(stream, conn_shutdown, conn_state));
+                            }
+                            Err(e) => {
+                                error!("RPC accept error: {}", e);
+                            }
+                        }
+                    }
+                    _ = shutdown_rx.recv() => break,
+                }
+            }
+        });
+    }
+
+    // Main event loop
     loop {
-        let shutdown_rx = shutdown_tx.subscribe();
         let state = Arc::clone(&state);
 
         tokio::select! {
-            // Accept new connections
-            result = listener.accept() => {
-                match result {
-                    Ok((stream, _addr)) => {
-                        debug!("New connection");
-                        tokio::spawn(rpc::handle_connection(stream, shutdown_rx, state));
-                    }
-                    Err(e) => {
-                        error!("Accept error: {}", e);
-                    }
-                }
-            }
-
             // Forward webhook messages to channel and nudge PR owners on comments
             Some(webhook_event) = async {
                 match webhook_rx.as_mut() {


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Moved RPC listener.accept() out of the main tokio::select! loop into a dedicated spawned task
- Prevents CLI timeouts when heavy tick handlers (TaskDispatchTick, PrPollTick) block for 15+ seconds
- Each accepted connection still spawns its own handler task with proper shutdown signaling

## Problem
Previously, the RPC listener was inside the main event loop's tokio::select!. When a tick handler took >15 seconds (e.g., task dispatch with complex decisions, PR polling with many PRs), the listener couldn't accept new connections during that time. This caused CLI commands to timeout waiting for the RPC socket.

## Solution
The RPC listener now runs in its own dedicated task that continuously accepts connections regardless of what the main event loop is doing. Each accepted connection spawns a handler task, and the listener respects the global shutdown signal.

## Test plan
- [x] Cargo build succeeds
- [x] Cargo clippy passes
- [ ] Manual testing: Run daemon under heavy load and verify CLI commands respond promptly
- [ ] Wait for CI to pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)