### PR TITLE
fix: resolve_attach_target async lock in session.attach RPC [Midtown !1163]

### DIFF
--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -3244,7 +3244,7 @@ fn parse_attach_target(target: &str) -> Result<AttachTarget, String> {
 }
 
 /// Resolve an attach target to a coworker name using daemon state.
-fn resolve_attach_target(target: &str, state: &DaemonState) -> Result<String, String> {
+async fn resolve_attach_target(target: &str, state: &DaemonState) -> Result<String, String> {
     let parsed = parse_attach_target(target)?;
 
     match parsed {
@@ -3261,7 +3261,7 @@ fn resolve_attach_target(target: &str, state: &DaemonState) -> Result<String, St
         }
         AttachTarget::Pr(pr_num) => {
             // Check reviewer assignments
-            let persistent = state.persistent_state.blocking_lock();
+            let persistent = state.persistent_state.lock().await;
             if let Some(reviewer) = persistent.github.get_reviewer(pr_num) {
                 return Ok(reviewer.to_lowercase());
             }
@@ -3287,7 +3287,7 @@ fn resolve_attach_target(target: &str, state: &DaemonState) -> Result<String, St
 /// Pauses the headless coworker process and returns session info so the CLI
 /// can create a tmux window with `claude --resume <session-id>`.
 async fn handle_session_attach(id: RequestId, target: &str, state: &DaemonState) -> Response {
-    let name = match resolve_attach_target(target, state) {
+    let name = match resolve_attach_target(target, state).await {
         Ok(n) => n,
         Err(e) => return Response::error(id, RpcError::new(-32602, e)),
     };


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Fixed panic where `blocking_lock()` was called in `resolve_attach_target()` (sync function) called from async `handle_session_attach()`
- Made `resolve_attach_target()` async and replaced `blocking_lock()` with `.lock().await`
- Added `.await` to call site in `handle_session_attach()`

## Details
This follows the same pattern as PR #965 for `handle_task_update`. The issue occurs when `midtown session attach` is called with a PR target (e.g., `midtown attach pr:42`), which needs to look up the reviewer assignment. Using `blocking_lock()` in an async context causes a panic with tokio's multi-threaded runtime.

## Test plan
- [x] Unit tests pass: `cargo test --lib` (1191 passed)
- [x] Clippy passes with no warnings: `cargo clippy -- -D warnings`

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)