### PR TITLE
fix: allow sandbox writes to XDG state directory

### DIFF
--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -18,6 +18,7 @@ use std::path::{Path, PathBuf};
 /// - `~/.midtown` (daemon state, channel logs, worktrees)
 /// - `~/.claude` (Claude Code config, sessions, tasks)
 /// - `~/.codex` (Codex config)
+/// - `~/.local/state/midtown` (daemon socket, runtime state)
 /// - `/tmp` and platform-specific temp directories
 pub fn writable_dirs(primary_repo: &Path, additional_repos: &[PathBuf]) -> Vec<String> {
     let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/root"));
@@ -48,6 +49,13 @@ pub fn writable_dirs(primary_repo: &Path, additional_repos: &[PathBuf]) -> Vec<S
     dirs.push(home.join(".midtown").to_string_lossy().to_string());
     dirs.push(home.join(".claude").to_string_lossy().to_string());
     dirs.push(home.join(".codex").to_string_lossy().to_string());
+
+    // XDG state directory (daemon socket, runtime state)
+    dirs.push(
+        home.join(".local/state/midtown")
+            .to_string_lossy()
+            .to_string(),
+    );
 
     // Temp directories
     dirs.push("/tmp".to_string());


### PR DESCRIPTION
## Summary
- Adds `~/.local/state/midtown` to the sandbox writable directories list
- The daemon socket lives at this XDG state path, but the sandbox only allowed writes to `~/.midtown`, causing sandboxed processes to fail connecting to the daemon
- Discovered during first live run with the new sandbox-exec sandboxing from #980

## Test plan
- [x] `cargo clippy` and `cargo fmt` pass
- [x] All 13 sandbox unit tests pass
- [x] Rebuilt, installed, and restarted daemon — coworkers reconnected successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)