### PR TITLE
feat: Add @mention, #channel, and !task autocomplete to TUI input bar [Midtown !1086]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -246,6 +246,34 @@ pub struct App {
     pub message_render_cache: Option<MessageRenderCache>,
     /// Unread message counts per channel (channel_name -> unread_count)
     pub channel_unread_counts: HashMap<String, usize>,
+    /// Autocomplete state
+    pub autocomplete: AutocompleteState,
+}
+
+/// Autocomplete state for @mentions, #channels, and !task-ids
+#[derive(Debug, Clone, Default)]
+pub struct AutocompleteState {
+    /// Whether autocomplete dropdown is shown
+    pub show: bool,
+    /// Type of autocomplete trigger: '@' for mentions, '#' for channels, '!' for tasks
+    pub trigger_type: Option<char>,
+    /// Query string after the trigger character
+    pub query: String,
+    /// Filtered autocomplete items to display
+    pub items: Vec<AutocompleteItem>,
+    /// Selected index in the items list
+    pub selected_index: usize,
+    /// Byte position in input_text where the trigger character starts
+    pub trigger_start_pos: usize,
+}
+
+/// An autocomplete suggestion item
+#[derive(Debug, Clone)]
+pub struct AutocompleteItem {
+    /// The full value to insert (e.g., "@park", "#auth-refactor", "!42")
+    pub value: String,
+    /// Optional description (e.g., coworker's current task, channel purpose, task subject)
+    pub description: Option<String>,
 }
 
 /// Interval between kanban data refreshes (30 seconds)
@@ -311,6 +339,7 @@ impl App {
             selection_mode: false,
             message_render_cache: None,
             channel_unread_counts: HashMap::new(),
+            autocomplete: AutocompleteState::default(),
         };
 
         // Initial load
@@ -1054,6 +1083,205 @@ impl App {
             }
         }
     }
