### PR TITLE
fix: task update RPC panic from blocking_lock in async context [Midtown !1154]

### DIFF
--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -445,6 +445,7 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
                         model,
                         state,
                     )
+                    .await
                 }
                 None => Response::error(request.id, RpcError::invalid_params()),
             }
@@ -1886,7 +1887,7 @@ fn apply_task_channel_mapping(
 
 /// Handle task.update RPC — update specific fields on a task directly.
 #[allow(clippy::too_many_arguments)]
-fn handle_task_update(
+async fn handle_task_update(
     id: RequestId,
     task_id: &str,
     owner: Option<&str>,
@@ -1936,7 +1937,7 @@ fn handle_task_update(
 
     // Update daemon-side task-to-channel and task-to-model mappings
     {
-        let mut ps = state.persistent_state.blocking_lock();
+        let mut ps = state.persistent_state.lock().await;
         let mut needs_save = false;
 
         // Apply channel mapping


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Fixed panic in `handle_task_update` (src/daemon/rpc.rs:1682) where `blocking_lock()` was called inside an async context
- Changed `handle_task_update` to async fn and replaced `blocking_lock()` with `.lock().await`
- Added `.await` to the call site in `handle_request`

## Details
The issue occurred when a coworker called `midtown task update`, which invoked the RPC endpoint. The function `handle_task_update` was synchronous but needed to access `state.persistent_state`, which is an async mutex. Using `blocking_lock()` in an async context causes a panic with tokio's multi-threaded runtime.

The fix makes the function async and uses proper async locking with `.lock().await`.

## Test plan
- [x] Unit tests pass: `cargo test`
- [x] Clippy passes with no warnings: `cargo clippy -- -D warnings`
- [x] E2E tests pass (non-ignored): `cargo test --test daemon_e2e`

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)