### PR TITLE
feat: Add manual channel creation to TUI [Midtown !1236]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -1018,11 +1018,41 @@ impl App {
         }
     }
 
+    /// Validate that a channel name is safe for use as a filesystem path component.
+    ///
+    /// Rejects names containing path separators, traversal sequences, or other
+    /// filesystem-unsafe characters that could escape the channels/ directory.
+    fn is_valid_channel_name(name: &str) -> bool {
+        if name.is_empty() {
+            return false;
+        }
+
+        // Reject path separators and traversal sequences
+        if name.contains('/') || name.contains('\\') || name.contains("..") {
+            return false;
+        }
+
+        // Reject null bytes (filesystem-unsafe on all platforms)
+        if name.contains('\0') {
+            return false;
+        }
+
+        // Only allow alphanumeric, hyphens, underscores, and dots (not leading)
+        name.chars()
+            .all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == '.')
+            && !name.starts_with('.')
+    }
+
     /// Create a new channel and switch to it
     ///
     /// Returns `true` if the channel was successfully created (or already exists),
-    /// `false` on error.
+    /// `false` on error. Rejects channel names with path-unsafe characters.
     pub fn create_channel(&mut self, channel_name: &str) -> bool {
+        // Validate channel name to prevent path traversal
+        if !Self::is_valid_channel_name(channel_name) {
+            return false;
+        }
+
         let channel_repo =
             midtown::paths::detect_repo_name().unwrap_or_else(|| "default".to_string());
         let base_dir = midtown::paths::projects_dir_for_repo(&channel_repo);
@@ -3040,5 +3070,34 @@ pub(super) mod tests {
 
         // Selected channel should update
         assert_eq!(app.selected_channel, "features");
+    }
+
+    #[test]
+    fn test_valid_channel_names() {
+        assert!(App::is_valid_channel_name("my-channel"));
+        assert!(App::is_valid_channel_name("features"));
+        assert!(App::is_valid_channel_name("task_42"));
+        assert!(App::is_valid_channel_name("v2.0"));
+        assert!(App::is_valid_channel_name("UPPER"));
+        assert!(App::is_valid_channel_name("a"));
+    }
+
+    #[test]
+    fn test_invalid_channel_names_path_traversal() {
+        assert!(!App::is_valid_channel_name("../../etc/passwd"));
+        assert!(!App::is_valid_channel_name(".."));
+        assert!(!App::is_valid_channel_name("foo/bar"));
+        assert!(!App::is_valid_channel_name("foo\\bar"));
+        assert!(!App::is_valid_channel_name("../sibling"));
+    }
+
+    #[test]
+    fn test_invalid_channel_names_special_chars() {
+        assert!(!App::is_valid_channel_name(""));
+        assert!(!App::is_valid_channel_name(".hidden"));
+        assert!(!App::is_valid_channel_name("has space"));
+        assert!(!App::is_valid_channel_name("has\0null"));
+        assert!(!App::is_valid_channel_name("emoji🎉"));
+        assert!(!App::is_valid_channel_name("semi;colon"));
     }
 }

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -421,7 +421,8 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                     app.scroll_to_bottom();
                     EventResult::Continue
                 }
-                // Enter: select autocomplete item if showing, otherwise auto-focus InputBar or send message
+                // Enter: select autocomplete item if showing, execute /channel create command,
+                //        auto-focus InputBar, or send message to the selected channel
                 // Shift+Enter: insert newline
                 KeyCode::Enter => {
                     if key.modifiers.contains(KeyModifiers::SHIFT) {
@@ -1341,5 +1342,73 @@ mod tests {
         // because /channel create is not at the start
         #[cfg(test)]
         assert_eq!(app.last_posted_channel, Some("midtown".to_string()));
+    }
+
+    #[test]
+    fn test_channel_create_rejects_path_traversal() {
+        use app::FocusedPane;
+        let mut app = test_app();
+        app.focused_pane = FocusedPane::InputBar;
+        app.input_text = "/channel create ../../etc/passwd".to_string();
+        app.input_cursor = app.input_text.len();
+        let original_channel = app.selected_channel.clone();
+
+        let event = key_press(KeyCode::Enter);
+        let result = handle_event(&mut app, event);
+
+        assert!(matches!(result, EventResult::Continue));
+        // Path traversal name should be rejected — input preserved, channel unchanged
+        assert_eq!(
+            app.input_text, "/channel create ../../etc/passwd",
+            "Input should be preserved when channel name is invalid"
+        );
+        assert_eq!(
+            app.selected_channel, original_channel,
+            "Selected channel should not change on invalid name"
+        );
+    }
+
+    #[test]
+    fn test_channel_create_rejects_name_with_slashes() {
+        use app::FocusedPane;
+        let mut app = test_app();
+        app.focused_pane = FocusedPane::InputBar;
+        app.input_text = "/channel create foo/bar".to_string();
+        app.input_cursor = app.input_text.len();
+        let original_channel = app.selected_channel.clone();
+
+        let event = key_press(KeyCode::Enter);
+        handle_event(&mut app, event);
+
+        // Slash in name should be rejected
+        assert_eq!(
+            app.input_text, "/channel create foo/bar",
+            "Input should be preserved when channel name contains slash"
+        );
+        assert_eq!(app.selected_channel, original_channel);
+    }
+
+    #[test]
+    fn test_channel_create_preserves_input_on_failure() {
+        use app::FocusedPane;
+        let mut app = test_app();
+        app.focused_pane = FocusedPane::InputBar;
+        // Use a name with backslash which should be rejected by validation
+        app.input_text = "/channel create bad\\name".to_string();
+        app.input_cursor = app.input_text.len();
+        let original_cursor = app.input_cursor;
+
+        let event = key_press(KeyCode::Enter);
+        handle_event(&mut app, event);
+
+        // On failure, input text and cursor should be preserved
+        assert_eq!(
+            app.input_text, "/channel create bad\\name",
+            "Input text should be preserved on creation failure"
+        );
+        assert_eq!(
+            app.input_cursor, original_cursor,
+            "Input cursor should be preserved on creation failure"
+        );
     }
 }


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Added `/channel create <name>` command to TUI for creating new channels
- Users can now create channels without leaving the TUI
- Channel creation automatically switches to the newly created channel

## Implementation Details
- Added `create_channel()` method in `app.rs` that creates a new channel and switches to it
- Modified Enter key handler in `mod.rs` to detect `/channel create` commands before posting as messages
- Channel creation uses `Channel::new()` which is idempotent (safe to call on existing channels)
- After creation, automatically loads the new channel's (empty) message history

## Test plan
- [x] Unit tests pass for channel creation command parsing
- [x] Unit tests verify input is cleared after successful creation
- [x] Unit tests verify channel switching works correctly
- [x] Unit tests verify empty channel names are rejected
- [x] Unit tests verify regular messages aren't treated as commands
- [x] All existing TUI tests pass (207 tests)
- [x] Clippy passes with no warnings

## Testing Instructions
1. Start the TUI with `midtown chat`
2. Type `/channel create test-channel` and press Enter
3. Verify the channel sidebar shows the new "test-channel"
4. Verify the chat view switches to the new channel
5. Verify the input is cleared after creation

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)