### PR TITLE
Fix test isolation: chat tests posting to live channel [Midtown !1129]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -198,6 +198,8 @@ pub struct App {
     history_start_position: u64,
     /// Whether all history has been loaded
     history_fully_loaded: bool,
+    /// Test mode: when true, skip daemon communication to avoid side effects
+    test_mode: bool,
     /// Tasks for the kanban board
     pub tasks: Vec<KanbanTask>,
     /// Open PRs for the kanban board (Review column)
@@ -330,6 +332,7 @@ impl App {
             initial_load_done: false,
             history_start_position: 0,
             history_fully_loaded: false,
+            test_mode: false,
             tasks: Vec::new(),
             prs: Vec::new(),
             merged_prs: Vec::new(),
@@ -919,10 +922,23 @@ impl App {
     /// Tries daemon RPC first (preferred - allows daemon to nudge lead),
     /// then falls back to direct channel write if daemon is unavailable.
     ///
+    /// In test mode, skips daemon RPC to avoid side effects on the live system.
+    ///
     /// Returns `true` if the message was successfully posted via either path.
     pub fn post_message(&self, message: &str, sender: &str, channel_name: Option<&str>) -> bool {
         use crate::client::DaemonClient;
         use midtown::{Message, MessageType};
+
+        // In test mode, skip daemon communication to avoid side effects
+        if self.test_mode {
+            // Test mode: only try channel write if channel is available
+            if let Some(ref channel) = self.channel {
+                let mut msg = Message::new(sender, message, MessageType::Text);
+                msg.channel = channel_name.map(|s| s.to_string());
+                return channel.send(&msg).is_ok();
+            }
+            return false;
+        }
 
         // Try daemon RPC first (preferred path - allows daemon to nudge lead)
         // Note: DaemonClient::connect() is synchronous with a 15s timeout.
@@ -2077,6 +2093,7 @@ pub(super) mod tests {
             initial_load_done: true,
             history_start_position: 0,
             history_fully_loaded: true,
+            test_mode: true, // Prevent daemon communication in tests
             tasks: Vec::new(),
             prs: Vec::new(),
             merged_prs: Vec::new(),

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -802,9 +802,9 @@ mod tests {
         app.input_text = "test message".to_string();
 
         handle_event(&mut app, key_press(KeyCode::Enter));
-        // If daemon or channel is available, message sent and input cleared
-        // (may not clear if both are unavailable, but that's environment-dependent)
-        // This test primarily ensures no panic occurs
+        // In test mode, posting fails because test_app() has no channel
+        // Input should be preserved when posting fails
+        assert_eq!(app.input_text, "test message");
         assert!(app.input_cursor <= app.input_text.len());
     }
 
@@ -831,14 +831,13 @@ mod tests {
         app.input_text = "test message".to_string();
         app.input_cursor = 12;
 
-        // If daemon is also unavailable, input should be preserved
-        // Note: This test may pass or fail depending on whether the daemon is running
-        // The key behavior is: input is only cleared on successful post
+        // In test mode, daemon communication is skipped and posting fails
+        // because test_app() has no channel. Input should be preserved.
         handle_event(&mut app, key_press(KeyCode::Enter));
 
-        // The input might be cleared if daemon is available, or preserved if not.
-        // We just verify the cursor position is valid.
-        assert!(app.input_cursor <= app.input_text.len());
+        // Input should be preserved when posting fails
+        assert_eq!(app.input_text, "test message");
+        assert_eq!(app.input_cursor, 12);
     }
 
     #[test]


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

Two unit tests in `src/bin/midtown/cli/chat/mod.rs` were posting real messages to the live channel when the daemon was running:

- `test_enter_sends_message_when_input_has_text` (line 798)
- `test_enter_preserves_input_when_posting_unavailable` (line 825)

Both tests set `input_text` to "test message" and simulate pressing Enter, which called `post_message()`. The `post_message()` method tries `DaemonClient::connect()` first, and when the daemon is running, this succeeds and posts to the real channel — **violating test isolation**.

## Root Cause

The `test_app()` helper creates an `App` with `channel: None`, but `post_message()` tries daemon RPC before checking the channel. When the daemon is running, the tests leak "test message" into the live channel log.

## Solution

Added a `test_mode: bool` field to the `App` struct:

- `App::new()` sets `test_mode = false` (production behavior unchanged)
- `test_app()` sets `test_mode = true` to prevent daemon communication
- `post_message()` skips daemon RPC when `test_mode` is true

This ensures tests **never leak into the live system**, making them deterministic regardless of daemon state.

## Changes

### `src/bin/midtown/cli/chat/app.rs`

- Added `test_mode: bool` field to `App` struct
- Updated `App::new()` to set `test_mode: false`
- Updated `test_app()` to set `test_mode: true`
- Modified `post_message()` to skip daemon communication when in test mode

### `src/bin/midtown/cli/chat/mod.rs`

- Updated test assertions to verify deterministic behavior
- Removed comments about environment-dependent test outcomes

## Test Plan

- [x] All 139 chat module tests pass
- [x] Tests now have deterministic behavior (input always preserved when `test_app()` has no channel)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] No "test message" entries appear in live channel during test runs

## Testing Instructions

Before the fix, running tests while the daemon is active would produce "test message" entries in the channel log. After the fix:

```bash
# Start daemon and monitor channel
midtown daemon &
tail -f ~/.midtown/projects/midtown/channel.jsonl

# Run tests in another terminal
cargo test --bin midtown cli::chat::tests::test_enter_sends_message_when_input_has_text
cargo test --bin midtown cli::chat::tests::test_enter_preserves_input_when_posting_unavailable

# Verify: NO "test message" entries should appear in channel log
```

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)