### PR TITLE
fix: stop killing detached processes and prevent duplicate task assignment on restart [Midtown !1159]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1648,11 +1648,34 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
     startup::recover_coworker_records(&repo_name, &state.coworkers, &state.coworker_records).await;
 
     // Kill any zombie Claude headless processes left from crashes or unclean shutdowns.
-    // This must run BEFORE session recovery to clean up processes before spawning new ones.
+    // This only kills truly orphaned (PPID=1) processes from crashes — NOT processes
+    // that were intentionally detached during a clean daemon restart.
     startup::kill_zombie_claude_processes();
 
+    // CRITICAL: Restore task assignments from disk BEFORE session recovery.
+    // This must happen first so that the in-memory coworker_task_assignments map
+    // is populated before any dispatch ticks fire. Otherwise, the task dispatch
+    // sees in_progress tasks as "orphaned" and spawns duplicate coworkers.
+    state.restore_task_assignments_from_disk();
+
+    // Pre-register recovering coworker names so dispatch doesn't double-assign.
+    // This creates CoworkerRecords for coworkers about to be resumed, ensuring
+    // they appear in active_names before the first TaskDispatchTick fires.
+    let recovering_names = startup::recovering_coworker_names(&state.persistent_state).await;
+    if !recovering_names.is_empty() {
+        let mut records = state.coworker_records.write().await;
+        for name in &recovering_names {
+            if !records.contains_key(name) {
+                info!("Pre-registering recovering coworker: {}", name);
+                records.insert(name.to_string(), crate::rules::CoworkerRecord::new_spawn());
+            }
+        }
+    }
+
     // Recover headless coworker sessions from persisted state (session survival).
-    // This kills orphaned processes and spawns with --resume to continue previous work.
+    // Spawns new processes with --resume <session_id> to continue previous work.
+    // Old processes are NOT killed — they die naturally from broken pipes after
+    // the previous daemon detached its stdin/stdout handles during shutdown.
     let recovery_effects =
         startup::recover_headless_sessions(&state.persistent_state, &repo_name).await;
     if !recovery_effects.is_empty() {
@@ -1662,10 +1685,6 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
         );
         effects::execute_effects(recovery_effects, &state).await;
     }
-
-    // Restore task assignments from disk (rebuild the in-memory map).
-    // This ensures coworker task assignments survive daemon restarts.
-    state.restore_task_assignments_from_disk();
 
     // Set up shutdown signal handler
     let (shutdown_tx, _) = broadcast::channel::<()>(1);

