### PR TITLE
fix: prevent duplicate review-feedback addressing

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -232,7 +232,11 @@ gh pr view <number> --json state --jq '.state'
        -f body="✅ Addressed in $(git rev-parse --short HEAD)"
      ```
 
-2. **Request a follow-up task** - If the suggestion is out of scope or would significantly expand the PR:
+2. **Unsure about a comment** - If you're not sure what the reviewer means or disagree:
+   - Post a **GitHub PR comment** as a follow-up question to the reviewer. The daemon detects the new comment via webhook and automatically resumes the reviewer's session.
+   - **Do NOT use @mentions in the GitHub comment** — GitHub sends email notifications to real accounts that share coworker names. Just post a plain reply; the daemon handles routing.
+
+3. **Request a follow-up task** - If the suggestion is out of scope or would significantly expand the PR:
    - Reply to the comment immediately with an acknowledgment:
      ```bash
      COMMENT_URL=$(gh api -X POST "/repos/{owner}/{repo}/issues/comments/{review_comment_id}/replies" \
@@ -245,6 +249,12 @@ gh pr view <number> --json state --jq '.state'
      gh api -X PATCH "/repos/{owner}/{repo}/issues/comments/$REPLY_ID" \
        -f body="📋 Created follow-up task: [description]"
      ```
+
+**After addressing all feedback**, enable auto-merge immediately:
+```bash
+gh pr merge --auto --squash
+```
+This prevents the window between "feedback addressed" and "PR merged" where the task could be re-dispatched to another coworker.
 
 **Never ignore review feedback.** Every suggestion must be either:
 - Addressed in the current PR, OR
@@ -268,7 +278,7 @@ We share a GitHub API rate limit across the daemon, lead, and all coworkers. **D
 - Don't run `gh pr list` to check PR status — read the channel instead
 - **NEVER merge before addressing review feedback.** Every review comment must be either addressed in the PR or deferred via `midtown task request` before merging.
 - Do NOT enable auto-merge when creating the PR — wait for review first
-- After all feedback is addressed/deferred and CI is green, merge using `gh pr merge --auto --squash` or `gh pr merge --squash`
+- After all feedback is addressed/deferred, enable auto-merge: `gh pr merge --auto --squash`
 
 **Using `gh` to investigate (after notification) is fine:**
 - `gh pr create` — creating your PR

--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -1868,7 +1868,7 @@ pub(super) fn reset_orphaned_tasks(snap: &snapshot::WorldSnapshot) -> Vec<Effect
         .map(|(name, _)| name.clone())
         .collect();
 
-    for (task_id, _subject, owner) in &snap.in_progress_tasks {
+    for (task_id, subject, owner) in &snap.in_progress_tasks {
         let owner_clean = owner.trim().trim_matches('"').to_lowercase();
         if owner_clean.is_empty() {
             continue;
@@ -1878,6 +1878,25 @@ pub(super) fn reset_orphaned_tasks(snap: &snapshot::WorldSnapshot) -> Vec<Effect
         // (tasks with PRs are handled by reconcile_tasks_in_review)
         if snap.tasks_with_open_prs.contains_key(task_id) {
             continue;
+        }
+
+        // Also protect tasks that REFERENCE an open PR in their subject
+        // (e.g., "Address review feedback on PR #1032") — these don't own
+        // the PR but shouldn't be reset while the PR is still open.
+        if let Some(pr_num_str) = crate::tasks::extract_pr_number(subject)
+            && let Ok(pr_num) = pr_num_str.parse::<u64>()
+        {
+            let pr_is_open = snap
+                .open_prs_data
+                .iter()
+                .any(|pr| pr.get("number").and_then(|n| n.as_u64()) == Some(pr_num));
+            if pr_is_open {
+                debug!(
+                    "Task !{} references open PR #{} — skipping orphan reset",
+                    task_id, pr_num
+                );
+                continue;
+            }
         }
 
         // Only reset if the owner is NOT active (already shut down / on break)
@@ -4226,6 +4245,60 @@ mod tests {
             effects.is_empty(),
             "Should not reset task with open PR (handled by reconcile_tasks_in_review)"
         );
+    }
+
+    #[test]
+    fn test_reset_orphaned_tasks_pr_reference_in_subject_protects() {
+        // Bug: "Address review feedback on PR #42" tasks reference an open PR
+        // but don't own it (not in tasks_with_open_prs). Without the PR-reference
+        // guard, this task would be reset when the owner goes inactive, causing
+        // duplicate feedback addressing by another coworker.
+        let in_progress = vec![(
+            "100".to_string(),
+            "Address review feedback on PR #42".to_string(),
+            "columbus".to_string(),
+        )];
+        let tasks_with_open_prs = HashMap::new(); // Task doesn't OWN the PR
+        let active_names = HashSet::new(); // columbus is NOT active
+
+        let mut snap = make_reconcile_snapshot(in_progress, tasks_with_open_prs, active_names);
+
+        // PR #42 is open (in open_prs_data but not tasks_with_open_prs)
+        snap.open_prs_data = vec![serde_json::json!({"number": 42})];
+
+        let effects = reset_orphaned_tasks(&snap);
+        assert!(
+            effects.is_empty(),
+            "Should not reset task referencing open PR #42 in subject"
+        );
+    }
+
+    #[test]
+    fn test_reset_orphaned_tasks_pr_reference_closed_pr_resets() {
+        // Same scenario but PR #42 is closed/merged — task should be reset
+        let in_progress = vec![(
+            "100".to_string(),
+            "Address review feedback on PR #42".to_string(),
+            "columbus".to_string(),
+        )];
+        let tasks_with_open_prs = HashMap::new();
+        let active_names = HashSet::new();
+
+        let mut snap = make_reconcile_snapshot(in_progress, tasks_with_open_prs, active_names);
+        snap.open_prs_data = vec![]; // PR #42 is NOT open
+
+        let effects = reset_orphaned_tasks(&snap);
+        assert_eq!(
+            effects.len(),
+            1,
+            "Should reset task when referenced PR is closed"
+        );
+        match &effects[0] {
+            Effect::ResetTaskToPending { task_id, .. } => {
+                assert_eq!(task_id, "100");
+            }
+            other => panic!("Expected ResetTaskToPending, got {:?}", other),
+        }
     }
 
     #[test]

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -2546,16 +2546,71 @@ pub(super) async fn handle_pr_comment_nudge(
         return;
     };
 
-    // Don't create tasks for self-comments
+    // Author posted a comment on their own PR — notify the reviewer
+    // (e.g., author is asking a follow-up question about review feedback)
     if activity
         .owner_coworker
         .as_ref()
         .is_some_and(|o| o == &activity.actor)
     {
         debug!(
-            "PR #{} comment is from owner {}, skipping self-nudge",
+            "PR #{} comment is from author {} — checking for reviewer to notify",
             pr_number, activity.actor
         );
+
+        // Look up the reviewer assignment from persistent state
+        let reviewer_info = {
+            let ps = state.persistent_state.lock().await;
+            ps.github.pr_reviewers.get(&pr_number).cloned()
+        };
+
+        let Some(assignment) = reviewer_info else {
+            debug!("PR #{} has no reviewer assignment, skipping", pr_number);
+            return;
+        };
+
+        let reviewer_name = assignment.reviewer;
+        let reviewer_session_id = assignment.reviewer_session_id;
+        let nudge_msg = format!(
+            "PR #{} author {} posted a follow-up comment. Please review and respond.",
+            pr_number, activity.actor
+        );
+
+        // Check if the reviewer is currently active
+        let is_active = state
+            .coworkers
+            .list()
+            .iter()
+            .any(|c| c.name == reviewer_name);
+
+        let effects = if is_active {
+            vec![Effect::NudgeCoworker {
+                name: reviewer_name.clone(),
+                message: nudge_msg,
+                session_id: reviewer_session_id,
+            }]
+        } else if let Some(session_id) = reviewer_session_id {
+            // Reviewer stopped — resume their session with the follow-up context
+            let config = crate::launch::LaunchConfig::coworker(
+                reviewer_name.clone(),
+                state.repo_name.clone(),
+                crate::launch::SessionMode::ResumeSession(session_id.clone()),
+                Some(nudge_msg),
+            );
+            vec![Effect::ResumeCoworker {
+                name: reviewer_name.clone(),
+                session_id,
+                config,
+            }]
+        } else {
+            debug!(
+                "PR #{} reviewer {} has no session ID and is inactive, cannot resume",
+                pr_number, reviewer_name
+            );
+            return;
+        };
+
+        super::effects::execute_effects(effects, state).await;
         return;
     }
 


### PR DESCRIPTION
## Summary
- **Agent prompt**: coworkers now `gh pr merge --auto --squash` after addressing all review feedback, closing the re-dispatch window. Adds guidance for posting follow-up questions via GitHub PR comments (no @mentions) with automatic reviewer session resumption.
- **Defense-in-depth**: `reset_orphaned_tasks()` now protects tasks that *reference* an open PR in their subject (e.g., "Address review feedback on PR #1032"), not just tasks that *own* one. Prevents re-dispatch when the feedback-addressing coworker goes idle.
- **Reviewer resumption**: when a PR author posts a self-comment, the daemon notifies or resumes the reviewer session instead of silently dropping the event — enabling follow-up questions between author and reviewer.

## Context
PR #1032 exposed a bug where review feedback was addressed 3 times by 2 different coworkers. Root cause: review-feedback tasks reference an existing PR but don't own it, so `reset_orphaned_tasks` didn't protect them. When the coworker finished and went idle, the task was reset to pending and picked up again.

## Test plan
- [x] New unit tests: `test_reset_orphaned_tasks_pr_reference_in_subject_protects` and `test_reset_orphaned_tasks_pr_reference_closed_pr_resets`
- [x] `cargo test` — all 1242 unit tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] `midtown e2e run coordination` — containerized E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)