### PR TITLE
docs: require checking for new PR comments before merging [Midtown !1211]

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -250,6 +250,12 @@ gh pr view <number> --json state --jq '.state'
        -f body="📋 Created follow-up task: [description]"
      ```
 
+**Before merging**, check for new comments that arrived after the review:
+```bash
+gh pr view <number> --comments --json comments --jq '.comments[-2:][] | "\(.author.login): \(.body[:120])"'
+```
+The user (repo owner) may leave additional requests after the reviewer posts. Merging without addressing these is a process failure.
+
 **After addressing all feedback**, enable auto-merge immediately:
 ```bash
 gh pr merge --auto --squash


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Adds guidance to coworker.md requiring authors to check for new PR comments before enabling auto-merge
- Uses `gh pr view --comments` to check the last 2 comments for any user feedback that arrived after review
- Prevents process failure where user comments get ignored when author merges without checking

## Context
The Lead identified that user comments on coworker PRs can be missed when authors enable auto-merge immediately after review feedback is addressed. This adds an explicit check step to ensure user comments are never ignored.

## Test plan
- [x] Verified the command syntax works
- [x] Guidance is clear and actionable

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)