### PR TITLE
fix: Ensure refresh_unread_counts includes current channel [Midtown !1120]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -1024,13 +1024,21 @@ impl App {
             None => return, // No channel, can't calculate unread counts
         };
 
-        // List all available channels
-        let channels = match Channel::list(&base_dir) {
-            Ok(list) => list,
-            Err(_) => return, // Can't read channel list, skip
-        };
+        // Build list of channels to check
+        // Always include the current channel if we have one, plus any others discovered by list()
+        let mut channels_to_check = std::collections::HashSet::new();
 
-        for channel_name in channels {
+        // Add the current channel first (if we have one)
+        if let Some(ref ch) = self.channel {
+            channels_to_check.insert(ch.channel_name().to_string());
+        }
+
+        // Also add any channels discovered by scanning the directory
+        if let Ok(discovered) = Channel::list(&base_dir) {
+            channels_to_check.extend(discovered);
+        }
+
+        for channel_name in channels_to_check {
             // Open the channel
             let channel = match Channel::new(&base_dir, &channel_name) {
                 Ok(ch) => ch,


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Fixed `test_unread_count_calculation` failing in CI due to race condition
- Bug: `refresh_unread_counts()` relied solely on `Channel::list()` to discover channels, which could miss newly created channels on slow filesystems
- Solution: Always include `app.channel` in the channels to check, in addition to channels discovered by `Channel::list()`

## Root Cause
The test creates a channel with `Channel::new(temp_dir, "test-channel")` and immediately calls `refresh_unread_counts()`. In CI environments (especially with filesystem buffering), `Channel::list()` may not immediately see the newly created channel file, causing the unread count calculation to be skipped entirely and returning `None` instead of `Some(3)`.

## Test Evidence
- Test passes locally but failed consistently in CI
- CI logs showed: `assertion 'left == right' failed: All 3 messages should be unread initially, left: None, right: Some(3)`
- The fix ensures the current channel is always checked, regardless of filesystem timing

## Test plan
- [x] `cargo test test_unread_count_calculation` passes
- [x] All unit tests pass (`cargo test --lib --bins`)
- [x] `cargo clippy -- -D warnings` passes
- [ ] CI tests pass (will verify after PR creation)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)