### PR TITLE
docs: Prevent orphaned review feedback branches [Midtown !1096]

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -200,6 +200,15 @@ A code review is **not complete** until you have:
 ### Responding to PR Review Feedback
 When your PR receives review comments with suggested changes:
 
+**First, check if the PR is still open.** If the PR was already merged before you push fixes, your commits will sit on an orphaned branch with no PR — and no one will ever land them. Always verify:
+
+```bash
+gh pr view <number> --json state --jq '.state'
+```
+
+- If **OPEN**: push fixes to the branch as normal.
+- If **MERGED**: open a **new PR** from your branch targeting main. Include context like "Follow-up to PR #N — addresses review feedback."
+
 **IMMEDIATE ACKNOWLEDGMENT**: Post an initial reply to each review comment immediately, then edit it with the final resolution. This provides visibility that you're actively addressing the feedback.
 
 1. **Address in the PR** - If the change is small or directly related to the PR's scope:


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Added guidance in `agents/coworker.md` for coworkers to check if a PR is still open before pushing review feedback fixes
- Prevents orphaned branches where review fixes are pushed after the original PR was already merged
- Instructs coworkers to open a new PR if the original was merged

## Context
When a coworker receives review feedback and addresses it, they might push commits to a branch whose PR was already merged by another coworker or the lead. This creates an orphaned branch with unmerged changes that no one will ever land.

The new guidance adds a workflow step:
1. Check PR state with `gh pr view <number> --json state --jq '.state'`
2. If OPEN: push fixes normally
3. If MERGED: open a new follow-up PR with context

## Test plan
- [x] Documentation changes reviewed
- [x] Guidance is clear and actionable

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)