### PR TITLE
feat: Align coworker status panel columns using ratatui Table [Midtown !1136]

### DIFF
--- a/src/bin/midtown/cli/chat/ui.rs
+++ b/src/bin/midtown/cli/chat/ui.rs
@@ -227,8 +227,8 @@ fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> Vec<Hyperlink> 
     // Split board area vertically: tasks at top, coworkers at bottom
     let active_coworker_count = app.coworkers.len();
     let coworker_section_height = if active_coworker_count > 0 {
-        // 1 header line + 1 blank line + N coworker lines + 2 for borders
-        active_coworker_count as u16 + 4
+        // 1 header line + N coworker rows + 2 for table borders
+        active_coworker_count as u16 + 3
     } else {
         0 // No coworkers, don't show the section
     };


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Replaced manual string formatting with ratatui Table widget for proper column alignment in the TUI sidebar coworker status panel
- Fixed coworker section height calculation to match new rendering structure

## Changes

### Main Implementation (c59cb86)
- Added Table, Row, Cell imports from ratatui::widgets
- Rewrote `draw_coworker_status()` to use Table with fixed-width columns
- Defined column constraints:
  - Health dot: 2 chars (fixed)
  - Name: Min 10 chars (flexible)
  - Task ID: 6 chars (fixed, format: !1234)
  - Phase: 6 chars (fixed, abbreviations like dev/test/PR)
  - PR number: 5 chars (fixed, format: #123)
- Separated header rendering from table content
- Preserved health dot color styling via Cell::style()

### Height Calculation Fix (65e8395)
- Corrected coworker section height from N+4 to N+3
- New calculation: 1 header line + N rows + 2 for table borders
- Addresses review feedback from madison

## Test Plan
- [x] Code compiles without warnings
- [x] Tests pass
- [x] Clippy passes with -D warnings

## Before/After

**Before:** Unaligned text with variable spacing
```
Coworkers (5/10)
● lexington !1128 dev #936
● columbus !1131 dev #940
● york !1112 debug
● riverside !1129 dev #941
● pleasant !1134 dev
```

**After:** Aligned columns using ratatui Table
```
Coworkers (5/10)
┌────────────────────────────────┐
│● lexington  !1128  dev    #936 │
│● columbus   !1131  dev    #940 │
│● york       !1112  debug       │
│● riverside  !1129  dev    #941 │
│● pleasant   !1134  dev         │
└────────────────────────────────┘
```

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)