### PR TITLE
fix: build multi-platform Docker images (amd64 + arm64)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,9 @@ jobs:
           echo "Version verified: $CARGO_VERSION"
           echo "version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
 
+      - name: Set up QEMU (for cross-platform builds)
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -76,6 +79,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
             ${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
## Summary

- Add `docker/setup-qemu-action` for cross-platform emulation
- Add `platforms: linux/amd64,linux/arm64` to the build-push step

The v0.5.2 image was only published for `linux/amd64`, causing `no matching manifest for linux/arm64/v8` on Apple Silicon Macs.

## Test plan

- [ ] CI passes
- [ ] After merge: bump to v0.5.3, release, verify `docker pull ghcr.io/btucker/midtown:latest` works on arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)