### PR TITLE
feat: Add arrow key navigation and channel selection to TUI board [Midtown !1084]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -156,6 +156,15 @@ pub enum FocusedPane {
     InputBar,
 }
 
+/// Identifies a selectable item in the board panel
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BoardSelection {
+    /// A channel header (channel name)
+    Channel(String),
+    /// A task within a channel (channel name, task ID)
+    Task(String, String),
+}
+
 /// Application state
 pub struct App {
     /// All messages from the channel (VecDeque for O(1) front insertion)
@@ -223,9 +232,10 @@ pub struct App {
     usage_last_refresh: Instant,
     /// Which pane currently has focus
     pub focused_pane: FocusedPane,
-    /// Currently selected channel index in the board
-    #[allow(dead_code)] // Will be used for multi-channel navigation
-    pub selected_channel_index: usize,
+    /// Currently selected item in the board panel (channel or task)
+    pub board_selection: Option<BoardSelection>,
+    /// Currently selected channel for viewing messages
+    pub selected_channel: String,
     /// Text input buffer for the input bar
     pub input_text: String,
     /// Cursor position in the input text
@@ -294,7 +304,8 @@ impl App {
             usage_receiver: None,
             usage_last_refresh: Instant::now() - USAGE_REFRESH_INTERVAL, // Force initial refresh
             focused_pane: FocusedPane::Board,
-            selected_channel_index: 0,
+            board_selection: None,
+            selected_channel: "midtown".to_string(),
             input_text: String::new(),
             input_cursor: 0,
             selection_mode: false,
@@ -639,6 +650,125 @@ impl App {
             FocusedPane::Chat => FocusedPane::InputBar,
             FocusedPane::InputBar => FocusedPane::Board,
         };
+    }
+
+    /// Build the ordered list of selectable items in the board
+    pub fn build_board_selections(&self) -> Vec<BoardSelection> {
+        use std::collections::BTreeMap;
+
+        let mut selections = Vec::new();
+
+        // Discover available channels
+        let channel_repo =
+            midtown::paths::detect_repo_name().unwrap_or_else(|| "default".to_string());
+        let base_dir = midtown::paths::projects_dir_for_repo(&channel_repo);
+        let channels = midtown::Channel::list(&base_dir).unwrap_or_default();
+        let main_channel = channels.first().map(|s| s.as_str()).unwrap_or("midtown");
+
+        // Group tasks by channel
+        let mut tasks_by_channel: BTreeMap<String, Vec<&KanbanTask>> = BTreeMap::new();
+        let (pending, in_progress, _completed) = self.tasks_by_status();
+
+        for task in in_progress.iter().chain(pending.iter()) {
+            let channel_key = task.channel.as_deref().unwrap_or(main_channel).to_string();
+            tasks_by_channel.entry(channel_key).or_default().push(task);
+        }
+
+        // Build selection list: channel headers followed by their tasks
+        for (channel_name, tasks) in &tasks_by_channel {
+            selections.push(BoardSelection::Channel(channel_name.clone()));
+            for task in tasks {
+                selections.push(BoardSelection::Task(channel_name.clone(), task.id.clone()));
+            }
+        }
+
+        selections
+    }
+
+    /// Navigate board selection up
+    pub fn board_selection_up(&mut self) {
+        let selections = self.build_board_selections();
+        if selections.is_empty() {
+            return;
+        }
+
+        if let Some(ref current) = self.board_selection {
+            // Find current position and move up
+            if let Some(pos) = selections.iter().position(|s| s == current)
+                && pos > 0
+            {
+                self.board_selection = Some(selections[pos - 1].clone());
+                self.update_selected_channel();
+            }
+        } else {
+            // No selection - select the last item
+            self.board_selection = selections.last().cloned();
+            self.update_selected_channel();
+        }
+    }
+
+    /// Navigate board selection down
+    pub fn board_selection_down(&mut self) {
+        let selections = self.build_board_selections();
+        if selections.is_empty() {
+            return;
+        }
+
+        if let Some(ref current) = self.board_selection {
+            // Find current position and move down
+            if let Some(pos) = selections.iter().position(|s| s == current)
+                && pos < selections.len() - 1
+            {
+                self.board_selection = Some(selections[pos + 1].clone());
+                self.update_selected_channel();
+            }
+        } else {
+            // No selection - select the first item
+            self.board_selection = selections.first().cloned();
+            self.update_selected_channel();
+        }
+    }
+
+    /// Update the selected channel when a board selection changes
+    fn update_selected_channel(&mut self) {
+        if let Some(ref selection) = self.board_selection {
+            let new_channel = match selection {
+                BoardSelection::Channel(ch) => ch.clone(),
+                BoardSelection::Task(ch, _) => ch.clone(),
+            };
+
+            // Only reload messages if the channel actually changed
+            if new_channel != self.selected_channel {
+                self.selected_channel = new_channel;
+                self.load_channel_messages();
+            }
+        }
+    }
+
+    /// Load messages from the currently selected channel
+    fn load_channel_messages(&mut self) {
+        let channel_repo =
+            midtown::paths::detect_repo_name().unwrap_or_else(|| "default".to_string());
+        let base_dir = midtown::paths::projects_dir_for_repo(&channel_repo);
+
+        // Try to open the channel file
+        if let Ok(channel) = midtown::Channel::new(&base_dir, &self.selected_channel) {
+            // Load last N messages
+            if let Ok((messages, start_pos)) = channel.read_last_n_messages(INITIAL_MESSAGE_COUNT) {
+                self.messages = VecDeque::from(messages);
+                self.history_start_position = start_pos;
+                self.history_fully_loaded = start_pos == 0;
+                self.scroll_offset = 0;
+
+                // Update the channel reference for future refresh
+                self.channel = Some(channel);
+
+                // Set cursor to end for new messages
+                if let Some(ref ch) = self.channel {
+                    let _ = ch.set_cursor_to_end("chat-tui");
+                }
+            }
+        }
     }
 
     /// Maximum scroll offset
@@ -1607,7 +1737,8 @@ pub(super) mod tests {
             usage_receiver: None,
             usage_last_refresh: Instant::now(),
             focused_pane: FocusedPane::Board,
-            selected_channel_index: 0,
+            board_selection: None,
+            selected_channel: "midtown".to_string(),
             input_text: String::new(),
             input_cursor: 0,
             selection_mode: false,
@@ -2220,5 +2351,106 @@ pub(super) mod tests {
             Some(&1),
             "After new message arrives, unread count should be 1"
         );
+    }
+
+    #[test]
+    fn test_board_selection_navigation() {
+        let mut app = App {
+            tasks: vec![
+                KanbanTask {
+                    id: "1".to_string(),
+                    subject: "Task 1".to_string(),
+                    owner: None,
+                    status: TaskStatus::Pending,
+                    modified_at: None,
+                    channel: Some("midtown".to_string()),
+                },
+                KanbanTask {
+                    id: "2".to_string(),
+                    subject: "Task 2".to_string(),
+                    owner: Some("park".to_string()),
+                    status: TaskStatus::InProgress,
+                    modified_at: None,
+                    channel: Some("midtown".to_string()),
+                },
+                KanbanTask {
+                    id: "3".to_string(),
+                    subject: "Task 3".to_string(),
+                    owner: None,
+                    status: TaskStatus::Pending,
+                    modified_at: None,
+                    channel: Some("features".to_string()),
+                },
+            ],
+            ..test_app()
+        };
+
+        // Initial state: no selection
+        assert_eq!(app.board_selection, None);
+
+        // Navigate down - should select first item (first channel)
+        app.board_selection_down();
+        assert!(
+            matches!(
+                &app.board_selection,
+                Some(BoardSelection::Channel(ch)) if ch == "features"
+            ),
+            "First down should select first channel"
+        );
+
+        // Navigate down again - should select first task in that channel
+        app.board_selection_down();
+        assert!(
+            matches!(
+                &app.board_selection,
+                Some(BoardSelection::Task(ch, id)) if ch == "features" && id == "3"
+            ),
+            "Second down should select first task"
+        );
+
+        // Navigate up - should go back to channel
+        app.board_selection_up();
+        assert!(
+            matches!(
+                &app.board_selection,
+                Some(BoardSelection::Channel(ch)) if ch == "features"
+            ),
+            "Up should go back to channel"
+        );
+    }
+
+    #[test]
+    fn test_board_selection_changes_selected_channel() {
+        let mut app = App {
+            tasks: vec![
+                KanbanTask {
+                    id: "1".to_string(),
+                    subject: "Task 1".to_string(),
+                    owner: None,
+                    status: TaskStatus::Pending,
+                    modified_at: None,
+                    channel: Some("midtown".to_string()),
+                },
+                KanbanTask {
+                    id: "2".to_string(),
+                    subject: "Task 2".to_string(),
+                    owner: None,
+                    status: TaskStatus::Pending,
+                    modified_at: None,
+                    channel: Some("features".to_string()),
+                },
+            ],
+            ..test_app()
+        };
+
+        // Initial selected channel
+        assert_eq!(app.selected_channel, "midtown");
+
+        // Select a channel
+        app.board_selection = Some(BoardSelection::Channel("features".to_string()));
+        app.update_selected_channel();
+
+        // Selected channel should update
+        assert_eq!(app.selected_channel, "features");
     }
 }

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -370,30 +370,26 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                     }
                 }
                 // Arrow keys for scrolling - don't auto-focus input
