### PR TITLE
feat: Auto-clean worktree target/ dirs when coworkers go on break [Midtown !1143]

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use tracing::{debug, info, warn};
 
 use super::DaemonState;
@@ -237,7 +239,11 @@ pub enum Effect {
     /// Called when a coworker goes on break. Deletes the build artifacts
     /// (target/ dir) to free up 4-7GB per coworker. They'll rebuild when
     /// recalled. This prevents disk exhaustion from idle coworker builds.
-    CleanWorktreeTarget { name: String },
+    ///
+    /// `working_dir` is the coworker's actual working directory (resolved
+    /// from the coworker record at decision time), not the legacy
+    /// `worktree_path()` which only covers coworker-named worktrees.
+    CleanWorktreeTarget { name: String, working_dir: PathBuf },
     /// Clean up a task-based worktree after its PR is merged.
     ///
     /// Looks up the worktree in the registry by PR number or branch name,
@@ -991,35 +997,50 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                     );
                 }
             }
-            Effect::CleanWorktreeTarget { name } => {
-                let coworker_path = state.coworkers.worktree_manager().worktree_path(&name);
-                let target_path = coworker_path.join("target");
+            Effect::CleanWorktreeTarget { name, working_dir } => {
+                let target_path = working_dir.join("target");
 
                 if !target_path.exists() {
                     debug!(
-                        "Target directory for {} doesn't exist, skipping cleanup",
-                        name
+                        "Target directory for {} doesn't exist at {}, skipping cleanup",
+                        name,
+                        target_path.display()
                     );
                     continue;
                 }
 
+                // Brief delay to let the coworker process finish terminating.
+                // ShutdownCoworker sends a non-blocking kill signal, so the
+                // process may still be writing to target/ when we get here.
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
                 let name_clone = name.clone();
-                tokio::task::spawn_blocking(move || match std::fs::remove_dir_all(&target_path) {
-                    Ok(()) => {
-                        info!(
-                            "Cleaned target/ directory for {} to reclaim disk space",
-                            name_clone
-                        );
-                    }
-                    Err(e) => {
-                        warn!(
-                            "Failed to clean target/ directory for {}: {}",
-                            name_clone, e
-                        );
+                match tokio::task::spawn_blocking(move || {
+                    match std::fs::remove_dir_all(&target_path) {
+                        Ok(()) => {
+                            info!(
+                                "Cleaned target/ directory for {} to reclaim disk space",
+                                name_clone
+                            );
+                        }
+                        Err(e) => {
+                            warn!(
+                                "Failed to clean target/ directory for {}: {}",
+                                name_clone, e
+                            );
+                        }
                     }
                 })
                 .await
-                .ok();
+                {
+                    Ok(()) => {}
+                    Err(e) => {
+                        warn!(
+                            "spawn_blocking panicked during target/ cleanup for {}: {}",
+                            name, e
+                        );
+                    }
+                }
             }
             Effect::CleanupMergedWorktree { pr_number, branch } => {
                 // Remove from registry

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -374,8 +374,24 @@ pub(super) async fn check_and_shutdown_idle_coworkers(
             message: String::new(),
             session_id: None,
         });
-        // Clean the coworker's target/ directory to reclaim disk space
-        effects.push(Effect::CleanWorktreeTarget { name: name.clone() });
+        // Clean the coworker's target/ directory to reclaim disk space.
+        // Resolve working_dir from the snapshot so we target the actual
+        // directory (task-based worktree), not the legacy coworker-named path.
+        if let Some(cw) = snap
+            .active_coworkers
+            .iter()
+            .find(|cw| cw.name.eq_ignore_ascii_case(name))
+        {
+            effects.push(Effect::CleanWorktreeTarget {
+                name: name.clone(),
+                working_dir: PathBuf::from(&cw.working_dir),
+            });
+        } else {
+            debug!(
+                "Coworker {} not found in snapshot, skipping target/ cleanup",
+                name
+            );
+        }
     }
 
     effects


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Added automatic cleanup of coworker `target/` directories when they go on break
- Reclaims 4-7GB per coworker to prevent disk exhaustion

## Implementation
- Added `Effect::CleanWorktreeTarget` variant to the effect system
- Modified `decide_idle_shutdowns` in `health.rs` to emit cleanup effect after shutdown
- Added execute handler in `effects.rs` that deletes `target/` directory via `spawn_blocking`

## Rationale
Disk space has been at 100% capacity, requiring manual cleanup twice today. Each coworker's target/ directory contains 4-7GB of build artifacts. When a coworker goes on break, these artifacts are no longer needed and can be safely deleted. They'll rebuild when the coworker is recalled.

## Test plan
- [x] All existing tests pass
- [x] Clippy passes with no warnings
- [ ] Manual test: verify target/ is deleted when a coworker goes on break
- [ ] Manual test: verify coworker can rebuild successfully when recalled

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)