### PR TITLE
feat: Add explicit task-PR associations [Midtown !1151]

### DIFF
--- a/agents/lead.md
+++ b/agents/lead.md
@@ -303,6 +303,9 @@ Use `midtown task` CLI commands to manage tasks. The daemon writes directly — 
 # Create a task (daemon assigns it automatically)
 midtown task create "Subject" --description "Details..."
 
+# Create a task linked to an existing PR (for review feedback, fixes, etc.)
+midtown task create "Address review feedback" --description "Fix issues from PR #940 review" --pr 940
+
 # View tasks
 midtown task list
 midtown task view <id>
@@ -313,9 +316,17 @@ midtown task update <id> --status in_progress
 midtown task update <id> --description "Updated details..."
 midtown task update <id> --blocked-by 5,6
 
+# Link a task to an existing PR (if not auto-detected)
+midtown task update <id> --pr <pr-number>
+
 # Mark a task as done
 midtown task done <id>
 ```
+
+**Task-PR associations:**
+- When a coworker opens a PR with `[Midtown !XXX]` in the title, the daemon automatically links task XXX to that PR
+- Use `--pr` when creating tasks for existing PRs (review feedback, follow-up fixes)
+- Explicit PR links prevent false positives (e.g., task mentions "PR #940 fix insufficient" as context but creates a different PR)
 
 **Do NOT use Claude Code's TaskCreate/TaskUpdate/TaskList tools** — those write to a different location and won't be seen by coworkers or the daemon.
 

--- a/src/bin/midtown/cli/task.rs
+++ b/src/bin/midtown/cli/task.rs
@@ -22,6 +22,9 @@ pub enum TaskCommand {
         /// Optional model for coworker (e.g., claude/opus, claude/sonnet)
         #[arg(long)]
         model: Option<String>,
+        /// Explicit PR number associated with this task
+        #[arg(long)]
+        pr: Option<u64>,
     },
     /// Claim a task
     Claim {
@@ -50,6 +53,9 @@ pub enum TaskCommand {
         /// Set model for coworker (e.g., claude/opus, claude/sonnet)
         #[arg(long)]
         model: Option<String>,
+        /// Set explicit PR number associated with this task
+        #[arg(long)]
+        pr: Option<u64>,
     },
     /// Mark a task as done
     Done {
@@ -92,12 +98,14 @@ pub fn handle(cmd: &TaskCommand, client: &DaemonClient) -> Result<Response, Stri
             blocked_by,
             channel,
             model,
+            pr,
         } => client.task_create(
             subject,
             description,
             blocked_by.as_deref(),
             channel.as_deref(),
             model.as_deref(),
+            *pr,
         ),
         TaskCommand::Update {
             id,
@@ -107,6 +115,7 @@ pub fn handle(cmd: &TaskCommand, client: &DaemonClient) -> Result<Response, Stri
             blocked_by,
             channel,
             model,
+            pr,
         } => client.task_update(
             id,
             owner.as_deref(),
@@ -115,6 +124,7 @@ pub fn handle(cmd: &TaskCommand, client: &DaemonClient) -> Result<Response, Stri
             blocked_by.as_deref(),
             channel.as_deref(),
             model.as_deref(),
+            *pr,
         ),
         TaskCommand::Claim { id } => client.task_claim(id),
         TaskCommand::Done { id } => client.task_done(id),

--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -311,6 +311,7 @@ impl DaemonClient {
         blocked_by: Option<&[String]>,
         channel: Option<&str>,
         model: Option<&str>,
+        pr: Option<u64>,
     ) -> Result<Response, String> {
         let mut params = serde_json::json!({
             "subject": subject,
@@ -325,6 +326,9 @@ impl DaemonClient {
         if let Some(m) = model {
             params["model"] = serde_json::json!(m);
         }
+        if let Some(pr_num) = pr {
+            params["pr"] = serde_json::json!(pr_num);
+        }
         self.send("task.create", Some(params))
     }
 
@@ -338,6 +342,7 @@ impl DaemonClient {
         blocked_by: Option<&[String]>,
         channel: Option<&str>,
         model: Option<&str>,
+        pr: Option<u64>,
     ) -> Result<Response, String> {
         let mut params = serde_json::json!({ "id": id });
         if let Some(o) = owner {
@@ -357,6 +362,9 @@ impl DaemonClient {
         }
         if let Some(m) = model {
             params["model"] = serde_json::json!(m);
+        }
+        if let Some(pr_num) = pr {
+            params["pr"] = serde_json::json!(pr_num);
         }
         self.send("task.update", Some(params))
     }

--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -30,22 +30,56 @@ use super::{DaemonState, snapshot};
 /// 5. Coworker gets recovered and creates duplicate PR
 ///
 /// Returns `true` if the PR is merged, `false` if open/closed, `None` if the check fails.
+fn is_pr_merged(pr_number: u64, repo_path: &std::path::Path) -> Option<bool> {
+    let output = std::process::Command::new("gh")
+        .current_dir(repo_path)
+        .args([
+            "pr",
+            "view",
+            &pr_number.to_string(),
+            "--json",
+            "state",
+            "--jq",
+            ".state",
+        ])
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => {
+            let state = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            Some(state == "MERGED")
+        }
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            debug!(
+                "Failed to check PR #{} state via gh CLI: {}",
+                pr_number,
+                stderr.trim()
+            );
+            None
+        }
+        Err(e) => {
+            warn!("Failed to execute gh pr view for PR #{}: {}", pr_number, e);
+            None
+        }
+    }
+}
+
 /// Determine whether an orphaned task should be recovered.
 ///
 /// Decision function: returns `true` if the task should be recovered,
 /// `false` if it should be skipped. A task should NOT be recovered if:
 /// - It is already completed (race condition: RPC marked it done after snapshot)
-/// - It has a canonical PR (with [Midtown !XX] in PR title) that is merged
+/// - It has an explicit `pr` field pointing to a merged PR
 ///
-/// The function does NOT skip recovery for contextual PR mentions in task text
-/// (e.g., "PR #940 fix insufficient"). Only the canonical task-to-PR link via
-/// pr_task_associations matters.
+/// Note: This function performs I/O (reads task from disk, queries GitHub API) which
+/// violates the pure decision function pattern. The target architecture would move
+/// this to snapshot collection, but orphan recovery is already impure (reads tasks
+/// from disk) so we handle it here for now.
 fn should_recover_task(
     task: &crate::tasks::Task,
     merged_pr_numbers: &HashSet<u64>,
-    tasks_with_open_prs: &HashSet<String>,
-    pr_task_associations: &HashMap<u64, String>,
-    _repo_path: &std::path::Path,
+    repo_path: &std::path::Path,
 ) -> bool {
     // Check if task is already completed
     // Race condition: coworker reports completion via RPC, task is marked completed,
@@ -58,34 +92,49 @@ fn should_recover_task(
         return false;
     }
 
-    // Check if this task has an associated MERGED PR (canonical link via [Midtown !XX] in PR title).
-    // Do NOT skip recovery for contextual PR mentions in task text (e.g., "PR #940 fix insufficient").
-    //
-    // Bug fix: The old logic extracted ALL PR numbers from task text and skipped recovery if those
-    // PRs were merged. This incorrectly treated contextual mentions as task completion.
-    //
-    // New logic: Only skip if a PR with [Midtown !{task_id}] in its title is merged.
-    // This is the canonical task-to-PR link used by auto-completion.
-
-    // Check pr_task_associations: merged PRs that have [Midtown !XX] in their title
-    for (pr_number, task_id) in pr_task_associations {
-        if task_id == &task.id && merged_pr_numbers.contains(pr_number) {
+    // Check if this task has an explicit PR association that's already merged.
+    // ONLY check the explicit pr field - never fall back to text extraction.
+    // This prevents false positives like task 1142 which mentioned "PR #940 fix insufficient"
+    // as context but was actually creating a different PR.
+    if let Some(pr_number) = task.pr {
+        // Check cache first (fast path)
+        if merged_pr_numbers.contains(&pr_number) {
             debug!(
-                "Skipping orphan recovery for task !{}: associated PR #{} is merged",
+                "Skipping orphan recovery for task !{}: explicit PR #{} is in merged cache",
                 task.id, pr_number
             );
             return false;
         }
-    }
 
-    // If the task has an OPEN PR (in tasks_with_open_prs), allow recovery.
-    // The coworker may have crashed mid-work, so orphan recovery should respawn.
-    if tasks_with_open_prs.contains(&task.id) {
-        debug!(
-            "Allowing orphan recovery for task !{}: has open PR but coworker is down",
-            task.id
-        );
-        return true;
+        // Cache miss — check GitHub directly (safety net against stale cache)
+        // The merged PR cache only includes last 10 PRs and refreshes every 5 minutes.
+        // This direct check prevents duplicate PRs when:
+        // 1. A PR merges but auto-completion fails
+        // 2. Coworker shuts down before next cache refresh
+        // 3. Orphan recovery would otherwise spawn duplicate work
+        match is_pr_merged(pr_number, repo_path) {
+            Some(true) => {
+                info!(
+                    "Skipping orphan recovery for task !{}: explicit PR #{} is merged (direct check)",
+                    task.id, pr_number
+                );
+                return false;
+            }
+            Some(false) => {
+                debug!(
+                    "PR #{} is open/closed (not merged), allowing orphan recovery for task !{}",
+                    pr_number, task.id
+                );
+            }
+            None => {
+                // GitHub API check failed — be conservative and allow recovery.
+                // If the PR was actually merged, auto-completion will clean it up.
+                warn!(
+                    "Failed to check PR #{} merge status for task !{}, allowing recovery",
+                    pr_number, task.id
+                );
+            }
+        }
     }
 
     // No associated PR found — this is a non-PR task (investigation, review, etc.)
@@ -129,11 +178,6 @@ pub(super) fn check_and_recover_orphans(
     // by the PR merge cleanup path. Attempting orphan recovery on them creates
     // a loop: spawn → coworker sees task done → goes idle → grace period
     // expires → spawn again.
-
-    // Convert tasks_with_open_prs (HashMap<String, u64>) to a HashSet of task IDs for efficient lookup
-    let tasks_with_open_prs_set: HashSet<String> =
-        snap.tasks_with_open_prs.keys().cloned().collect();
-
     let in_progress_tasks_active: Vec<(String, String, String)> = snap
         .in_progress_tasks
         .iter()
@@ -144,13 +188,7 @@ pub(super) fn check_and_recover_orphans(
                 None => return true, // Task doesn't exist on disk? Keep it for recovery attempt
             };
 
-            should_recover_task(
-                &task,
-                &snap.merged_pr_numbers,
-                &tasks_with_open_prs_set,
-                &snap.pr_task_associations,
-                repo_path,
-            )
+            should_recover_task(&task, &snap.merged_pr_numbers, repo_path)
         })
         .cloned()
         .collect();
@@ -1641,48 +1679,77 @@ pub(super) fn build_description_based_completion_effects(
             continue;
         }
 
-        // Extract PR numbers from both subject and description (matching orphan recovery logic)
-        let mut all_text = task.subject.clone();
-        if let Some(desc) = &task.description {
-            all_text.push('\n');
-            all_text.push_str(desc);
-        }
+        // Two paths for auto-completion:
+        // 1. Explicit PR field (preferred) - set via --pr flag or auto-detected from PR title
+        // 2. Text extraction (fallback) - for meta-tasks like "Merge PRs: #901, #902, #903"
 
-        let pr_numbers = crate::tasks::extract_pr_numbers_from_text(&all_text);
+        if let Some(pr_number) = task.pr {
+            // Path 1: Task has explicit PR association
+            // This prevents false positives (e.g., task mentions "PR #940 fix insufficient" as context)
+            if snap.merged_pr_numbers.contains(&pr_number) {
+                let task_id_str = task.id.clone();
+                effects.push(Effect::CompleteTask {
+                    task_id: task_id_str.clone(),
+                    repo_name: snap.repo_name.clone(),
+                });
+                effects.push(Effect::ClearBlockedBy {
+                    completed_task_id: task_id_str.clone(),
+                    repo_name: snap.repo_name.clone(),
+                });
+                effects.push(Effect::PostToChannel {
+                    sender: "midtown".to_string(),
+                    message: format!(
+                        "✅ Auto-completed task !{} (PR #{} merged)",
+                        task.id, pr_number
+                    ),
+                    channel: None,
+                });
+            }
+        } else {
+            // Path 2: No explicit PR field - fall back to text extraction
+            // This supports meta-tasks that track multiple PRs
+            let mut all_text = task.subject.clone();
+            if let Some(desc) = &task.description {
+                all_text.push('\n');
+                all_text.push_str(desc);
+            }
 
-        // Skip if no PR references found
-        if pr_numbers.is_empty() {
-            continue;
-        }
+            let pr_numbers = crate::tasks::extract_pr_numbers_from_text(&all_text);
 
-        // Check if ALL referenced PRs are merged
-        let all_merged = pr_numbers
-            .iter()
-            .all(|pr_num| snap.merged_pr_numbers.contains(pr_num));
+            // Skip if no PR references found
+            if pr_numbers.is_empty() {
+                continue;
+            }
 
-        if all_merged {
-            let task_id_str = task.id.clone();
-            effects.push(Effect::CompleteTask {
-                task_id: task_id_str.clone(),
-                repo_name: snap.repo_name.clone(),
-            });
-            effects.push(Effect::ClearBlockedBy {
-                completed_task_id: task_id_str.clone(),
-                repo_name: snap.repo_name.clone(),
-            });
-            effects.push(Effect::PostToChannel {
-                sender: "midtown".to_string(),
-                message: format!(
-                    "✅ Auto-completed task !{} (all referenced PRs merged: {})",
-                    task.id,
-                    pr_numbers
-                        .iter()
-                        .map(|n| format!("#{}", n))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                ),
-                channel: None,
-            });
+            // Check if ALL referenced PRs are merged
+            let all_merged = pr_numbers
+                .iter()
+                .all(|pr_num| snap.merged_pr_numbers.contains(pr_num));
+
+            if all_merged {
+                let task_id_str = task.id.clone();
+                effects.push(Effect::CompleteTask {
+                    task_id: task_id_str.clone(),
+                    repo_name: snap.repo_name.clone(),
+                });
+                effects.push(Effect::ClearBlockedBy {
+                    completed_task_id: task_id_str.clone(),
+                    repo_name: snap.repo_name.clone(),
+                });
+                effects.push(Effect::PostToChannel {
+                    sender: "midtown".to_string(),
+                    message: format!(
+                        "✅ Auto-completed task !{} (all referenced PRs merged: {})",
+                        task.id,
+                        pr_numbers
+                            .iter()
+                            .map(|n| format!("#{}", n))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ),
+                    channel: None,
+                });
+            }
         }
     }
 
@@ -1744,17 +1811,9 @@ pub(super) fn reconcile_tasks_in_review(snap: &snapshot::WorldSnapshot) -> Vec<E
 pub fn should_recover_task_test_helper(
     task: &crate::tasks::Task,
     merged_pr_numbers: &HashSet<u64>,
-    tasks_with_open_prs: &HashSet<String>,
-    pr_task_associations: &HashMap<u64, String>,
     repo_path: &std::path::Path,
 ) -> bool {
-    should_recover_task(
-        task,
-        merged_pr_numbers,
-        tasks_with_open_prs,
-        pr_task_associations,
-        repo_path,
-    )
+    should_recover_task(task, merged_pr_numbers, repo_path)
 }
 
 // ============================================================================
@@ -1918,6 +1977,53 @@ mod tests {
 
         let result = filter_orphans_with_open_prs(flagged, &open_pr_owners);
         assert_eq!(result, vec!["amsterdam", "park"]);
+    }
+
+    #[test]
+    fn test_should_recover_task_with_explicit_pr_association() {
+        // Bug context: Task 1142 had "PR #940 fix insufficient" in the subject as context,
+        // not as the actual task's PR. The task's real PR would be different.
+        // should_recover_task() should use the explicit pr field, not extract_pr_numbers_from_text().
+        use std::collections::HashSet;
+        use std::path::Path;
+
+        let merged_prs: HashSet<u64> = vec![940].into_iter().collect();
+        let repo_path = Path::new("/tmp/test-repo");
+
+        // Task with PR #940 mentioned in subject as context, but explicit pr field is None
+        // (because the task's actual work will create a different PR)
+        let task = crate::tasks::Task {
+            id: "1142".to_string(),
+            subject: "Fix remaining orphan worktree false positives — PR #940 fix insufficient"
+                .to_string(),
+            status: crate::tasks::TaskStatus::InProgress,
+            owner: Some("amsterdam".to_string()),
+            description: Some("The fix in PR #940 suppresses warnings...".to_string()),
+            blocked_by: vec![],
+            channel: Some("midtown".to_string()),
+            pr: None, // No explicit PR association yet — task will create a new PR
+            created_at: None,
+        };
+
+        // EXPECTED: should_recover_task returns true (allow recovery)
+        // ACTUAL (before fix): returns false because extract_pr_numbers_from_text finds #940 in subject
+        let result = should_recover_task(&task, &merged_prs, repo_path);
+        assert!(
+            result,
+            "should_recover_task should return true when explicit pr field is None, even if merged PR mentioned in text"
+        );
+
+        // Now test with explicit PR association
+        let task_with_pr = crate::tasks::Task {
+            pr: Some(940),
+            ..task
+        };
+
+        let result = should_recover_task(&task_with_pr, &merged_prs, repo_path);
+        assert!(
+            !result,
+            "should_recover_task should return false when explicit pr field matches merged PR"
+        );
     }
 
     #[test]
@@ -2169,6 +2275,7 @@ mod tests {
             description: Some("Merge reviewed PRs: #901, #902, #903".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         };
 
@@ -2222,6 +2329,7 @@ mod tests {
             description: Some("Merge PRs: #901, #902, #903".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         };
 
@@ -2258,6 +2366,7 @@ mod tests {
             description: Some("No PR references in this description".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         };
 
@@ -2288,6 +2397,7 @@ mod tests {
             description: Some("Fix PR #904".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         };
 
@@ -2321,6 +2431,7 @@ mod tests {
             description: None, // No description
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         };
 
@@ -2353,6 +2464,7 @@ mod tests {
             description: Some("Fix PR #904 review feedback".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         };
 
@@ -2365,6 +2477,7 @@ mod tests {
             description: Some("Merge PRs: #904, #905".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         };
 
@@ -2713,6 +2826,7 @@ mod tests {
                 blocked_by: vec![],
                 description: None,
                 channel: None,
+                pr: None,
                 created_at: Some(SystemTime::now()),
             }],
             tasks_with_worktrees: HashSet::new(), // Task not in registry yet
@@ -3257,6 +3371,7 @@ mod tests {
                 description: None,
                 blocked_by: vec![],
                 channel: None,
+                pr: None,
                 created_at: None,
             }],
             // broadway is NOT running (will be spawned by Case 1)
@@ -3280,6 +3395,7 @@ mod tests {
                 description: None,
                 blocked_by: vec![],
                 channel: None,
+                pr: None,
                 created_at: None,
             }],
             task_channel: HashMap::new(),
@@ -3730,6 +3846,7 @@ mod tests {
                 blocked_by: vec![],
                 description: None,
                 channel: None,
+                pr: None,
                 created_at: Some(SystemTime::now()),
             }],
             tasks_with_worktrees: ["42".to_string()].into_iter().collect(),
@@ -4341,18 +4458,13 @@ mod tests {
             owner: Some("vernon".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         };
 
         let merged_prs = HashSet::new();
         assert!(
-            !should_recover_task(
-                &completed_task,
-                &merged_prs,
-                &HashSet::new(),
-                &HashMap::new(),
-                std::path::Path::new(".")
-            ),
+            !should_recover_task(&completed_task, &merged_prs, std::path::Path::new(".")),
             "Should NOT recover a completed task"
         );
     }
@@ -4372,22 +4484,17 @@ mod tests {
             owner: Some("vernon".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: Some(923), // Explicit PR association (auto-set from PR title or --pr flag)
             created_at: None,
         };
 
         // PR #923 is merged, but it's not associated with task !1120
         let merged_prs: HashSet<u64> = [923].into_iter().collect();
 
-        // New behavior: SHOULD recover because PR #923 doesn't have [Midtown !1120] in its title
+        // With explicit PR associations: should NOT recover because task.pr = Some(923) and PR #923 is merged
         assert!(
-            should_recover_task(
-                &task,
-                &merged_prs,
-                &HashSet::new(),
-                &HashMap::new(),
-                std::path::Path::new(".")
-            ),
-            "Should recover task with contextual PR mention (PR is not the task's canonical PR)"
+            !should_recover_task(&task, &merged_prs, std::path::Path::new(".")),
+            "Should NOT recover a task whose PR is already merged (explicit pr field)"
         );
     }
 
@@ -4404,22 +4511,17 @@ mod tests {
             owner: Some("park".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: Some(925), // Explicit PR association
             created_at: None,
         };
 
         // PR #925 is merged, but it's not associated with task !1121
         let merged_prs: HashSet<u64> = [925].into_iter().collect();
 
-        // New behavior: SHOULD recover because PR #925 is just contextual mention
+        // With explicit PR associations: should NOT recover because task.pr = Some(925) and PR #925 is merged
         assert!(
-            should_recover_task(
-                &task,
-                &merged_prs,
-                &HashSet::new(),
-                &HashMap::new(),
-                std::path::Path::new(".")
-            ),
-            "Should recover task with contextual PR mention in description"
+            !should_recover_task(&task, &merged_prs, std::path::Path::new(".")),
+            "Should NOT recover a task whose PR is already merged (explicit pr field)"
         );
     }
 
@@ -4435,18 +4537,13 @@ mod tests {
             owner: Some("lexington".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         };
 
         let merged_prs = HashSet::new();
         assert!(
-            should_recover_task(
-                &task,
-                &merged_prs,
-                &HashSet::new(),
-                &HashMap::new(),
-                std::path::Path::new(".")
-            ),
+            should_recover_task(&task, &merged_prs, std::path::Path::new(".")),
             "Should recover an active in-progress task with no merged PR"
         );
     }
@@ -4463,6 +4560,7 @@ mod tests {
             owner: Some("vernon".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         };
 
@@ -4471,13 +4569,7 @@ mod tests {
         // should be conservative and allow recovery.
         let merged_prs: HashSet<u64> = [900, 910].into_iter().collect();
         assert!(
-            should_recover_task(
-                &task,
-                &merged_prs,
-                &HashSet::new(),
-                &HashMap::new(),
-                std::path::Path::new(".")
-            ),
+            should_recover_task(&task, &merged_prs, std::path::Path::new(".")),
             "Should recover a task whose PR is NOT yet merged (cache miss, API fails)"
         );
     }
@@ -4498,21 +4590,16 @@ mod tests {
             owner: Some("riverside".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         };
 
         // PR #935 is NOT in the cache
         let merged_prs: HashSet<u64> = HashSet::new();
 
-        // New behavior: SHOULD recover because PR #935 is just a contextual mention
+        // New behavior: SHOULD recover because PR #935 is just a contextual mention (no explicit pr field)
         assert!(
-            should_recover_task(
-                &task,
-                &merged_prs,
-                &HashSet::new(),
-                &HashMap::new(),
-                std::path::Path::new(".")
-            ),
+            should_recover_task(&task, &merged_prs, std::path::Path::new(".")),
             "Should recover task with contextual PR mention (no longer checks GitHub API)"
         );
     }
@@ -4521,7 +4608,8 @@ mod tests {
     fn test_should_recover_task_with_bare_hash_pr_reference() {
         use crate::tasks::{Task, TaskStatus};
 
-        // Task with bare "#904" format - this is a contextual reference, not a canonical link
+        // Task with bare "#904" format (no "PR #" prefix)
+        // With explicit PR associations, the pr field should be set to 904
         let task = Task {
             id: "1122".to_string(),
             subject: "Fix #904 review feedback".to_string(),
@@ -4530,22 +4618,17 @@ mod tests {
             owner: Some("columbus".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: Some(904), // Explicit PR association
             created_at: None,
         };
 
         let merged_prs: HashSet<u64> = [904].into_iter().collect();
         let repo_path = std::path::Path::new("/tmp/test-repo");
 
-        // New behavior: SHOULD recover because #904 is contextual mention
+        // With explicit PR associations: should NOT recover because task.pr = Some(904) and PR #904 is merged
         assert!(
-            should_recover_task(
-                &task,
-                &merged_prs,
-                &HashSet::new(),
-                &HashMap::new(),
-                repo_path
-            ),
-            "Should recover task with contextual PR reference (even bare # format)"
+            !should_recover_task(&task, &merged_prs, repo_path),
+            "Should NOT recover a task whose PR (#904) is already merged (explicit pr field)"
         );
     }
 
@@ -4564,6 +4647,7 @@ mod tests {
             owner: Some("madison".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         };
 
@@ -4571,13 +4655,7 @@ mod tests {
         let merged_prs: HashSet<u64> = [901].into_iter().collect();
         let repo_path = std::path::Path::new("/tmp/test-repo");
         assert!(
-            should_recover_task(
-                &task,
-                &merged_prs,
-                &HashSet::new(),
-                &HashMap::new(),
-                repo_path
-            ),
+            should_recover_task(&task, &merged_prs, repo_path),
             "Should recover task with multi-PR reference where only SOME PRs are merged"
         );
     }
@@ -4586,7 +4664,10 @@ mod tests {
     fn test_should_recover_task_with_multi_pr_when_all_merged() {
         use crate::tasks::{Task, TaskStatus};
 
-        // Task referencing PRs #901, #902, #903 - these are contextual mentions
+        // Meta-task referencing PRs #901, #902, #903, and ALL are merged
+        // With explicit PR associations: should_recover_task() returns true because
+        // it only checks the explicit pr field (which is None for meta-tasks).
+        // Auto-completion will handle cleanup when all PRs are merged.
         let task = Task {
             id: "1124".to_string(),
             subject: "Merge PRs #901, #902, #903".to_string(),
@@ -4595,6 +4676,7 @@ mod tests {
             owner: Some("madison".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: None, // Meta-tasks don't have explicit PR associations
             created_at: None,
         };
 
@@ -4602,16 +4684,10 @@ mod tests {
         let merged_prs: HashSet<u64> = [901, 902, 903].into_iter().collect();
         let repo_path = std::path::Path::new("/tmp/test-repo");
 
-        // New behavior: SHOULD recover because these are contextual mentions
+        // New behavior: SHOULD recover because pr field is None (contextual mentions only)
         assert!(
-            should_recover_task(
-                &task,
-                &merged_prs,
-                &HashSet::new(),
-                &HashMap::new(),
-                repo_path
-            ),
-            "Should recover task with contextual multi-PR references"
+            should_recover_task(&task, &merged_prs, repo_path),
+            "Should recover task with no explicit pr field (auto-completion will handle cleanup)"
         );
     }
 
@@ -4619,7 +4695,10 @@ mod tests {
     fn test_should_recover_task_with_pr_in_subject_only() {
         use crate::tasks::{Task, TaskStatus};
 
-        // Task with PR reference only in subject - this is a contextual reference
+        // Task with PR reference only in subject (not description)
+        // With explicit PR associations: should_recover_task() returns true because
+        // it only checks the explicit pr field (which is None).
+        // If this task is actually FOR PR #905, it should have pr: Some(905).
         let task = Task {
             id: "1125".to_string(),
             subject: "Close PR #905".to_string(),
@@ -4628,22 +4707,17 @@ mod tests {
             owner: Some("broadway".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: None, // Should be Some(905) if this task is for PR #905
             created_at: None,
         };
 
         let merged_prs: HashSet<u64> = [905].into_iter().collect();
         let repo_path = std::path::Path::new("/tmp/test-repo");
 
-        // New behavior: SHOULD recover because PR #905 is just a contextual mention
+        // New behavior: SHOULD recover because pr field is None (contextual mentions only)
         assert!(
-            should_recover_task(
-                &task,
-                &merged_prs,
-                &HashSet::new(),
-                &HashMap::new(),
-                repo_path
-            ),
-            "Should recover task with contextual PR mention in subject"
+            should_recover_task(&task, &merged_prs, repo_path),
+            "Should recover task with no explicit pr field (auto-completion will handle cleanup)"
         );
     }
 
@@ -4665,6 +4739,7 @@ mod tests {
                 blocked_by: vec![],
                 description: None,
                 channel: None,
+                pr: None,
                 created_at: Some(SystemTime::now()),
             }],
             tasks_with_worktrees: HashSet::new(),

--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -216,6 +216,14 @@ pub enum Effect {
         completed_task_id: String,
         repo_name: String,
     },
+    /// Set the explicit PR association for a task.
+    ///
+    /// Called when a PR is opened with `[Midtown !XX]` in the title to link the task to the PR.
+    SetTaskPr {
+        task_id: String,
+        pr_number: u64,
+        repo_name: String,
+    },
     /// Force-delete orphaned worktrees whose PRs were merged (squash-merge).
     ///
     /// These worktrees appear to have "unmerged commits" because the squash-merge
@@ -930,6 +938,29 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                     );
                 }
             }
+            Effect::SetTaskPr {
+                task_id,
+                pr_number,
+                repo_name,
+            } => {
+                if let Err(e) = crate::tasks::update_task_fields_for_repo(
+                    &task_id,
+                    &repo_name,
+                    None, // owner
+                    None, // status
+                    None, // description
+                    None, // blocked_by
+                    None, // channel
+                    Some(pr_number),
+                ) {
+                    warn!("Failed to set PR association for task !{}: {}", task_id, e);
+                } else {
+                    info!(
+                        "Set PR association for task !{}: PR #{}",
+                        task_id, pr_number
+                    );
+                }
+            }
             Effect::ForceCleanupWorktrees { names } => {
                 if names.is_empty() {
                     continue;
@@ -1347,6 +1378,7 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                     &repo_name,
                     None, // blocked_by
                     None, // channel
+                    None, // pr
                 ) {
                     Ok(task_id) => {
                         info!("Created task !{}: {}", task_id, subject);

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1886,7 +1886,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                     );
                 }
 
-                // Handle PR-opened events: store author session + auto-complete task
+                // Handle PR-opened events: store author session + auto-set task PR association
                 if let Some(ref pr_opened) = webhook_event.pr_opened {
                     let mut pr_effects = Vec::new();
 
@@ -1906,6 +1906,21 @@ pub async fn run(config: DaemonConfig) -> crate::Result<()> {
                                 pr_opened.pr_number, author
                             );
                         }
+                    }
+
+                    // Auto-set task PR association when PR title contains [Midtown !XX]
+                    if let Some(task_id) =
+                        crate::tasks::extract_task_id_from_pr_title(&pr_opened.title)
+                    {
+                        pr_effects.push(effects::Effect::SetTaskPr {
+                            task_id: task_id.to_string(),
+                            pr_number: pr_opened.pr_number,
+                            repo_name: state.repo_name.clone(),
+                        });
+                        info!(
+                            "Auto-setting PR #{} association for task !{}",
+                            pr_opened.pr_number, task_id
+                        );
                     }
 
                     // NOTE: Task auto-completion has been moved to the PR merged handler

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -390,6 +390,7 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
                 .and_then(|p| p.get("channel"))
                 .and_then(|v| v.as_str());
             let model = params.and_then(|p| p.get("model")).and_then(|v| v.as_str());
+            let pr = params.and_then(|p| p.get("pr")).and_then(|v| v.as_u64());
 
             match subject {
                 Some(subject) => {
@@ -400,6 +401,7 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
                         blocked_by.as_deref(),
                         channel,
                         model,
+                        pr,
                         state,
                     )
                     .await
@@ -433,6 +435,7 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
                         .and_then(|p| p.get("channel"))
                         .and_then(|v| v.as_str());
                     let model = params.and_then(|p| p.get("model")).and_then(|v| v.as_str());
+                    let pr = params.and_then(|p| p.get("pr")).and_then(|v| v.as_u64());
 
                     handle_task_update(
                         request.id,
@@ -443,6 +446,7 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
                         blocked_by.as_deref(),
                         channel,
                         model,
+                        pr,
                         state,
                     )
                 }
@@ -1649,6 +1653,7 @@ async fn handle_task_request(
 /// happens on the next `TaskDispatchTick` via the canonical event loop pipeline.
 ///
 /// If no channel is provided, invokes the clusterer to assign one automatically.
+#[allow(clippy::too_many_arguments)]
 async fn handle_task_create(
     id: RequestId,
     subject: &str,
@@ -1656,6 +1661,7 @@ async fn handle_task_create(
     blocked_by: Option<&[String]>,
     channel: Option<&str>,
     model: Option<&str>,
+    pr: Option<u64>,
     state: &DaemonState,
 ) -> Response {
     let repo_name = state.repo_name.clone();
@@ -1687,6 +1693,7 @@ async fn handle_task_create(
         &repo_name,
         blocked_by,
         assigned_channel.as_deref(),
+        pr,
     ) {
         Ok(task_id) => {
             // Update daemon-side task-to-channel and task-to-model mappings if provided
@@ -1895,6 +1902,7 @@ fn handle_task_update(
     blocked_by: Option<&[String]>,
     channel: Option<&str>,
     model: Option<&str>,
+    pr: Option<u64>,
     state: &DaemonState,
 ) -> Response {
     // Validate status if provided
@@ -1914,6 +1922,7 @@ fn handle_task_update(
         description,
         blocked_by,
         channel,
+        pr,
     ) {
         return Response::error(
             id,
@@ -2063,6 +2072,7 @@ fn handle_task_claim(id: RequestId, task_id: &str, from: &str, state: &DaemonSta
             &repo_name,
             Some(from),
             Some("in_progress"),
+            None,
             None,
             None,
             None,

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -22,6 +22,10 @@ pub struct Task {
     /// Optional channel to route coworker messages for this task.
     #[serde(default)]
     pub channel: Option<String>,
+    /// Explicit PR number associated with this task.
+    /// Set via --pr flag or auto-detected from [Midtown !XXX] in PR title.
+    #[serde(default)]
+    pub pr: Option<u64>,
     /// File creation time, populated from filesystem metadata (not serialized).
     #[serde(skip)]
     pub created_at: Option<std::time::SystemTime>,
@@ -220,6 +224,8 @@ fn parse_task_json(content: &str) -> Result<Task, serde_json::Error> {
         .and_then(|v| v.as_str())
         .map(String::from);
 
+    let pr = value.get("pr").and_then(|v| v.as_u64());
+
     Ok(Task {
         id,
         subject,
@@ -228,6 +234,7 @@ fn parse_task_json(content: &str) -> Result<Task, serde_json::Error> {
         description,
         blocked_by,
         channel,
+        pr,
         created_at: None,
     })
 }
@@ -539,7 +546,8 @@ fn update_task_owner_in_dir(
 /// Only fields that are `Some` are updated; `None` fields are left unchanged.
 /// This is the daemon's direct write path — no Lead proxy needed.
 ///
-/// Supports updating: owner, status, description, blocked_by, channel.
+/// Supports updating: owner, status, description, blocked_by, channel, pr.
+#[allow(clippy::too_many_arguments)]
 pub fn update_task_fields_for_repo(
     task_id: &str,
     repo_name: &str,
@@ -548,6 +556,7 @@ pub fn update_task_fields_for_repo(
     description: Option<&str>,
     blocked_by: Option<&[String]>,
     channel: Option<&str>,
+    pr: Option<u64>,
 ) -> Result<(), String> {
     use fs2::FileExt;
 
@@ -588,6 +597,9 @@ pub fn update_task_fields_for_repo(
     }
     if let Some(ch) = channel {
         task["channel"] = serde_json::json!(ch);
+    }
+    if let Some(pr_num) = pr {
+        task["pr"] = serde_json::json!(pr_num);
     }
 
     let updated_content = serde_json::to_string_pretty(&task)
@@ -1124,6 +1136,7 @@ pub fn shared_tasks_dir_for_repo(repo: &str) -> std::path::PathBuf {
 ///
 /// Assigns the next sequential ID by scanning existing task files.
 /// Returns the assigned task ID on success.
+#[allow(clippy::too_many_arguments)]
 pub fn create_task_for_repo(
     subject: &str,
     description: &str,
@@ -1132,6 +1145,7 @@ pub fn create_task_for_repo(
     repo_name: &str,
     blocked_by: Option<&[String]>,
     channel: Option<&str>,
+    pr: Option<u64>,
 ) -> Result<String, String> {
     let Some(home) = dirs::home_dir() else {
         return Err("Could not determine home directory".to_string());
@@ -1154,6 +1168,7 @@ pub fn create_task_for_repo(
         owner,
         blocked_by,
         channel,
+        pr,
     )
 }
 
@@ -1162,6 +1177,7 @@ pub fn create_task_for_repo(
 /// Reads existing tasks once to both determine the next ID and check for duplicates.
 /// A task with the same subject and owner (regardless of status) is considered a duplicate.
 /// Uses directory-level locking to prevent concurrent ID collisions.
+#[allow(clippy::too_many_arguments)]
 fn create_task_in_dir(
     tasks_dir: &std::path::Path,
     subject: &str,
@@ -1170,6 +1186,7 @@ fn create_task_in_dir(
     owner: &str,
     blocked_by: Option<&[String]>,
     channel: Option<&str>,
+    pr: Option<u64>,
 ) -> Result<String, String> {
     use fs2::FileExt;
 
@@ -1220,6 +1237,11 @@ fn create_task_in_dir(
     // Add optional channel field if provided
     if let Some(ch) = channel {
         task["channel"] = serde_json::json!(ch);
+    }
+
+    // Add optional pr field if provided
+    if let Some(pr_num) = pr {
+        task["pr"] = serde_json::json!(pr_num);
     }
 
     let path = tasks_dir.join(format!("{}.json", task_id));
@@ -1494,6 +1516,7 @@ mod tests {
                 description: None,
                 blocked_by: vec![],
                 channel: None,
+                pr: None,
                 created_at: None,
             },
             Task {
@@ -1504,6 +1527,7 @@ mod tests {
                 description: None,
                 blocked_by: vec![],
                 channel: None,
+                pr: None,
                 created_at: None,
             },
             Task {
@@ -1514,6 +1538,7 @@ mod tests {
                 description: None,
                 blocked_by: vec![],
                 channel: None,
+                pr: None,
                 created_at: None,
             },
         ];
@@ -1542,6 +1567,7 @@ mod tests {
                 description: Some("Review PR #239 changes".to_string()),
                 blocked_by: vec![],
                 channel: None,
+                pr: None,
                 created_at: None,
             },
             Task {
@@ -1552,6 +1578,7 @@ mod tests {
                 description: Some("Sub-task for PR #239 review".to_string()),
                 blocked_by: vec!["10".to_string()],
                 channel: None,
+                pr: None,
                 created_at: None,
             },
         ];
@@ -1579,6 +1606,7 @@ mod tests {
             description: None,
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         };
         assert_eq!(extract_pr_number_from_task(&task), Some("42".to_string()));
@@ -1594,6 +1622,7 @@ mod tests {
             description: Some("Part of PR #239 review workflow".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         };
         assert_eq!(extract_pr_number_from_task(&task), Some("239".to_string()));
@@ -1609,6 +1638,7 @@ mod tests {
             description: Some("Generic scoring task".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         };
         assert_eq!(extract_pr_number_from_task(&task), None);
@@ -1625,6 +1655,7 @@ mod tests {
                 description: None,
                 blocked_by: vec![],
                 channel: None,
+                pr: None,
                 created_at: None,
             },
             Task {
@@ -1635,6 +1666,7 @@ mod tests {
                 description: None,
                 blocked_by: vec!["100".to_string()],
                 channel: None,
+                pr: None,
                 created_at: None,
             },
             Task {
@@ -1645,6 +1677,7 @@ mod tests {
                 description: None,
                 blocked_by: vec!["101".to_string()],
                 channel: None,
+                pr: None,
                 created_at: None,
             },
         ];
@@ -1673,6 +1706,7 @@ mod tests {
             description: Some("Reviewing PR #88 changes".to_string()),
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         }];
 
@@ -1713,6 +1747,7 @@ mod tests {
             description: None,
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: Some(now - Duration::from_secs(10)),
         };
         assert!(is_within_grace_period(&recent_task, now, grace));
@@ -1726,6 +1761,7 @@ mod tests {
             description: None,
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: Some(now - Duration::from_secs(60)),
         };
         assert!(!is_within_grace_period(&old_task, now, grace));
@@ -1739,6 +1775,7 @@ mod tests {
             description: None,
             blocked_by: vec![],
             channel: None,
+            pr: None,
             created_at: None,
         };
         assert!(!is_within_grace_period(&no_time_task, now, grace));
@@ -1755,6 +1792,7 @@ mod tests {
                 description: None,
                 blocked_by: vec![],
                 channel: None,
+                pr: None,
                 created_at: None,
             },
             Task {
@@ -1765,6 +1803,7 @@ mod tests {
                 description: None,
                 blocked_by: vec![],
                 channel: None,
+                pr: None,
                 created_at: None,
             },
             Task {
@@ -1775,6 +1814,7 @@ mod tests {
                 description: None,
                 blocked_by: vec!["1".to_string()],
                 channel: None,
+                pr: None,
                 created_at: None,
             },
             Task {
@@ -1785,6 +1825,7 @@ mod tests {
                 description: None,
                 blocked_by: vec!["2".to_string()],
                 channel: None,
+                pr: None,
                 created_at: None,
             },
             Task {
@@ -1795,6 +1836,7 @@ mod tests {
                 description: None,
                 blocked_by: vec!["999".to_string()],
                 channel: None,
+                pr: None,
                 created_at: None,
             },
             Task {
@@ -1805,6 +1847,7 @@ mod tests {
                 description: None,
                 blocked_by: vec!["1".to_string(), "2".to_string()],
                 channel: None,
+                pr: None,
                 created_at: None,
             },
             Task {
@@ -1815,6 +1858,7 @@ mod tests {
                 description: None,
                 blocked_by: vec![],
                 channel: None,
+                pr: None,
                 created_at: None,
             },
         ];
@@ -1856,6 +1900,7 @@ mod tests {
                 description: Some("Check if PR #246 is eligible".to_string()),
                 blocked_by: vec![],
                 channel: None,
+                pr: None,
                 created_at: Some(now - Duration::from_secs(5)),
             },
             // Another sub-task just created (3 seconds ago)
@@ -1867,6 +1912,7 @@ mod tests {
                 description: Some("Review agents for PR #246".to_string()),
                 blocked_by: vec![],
                 channel: None,
+                pr: None,
                 created_at: Some(now - Duration::from_secs(3)),
             },
             // An older task that legitimately has no owner (created 2 minutes ago)
@@ -1878,6 +1924,7 @@ mod tests {
                 description: None,
                 blocked_by: vec![],
                 channel: None,
+                pr: None,
                 created_at: Some(now - Duration::from_secs(120)),
             },
         ];
@@ -2168,6 +2215,7 @@ mod tests {
             "madison",
             None,
             None,
+            None,
         );
         assert!(result.is_ok());
         let task_id = result.unwrap();
@@ -2192,6 +2240,7 @@ mod tests {
             "madison",
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -2202,6 +2251,7 @@ mod tests {
             "desc",
             "Addressing review feedback on PR #42",
             "madison",
+            None,
             None,
             None,
         )
@@ -2235,6 +2285,7 @@ mod tests {
             "madison",
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -2258,6 +2309,7 @@ mod tests {
             "madison",
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -2268,6 +2320,7 @@ mod tests {
             "desc",
             "Addressing feedback",
             "lexington",
+            None,
             None,
             None,
         )
@@ -2291,6 +2344,7 @@ mod tests {
             "desc",
             "Working on new task",
             "carol",
+            None,
             None,
             None,
         )
@@ -2318,6 +2372,7 @@ mod tests {
             "bob",
             None,
             None,
+            None,
         )
         .unwrap();
         assert_eq!(id, "4");
@@ -2329,6 +2384,7 @@ mod tests {
             "desc",
             "Working",
             "bob",
+            None,
             None,
             None,
         )
@@ -2719,6 +2775,7 @@ mod tests {
                     &format!("worker-{}", i),
                     None,
                     None,
+                    None,
                 )
                 .unwrap()
             }));
@@ -2769,6 +2826,7 @@ mod tests {
             "madison",
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -2788,7 +2846,7 @@ mod tests {
 
         // Create first task
         let id1 = create_task_in_dir(
-            tasks_dir, "Task one", "desc", "Working", "alice", None, None,
+            tasks_dir, "Task one", "desc", "Working", "alice", None, None, None,
         )
         .unwrap();
         assert_eq!(id1, "1");
@@ -2797,8 +2855,10 @@ mod tests {
         assert_eq!(read_highwatermark(tasks_dir), 1);
 
         // Create second task
-        let id2 = create_task_in_dir(tasks_dir, "Task two", "desc", "Working", "bob", None, None)
-            .unwrap();
+        let id2 = create_task_in_dir(
+            tasks_dir, "Task two", "desc", "Working", "bob", None, None, None,
+        )
+        .unwrap();
         assert_eq!(id2, "2");
         assert_eq!(read_highwatermark(tasks_dir), 2);
     }
@@ -2831,8 +2891,10 @@ mod tests {
         std::fs::write(tasks_dir.join(".highwatermark"), "50").unwrap();
         create_task_file(tasks_dir, "100", "pending", Some("alice"));
 
-        let id = create_task_in_dir(tasks_dir, "New task", "desc", "Working", "bob", None, None)
-            .unwrap();
+        let id = create_task_in_dir(
+            tasks_dir, "New task", "desc", "Working", "bob", None, None, None,
+        )
+        .unwrap();
         assert_eq!(id, "101", "should use max(files, watermark) + 1");
 
         // Watermark updated to new value
@@ -2852,6 +2914,7 @@ mod tests {
             "alice",
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -2864,6 +2927,7 @@ mod tests {
             "Working",
             "bob",
             Some(&blocked_by),
+            None,
             None,
         )
         .unwrap();
@@ -2886,6 +2950,7 @@ mod tests {
             "alice",
             Some(&[]),
             None,
+            None,
         )
         .unwrap();
 
@@ -2904,6 +2969,7 @@ mod tests {
             "desc",
             "Working",
             "alice",
+            None,
             None,
             None,
         )
@@ -2926,6 +2992,7 @@ mod tests {
             "alice",
             None,
             Some("feature-auth"),
+            None,
         )
         .unwrap();
 
@@ -2944,6 +3011,7 @@ mod tests {
             "desc",
             "Working",
             "alice",
+            None,
             None,
             None,
         )
@@ -2966,6 +3034,7 @@ mod tests {
             "alice",
             None,
             Some("infra-deploy"),
+            None,
         )
         .unwrap();
 

--- a/tests/orphan_recovery_pr_ref_bug_test.rs
+++ b/tests/orphan_recovery_pr_ref_bug_test.rs
@@ -8,11 +8,11 @@
 // Example: Task !1142 subject is "Fix remaining orphan worktree false positives — PR #940 fix insufficient"
 // PR #940 is merged, so should_recover_task() returns false, preventing orphan recovery.
 //
-// Expected: Only skip recovery when the task has an ASSOCIATED PR (one with
-// [Midtown !{task_id}] in its title) that is merged.
+// Fix: Only skip recovery when the task has an explicit `pr` field pointing to a merged PR.
+// Contextual PR mentions in text are ignored.
 
 use midtown::tasks::{Task, TaskStatus};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 /// Helper to create a minimal task for testing
@@ -25,6 +25,7 @@ fn create_test_task(id: &str, subject: &str, description: Option<String>) -> Tas
         owner: Some("amsterdam".to_string()),
         blocked_by: vec![],
         channel: None,
+        pr: None,
         created_at: None,
     }
 }
@@ -33,6 +34,7 @@ fn create_test_task(id: &str, subject: &str, description: Option<String>) -> Tas
 fn test_should_recover_task_with_contextual_pr_mention() {
     // Task !1142 mentions PR #940 in context ("PR #940 fix insufficient")
     // but is NOT completed by PR #940. PR #940 is merged.
+    // The task has no explicit pr field (it will create a different PR).
     let task = create_test_task(
         "1142",
         "Fix remaining orphan worktree false positives — PR #940 fix insufficient",
@@ -44,81 +46,56 @@ fn test_should_recover_task_with_contextual_pr_mention() {
 
     let repo_path = PathBuf::from("/fake/repo");
 
-    // BUG: Current implementation returns false (skip recovery) because it extracts
-    // PR #940 from the subject and sees it's merged.
-    // EXPECTED: Should return true (allow recovery) because PR #940 doesn't have
-    // [Midtown !1142] in its title — it's just mentioned as context.
-
-    // This test will FAIL with the current buggy implementation
-    let result = midtown::daemon::should_recover_task_test_helper(
-        &task,
-        &merged_pr_numbers,
-        &HashSet::new(), // no open PR associations for task 1142
-        &HashMap::new(), // no merged PR associations for task 1142
-        &repo_path,
-    );
+    // Should return true (allow recovery) because task.pr is None —
+    // PR #940 is just mentioned as context, not the task's actual PR.
+    let result =
+        midtown::daemon::should_recover_task_test_helper(&task, &merged_pr_numbers, &repo_path);
 
     assert!(
         result,
-        "should_recover_task should return true for task with contextual PR mention, not false"
+        "should_recover_task should return true for task with contextual PR mention (pr field is None)"
     );
 }
 
 #[test]
 fn test_should_skip_recovery_when_task_pr_is_merged() {
-    // Task !1131 has PR #940 with [Midtown !1131] in title
-    let task = create_test_task("1131", "Fix orphan worktree detector false positives", None);
+    // Task !1131 has explicit PR association to #940
+    let mut task = create_test_task("1131", "Fix orphan worktree detector false positives", None);
+    task.pr = Some(940); // Explicit PR association
 
     let mut merged_pr_numbers = HashSet::new();
     merged_pr_numbers.insert(940);
 
-    // PR #940 has [Midtown !1131] in its title
-    let mut merged_pr_task_associations = HashMap::new();
-    merged_pr_task_associations.insert(940, "1131".to_string());
-
     let repo_path = PathBuf::from("/fake/repo");
 
-    // Should skip recovery because PR #940 (associated with task !1131) is merged
-    let result = midtown::daemon::should_recover_task_test_helper(
-        &task,
-        &merged_pr_numbers,
-        &HashSet::new(),
-        &merged_pr_task_associations,
-        &repo_path,
-    );
+    // Should skip recovery because task.pr = Some(940) and PR #940 is merged
+    let result =
+        midtown::daemon::should_recover_task_test_helper(&task, &merged_pr_numbers, &repo_path);
 
     assert!(
         !result,
-        "should_recover_task should return false when task's associated PR is merged"
+        "should_recover_task should return false when task's explicit PR is merged"
     );
 }
 
 #[test]
 fn test_should_recover_when_task_pr_is_open() {
-    // Task !1142 has PR #958 with [Midtown !1142] in title, but it's still open
-    let task = create_test_task(
+    // Task !1142 has explicit PR association to #958, but it's still open
+    let mut task = create_test_task(
         "1142",
         "Fix remaining orphan worktree false positives",
         None,
     );
+    task.pr = Some(958); // Explicit PR association to open PR
 
     let merged_pr_numbers = HashSet::new(); // PR #958 NOT merged
 
-    // PR #958 is open and associated with task !1142
-    let mut open_pr_task_associations = HashSet::new();
-    open_pr_task_associations.insert("1142".to_string());
-
     let repo_path = PathBuf::from("/fake/repo");
 
-    // Should allow recovery because PR #958 is open (not merged yet)
-    // The coworker might have crashed/disconnected mid-work
-    let result = midtown::daemon::should_recover_task_test_helper(
-        &task,
-        &merged_pr_numbers,
-        &open_pr_task_associations,
-        &HashMap::new(),
-        &repo_path,
-    );
+    // Should allow recovery because PR #958 is not in the merged set
+    // (and the GitHub API check in tests will fail/return None, so recovery is allowed)
+    let result =
+        midtown::daemon::should_recover_task_test_helper(&task, &merged_pr_numbers, &repo_path);
 
     assert!(
         result,
@@ -139,14 +116,9 @@ fn test_should_recover_task_with_no_pr() {
 
     let repo_path = PathBuf::from("/fake/repo");
 
-    // Should allow recovery for non-PR tasks
-    let result = midtown::daemon::should_recover_task_test_helper(
-        &task,
-        &merged_pr_numbers,
-        &HashSet::new(),
-        &HashMap::new(),
-        &repo_path,
-    );
+    // Should allow recovery for non-PR tasks (pr field is None)
+    let result =
+        midtown::daemon::should_recover_task_test_helper(&task, &merged_pr_numbers, &repo_path);
 
     assert!(
         result,


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Add `--pr <number>` flag to `midtown task create` and `midtown task update` to explicitly link tasks to PRs
- Daemon automatically sets the `pr` field when a PR is opened with `[Midtown !XXX]` in the title
- Auto-completion checks explicit `pr` field first, falls back to text extraction for meta-tasks
- Orphan recovery only checks explicit `pr` field to prevent false positives

## Bug Context
Task 1142 mentioned "PR #940 fix insufficient" in the subject as context (not as the actual task's PR). The old text extraction logic in `should_recover_task()` wrongly skipped orphan recovery for this task. Explicit PR associations prevent these false positives.

## Changes
- **CLI**: Add `--pr <number>` flag to task create and update commands
- **Task storage**: Add `pr: Option<u64>` field to Task struct
- **Daemon**: Auto-set `pr` field via webhook when PR opened with `[Midtown !XXX]` in title
- **Auto-completion**: Check explicit `pr` field first, fall back to text extraction for meta-tasks (e.g., "Merge PRs: #901, #902, #903")
- **Orphan recovery**: Only check explicit `pr` field (never fall back to text extraction to avoid false positives)
- **Agent prompts**: Document `--pr` flag usage in lead.md

## Test Plan
- [x] Unit tests pass (including new test for task 1142 scenario)
- [x] Clippy passes
- [x] Auto-completion works for tasks with explicit PR field
- [x] Auto-completion falls back to text extraction for meta-tasks without explicit PR
- [x] Orphan recovery respects explicit PR field only

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)