-                KeyCode::Up => {
-                    match app.focused_pane {
-                        FocusedPane::Board => {
-                            // Navigate channel/task list (future implementation)
-                            EventResult::Continue
-                        }
-                        FocusedPane::Chat | FocusedPane::InputBar => {
-                            app.scroll_up();
-                            EventResult::Continue
-                        }
+                KeyCode::Up => match app.focused_pane {
+                    FocusedPane::Board => {
+                        app.board_selection_up();
+                        EventResult::Continue
                     }
-                }
-                KeyCode::Down => {
-                    match app.focused_pane {
-                        FocusedPane::Board => {
-                            // Navigate channel/task list (future implementation)
-                            EventResult::Continue
-                        }
-                        FocusedPane::Chat | FocusedPane::InputBar => {
-                            app.scroll_down();
-                            EventResult::Continue
-                        }
+                    FocusedPane::Chat | FocusedPane::InputBar => {
+                        app.scroll_up();
+                        EventResult::Continue
                     }
-                }
+                },
+                KeyCode::Down => match app.focused_pane {
+                    FocusedPane::Board => {
+                        app.board_selection_down();
+                        EventResult::Continue
+                    }
+                    FocusedPane::Chat | FocusedPane::InputBar => {
+                        app.scroll_down();
+                        EventResult::Continue
+                    }
+                },
                 KeyCode::PageUp => {
                     app.page_up();
                     EventResult::Continue

--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -307,12 +307,21 @@ fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> Vec<Hyperlink> 
         }
 
         let channel_header = header_parts.join("");
-        lines.push(Line::from(vec![Span::styled(
-            channel_header,
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        )]));
+
+        // Check if this channel is selected
+        let is_selected = app.board_selection.as_ref().is_some_and(|sel| match sel {
+            super::app::BoardSelection::Channel(ch) => ch == channel_name,
+            _ => false,
+        });
+
+        let mut style = Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD);
+        if is_selected {
+            style = style.bg(Color::DarkGray);
+        }
+
+        lines.push(Line::from(vec![Span::styled(channel_header, style)]));
         lines.push(Line::from("")); // Blank line after header
 
         // Render tasks for this channel
@@ -334,6 +343,12 @@ fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> Vec<Hyperlink> 
                 status_marker, task.id, task.subject, owner_text
             );
 
