### PR TITLE
feat: Add support for pre-populated seed channels in project config [Midtown !1237]

### DIFF
--- a/agents/clusterer.md
+++ b/agents/clusterer.md
@@ -56,6 +56,7 @@ You will receive:
    - Channel name
    - Tasks currently assigned to that channel (with status: pending, in_progress, completed)
    - Task subjects and descriptions
+   - **Note**: This includes pre-populated seed channels from the project config. Seed channels are durable channels created at daemon startup to guide task organization — prefer routing tasks to existing seed channels when appropriate.
 
 3. **Recently Completed Tasks**: Tasks that were recently finished
    - Helps identify when a channel's theme is exhausted and should be archived

--- a/src/config.rs
+++ b/src/config.rs
@@ -182,6 +182,10 @@ pub struct FullProjectConfig {
     /// Project-specific daemon configuration overrides
     #[serde(default)]
     pub daemon: DaemonSection,
+
+    /// Channel configuration (seed channels)
+    #[serde(default)]
+    pub channels: ChannelsSection,
 }
 
 impl FullProjectConfig {
@@ -223,6 +227,7 @@ impl FullProjectConfig {
                 ..ProjectConfig::default()
             },
             daemon: DaemonSection::default(),
+            channels: ChannelsSection::default(),
         }
     }
 
@@ -358,6 +363,17 @@ pub struct PluginsConfig {
     /// List of required plugin names (e.g., "superpowers@claude-plugins-official")
     #[serde(default)]
     pub required: Vec<String>,
+}
+
+/// Channels configuration section.
+///
+/// Pre-populated seed channels that should exist from daemon startup.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct ChannelsSection {
+    /// Seed channels to create at daemon startup if they don't exist.
+    /// Example: ["tui", "web-interface", "daemon", "auth", "docs"]
+    #[serde(default)]
+    pub seed: Vec<String>,
 }
 
 /// Daemon configuration section.
@@ -2342,5 +2358,54 @@ auth_profile = "old@example.com"
 
         // Verify: other config fields survived
         assert_eq!(loaded_after.project.name.as_deref(), Some("test-repo"));
+    }
+
+    #[test]
+    fn test_channels_section_parse() {
+        let toml = r#"
+[channels]
+seed = ["tui", "web-interface", "daemon", "docs"]
+"#;
+        let config: FullProjectConfig = toml::from_str(toml).unwrap();
+        assert_eq!(
+            config.channels.seed,
+            vec!["tui", "web-interface", "daemon", "docs"]
+        );
+    }
+
+    #[test]
+    fn test_channels_section_default() {
+        let config = FullProjectConfig::default();
+        assert!(config.channels.seed.is_empty());
+    }
+
+    #[test]
+    fn test_channels_section_roundtrip() {
+        let toml = r#"
+[project]
+name = "testproj"
+
+[channels]
+seed = ["daemon", "tui", "web"]
+"#;
+        let config: FullProjectConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.channels.seed, vec!["daemon", "tui", "web"]);
+
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let reparsed: FullProjectConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(reparsed.channels.seed, vec!["daemon", "tui", "web"]);
+    }
+
+    #[test]
+    fn test_channels_section_save_and_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let mut config = FullProjectConfig::minimal("testproj", "/tmp/testproj");
+        config.channels.seed = vec!["daemon".to_string(), "tui".to_string(), "web".to_string()];
+        config.save_to(&path).unwrap();
+
+        let loaded = FullProjectConfig::load_from(&path).unwrap();
+        assert_eq!(loaded.channels.seed, vec!["daemon", "tui", "web"]);
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1594,6 +1594,27 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
     let channel_router = crate::ChannelRouter::new(&channel_base_dir, "midtown");
     info!("Channel base: {}", channel_base_dir.display());
 
+    // Create seed channels if configured
+    if let Some(ref full_config) = full_project_config {
+        for seed_channel in &full_config.channels.seed {
+            match crate::channel::Channel::create(&channel_base_dir, seed_channel) {
+                Ok(_) => {
+                    debug!("Seed channel '{}' ready", seed_channel);
+                }
+                Err(e) => {
+                    warn!("Failed to create seed channel '{}': {}", seed_channel, e);
+                }
+            }
+        }
+        if !full_config.channels.seed.is_empty() {
+            info!(
+                "Created {} seed channels: {:?}",
+                full_config.channels.seed.len(),
+                full_config.channels.seed
+            );
+        }
+    }
+
     // Remove existing socket file if present
     if config.socket_path.exists() {
         std::fs::remove_file(&config.socket_path)?;


### PR DESCRIPTION
<!-- midtown: park -->

## Summary

Adds support for pre-populated seed channels in project configuration. Projects can now define a `[channels]` section with a `seed` field to specify channels that should be created at daemon startup.

**Why this is useful:**
- The clusterer currently creates channels on-the-fly when tasks are created
- It doesn't always make optimal grouping decisions (e.g., putting TUI tasks under `#web-interface`)
- Seed channels provide established architectural buckets for the clusterer to route tasks into
- Improves task organization consistency across the project

**Config example:**
```toml
[channels]
seed = ["tui", "web-interface", "daemon", "auth", "docs"]
```

When the daemon starts, these channels are created (if they don't exist). The clusterer sees them in its "Current Channel List" input and can route tasks to them.

**Implementation:**
- Added `ChannelsSection` struct with `seed: Vec<String>` field
- Updated `FullProjectConfig` to include `channels: ChannelsSection`
- Daemon creates seed channels after channel router initialization
- Updated clusterer system prompt to mention seed channels
- Added tests for config serialization/deserialization

## Test plan

- [x] Config tests pass (serialization, deserialization, roundtrip)
- [x] Daemon compiles and builds
- [x] All lib tests pass (except pre-existing sandbox test failure)
- [ ] Manual testing: add seed channels to config, verify they're created at startup
- [ ] Manual testing: verify clusterer routes tasks to seed channels

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)