### PR TITLE
refactor: Simplify src/rules.rs with test builders (-7%, -260 lines) [Midtown !1183]

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1571,7 +1571,7 @@ mod tests {
             self.on_cooldown = true;
             self
         }
-        fn as_reviewer(mut self) -> Self {
+        fn for_reviewer(mut self) -> Self {
             self.is_reviewer = true;
             self
         }
@@ -3279,7 +3279,7 @@ Now implementing the fix.
         let action = PendingTaskCtx::new("madison")
             .task("6", "Prevent coworkers from checking out default branch")
             .active(&["madison"])
-            .as_reviewer()
+            .for_reviewer()
             .run();
         assert!(
             matches!(action, PendingTaskAction::Skip { .. }),
@@ -3322,7 +3322,7 @@ Now implementing the fix.
         // Reviewer check fires before active check — still skip even if inactive.
         let action = PendingTaskCtx::new("madison")
             .task("6", "Prevent coworkers from checking out default branch")
-            .as_reviewer()
+            .for_reviewer()
             .run();
         assert!(
             matches!(action, PendingTaskAction::Skip { .. }),


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- **Add 4 test builder patterns** (OrphanCtx, StuckCheckCtx, PendingTaskCtx, StuckReviewerCtx) to eliminate repetitive multi-argument function calls across ~50 tests
- **Net reduction: 260 lines** (718 deleted, 458 added) — tests now read as declarative scenario descriptions instead of verbose argument lists
- Supersedes PR #1044 which had unresolvable merge conflicts with 18 commits on main

## Test builders added

| Builder | Replaces | Tests simplified |
|---------|----------|-----------------|
| `OrphanCtx` | 7-arg `decide_orphan_recovery` calls with `&empty`/`&HashSet::new()` | 22 |
| `StuckCheckCtx` | 6-arg `run_stuck_check` + `stuck_health` + empty exemptions | 8 |
| `PendingTaskCtx` | 8-arg `decide_pending_task_action` with boolean flags | 12 |
| `StuckReviewerCtx` | 6-arg `run_stuck_reviewer_check` | 5 |

## Before/after example

```rust
// Before (7 args, 10 lines):
let tasks = vec![("789".to_string(), "Add usage bars".to_string(), "amsterdam".to_string())];
let active = set(&[]);
let coworkers_with_open_prs = set(&["amsterdam"]);
let review_feedback = set(&["amsterdam"]);
let result = decide_orphan_recovery(&tasks, &active, false, &coworkers_with_open_prs, &review_feedback, &HashSet::new(), &HashSet::new());

// After (4 lines):
let result = OrphanCtx::task("789", "Add usage bars", "amsterdam")
    .open_prs(&["amsterdam"])
    .review_feedback(&["amsterdam"])
    .run();
```

## Test plan
- [x] All 138 rules tests pass
- [x] Full test suite passes (1244 pass, 2 pre-existing environment failures)
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)