### PR TITLE
fix: Remove misleading 'idle' from graceful restart drain status check [Midtown !1172]

### DIFF
--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -1072,11 +1072,11 @@ fn kill_orphaned_webhook_forwarders(messages: &mut Vec<String>) {
     }
 }
 
-/// Wait for coworkers to drain (reach idle state) before shutdown.
+/// Wait for coworkers to drain (reach stopped/stopping state) before shutdown.
 ///
 /// First signals the daemon to enter draining mode (stops new task assignments).
 /// Then polls coworker status every 500ms and displays progress. Returns once all
-/// coworkers are idle/stopped, or after the timeout expires (5 minutes).
+/// coworkers are stopped/stopping, or after the timeout expires (5 minutes).
 fn wait_for_coworkers_to_drain(timeout_secs: u64) -> Result<(), String> {
     use std::collections::HashMap;
 
@@ -1192,7 +1192,7 @@ fn wait_for_coworkers_to_drain(timeout_secs: u64) -> Result<(), String> {
 /// session and all running Claude processes (Lead and coworkers).
 ///
 /// When `force` is false (default):
-/// - Waits for all coworkers to finish their current work and reach idle state
+/// - Waits for all coworkers to finish their current work and reach stopped state
 /// - Displays real-time status of which coworkers are still working
 /// - Times out after 5 minutes and force-kills stuck coworkers
 ///
@@ -1841,7 +1841,7 @@ mod tests {
         let is_working = invalid_status != "stopped" && invalid_status != "stopping";
         assert!(
             is_working,
-            "Status 'idle' doesn't exist in CoworkerStatus, but would be incorrectly considered 'working'"
+            "Status 'idle' doesn't exist in CoworkerStatus — if it appeared, it would be conservatively treated as 'working' (safe default for unknown statuses)"
         );
     }
 }


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Fixed misleading comment in `wait_for_coworkers_to_drain()` that mentioned "idle" as a valid status
- Added test documenting the valid CoworkerStatus values and the confusion between CoworkerStatus and WorkflowPhase

## Context
The drain loop comment claimed to check for "idle", "stopped", "stopping" as done states, but:
- CoworkerStatus enum only has: Starting, Running, Stopping, Stopped (no Idle variant)
- The confusion stems from mixing up CoworkerStatus (lifecycle) with WorkflowPhase (activity)
- When a coworker reports WorkflowPhase::Idle, daemon immediately shuts it down (Stopping → Stopped)
- The actual code condition was already correct (`status != "stopped" && status != "stopping"`)

## Changes
1. Updated first comment from "Check if all coworkers are idle or stopped" to "Check if all coworkers are stopped or stopping"
2. Updated loop comment from "Consider 'idle', 'stopped', 'stopping' as done" to "Consider 'stopped', 'stopping' as done (CoworkerStatus lifecycle states)"
3. Added `test_drain_status_check_recognizes_valid_statuses()` to document the valid status values

## Test plan
- [x] New test passes: `cargo test test_drain_status_check_recognizes_valid_statuses`
- [x] All existing tests pass: `cargo test --bin midtown`
- [x] Clippy passes: `cargo clippy --bin midtown -- -D warnings`
- [x] Pre-commit hooks pass (fmt + clippy)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)