+
+    /// Detect autocomplete trigger and update autocomplete state
+    ///
+    /// Scans backward from the cursor position to find trigger characters (@, #, !)
+    /// that are preceded by whitespace or start of line.
+    pub fn detect_autocomplete_trigger(&mut self) {
+        let cursor_pos = self.input_cursor;
+        let text = &self.input_text;
+
+        // Look backward from cursor to find trigger character
+        let mut trigger_pos: Option<usize> = None;
+        let mut trigger_char: Option<char> = None;
+
+        // Convert character indices to byte positions
+        let chars: Vec<(usize, char)> = text.char_indices().collect();
+        if cursor_pos > chars.len() {
+            self.autocomplete.show = false;
+            return;
+        }
+
+        // Find byte position of cursor
+        let cursor_byte_pos = if cursor_pos < chars.len() {
+            chars[cursor_pos].0
+        } else {
+            text.len()
+        };
+
+        // Scan backward from cursor
+        for i in (0..cursor_pos).rev() {
+            let (byte_idx, ch) = chars[i];
+            let prev_char = if i > 0 { Some(chars[i - 1].1) } else { None };
+
+            // Check if this is a trigger character preceded by whitespace or start of line
+            if matches!(ch, '@' | '#' | '!')
+                && (prev_char.is_none() || prev_char == Some(' ') || prev_char == Some('\n'))
+            {
+                trigger_pos = Some(byte_idx);
+                trigger_char = Some(ch);
+                break;
+            }
+
+            // Stop if we hit a space or newline (no trigger found in this word)
+            if ch == ' ' || ch == '\n' {
+                break;
+            }
+        }
+
+        if let (Some(trigger_byte_pos), Some(trigger)) = (trigger_pos, trigger_char) {
+            // Extract query string between trigger and cursor
+            let query = text[trigger_byte_pos + 1..cursor_byte_pos].to_string();
+
+            // Update autocomplete state
+            self.autocomplete.trigger_type = Some(trigger);
+            self.autocomplete.query = query.clone();
+            self.autocomplete.trigger_start_pos = trigger_byte_pos;
+            self.autocomplete.items = self.get_autocomplete_items(trigger, &query);
+            self.autocomplete.selected_index = 0;
+            self.autocomplete.show = !self.autocomplete.items.is_empty();
+        } else {
+            self.autocomplete.show = false;
+        }
+    }
+
+    /// Get autocomplete items for the given trigger and query
+    fn get_autocomplete_items(&self, trigger: char, query: &str) -> Vec<AutocompleteItem> {
+        let query_lower = query.to_lowercase();
+
+        match trigger {
+            '@' => self.get_mention_items(&query_lower),
+            '#' => self.get_channel_items(&query_lower),
+            '!' => self.get_task_items(&query_lower),
+            _ => Vec::new(),
+        }
+    }
+
+    /// Get @mention autocomplete items (coworkers + lead)
+    fn get_mention_items(&self, query: &str) -> Vec<AutocompleteItem> {
+        use crate::cli::response::Response;
+        use crate::client::DaemonClient;
+
+        let mut items = Vec::new();
+
+        // Add "lead" first
+        if "lead".contains(query) {
+            items.push(AutocompleteItem {
+                value: "@lead".to_string(),
+                description: None,
+            });
+        }
+
+        // Try to get coworkers from daemon
+        if let Ok(client) = DaemonClient::connect()
+            && let Ok(Response::Status(status)) = client.status()
+            && let Some(ref full_status) = status.full_status
+        {
+            for cw in &full_status.coworkers {
+                if cw.name.to_lowercase().contains(query) {
+                    items.push(AutocompleteItem {
+                        value: format!("@{}", cw.name),
+                        description: cw.current_task.clone(),
+                    });
+                }
+            }
+        }
+
+        items
+    }
+
+    /// Get #channel autocomplete items
+    fn get_channel_items(&self, query: &str) -> Vec<AutocompleteItem> {
+        let mut items = Vec::new();
+
+        // Get available channels from the channel system
+        if let Some(ref channel) = self.channel {
+            let base_dir = channel.base_dir();
+            if let Ok(channels) = Channel::list(base_dir) {
+                for channel_name in channels {
+                    if channel_name.to_lowercase().contains(query) {
+                        items.push(AutocompleteItem {
+                            value: format!("#{}", channel_name),
+                            description: None,
+                        });
+                    }
+                }
+            }
+        }
+
+        items
+    }
+
+    /// Get !task autocomplete items
+    fn get_task_items(&self, query: &str) -> Vec<AutocompleteItem> {
+        self.tasks
+            .iter()
+            .filter(|task| task.id.contains(query) || task.subject.to_lowercase().contains(query))
+            .map(|task| AutocompleteItem {
+                value: format!("!{}", task.id),
+                description: Some(task.subject.clone()),
+            })
+            .collect()
+    }
+
+    /// Insert the selected autocomplete item into the input text
+    pub fn insert_autocomplete_item(&mut self) {
+        if !self.autocomplete.show
+            || self.autocomplete.selected_index >= self.autocomplete.items.len()
+        {
+            return;
+        }
+
+        let item = &self.autocomplete.items[self.autocomplete.selected_index];
+        let value = item.value.clone(); // Clone to avoid borrow issues
+
+        // Convert cursor position (character index) to byte position
+        let chars: Vec<(usize, char)> = self.input_text.char_indices().collect();
+        let cursor_byte_pos = if self.input_cursor < chars.len() {
+            chars[self.input_cursor].0
+        } else {
+            self.input_text.len()
+        };
+
+        // Extract parts before trigger and after cursor
+        let before_trigger = self.input_text[..self.autocomplete.trigger_start_pos].to_string();
+        let after_cursor = self.input_text[cursor_byte_pos..].to_string();
+
+        // Construct new input text with selected value + space
+        self.input_text = format!("{}{} {}", before_trigger, value, after_cursor);
+
+        // Update cursor position (in character indices)
+        let new_cursor_chars = format!("{}{} ", before_trigger, value).chars().count();
+        self.input_cursor = new_cursor_chars;
+
+        // Hide autocomplete
+        self.autocomplete.show = false;
+    }
+
+    /// Navigate autocomplete selection up
+    pub fn autocomplete_select_prev(&mut self) {
+        if self.autocomplete.show && !self.autocomplete.items.is_empty() {
+            if self.autocomplete.selected_index == 0 {
+                self.autocomplete.selected_index = self.autocomplete.items.len() - 1;
+            } else {
+                self.autocomplete.selected_index -= 1;
+            }
+        }
+    }
+
+    /// Navigate autocomplete selection down
+    pub fn autocomplete_select_next(&mut self) {
+        if self.autocomplete.show && !self.autocomplete.items.is_empty() {
+            self.autocomplete.selected_index =
+                (self.autocomplete.selected_index + 1) % self.autocomplete.items.len();
+        }
+    }
+
+    /// Dismiss autocomplete dropdown
+    pub fn dismiss_autocomplete(&mut self) {
+        self.autocomplete.show = false;
+    }
 }
 
 /// Fetch tasks from Claude Code's task storage.