+            // Check if this task is selected
+            let is_task_selected = app.board_selection.as_ref().is_some_and(|sel| match sel {
+                super::app::BoardSelection::Task(ch, tid) => ch == channel_name && tid == &task.id,
+                _ => false,
+            });
+
             // Pre-wrap the task line if it exceeds available width
             let wrapped_lines = wrap_content(&task_line, wrap_width);
             for (i, wrapped) in wrapped_lines.iter().enumerate() {
@@ -350,10 +365,12 @@ fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> Vec<Hyperlink> 
                     Color::DarkGray
                 };
 
-                lines.push(Line::from(vec![Span::styled(
-                    text,
-                    Style::default().fg(color),
-                )]));
+                let mut style = Style::default().fg(color);
+                if is_task_selected {
+                    style = style.bg(Color::DarkGray);
+                }
+
+                lines.push(Line::from(vec![Span::styled(text, style)]));
             }
         }
     }
@@ -926,9 +943,9 @@ fn draw_chat_panel(f: &mut Frame, app: &mut App, area: Rect) {
 /// Draw the chat messages area (top of chat panel)
 fn draw_chat_messages(f: &mut Frame, app: &mut App, area: Rect) {
     let title = if app.selection_mode {
-        " #midtown [SELECT] "
+        format!(" #{} [SELECT] ", app.selected_channel)
     } else {
-        " #midtown "
+        format!(" #{} ", app.selected_channel)
     };
     let border_color = if app.selection_mode {
         Color::Yellow


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Implements arrow key navigation (Up/Down) in the board panel to select channels and tasks
- When a channel or task is selected, the chat panel switches to display that channel's messages
- Chat panel title dynamically updates to show the selected channel name (e.g., "#frontend", "#backend")
- Visual highlighting (dark gray background) for the selected item in the board

## Implementation Details
- Added `BoardSelection` enum to track whether a channel header or task is selected
- Added `selected_channel` field to App to track the currently viewed channel
- Implemented `board_selection_up()` and `board_selection_down()` methods for navigation
- Wire arrow key handling in Board pane to call selection methods
- Added highlighting logic in UI rendering for both channel headers and task rows
- When selection changes to a different channel, messages are reloaded from that channel's JSONL file

## Test plan
- [x] Build passes
- [x] All tests pass
- [x] Clippy passes with `-D warnings`
- [x] Manual testing: Arrow keys navigate between channels and tasks
- [x] Manual testing: Chat panel title updates when selection changes
- [x] Manual testing: Chat panel loads messages from selected channel

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)