### PR TITLE
fix: Align web app autocomplete with TUI prefix matching [Midtown !1231]

### DIFF
--- a/web-app/e2e/autocomplete.spec.js
+++ b/web-app/e2e/autocomplete.spec.js
@@ -2,7 +2,7 @@
 import { test, expect } from '@playwright/test'
 import { MOCK_STATUS, mockAllRoutes } from './helpers.js'
 
-/** Custom status with madison coworker for autocomplete testing. */
+/** Custom status with madison and mercer coworkers for prefix-based autocomplete testing. */
 const AUTOCOMPLETE_STATUS = {
   ...MOCK_STATUS,
   coworkers: [
@@ -12,6 +12,12 @@ const AUTOCOMPLETE_STATUS = {
       status: 'active',
       current_task: 'Fix autocomplete bug',
       started_at: '2025-01-15T09:15:00Z',
+    },
+    {
+      name: 'mercer',
+      status: 'active',
+      current_task: 'Review PR #42',
+      started_at: '2025-01-15T10:00:00Z',
     },
   ],
 }
@@ -60,15 +66,15 @@ test.describe('Autocomplete', () => {
     const textarea = page.locator('textarea[placeholder*="Message to"]')
     await textarea.click()
 
-    // Type '@m' - should show multiple results (madison, amsterdam, etc.)
+    // Type '@m' - with prefix matching, should show madison and mercer (both start with 'm')
     await textarea.type('@m', { delay: 50 })
     await page.waitForSelector('.autocomplete-dropdown', { timeout: 1000 })
 
     let items = page.locator('.autocomplete-item')
     const initialCount = await items.count()
-    expect(initialCount).toBeGreaterThanOrEqual(2) // At least madison and amsterdam
+    expect(initialCount).toBeGreaterThanOrEqual(2) // At least madison and mercer
 
-    // Type 'ad' to make it '@mad' - should show only madison
+    // Type 'ad' to make it '@mad' - should show only madison (prefix matching)
     await textarea.type('ad', { delay: 50 })
 
     items = page.locator('.autocomplete-item')

--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -36,7 +36,7 @@
         { name: 'lead', type: 'lead' },
         ...$coworkers.map(cw => ({ name: cw.name, type: 'coworker', task: cw.current_task }))
       ]
-      return people.filter(p => p.name.toLowerCase().includes(lowerQuery))
+      return people.filter(p => p.name.toLowerCase().startsWith(lowerQuery))
     }
 
     if (type === '!') {
@@ -44,8 +44,8 @@
       const tasks = $daemonStatus?.tasks || []
       return tasks
         .filter(t => {
-          const idMatch = String(t.id).includes(query)
-          const subjectMatch = t.subject?.toLowerCase().includes(lowerQuery)
+          const idMatch = String(t.id).startsWith(query)
+          const subjectMatch = t.subject?.toLowerCase().startsWith(lowerQuery)
           return idMatch || subjectMatch
         })
         .slice(0, 10) // Limit to 10 results
@@ -66,9 +66,9 @@
       const combined = [...prs, ...channelList]
       return combined.filter(item => {
         if (item.type === 'pr') {
-          return String(item.number).includes(query) || item.title?.toLowerCase().includes(lowerQuery)
+          return String(item.number).startsWith(query) || item.title?.toLowerCase().startsWith(lowerQuery)
         }
-        return item.name.toLowerCase().includes(lowerQuery)
+        return item.name.toLowerCase().startsWith(lowerQuery)
       }).slice(0, 10)
     }
 


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Changed web app autocomplete from substring matching (`.includes()`) to prefix matching (`.startsWith()`)
- Updated all three autocomplete types: @mentions, #channels/#PRs, and !tasks
- Updated e2e tests to reflect prefix-based filtering behavior

This aligns the web app with the TUI behavior from PR #1080, ensuring consistent UX across both interfaces.

## Matching Behavior

**Before (substring matching):**
- `@m` matched: madison, mercer, **amsterdam** (substring in name)
- `#m` matched: midtown, madison, **admin** (substring in name)
- `!12` matched: 1224, 1234, **2125** (substring in ID)

**After (prefix matching):**
- `@m` matches: madison, mercer (names starting with 'm')
- `#m` matches: midtown, madison (names starting with 'm')
- `!12` matches: 1224, 1234 (IDs starting with '12')

## Test plan
- [x] Web app builds successfully
- [x] Updated e2e test to add 'mercer' coworker for proper prefix filtering test
- [x] Updated test assertions to reflect prefix-based behavior
- [ ] Run e2e tests to verify autocomplete behavior

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)