### PR TITLE
fix: Desktop web UI improvements [Midtown !1245]

### DIFF
--- a/web-app/src/App.svelte
+++ b/web-app/src/App.svelte
@@ -198,11 +198,7 @@
       {#if activeView === 'board'}
         <!-- Desktop: Sidebar component -->
         <div class="desktop-sidebar">
-          <Sidebar
-            bind:projectDropdownOpen
-            onProjectSelect={selectProject}
-            onToggleProjectDropdown={toggleProjectDropdown}
-          />
+          <Sidebar />
         </div>
 
         <!-- Mobile: overlay drawer + channel bar -->

--- a/web-app/src/lib/Sidebar.svelte
+++ b/web-app/src/lib/Sidebar.svelte
@@ -3,7 +3,7 @@
   import CoworkerStatus from './CoworkerStatus.svelte'
   import UsageBars from './UsageBars.svelte'
   import AuthSwitcher from './AuthSwitcher.svelte'
-  import { projects, activeProject, connected } from './store.js'
+  import { connected } from './store.js'
   import {
     pushSupported,
     pushPermission,
@@ -11,12 +11,6 @@
     subscribePush,
     unsubscribePush,
   } from './push.js'
-
-  let {
-    projectDropdownOpen = $bindable(false),
-    onProjectSelect = () => {},
-    onToggleProjectDropdown = () => {},
-  } = $props()
 
   let channelsExpanded = $state(true)
 
@@ -34,40 +28,6 @@
 </script>
 
 <div class="sidebar">
-  <!-- Project selector -->
-  <div class="sidebar-section project-section">
-    <div class="project-selector">
-      <button class="project-trigger" onclick={onToggleProjectDropdown}>
-        <span
-          class="project-status-dot"
-          class:running={$projects.find((p) => p.name === $activeProject)?.status === 'running'}
-        ></span>
-        <span class="project-name">{$activeProject || 'Select project'}</span>
-        <span class="dropdown-arrow">{projectDropdownOpen ? '\u25B4' : '\u25BE'}</span>
-      </button>
-      {#if projectDropdownOpen}
-        <div class="project-dropdown">
-          {#each $projects as project}
-            <button
-              class="project-option"
-              class:active={$activeProject === project.name}
-              class:stopped={project.status !== 'running'}
-              onclick={() => onProjectSelect(project)}
-              disabled={project.status !== 'running'}
-              title={project.status === 'running' ? `Port ${project.webhook_port || 'N/A'}` : 'Stopped'}
-            >
-              <span class="project-status-dot" class:running={project.status === 'running'}></span>
-              <span class="option-name">{project.name}</span>
-              {#if $activeProject === project.name}
-                <span class="active-check">\u2713</span>
-              {/if}
-            </button>
-          {/each}
-        </div>
-      {/if}
-    </div>
-  </div>
-
   <!-- Channels section -->
   <div class="sidebar-section channels-section">
     <button class="section-header" onclick={toggleChannels}>
@@ -123,116 +83,6 @@
 
   .sidebar-section {
     border-bottom: 1px solid #1a1a1a;
-  }
-
-  .project-section {
-    padding: 14px 12px;
-  }
-
-  /* Project selector */
-  .project-selector {
-    position: relative;
-  }
-
-  .project-trigger {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    width: 100%;
-    background: transparent;
-    border: 1px solid #2a2a2a;
-    color: #5faf5f;
-    font-size: 0.95rem;
-    font-weight: 700;
-    cursor: pointer;
-    padding: 8px 10px;
-    border-radius: 6px;
-    transition: all 0.15s;
-  }
-
-  .project-trigger:hover {
-    background: #1a1a1a;
-    border-color: #5faf5f;
-  }
-
-  .project-name {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    text-align: left;
-  }
-
-  .dropdown-arrow {
-    font-size: 0.7rem;
-    color: #606060;
-  }
-
-  .project-dropdown {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    margin-top: 6px;
-    background: #1a1a1a;
-    border: 2px solid #2a2a2a;
-    border-radius: 6px;
-    z-index: 100;
-    overflow: hidden;
-    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.6);
-  }
-
-  .project-option {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    width: 100%;
-    padding: 10px 12px;
-    border: none;
-    background: transparent;
-    color: #a0a0a0;
-    font-size: 0.85rem;
-    cursor: pointer;
-    text-align: left;
-    transition: background 0.1s;
-  }
-
-  .project-option:hover:not(:disabled) {
-    background: #252525;
-    color: #d0d0d0;
-  }
-
-  .project-option.active {
-    color: #5faf5f;
-  }
-
-  .project-option.stopped {
-    opacity: 0.5;
-    cursor: default;
-  }
-
-  .option-name {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .active-check {
-    color: #5faf5f;
-    font-size: 0.8rem;
-  }
-
-  .project-status-dot {
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    background: #606060;
-    flex-shrink: 0;
-  }
-
-  .project-status-dot.running {
-    background: #5faf5f;
   }
 
   /* Section headers */

--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -134,7 +134,10 @@ export function switchProject(projectName, webhookPort) {
 
   // Load data from the new project
   if (projectApiBase) {
-    fetchChannels() // Fetch available channels first
+    // Fetch channels first to populate the sidebar immediately.
+    // Note: fetchHistory() also builds a channel list from messages,
+    // but this ensures all channels (including empty ones) appear immediately.
+    fetchChannels()
     fetchHistory()
     fetchStatus()
     fetchUsage()
@@ -186,20 +189,28 @@ export async function fetchHistory(channelName = null) {
 
         messagesByChannel.set(byChannel)
 
-        // Build channel list
-        const channelList = Array.from(channelSet).map((name) => ({
-          name,
-          unread: 0,
-          has_pr: false,
-          ci_status: null,
-        }))
-        // Ensure midtown is first
-        channelList.sort((a, b) => {
-          if (a.name === 'midtown') return -1
-          if (b.name === 'midtown') return 1
-          return a.name.localeCompare(b.name)
+        // Merge message-derived channels with existing channel list (preserves
+        // channels loaded from GET /api/channels that may have no messages yet).
+        channels.update((existingChannels) => {
+          const existingNames = new Set(existingChannels.map((ch) => ch.name))
+          const newChannels = Array.from(channelSet)
+            .filter((name) => !existingNames.has(name))
+            .map((name) => ({
+              name,
+              unread: 0,
+              has_pr: false,
+              ci_status: null,
+            }))
+
+          const merged = [...existingChannels, ...newChannels]
+          // Ensure midtown is first
+          merged.sort((a, b) => {
+            if (a.name === 'midtown') return -1
+            if (b.name === 'midtown') return 1
+            return a.name.localeCompare(b.name)
+          })
+          return merged
         })
-        channels.set(channelList)
       }
     }
   } catch (err) {


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary

Fixes desktop web UI issues:
- ✅ All channels now load on page load (including empty channels)
- ✅ Removed duplicate project selector from Sidebar (kept header one)
- ✅ Channel task lists display correctly with TaskList component
- ✅ Chat input is present in Channel component

## Changes

1. **Channel loading**: Modified `fetchHistory()` in `api.js` to merge message-derived channels with existing channels instead of overwriting. This preserves empty channels loaded from `GET /api/channels`.

2. **Removed duplicate project selector**: Deleted redundant project selector UI and props from `Sidebar.svelte` and updated `App.svelte` to not pass unused props.

3. **Task list display**: No changes needed - TaskList component already correctly displays individual tasks with status indicators (● in-progress, ○ pending) and assignee names when channels are expanded.

4. **Chat input**: No changes needed - input area already present in Channel.svelte.

## Test plan

- [ ] Channels appear immediately on page load (including empty channels)
- [ ] Only one project selector visible (in header)
- [ ] Tasks display under channels when expanded with correct status and owner
- [ ] Chat input is visible and functional on desktop

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)