### PR TITLE
feat: Generic None-removal for merge_tables() across all Option<T> fields [Midtown !1134]

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -440,6 +440,9 @@ pub struct ProvidersConfig {
 /// serde omits it from serialization. Without removal, the old value persists in the file.
 ///
 /// Comment-only sections (tables with no key-value pairs) are preserved during removal.
+///
+/// **Note**: This function assumes all struct fields are serialized (no `skip_serializing_if`).
+/// If a field is omitted from serialization, Phase 2 will remove it from the file.
 fn merge_tables(target: &mut Table, new_table: &Table) {
     // Phase 1: Overlay new values onto target (add or update)
     for (key, new_value) in new_table.iter() {


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary

Fixes latent defect in `merge_tables()` where it only overlaid new values but never removed keys that exist in target but not in new_table. When `Option<T>` fields are set to `None`, serde omits them from serialization, causing stale values to persist in TOML files.

This was previously only handled for `auth_profile` via special-case code in `FullProjectConfig::save_to()`, but the same issue affects **all** `Option<T>` fields in both `GlobalConfig` and `FullProjectConfig`.

## Changes

- **Phase 2 to `merge_tables()`**: After merging new values, remove keys from target that don't exist in new_table
- **Preserve comment-only sections**: Empty tables (containing only comments) are preserved during removal
- **Remove auth_profile special case**: `FullProjectConfig::save_to()` no longer needs explicit `auth_profile` removal - `merge_tables()` handles it generically
- **Comprehensive tests**: Added tests for both `GlobalConfig` and `FullProjectConfig` covering all `Option<T>` fields

## Affected Fields

All `Option<T>` fields now have correct None-removal behavior:

**ProjectConfig / GlobalConfig.default:**
- `bin_command`
- `chat_layout`
- `max_coworkers`
- `personality`
- `user_display_name`

**DaemonSection:**
- `webhook_port`
- `webhook_secret`
- `github_user`

**ProjectMetadata:**
- `auth_profile`

**ProvidersConfig.claude:**
- `auth_profile`

## Test Plan

- [x] New tests pass: `test_merge_tables_removes_none_fields_full_project_config`
- [x] New tests pass: `test_merge_tables_removes_none_fields_global_config`
- [x] All existing tests pass (1142 tests)
- [x] Clippy passes with `-D warnings`
- [x] Pre-commit hooks pass (fmt + clippy)

## Review Notes

This addresses the review feedback from PR #937: https://github.com/btucker/midtown/pull/937#issuecomment-3881867065

The fix is generic and applies to both `GlobalConfig::save_to()` and `FullProjectConfig::save_to()` through the shared `merge_tables()` helper.

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)