@@ -1778,6 +2006,7 @@ pub(super) mod tests {
             selection_mode: false,
             message_render_cache: None,
             channel_unread_counts: HashMap::new(),
+            autocomplete: AutocompleteState::default(),
         }
     }
 

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -342,19 +342,19 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
             }
             match key.code {
                 KeyCode::Esc => {
-                    // Esc exits when in Board or Chat, clears input when in InputBar
-                    if app.focused_pane == FocusedPane::InputBar {
+                    // Esc dismisses autocomplete if showing
+                    if app.autocomplete.show {
+                        app.dismiss_autocomplete();
+                        EventResult::Continue
+                    } else if app.focused_pane == FocusedPane::InputBar {
+                        // Esc clears input when in InputBar
                         app.input_text.clear();
                         app.input_cursor = 0;
                         EventResult::Continue
                     } else {
+                        // Esc exits when in Board or Chat
                         EventResult::Exit
                     }
-                }
-                // Tab cycles focus: Board → Chat → InputBar → Board
-                KeyCode::Tab => {
-                    app.cycle_focus();
-                    EventResult::Continue
                 }
                 // Number keys 1-9 open diagrams - only when diagrams exist
                 // This is checked BEFORE auto-focus to input to preserve diagram shortcuts
@@ -370,26 +370,41 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                     }
                 }
                 // Arrow keys for scrolling - don't auto-focus input
