### PR TITLE
fix: Use actual max_coworkers from daemon in TUI sidebar [Midtown !1206]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -47,6 +47,8 @@ struct KanbanData {
     repos: Vec<(String, String)>,
     /// Coworker status data from daemon
     coworkers: Vec<CoworkerInfo>,
+    /// Maximum number of coworkers from daemon config
+    max_coworkers: usize,
 }
 
 /// Coworker status information for the TUI board sidebar
@@ -210,6 +212,8 @@ pub struct App {
     pub merged_prs: Vec<MergedPr>,
     /// Active coworkers with their current status
     pub coworkers: Vec<CoworkerInfo>,
+    /// Maximum number of coworkers allowed
+    pub max_coworkers: usize,
     /// Repository name with owner (e.g., "btucker/midtown")
     /// Used for constructing GitHub PR URLs in kanban hyperlinks
     pub repo_name: String,
@@ -339,6 +343,7 @@ impl App {
             prs: Vec::new(),
             merged_prs: Vec::new(),
             coworkers: Vec::new(),
+            max_coworkers: 10, // Default, will be updated from daemon
             repo_name,
             kanban_last_refresh: Instant::now() - KANBAN_REFRESH_INTERVAL, // Force initial refresh
             kanban_receiver: None,
@@ -425,6 +430,7 @@ impl App {
                     self.prs = data.prs;
                     self.merged_prs = data.merged_prs;
                     self.coworkers = data.coworkers;
+                    self.max_coworkers = data.max_coworkers;
                     // Update repo info from daemon if available
                     if !data.repos.is_empty() {
                         let new_repos: Vec<RepoInfo> = data
@@ -554,14 +560,15 @@ impl App {
         self.kanban_receiver = Some(rx);
 
         thread::spawn(move || {
-            let (prs, merged_prs, repos, coworkers) = fetch_kanban_data_via_rpc()
-                .unwrap_or_else(|| (fetch_prs(), fetch_merged_prs(), Vec::new(), Vec::new()));
+            let (prs, merged_prs, repos, coworkers, max_coworkers) = fetch_kanban_data_via_rpc()
+                .unwrap_or_else(|| (fetch_prs(), fetch_merged_prs(), Vec::new(), Vec::new(), 10));
             // Ignore send error if receiver dropped (app closed)
             let _ = tx.send(KanbanData {
                 prs,
                 merged_prs,
                 repos,
                 coworkers,
+                max_coworkers,
             });
         });
     }
@@ -1739,6 +1746,7 @@ fn fetch_kanban_data_via_rpc() -> Option<(
     Vec<MergedPr>,
     Vec<(String, String)>,
     Vec<CoworkerInfo>,
+    usize,
 )> {
     use crate::client::DaemonClient;
 
@@ -1767,6 +1775,13 @@ fn fetch_kanban_data_via_rpc() -> Option<(
                 .collect()
         })
         .unwrap_or_default();
+
+    // Extract max_coworkers from daemon config
+    let max_coworkers = data
+        .get("max_coworkers")
+        .and_then(|v| v.as_u64())
+        .map(|n| n as usize)
+        .unwrap_or(10); // Default fallback
 
     let prs: Vec<KanbanPr> = prs_json
         .iter()
@@ -1901,7 +1916,7 @@ fn fetch_kanban_data_via_rpc() -> Option<(
         })
         .unwrap_or_default();
 
-    Some((prs, merged_prs, repos, coworkers))
+    Some((prs, merged_prs, repos, coworkers, max_coworkers))
 }
 
 /// Cache for default branch names, keyed by repo full name (or empty string for current repo).
@@ -2126,6 +2141,7 @@ pub(super) mod tests {
             prs: Vec::new(),
             merged_prs: Vec::new(),
             coworkers: Vec::new(),
+            max_coworkers: 10, // Test default
             repo_name: "test".to_string(),
             kanban_last_refresh: Instant::now(),
             kanban_receiver: None,

--- a/src/bin/midtown/cli/chat/ui/board.rs
+++ b/src/bin/midtown/cli/chat/ui/board.rs
@@ -236,8 +236,7 @@ fn draw_coworker_status(f: &mut Frame, app: &App, area: Rect) {
         .split(area);
 
     let active_count = app.coworkers.len();
-    let max_coworkers = 10;
-    let header = format!("  Coworkers ({}/{})", active_count, max_coworkers);
+    let header = format!("  Coworkers ({}/{})", active_count, app.max_coworkers);
     let header_paragraph = Paragraph::new(Line::from(vec![Span::styled(
         header,
         Style::default()

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -2928,6 +2928,7 @@ async fn handle_kanban_data(id: RequestId, state: &DaemonState) -> Response {
         "merged_prs": merged_prs,
         "repos": repos,
         "coworkers": coworkers_data,
+        "max_coworkers": state.max_coworkers,
     });
 
     state.kanban_cache.set(response_data.clone(), repo_hash);


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Fixed hardcoded max_coworkers value (10) in TUI sidebar to use actual daemon config
- The sidebar now correctly displays the real limit (e.g., "7/8" when max_coworkers=8)

## Changes
- **daemon/rpc.rs**: Added `max_coworkers` to kanban_data RPC response
- **cli/chat/app.rs**: Added `max_coworkers` field to `KanbanData` and `App` structs, parsed from daemon response
- **cli/chat/ui/board.rs**: Removed hardcoded value, now uses `app.max_coworkers`

## Test plan
- [x] Built successfully with `cargo build`
- [x] Tests pass (1245 passed, 1 pre-existing sandbox test failure unrelated)
- [x] Clippy passes with `-D warnings`
- [x] Verified data flow: daemon state → RPC → KanbanData → App → board rendering

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)