### PR TITLE
fix: Match [Midtown !XX] format in task auto-completion [Midtown !1141]

### DIFF
--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -693,8 +693,19 @@ pub fn reset_task_to_pending_for_repo(task_id: &str, repo_name: &str) -> Result<
     Ok(())
 }
 
-/// Extract task ID from PR title using the `[Midtown #XX]` format.
+/// Extract task ID from PR title using `[Midtown !XX]` or `[Midtown #XX]` format.
 pub fn extract_task_id_from_pr_title(title: &str) -> Option<u64> {
+    // Try `[Midtown !XX]` first (canonical format used by coworkers)
+    if let Some(start) = title.find("[Midtown !") {
+        let rest = &title[start + 10..]; // Skip "[Midtown !"
+        if let Some(end) = rest.find(']') {
+            let num_str = &rest[..end];
+            if let Ok(id) = num_str.parse::<u64>() {
+                return Some(id);
+            }
+        }
+    }
+    // Fall back to `[Midtown #XX]` for backwards compatibility
     if let Some(start) = title.find("[Midtown #") {
         let rest = &title[start + 10..]; // Skip "[Midtown #"
         if let Some(end) = rest.find(']') {
@@ -1888,6 +1899,16 @@ mod tests {
 
     #[test]
     fn test_extract_task_id_from_pr_title() {
+        // Canonical format with ! (used by coworkers)
+        assert_eq!(
+            extract_task_id_from_pr_title("feat: Add coworker panel [Midtown !1128]"),
+            Some(1128)
+        );
+        assert_eq!(
+            extract_task_id_from_pr_title("fix: Something [Midtown !7]"),
+            Some(7)
+        );
+        // Legacy format with # (backwards compatibility)
         assert_eq!(
             extract_task_id_from_pr_title("feat: Add auth endpoint [Midtown #42]"),
             Some(42)
@@ -1896,9 +1917,16 @@ mod tests {
             extract_task_id_from_pr_title("fix: Something [Midtown #7]"),
             Some(7)
         );
+        // No match
         assert_eq!(extract_task_id_from_pr_title("No task id here"), None);
         assert_eq!(extract_task_id_from_pr_title(""), None);
         assert_eq!(extract_task_id_from_pr_title("[Midtown #] empty id"), None);
+        assert_eq!(extract_task_id_from_pr_title("[Midtown !] empty id"), None);
+        // With surrounding text
+        assert_eq!(
+            extract_task_id_from_pr_title("prefix [Midtown !123] suffix"),
+            Some(123)
+        );
         assert_eq!(
             extract_task_id_from_pr_title("prefix [Midtown #123] suffix"),
             Some(123)


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary

This fixes the critical bug where task auto-completion NEVER worked. The `extract_task_id_from_pr_title()` function was looking for `[Midtown #XX]` but coworkers use `[Midtown !XX]` in PR titles (per the documented format in CLAUDE.md).

This one-character mismatch meant:
- Every PR merge failed to close its associated task
- Tasks accumulated as stale/orphaned
- The daemon couldn't auto-complete tasks, blocking the pipeline

## Changes

- Updated `extract_task_id_from_pr_title()` to match `[Midtown !XX]` format first (canonical)
- Falls back to `[Midtown #XX]` for backwards compatibility
- Added test coverage for both formats and edge cases

## Test plan

- [x] Unit test `test_extract_task_id_from_pr_title` passes
- [x] Clippy passes with `-D warnings`
- [x] Verified extraction logic handles both formats correctly

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)