-                KeyCode::Up => match app.focused_pane {
-                    FocusedPane::Board => {
-                        app.board_selection_up();
+                // BUT if autocomplete is showing, navigate the dropdown instead
+                KeyCode::Up => {
+                    if app.autocomplete.show {
+                        app.autocomplete_select_prev();
                         EventResult::Continue
+                    } else {
+                        match app.focused_pane {
+                            FocusedPane::Board => {
+                                app.board_selection_up();
+                                EventResult::Continue
+                            }
+                            FocusedPane::Chat | FocusedPane::InputBar => {
+                                app.scroll_up();
+                                EventResult::Continue
+                            }
+                        }
                     }
-                    FocusedPane::Chat | FocusedPane::InputBar => {
-                        app.scroll_up();
+                }
+                KeyCode::Down => {
+                    if app.autocomplete.show {
+                        app.autocomplete_select_next();
                         EventResult::Continue
+                    } else {
+                        match app.focused_pane {
+                            FocusedPane::Board => {
+                                app.board_selection_down();
+                                EventResult::Continue
+                            }
+                            FocusedPane::Chat | FocusedPane::InputBar => {
+                                app.scroll_down();
+                                EventResult::Continue
+                            }
+                        }
                     }
-                },
-                KeyCode::Down => match app.focused_pane {
-                    FocusedPane::Board => {
-                        app.board_selection_down();
-                        EventResult::Continue
-                    }
-                    FocusedPane::Chat | FocusedPane::InputBar => {
-                        app.scroll_down();
-                        EventResult::Continue
-                    }
-                },
+                }
                 KeyCode::PageUp => {
                     app.page_up();
                     EventResult::Continue
@@ -406,10 +421,14 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                     app.scroll_to_bottom();
                     EventResult::Continue
                 }
-                // Enter: auto-focus InputBar, send message if there's text
+                // Enter: select autocomplete item if showing, otherwise auto-focus InputBar or send message
                 KeyCode::Enter => {
-                    if app.focused_pane != FocusedPane::InputBar {
+                    if app.autocomplete.show {
+                        app.insert_autocomplete_item();
+                        EventResult::Continue
+                    } else if app.focused_pane != FocusedPane::InputBar {
                         app.focused_pane = FocusedPane::InputBar;
+                        EventResult::Continue
                     } else if !app.input_text.is_empty() {
                         // Post message to the main midtown channel
                         // TODO: Once PR #901 (channel selection) is merged, use app.selected_channel instead
@@ -425,8 +444,21 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                             app.input_cursor = 0;
                         }
                         // TODO: When error display is implemented, show error here if !posted
+                        EventResult::Continue
+                    } else {
+                        EventResult::Continue
                     }
-                    EventResult::Continue
+                }
+                // Tab: select autocomplete item if showing
+                KeyCode::Tab => {
+                    if app.autocomplete.show {
+                        app.insert_autocomplete_item();
+                        EventResult::Continue
+                    } else {
+                        // Tab cycles focus: Board → Chat → InputBar → Board
+                        app.cycle_focus();
+                        EventResult::Continue
+                    }
                 }
                 // Backspace: auto-focus if input has text, then delete
                 KeyCode::Backspace => {
@@ -443,6 +475,8 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                             let byte_idx =
                                 char_index_to_byte_index(&app.input_text, app.input_cursor);
                             app.input_text.remove(byte_idx);
+                            // Detect autocomplete trigger after deletion
+                            app.detect_autocomplete_trigger();
                         }
                     }
                     EventResult::Continue
@@ -455,6 +489,8 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                             let byte_idx =
                                 char_index_to_byte_index(&app.input_text, app.input_cursor);
                             app.input_text.remove(byte_idx);
+                            // Detect autocomplete trigger after deletion
+                            app.detect_autocomplete_trigger();
                         }
                     }
                     EventResult::Continue
@@ -522,6 +558,9 @@ fn auto_focus_and_insert_char(app: &mut App, c: char) {
     let byte_idx = char_index_to_byte_index(&app.input_text, app.input_cursor);
     app.input_text.insert(byte_idx, c);
     app.input_cursor += 1;
+
+    // Detect autocomplete trigger
+    app.detect_autocomplete_trigger();
 }
 
 #[cfg(test)]
