### PR TITLE
fix: Prevent spawn/nudge loops for assigned tasks [Midtown !1108]

### DIFF
--- a/tests/fixtures/snapshot/snapshot-spawn-loop-york-1107-20260210-205810.json
+++ b/tests/fixtures/snapshot/snapshot-spawn-loop-york-1107-20260210-205810.json
@@ -1760,5 +1760,6 @@
     "task-991-fix-diagram-viewer-full-width-on-tap": "amsterdam",
     "task-993-show-account-email-next-to-usage-heading": "riverside",
     "task-994-open-pr-for-lead-safe-area-inset-docs": "riverside"
-  }
+  },
+  "open_prs_data": []
 }

--- a/tests/fixtures/snapshot/snapshot-spawn-loop-york-1110-20260210-210413.json
+++ b/tests/fixtures/snapshot/snapshot-spawn-loop-york-1110-20260210-210413.json
@@ -1871,5 +1871,6 @@
     "task-991-fix-diagram-viewer-full-width-on-tap": "amsterdam",
     "task-993-show-account-email-next-to-usage-heading": "riverside",
     "task-994-open-pr-for-lead-safe-area-inset-docs": "riverside"
-  }
+  },
+  "open_prs_data": []
 }


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary

Fixes spawn loop where daemon repeatedly spawned coworkers for already-assigned tasks every ~5 seconds.

**Root causes:**
1. **SpawnCoworkerWithCallbacks** missing in-flight marker cleanup after spawn completion
2. **Case 2 grouped tasks** re-assigned the same task to the same coworker every tick, bypassing the busy check

**Fixes:**
1. Added in-flight marker cleanup to `SpawnCoworkerWithCallbacks` (matching `NudgeCoworkerWithCallbacks` pattern)
2. Added `is_coworker_assigned_to_task()` guard before assignment/nudge in Case 2 grouped task path
3. Added `RecordTaskAssignment` to Case 1 `NudgeOwner` on_success callbacks for cross-tick deduplication
4. Added `is_coworker_assigned_to_task()` guard to Case 1 to prevent re-nudge after cooldown expiry

**Test coverage:**
- `test_spawn_coworker_with_callbacks_records_task_assignment` - Case 1 spawn path
- `test_case1_nudge_records_assignment_and_prevents_loop` - Case 1 nudge path with assignment tracking
- `test_grouped_task_skips_if_already_assigned` - Case 2 grouped task path with fixture
- Captured production snapshots: `snapshot-spawn-loop-york-*.json`

All tests use the captured production snapshot fixtures to ensure regression coverage.

## Test plan
- [x] All 1115 unit tests pass
- [x] Spawn loop regression tests pass
- [x] Clippy clean (no warnings)
- [x] Formatting check passes

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)