### PR TITLE
fix: Prevent chat tests from posting to live channel [Midtown !1129]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -198,6 +198,8 @@ pub struct App {
     history_start_position: u64,
     /// Whether all history has been loaded
     history_fully_loaded: bool,
+    /// Test mode: when true, skip daemon communication to avoid side effects
+    test_mode: bool,
     /// Tasks for the kanban board
     pub tasks: Vec<KanbanTask>,
     /// Open PRs for the kanban board (Review column)
@@ -330,6 +332,7 @@ impl App {
             initial_load_done: false,
             history_start_position: 0,
             history_fully_loaded: false,
+            test_mode: false,
             tasks: Vec::new(),
             prs: Vec::new(),
             merged_prs: Vec::new(),
@@ -919,10 +922,23 @@ impl App {
     /// Tries daemon RPC first (preferred - allows daemon to nudge lead),
     /// then falls back to direct channel write if daemon is unavailable.
     ///
+    /// In test mode, skips daemon RPC to avoid side effects on the live system.
+    ///
     /// Returns `true` if the message was successfully posted via either path.
     pub fn post_message(&self, message: &str, sender: &str, channel_name: Option<&str>) -> bool {
         use crate::client::DaemonClient;
         use midtown::{Message, MessageType};
+
+        // In test mode, skip daemon communication to avoid side effects
+        if self.test_mode {
+            // Test mode: only try channel write if channel is available
+            if let Some(ref channel) = self.channel {
+                let mut msg = Message::new(sender, message, MessageType::Text);
+                msg.channel = channel_name.map(|s| s.to_string());
+                return channel.send(&msg).is_ok();
+            }
+            return false;
+        }
 
         // Try daemon RPC first (preferred path - allows daemon to nudge lead)
         // Note: DaemonClient::connect() is synchronous with a 15s timeout.
@@ -2077,6 +2093,7 @@ pub(super) mod tests {
             initial_load_done: true,
             history_start_position: 0,
             history_fully_loaded: true,
+            test_mode: true, // Prevent daemon communication in tests
             tasks: Vec::new(),
             prs: Vec::new(),
             merged_prs: Vec::new(),

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -802,9 +802,9 @@ mod tests {
         app.input_text = "test message".to_string();
 
         handle_event(&mut app, key_press(KeyCode::Enter));
-        // If daemon or channel is available, message sent and input cleared
-        // (may not clear if both are unavailable, but that's environment-dependent)
-        // This test primarily ensures no panic occurs
+        // In test mode, posting fails because test_app() has no channel
+        // Input should be preserved when posting fails
+        assert_eq!(app.input_text, "test message");
         assert!(app.input_cursor <= app.input_text.len());
     }
 
@@ -831,14 +831,13 @@ mod tests {
         app.input_text = "test message".to_string();
         app.input_cursor = 12;
 
-        // If daemon is also unavailable, input should be preserved
-        // Note: This test may pass or fail depending on whether the daemon is running
-        // The key behavior is: input is only cleared on successful post
+        // In test mode, daemon communication is skipped and posting fails
+        // because test_app() has no channel. Input should be preserved.
         handle_event(&mut app, key_press(KeyCode::Enter));
 
-        // The input might be cleared if daemon is available, or preserved if not.
-        // We just verify the cursor position is valid.
-        assert!(app.input_cursor <= app.input_text.len());
+        // Input should be preserved when posting fails
+        assert_eq!(app.input_text, "test message");
+        assert_eq!(app.input_cursor, 12);
     }
 
     #[test]


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Added `test_mode` field to `App` struct to prevent daemon communication during tests
- Modified `post_message()` to skip daemon RPC when `test_mode` is true
- Updated `test_app()` helper to set `test_mode = true`
- Fixed test assertions to reflect deterministic behavior

## Problem
Two unit tests were posting real messages to the live channel when the daemon was running:
- `test_enter_sends_message_when_input_has_text`
- `test_enter_preserves_input_when_posting_unavailable`

The tests simulated pressing Enter with "test message" in the input field, which called `post_message()`. This method tries `DaemonClient::connect()` first, and when the daemon is running, it succeeded and posted to the real channel.

## Solution
The `test_mode` flag ensures tests never leak into the live system, making them deterministic regardless of daemon state. When `test_mode` is true, `post_message()` only attempts direct channel writes (which fail since `test_app()` sets `channel: None`), and returns `false` immediately.

## Test Plan
- [x] All 187 chat module tests pass
- [x] Verified no new "test message" entries appear in live channel when running tests
- [x] Full test suite passes (1124 tests)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)