@@ -892,5 +931,154 @@ mod tests {
         handle_event(&mut app, key_press(KeyCode::Char(' ')));
         assert_eq!(app.focused_pane, FocusedPane::InputBar);
         assert_eq!(app.input_text, " ");
+    }
+
+    #[test]
+    fn test_autocomplete_trigger_detection_at_start() {
+        use app::FocusedPane;
+        let mut app = test_app();
+        app.focused_pane = FocusedPane::InputBar;
+
+        // Type @ at start of input
+        auto_focus_and_insert_char(&mut app, '@');
+        assert!(
+            app.autocomplete.show || app.autocomplete.trigger_type == Some('@'),
+            "Autocomplete should detect @ trigger"
+        );
+        assert_eq!(app.autocomplete.query, "");
+    }
+
+    #[test]
+    fn test_autocomplete_trigger_detection_after_space() {
+        use app::FocusedPane;
+        let mut app = test_app();
+        app.focused_pane = FocusedPane::InputBar;
+
+        // Type "hello @"
+        for ch in "hello @".chars() {
+            auto_focus_and_insert_char(&mut app, ch);
+        }
+        assert_eq!(app.autocomplete.trigger_type, Some('@'));
+        assert_eq!(app.autocomplete.query, "");
+    }
+
+    #[test]
+    fn test_autocomplete_with_query() {
+        use app::FocusedPane;
+        let mut app = test_app();
+        app.focused_pane = FocusedPane::InputBar;
+
+        // Type "@par" (partial coworker name)
+        for ch in "@par".chars() {
+            auto_focus_and_insert_char(&mut app, ch);
+        }
+        assert_eq!(app.autocomplete.trigger_type, Some('@'));
+        assert_eq!(app.autocomplete.query, "par");
+    }
+
+    #[test]
+    fn test_autocomplete_navigation() {
+        use app::{AutocompleteItem, FocusedPane};
+        let mut app = test_app();
+        app.focused_pane = FocusedPane::InputBar;
+
+        // Manually set up autocomplete state with multiple items
+        app.autocomplete.show = true;
+        app.autocomplete.items = vec![
+            AutocompleteItem {
+                value: "@lead".to_string(),
+                description: None,
+            },
+            AutocompleteItem {
+                value: "@park".to_string(),
+                description: Some("Working on task 5".to_string()),
+            },
+            AutocompleteItem {
+                value: "@madison".to_string(),
+                description: None,
+            },
+        ];
+        app.autocomplete.selected_index = 0;
+
+        // Arrow down should move to next item
+        app.autocomplete_select_next();
+        assert_eq!(app.autocomplete.selected_index, 1);
+
+        // Arrow down again
+        app.autocomplete_select_next();
+        assert_eq!(app.autocomplete.selected_index, 2);
+
+        // Arrow down should wrap to first item
+        app.autocomplete_select_next();
+        assert_eq!(app.autocomplete.selected_index, 0);
+
+        // Arrow up should wrap to last item
+        app.autocomplete_select_prev();
+        assert_eq!(app.autocomplete.selected_index, 2);
+    }
+
+    #[test]
+    fn test_autocomplete_dismiss_on_escape() {
+        use app::{AutocompleteItem, FocusedPane};
+        let mut app = test_app();
+        app.focused_pane = FocusedPane::InputBar;
+
+        // Set up autocomplete
+        app.autocomplete.show = true;
+        app.autocomplete.items = vec![AutocompleteItem {
+            value: "@lead".to_string(),
+            description: None,
+        }];
+
+        // Press Escape
+        handle_event(&mut app, key_press(KeyCode::Esc));
+        assert!(!app.autocomplete.show, "Escape should dismiss autocomplete");
+    }
+
+    #[test]
+    fn test_autocomplete_insert() {
+        use app::{AutocompleteItem, FocusedPane};
+        let mut app = test_app();
+        app.focused_pane = FocusedPane::InputBar;
+
+        // Set up input and autocomplete
+        app.input_text = "@pa".to_string();
+        app.input_cursor = 3;
+        app.autocomplete.show = true;
+        app.autocomplete.trigger_start_pos = 0;
+        app.autocomplete.trigger_type = Some('@');
+        app.autocomplete.query = "pa".to_string();
+        app.autocomplete.selected_index = 0;
+        app.autocomplete.items = vec![AutocompleteItem {
+            value: "@park".to_string(),
+            description: Some("Working on task 5".to_string()),
+        }];
+
+        // Insert autocomplete item
+        app.insert_autocomplete_item();
+
+        // Check that text was replaced and cursor moved
+        assert_eq!(app.input_text, "@park ");
+        assert_eq!(app.input_cursor, 6); // "@park " is 6 characters
+        assert!(
+            !app.autocomplete.show,
+            "Autocomplete should be hidden after insert"
+        );
+    }
+
+    #[test]
+    fn test_autocomplete_no_trigger_in_middle_of_word() {
+        use app::FocusedPane;
+        let mut app = test_app();
+        app.focused_pane = FocusedPane::InputBar;
+
+        // Type "email@example" - @ in middle of word should not trigger
+        for ch in "email@".chars() {
+            auto_focus_and_insert_char(&mut app, ch);
+        }
+        assert!(
+            !app.autocomplete.show,
+            "Autocomplete should not trigger for @ in middle of word"
+        );
     }
 }

