### PR TITLE
fix: Show source task IDs in web sidebar fallback path [Midtown !1229]

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -2546,7 +2546,7 @@ mod tests {
         // when building the task_id_by_pr map in the fallback path.
         use std::collections::HashMap;
 
-        let pull_requests = vec![
+        let pull_requests = &[
             serde_json::json!({
                 "number": 100,
                 "title": "Fix bug [Midtown !1234]"


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Fixed web sidebar fallback path to show source task IDs from PR titles instead of internal task IDs
- Applied the same `display_task_id` logic that was already in `rpc_kanban.rs` (commit e462f76)
- Ensures reviewers show meaningful task IDs (e.g., !1158) instead of ephemeral internal IDs (e.g., !62)

## Changes
- Added `task_id_by_pr` map in the fallback path to extract source task IDs from PR titles
- Renamed `task_id` to `internal_task_id` for clarity
- Added `display_task_id` that prefers source task ID over internal ID
- Updated phase derivation to use `display_task_id`

## Context
The RPC path (`kanban.data` in `rpc_kanban.rs`) already had this fix from task !1167, but the `web.rs` fallback path (used when daemon RPC is unavailable) was still showing internal IDs. Both paths now display consistent task IDs.

## Test plan
- [x] All existing web tests pass (31 tests)
- [x] All lib tests pass (1268 tests, 1 pre-existing failure in sandbox)
- [x] Clippy clean (no warnings with -D warnings)
- [x] Formatted with cargo fmt

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)