### PR TITLE
fix: use native arm64 runners instead of QEMU for Docker builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,13 +38,21 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-  # ─── Publish container image to GitHub Container Registry ─────────────────
-  docker:
-    name: Publish to GHCR
-    runs-on: ubuntu-latest
+  # ─── Build platform-specific Docker images ────────────────────────────────
+  # Uses native runners (no QEMU) for fast compilation on each architecture.
+  docker-build:
+    name: Docker (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
     steps:
       - uses: actions/checkout@v4
 
@@ -58,11 +66,7 @@ jobs:
             echo "Error: Cargo.toml version ($CARGO_VERSION) does not match release tag ($RELEASE_VERSION)"
             exit 1
           fi
-          echo "Version verified: $CARGO_VERSION"
           echo "version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
-
-      - name: Set up QEMU (for cross-platform builds)
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -74,14 +78,68 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-            ${{ env.IMAGE_NAME }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ─── Merge into multi-platform manifest and push tags ─────────────────────
+  docker-merge:
+    name: Publish to GHCR
+    runs-on: ubuntu-latest
+    needs: docker-build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: |
+          RELEASE_TAG="${{ github.event.release.tag_name }}"
+          echo "version=${RELEASE_TAG#v}" >> $GITHUB_OUTPUT
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }} \
+            --tag ${{ env.IMAGE_NAME }}:latest \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)


### PR DESCRIPTION
## Summary

Replaces the slow QEMU-emulated arm64 build with native compilation on GitHub's `ubuntu-24.04-arm` runner.

**Before:** Single job with QEMU emulating the entire Rust compiler for arm64 (very slow)
**After:** Two parallel native builds + a manifest merge job

### Workflow structure
1. **`docker-build` (matrix)** — Builds natively on `ubuntu-latest` (amd64) and `ubuntu-24.04-arm` (arm64) in parallel. Pushes platform-specific images by digest.
2. **`docker-merge`** — Downloads both digests and creates the multi-platform manifest with version + latest tags.

## Test plan

- [ ] CI passes
- [ ] After merge: republish v0.5.2, verify both `linux/amd64` and `linux/arm64` manifests exist
- [ ] `docker pull ghcr.io/btucker/midtown:latest` works on Apple Silicon

🤖 Generated with [Claude Code](https://claude.com/claude-code)