### PR TITLE
Release v0.5.1 [Midtown !1098]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,7 +1584,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "midtown"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "axum",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midtown"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Midtown - a multi-Claude Code workspace manager, inspired by Gastown"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- midtown: lexington -->

## v0.5.1

### Fixes
- **RPC timeout under load**: Moved RPC listener to dedicated tokio task so CLI commands no longer time out when daemon is busy with tick processing (#894)
- **Headless tool duplication**: Propagate --setting-sources to headless coworkers to prevent 'Tool names must be unique' API errors (#891)
- **Task completion timing**: Keep coworker sessions alive through PR review cycle instead of shutting down prematurely (#888)
- **Phase 4 web UI gaps**: Fixed channel creation API paths, missing source_channel in WebSocket messages, inconsistent API paths (#879)
- **Orphaned review branches**: Added coworker guidance to check PR state before pushing review fixes (#895)

### Features
- **Specialized headless sessions**: Abstract SpecializedRole trait for architect, clusterer, and future headless roles (#880)
- **Review-in-progress comments**: Reviewers now post initial comments when starting review, then edit with results (#893)
- **TUI improvements**: Unicode chevron prompt, block cursor, cross-posted insight attribution (#892, #886)
- **Multi-channel TUI board**: Wire TUI board to multi-channel backend with channel swimlanes (#887)
- **Clusterer system prompt**: Add structured diff format for AI channel clustering (#878)

### Docs
- Enforce review-before-merge in coworker prompt (#882)

## Test plan
- [x] All commits already reviewed and merged to main
- [x] Version bump is the only new commit
- [ ] After merge: Tag as v0.5.1 and push tag

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)