### PR TITLE
fix: Show source task IDs for reviewers in Board TUI [Midtown !1167]

### DIFF
--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -2693,19 +2693,22 @@ async fn handle_kanban_data(id: RequestId, state: &DaemonState) -> Response {
             health_guard.clone()
         };
 
-        // Build reviewer -> PR number map from GitHub state
-        let reviewer_pr_map: HashMap<String, u64> = {
-            let github_state = state.persistent_state.lock().await;
-            active_coworkers
-                .iter()
-                .filter_map(|cw| {
-                    github_state
-                        .github
-                        .pr_for_reviewer(&cw.name)
-                        .map(|pr| (cw.name.clone(), pr))
-                })
-                .collect()
-        };
+        // Build reviewer -> PR number map from GitHub state (best-effort via try_lock)
+        let reviewer_pr_map: HashMap<String, u64> = state
+            .persistent_state
+            .try_lock()
+            .map(|github_state| {
+                active_coworkers
+                    .iter()
+                    .filter_map(|cw| {
+                        github_state
+                            .github
+                            .pr_for_reviewer(&cw.name)
+                            .map(|pr| (cw.name.clone(), pr))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
 
         active_coworkers
             .iter()


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Fixed Board TUI coworker table to show source task IDs instead of reviewer internal task IDs
- When a coworker is reviewing a PR, display now shows the task ID from the PR title (e.g., !1158) instead of the reviewer's ephemeral internal ID (e.g., !62)

## Implementation
- Added `task_id_by_pr` map in `handle_kanban_data` RPC handler to extract source task IDs from PR titles using `extract_task_id_from_pr_title`
- Modified display logic to prefer source task ID (from `task_id_by_pr`) over internal task ID
- Refactored health snapshot handling to clone data before await (avoids holding lock across await)
- Added reviewer -> PR number map from GitHub state for finding which PR each reviewer is working on

## Test Plan
- [x] Added comprehensive unit test `test_reviewer_displays_source_task_id` that verifies the display logic
- [x] All existing tests pass (1192 tests)
- [x] Clippy clean (no warnings with -D warnings)
- [x] Formatted with cargo fmt
- [ ] Manual testing: verify Board TUI displays correct task IDs for reviewers

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)