### PR TITLE
fix: Add Clear widget to autocomplete dropdown for proper background rendering [Midtown !1224]

### DIFF
--- a/src/bin/midtown/cli/chat/ui/chat.rs
+++ b/src/bin/midtown/cli/chat/ui/chat.rs
@@ -5,7 +5,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph, Wrap},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
 };
 
 use crate::cli::chat::mermaid;
@@ -273,6 +273,9 @@ fn draw_autocomplete_dropdown(f: &mut Frame, app: &App, input_area: Rect) {
             )));
         }
     }
+
+    // Clear the area first to ensure background is rendered properly
+    f.render_widget(Clear, dropdown_area);
 
     let block = Block::default()
         .borders(Borders::ALL)


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Fixed autocomplete dropdown background rendering by adding the `Clear` widget
- This ensures the dropdown has a solid background instead of showing chat text underneath

## Details

The autocomplete dropdown was rendering without properly clearing the underlying area first, causing chat messages to show through the popup in some terminals. This was particularly noticeable with complex terminal setups.

### Changes Made
- Added `Clear` widget import to `src/bin/midtown/cli/chat/ui/chat.rs`
- Added `f.render_widget(Clear, dropdown_area);` before rendering the autocomplete dropdown
- This ensures the area is cleared before the dropdown is drawn, giving it a solid black background

### Other Issues Mentioned in Task
The task description mentioned three issues. Investigation revealed:

1. **Autocomplete background** ✅ - Fixed by this PR
2. **Shift+Enter for multi-line input** ✅ - Already implemented and working (mod.rs lines 426-430), tests pass
3. **Autocomplete matching 'pleasant'** ✅ - Logic is correct, uses `starts_with()` matching, tests pass

## Test plan
- [x] All existing autocomplete tests pass (19 tests)
- [x] All binary tests pass (200 tests)
- [x] Pre-commit hooks (clippy, fmt) pass
- [x] Manual verification: autocomplete dropdown now has solid black background

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)