--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -941,6 +941,11 @@ fn draw_chat_panel(f: &mut Frame, app: &mut App, area: Rect) {
 
     draw_chat_messages(f, app, chunks[0]);
     draw_input_bar(f, app, chunks[1]);
+
+    // Draw autocomplete dropdown overlay if showing
+    if app.autocomplete.show {
+        draw_autocomplete_dropdown(f, app, chunks[1]);
+    }
 }
 
 /// Draw the chat messages area (top of chat panel)
@@ -1147,6 +1152,80 @@ fn draw_input_bar(f: &mut Frame, app: &App, area: Rect) {
 
     f.render_widget(block, area);
     f.render_widget(paragraph, inner);
+}
+
+/// Draw autocomplete dropdown above the input bar
+fn draw_autocomplete_dropdown(f: &mut Frame, app: &App, input_area: Rect) {
+    let items = &app.autocomplete.items;
+    if items.is_empty() {
+        return;
+    }
+
+    // Calculate dropdown dimensions
+    let item_count = items.len().min(8); // Show max 8 items
+    let dropdown_height = (item_count * 2) as u16; // 2 lines per item (value + description or blank)
+    let dropdown_width = 40u16.min(input_area.width.saturating_sub(4));
+
+    // Position dropdown above input bar (with 1-line gap)
+    let dropdown_y = input_area
+        .y
+        .saturating_sub(dropdown_height)
+        .saturating_sub(1);
+    let dropdown_x = input_area.x + 2; // Indent slightly from input bar
+
+    let dropdown_area = Rect {
+        x: dropdown_x,
+        y: dropdown_y,
+        width: dropdown_width,
+        height: dropdown_height,
+    };
+
+    // Build dropdown lines
+    let mut lines = Vec::new();
+    for (i, item) in items.iter().enumerate().take(item_count) {
+        let is_selected = i == app.autocomplete.selected_index;
+
+        // Item value line (highlighted if selected)
+        let value_style = if is_selected {
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::White)
+        };
+
+        lines.push(Line::from(vec![Span::styled(
+            format!(" {} ", item.value),
+            value_style,
+        )]));
+
+        // Description line (if present)
+        if let Some(ref desc) = item.description {
+            let desc_text = if desc.len() > dropdown_width as usize - 4 {
+                format!(" {}...", &desc[..dropdown_width as usize - 7])
+            } else {
+                format!(" {}", desc)
+            };
+            let desc_style = if is_selected {
+                Style::default().fg(Color::Black).bg(Color::Yellow)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
+            lines.push(Line::from(vec![Span::styled(desc_text, desc_style)]));
+        } else {
+            // Blank line for spacing
+            lines.push(Line::from(""));
+        }
+    }
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .style(Style::default().bg(Color::Black));
+
+    let paragraph = Paragraph::new(lines).block(block);
+    f.render_widget(paragraph, dropdown_area);
 }
 
 /// Render a single message into one or more Lines


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Added Slack-style autocomplete to TUI chat input with @mention, #channel, and !task support
- Dropdown UI with keyboard navigation (arrows, Tab/Enter to select, Escape to dismiss)
- Dynamic filtering as user types
- Integration with daemon status for live coworker list
- Integration with channel system for available channels
- Integration with task list for task ID completion

## Test plan
- [x] All 7 autocomplete unit tests passing
- [x] All library tests passing (1097 passed)
- [x] Clippy warnings resolved
- [x] Code formatted per project style

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)