--- a/src/daemon/startup.rs
+++ b/src/daemon/startup.rs
@@ -164,9 +164,14 @@ fn verify_claude_process(pid: u32) -> bool {
 /// Recover headless coworker sessions from persisted state after daemon restart.
 ///
 /// For each saved session:
-/// 1. Kill the old orphaned process (zombie cleanup)
+/// 1. Let the old process die naturally (broken pipe from detached daemon)
 /// 2. Generate a `ResumeCoworker` effect to spawn with --resume <session_id>
-/// 3. Clear the headless_sessions map after recovery
+///
+/// **Important**: We do NOT kill the old processes here. The previous daemon
+/// detached its pipe handles during shutdown (`detach_on_drop`), so the child
+/// processes will receive SIGPIPE or a write error on their stdout and exit
+/// naturally. Killing them with SIGKILL is counterproductive — it defeats the
+/// purpose of session detachment and can cause data loss.
 ///
 /// Returns a Vec of effects to execute during startup.
 pub async fn recover_headless_sessions(
@@ -198,20 +203,19 @@ pub async fn recover_headless_sessions(
             name, session_info.session_id, session_info.purpose
         );
 
-        // Kill the old orphaned process if it still exists and is a claude process
+        // Don't kill the old process — let it die naturally from the broken pipe.
+        // When the previous daemon detached, it closed its end of stdin/stdout.
+        // The child process will get SIGPIPE or a write error and exit on its own.
+        // We'll spawn a fresh process with --resume to continue the session.
         if let Some(pid) = session_info.pid {
-            // Verify the PID belongs to a claude process before killing
-            // (PIDs can be reused between daemon restarts)
-            let is_claude = verify_claude_process(pid);
-            if is_claude {
-                info!("Killing orphaned claude process {} for {}", pid, name);
-                let _ = std::process::Command::new("kill")
-                    .arg("-9")
-                    .arg(pid.to_string())
-                    .output();
+            if verify_claude_process(pid) {
+                info!(
+                    "Previous process {} for {} still running — will die naturally from broken pipe",
+                    pid, name
+                );
             } else {
-                warn!(
-                    "PID {} for {} is not a claude process (or already dead), skipping kill",
+                info!(
+                    "Previous process {} for {} already exited (PID reused or dead)",
                     pid, name
                 );
             }
@@ -280,4 +284,157 @@ pub async fn recover_headless_sessions(
     // 3. Correct session_id tracking is critical for reviewer spawning
 
     effects
+}
+
+/// Extract the names of coworkers being recovered from persisted headless sessions.
+///
+/// Called during startup to pre-register recovering coworkers in the daemon's
+/// tracking maps BEFORE executing recovery effects. This prevents the task
+/// dispatch tick from seeing their in_progress tasks as "orphaned" and
+/// spawning duplicate coworkers for the same task.
+pub async fn recovering_coworker_names(
+    persistent_state: &tokio::sync::Mutex<DaemonPersistentState>,
+) -> Vec<String> {
+    let state = persistent_state.lock().await;
+    state.headless_sessions.keys().cloned().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use chrono::Utc;
+
+    /// Create a test HeadlessSessionInfo.
+    fn test_session_info(
+        name: &str,
+        task_id: Option<u64>,
+    ) -> crate::daemon::state::HeadlessSessionInfo {
+        crate::daemon::state::HeadlessSessionInfo {
+            session_id: format!("session-{}", name),
+            last_active: Utc::now(),
+            purpose: format!("test session for {}", name),
+            pid: Some(99999), // Non-existent PID
+            coworker_type: Some("dev".to_string()),
+            task_id,
+            pr_number: None,
+            working_dir: Some("/tmp/test".to_string()),
+            provider: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_recover_headless_sessions_generates_resume_effects() {
+        let persistent_state = tokio::sync::Mutex::new(DaemonPersistentState::default());
+
+        // Insert test sessions
+        {
+            let mut state = persistent_state.lock().await;
+            state.headless_sessions.insert(
+                "amsterdam".to_string(),
+                test_session_info("amsterdam", Some(42)),
+            );
+            state.headless_sessions.insert(
+                "columbus".to_string(),
+                test_session_info("columbus", Some(43)),
+            );
+        }
+
+        let effects = recover_headless_sessions(&persistent_state, "test-repo").await;
+
+        // Should generate exactly 2 ResumeCoworker effects (one per session)
+        assert_eq!(
+            effects.len(),
+            2,
+            "Should generate one ResumeCoworker per session"
+        );
+
+        for effect in &effects {
+            match effect {
+                Effect::ResumeCoworker {
+                    name, session_id, ..
+                } => {
+                    assert!(
+                        name == "amsterdam" || name == "columbus",
+                        "Unexpected coworker name: {}",
+                        name
+                    );
+                    assert!(
+                        session_id.starts_with("session-"),
+                        "Session ID should match what was persisted"
+                    );
+                }
+                _ => panic!("Expected only ResumeCoworker effects, got {:?}", effect),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_recover_headless_sessions_does_not_kill_processes() {
+        // This test verifies that recover_headless_sessions does NOT generate
+        // any kill effects. The old behavior was to kill -9 the processes,
+        // which defeated the purpose of session detachment.
+        //
+        // We verify this by checking that only ResumeCoworker effects are returned.
+        // If kill behavior were added back, it would need to be an Effect variant,
+        // and this test would catch the regression.
+        let persistent_state = tokio::sync::Mutex::new(DaemonPersistentState::default());
+
+        {
+            let mut state = persistent_state.lock().await;
+            state
+                .headless_sessions
+                .insert("park".to_string(), test_session_info("park", Some(100)));
+        }
+
+        let effects = recover_headless_sessions(&persistent_state, "test-repo").await;
+
+        // All effects should be ResumeCoworker — no kill effects
+        for effect in &effects {
+            assert!(
+                matches!(effect, Effect::ResumeCoworker { .. }),
+                "Recovery should only produce ResumeCoworker effects (no kills), got: {:?}",
+                effect
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_recover_headless_sessions_empty() {
+        let persistent_state = tokio::sync::Mutex::new(DaemonPersistentState::default());
+        let effects = recover_headless_sessions(&persistent_state, "test-repo").await;
+        assert!(
+            effects.is_empty(),
+            "No sessions to recover should produce no effects"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recovering_coworker_names_returns_session_names() {
+        let persistent_state = tokio::sync::Mutex::new(DaemonPersistentState::default());
+
+        {
+            let mut state = persistent_state.lock().await;
+            state.headless_sessions.insert(
+                "amsterdam".to_string(),
+                test_session_info("amsterdam", Some(42)),
+            );
+            state.headless_sessions.insert(
+                "columbus".to_string(),
+                test_session_info("columbus", Some(43)),
+            );
+        }
+
+        let names = recovering_coworker_names(&persistent_state).await;
+        assert_eq!(names.len(), 2);
+        assert!(names.contains(&"amsterdam".to_string()));
+        assert!(names.contains(&"columbus".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_recovering_coworker_names_empty_state() {
+        let persistent_state = tokio::sync::Mutex::new(DaemonPersistentState::default());
+        let names = recovering_coworker_names(&persistent_state).await;
+        assert!(names.is_empty());
+    }
 }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -907,8 +907,9 @@ impl HeadlessSession {
     /// Mark this session to be detached instead of killed on drop.
     ///
     /// Used during daemon shutdown to allow sessions to survive restarts.
-    /// The daemon will kill the orphaned process after restart and resume
-    /// the session with the persisted session_id.
+    /// The child process will die naturally from broken pipes (SIGPIPE)
+    /// after the daemon drops its stdin/stdout handles. The daemon will
+    /// then resume the session with `--resume <session_id>` on restart.
     pub fn detach_on_drop(&mut self) {
         self.detach_on_drop = true;
     }


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary

- **Stop killing detached processes on restart**: `recover_headless_sessions()` was killing processes with SIGKILL that were intentionally detached during daemon shutdown. Now they die naturally from broken pipes (SIGPIPE) when the previous daemon closed its stdin/stdout handles.

- **Prevent duplicate task assignment during startup**: Task dispatch could assign the same task to two coworkers because: (a) `restore_task_assignments_from_disk()` ran AFTER recovery effects executed (in-memory map empty during first dispatch tick), and (b) recovering coworkers weren't in `coworker_records` so they didn't appear in `active_names`.

- **Reorder startup sequence**: Task assignments are now restored from disk BEFORE recovery effects execute, and recovering coworker names are pre-registered in `coworker_records` so dispatch sees them as active immediately.

## Changes

- `startup.rs`: Remove kill -9 from `recover_headless_sessions()`, add `recovering_coworker_names()` helper, add 5 unit tests
- `mod.rs`: Reorder startup — restore task assignments first, pre-register recovering coworkers, then execute recovery effects
- `headless.rs`: Update `detach_on_drop()` doc comment to reflect actual behavior

## Test plan

- [x] 5 new unit tests for recovery behavior pass
- [x] Full test suite (1196+ tests) passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)