### PR TITLE
feat: Auto-clean worktree build dirs for coworkers on break [Midtown !1143]

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -326,6 +326,11 @@ pub enum Effect {
         subject: String,
         description: String,
     },
+    /// Clean up a coworker's build directory (target/) to reclaim disk space.
+    ///
+    /// Called when a coworker goes on break (shutdown). The target/ directory
+    /// will be rebuilt when the coworker is called back in.
+    CleanWorktreeTarget { working_dir: String },
 }
 
 /// Deduplicate nudge effects targeting the same coworker within a single batch.
@@ -1303,6 +1308,32 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                     Err(e) => {
                         warn!("Failed to create task '{}': {}", subject, e);
                     }
+                }
+            }
+            Effect::CleanWorktreeTarget { working_dir } => {
+                let target_dir = std::path::Path::new(&working_dir).join("target");
+                if target_dir.exists() {
+                    info!("Cleaning build directory: {}", target_dir.display());
+                    match tokio::fs::remove_dir_all(&target_dir).await {
+                        Ok(_) => {
+                            info!(
+                                "Successfully removed build directory: {}",
+                                target_dir.display()
+                            );
+                        }
+                        Err(e) => {
+                            warn!(
+                                "Failed to remove build directory {}: {}",
+                                target_dir.display(),
+                                e
+                            );
+                        }
+                    }
+                } else {
+                    debug!(
+                        "Build directory does not exist, skipping cleanup: {}",
+                        target_dir.display()
+                    );
                 }
             }
         }

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -358,6 +358,13 @@ pub(super) async fn check_and_shutdown_idle_coworkers(
             continue;
         }
 
+        // Look up working_dir for cleanup
+        let working_dir = snap
+            .active_coworkers
+            .iter()
+            .find(|cw| cw.name.eq_ignore_ascii_case(name))
+            .map(|cw| cw.working_dir.clone());
+
         // Post system message, broadcast status, and shut down
         effects.push(Effect::PostToChannel {
             sender: "system".to_string(),
@@ -374,6 +381,11 @@ pub(super) async fn check_and_shutdown_idle_coworkers(
             message: String::new(),
             session_id: None,
         });
+
+        // Clean up the build directory to reclaim disk space
+        if let Some(dir) = working_dir {
+            effects.push(Effect::CleanWorktreeTarget { working_dir: dir });
+        }
     }
 
     effects


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Automatically delete `target/` directories when coworkers go on break
- Reclaims 4-7GB per coworker to prevent disk space issues
- Target directory rebuilds automatically when coworker is called back in

## Implementation
- Added `Effect::CleanWorktreeTarget` to the daemon effects system
- Modified `check_and_shutdown_idle_coworkers()` to emit cleanup effects
- Cleanup happens asynchronously via `tokio::fs::remove_dir_all()`
- Logs success/failure for monitoring

## Test plan
- [x] Unit tests pass (`cargo test`)
- [x] Clippy passes with no warnings (`cargo clippy -- -D warnings`)
- [x] Code formatted (`cargo fmt`)
- [ ] Manual testing: observe coworker shutdown and verify target/ cleanup

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)