### PR TITLE
fix: Complete test isolation by preventing all channel writes in test mode [Midtown !1129]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -922,21 +922,16 @@ impl App {
     /// Tries daemon RPC first (preferred - allows daemon to nudge lead),
     /// then falls back to direct channel write if daemon is unavailable.
     ///
-    /// In test mode, skips daemon RPC to avoid side effects on the live system.
+    /// In test mode, all communication is disabled to prevent side effects on the live system.
     ///
     /// Returns `true` if the message was successfully posted via either path.
     pub fn post_message(&self, message: &str, sender: &str, channel_name: Option<&str>) -> bool {
         use crate::client::DaemonClient;
         use midtown::{Message, MessageType};
 
-        // In test mode, skip daemon communication to avoid side effects
+        // In test mode, skip ALL communication to avoid side effects
+        // This prevents tests from posting to live channels or calling daemon RPC
         if self.test_mode {
-            // Test mode: only try channel write if channel is available
-            if let Some(ref channel) = self.channel {
-                let mut msg = Message::new(sender, message, MessageType::Text);
-                msg.channel = channel_name.map(|s| s.to_string());
-                return channel.send(&msg).is_ok();
-            }
             return false;
         }
 
@@ -2892,5 +2887,42 @@ pub(super) mod tests {
 
         // Selected channel should update
         assert_eq!(app.selected_channel, "features");
+    }
+
+    #[test]
+    fn test_post_message_in_test_mode_never_writes_to_channel() {
+        use tempfile::TempDir;
+
+        // Create a temporary directory for the channel
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create a real channel (will write to temp_dir/channel.jsonl or temp_dir/channels/midtown.jsonl)
+        let channel = midtown::Channel::new(temp_dir.path(), "midtown").unwrap();
+
+        // Create app in test mode WITH a channel (the risky scenario)
+        let app = App {
+            channel: Some(channel),
+            test_mode: true,
+            ..test_app()
+        };
+
+        // Try to post a message
+        let posted = app.post_message("test leak", "test-sender", None);
+
+        // In test mode, posting should fail (return false)
+        assert!(!posted, "post_message should return false in test mode");
+
+        // Verify no message was written to any channel file
+        // Check both legacy channel.jsonl and channels/midtown.jsonl
+        let legacy_path = temp_dir.path().join("channel.jsonl");
+        let new_path = temp_dir.path().join("channels").join("midtown.jsonl");
+
+        let legacy_content = std::fs::read_to_string(&legacy_path).unwrap_or_default();
+        let new_content = std::fs::read_to_string(&new_path).unwrap_or_default();
+
+        assert!(
+            !legacy_content.contains("test leak") && !new_content.contains("test leak"),
+            "test_mode should prevent channel writes, but found message in channel files"
+        );
     }
 }


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Fixed incomplete test isolation from PR #935
- `test_mode` now prevents ALL communication: daemon RPC + direct channel writes
- Added test to verify no leaks even when App has both test_mode=true and a real Channel

## Context
PR #935 added `test_mode` to prevent daemon RPC, but tests could still leak via direct channel writes if `test_app()` ever set `channel` to `Some(...)`. The `post_message()` method had two paths:
1. Daemon RPC (blocked by test_mode ✓)
2. Direct channel write (NOT blocked by test_mode ✗)

Currently safe because `test_app()` sets `channel: None`, but fragile — anyone changing test_app() could accidentally introduce leaks.

## Solution
In test mode, `post_message()` now returns `false` immediately without ANY communication attempts. This makes test isolation complete and robust regardless of channel state.

## Test plan
- [x] Added `test_post_message_in_test_mode_never_writes_to_channel` — creates app with test_mode=true AND real channel, verifies no writes
- [x] All 188 existing tests pass
- [x] Clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)