### PR TITLE
fix: Web UI autocomplete drops on typing more characters [Midtown !1169]

### DIFF
--- a/web-app/e2e/autocomplete.spec.js
+++ b/web-app/e2e/autocomplete.spec.js
@@ -1,0 +1,103 @@
+import { test, expect } from '@playwright/test'
+import { mockAllRoutes } from './helpers.js'
+
+test.describe('Autocomplete', () => {
+  test.beforeEach(async ({ page }) => {
+    // Set up mocked API routes
+    await mockAllRoutes(page)
+    // Navigate to the web UI
+    await page.goto('/')
+    // Wait for the channel container to load
+    await expect(page.locator('.channel-container')).toBeVisible()
+  })
+
+  test('should maintain autocomplete dropdown when typing more characters for @mention', async ({ page }) => {
+    // Focus the input textarea
+    const textarea = page.locator('textarea[placeholder*="Message to"]')
+    await textarea.click()
+
+    // Type '@m' and verify autocomplete appears
+    await textarea.type('@m', { delay: 50 })
+    await page.waitForSelector('.autocomplete-dropdown', { timeout: 1000 })
+
+    // Verify autocomplete is visible
+    let dropdown = page.locator('.autocomplete-dropdown')
+    await expect(dropdown).toBeVisible()
+
+    // Type 'a' to make it '@ma'
+    await textarea.type('a', { delay: 50 })
+
+    // Autocomplete should still be visible
+    await expect(dropdown).toBeVisible()
+
+    // Type 'd' to make it '@mad'
+    await textarea.type('d', { delay: 50 })
+
+    // Autocomplete should STILL be visible (this was the bug)
+    await expect(dropdown).toBeVisible()
+
+    // Verify 'madison' is in the results
+    const items = page.locator('.autocomplete-item .item-label')
+    await expect(items).toContainText('@madison')
+  })
+
+  test('should filter autocomplete results as more characters are typed', async ({ page }) => {
+    const textarea = page.locator('textarea[placeholder*="Message to"]')
+    await textarea.click()
+
+    // Type '@m' - should show multiple results (madison, amsterdam, etc.)
+    await textarea.type('@m', { delay: 50 })
+    await page.waitForSelector('.autocomplete-dropdown', { timeout: 1000 })
+
+    let items = page.locator('.autocomplete-item')
+    const initialCount = await items.count()
+    expect(initialCount).toBeGreaterThanOrEqual(2) // At least madison and amsterdam
+
+    // Type 'ad' to make it '@mad' - should show only madison
+    await textarea.type('ad', { delay: 50 })
+
+    items = page.locator('.autocomplete-item')
+    const filteredCount = await items.count()
+    expect(filteredCount).toBe(1)
+
+    // Verify it's madison
+    const label = page.locator('.autocomplete-item .item-label')
+    await expect(label).toContainText('@madison')
+  })
+
+  test('should hide autocomplete when typing a space after @ trigger', async ({ page }) => {
+    const textarea = page.locator('textarea[placeholder*="Message to"]')
+    await textarea.click()
+
+    // Type '@m'
+    await textarea.type('@m', { delay: 50 })
+    await page.waitForSelector('.autocomplete-dropdown', { timeout: 1000 })
+
+    // Type space
+    await textarea.press('Space')
+
+    // Autocomplete should hide
+    const dropdown = page.locator('.autocomplete-dropdown')
+    await expect(dropdown).not.toBeVisible()
+  })
+
+  test('should complete @mention on Tab key', async ({ page }) => {
+    const textarea = page.locator('textarea[placeholder*="Message to"]')
+    await textarea.click()
+
+    // Type '@mad'
+    await textarea.type('@mad', { delay: 50 })
+    await page.waitForSelector('.autocomplete-dropdown', { timeout: 1000 })
+
+    // Press Tab to complete
+    await textarea.press('Tab')
+
+    // Verify the textarea contains '@madison '
+    const value = await textarea.inputValue()
+    expect(value).toBe('@madison ')
+
+    // Autocomplete should be hidden
+    const dropdown = page.locator('.autocomplete-dropdown')
+    await expect(dropdown).not.toBeVisible()
+  })
+})

--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -117,7 +117,9 @@
 
   function detectAutocompleteTrigger() {
     const cursorPos = textareaElement?.selectionStart || 0
-    const text = inputText
+    // Use textarea.value directly instead of inputText binding
+    // because oninput fires before the binding updates
+    const text = textareaElement?.value || inputText
 
     // Look backward from cursor to find trigger character
     let triggerPos = -1


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Fixed bug where typing '@m' showed autocomplete but '@mad' caused it to disappear
- Root cause was Svelte 5 binding timing issue - `oninput` fires before `bind:value` updates
- Solution: Read text directly from `textareaElement.value` instead of bound `inputText` variable
- Added comprehensive Playwright e2e tests to prevent regression

## Root Cause
In Svelte 5, when a user types in a `<textarea>` with `bind:value`:
1. The `oninput` event fires **before** the Svelte binding updates the bound variable
2. `detectAutocompleteTrigger()` was reading `inputText` (still containing old value '@m')
3. Meanwhile, `textareaElement.selectionStart` had the new cursor position (3, after 'd')
4. Trying to access `text[2]` when text.length is 2 returns `undefined` → detection fails

## Test Plan
- [x] Added Playwright e2e tests for autocomplete behavior
  - Verifies dropdown stays visible when typing more characters
  - Tests filtering (more characters = narrower results)
  - Tests dropdown hides on space
  - Tests Tab completion
- [x] Clippy clean
- [x] Cargo fmt clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)