### PR TITLE
chore: Bump version to 0.5.4 [Midtown !1251]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,7 +1594,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "midtown"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "axum",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midtown"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 description = "Midtown - a multi-Claude Code workspace manager, inspired by Gastown"
 license = "MIT"


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Bump version from 0.5.3 to 0.5.4 in Cargo.toml and Cargo.lock

## Release Notes

After merge, will tag and create GitHub release with:

### What is New

#### Auth and Multi-Provider
- Provider/profile switching in web UI (#1082)
- Show provider/account per coworker in status (#1079)
- Prompt for provider on auth switch/remove (#1075)
- Detect expired OAuth tokens and prompt re-auth (#1086)
- Multi-provider usage tracking in TUI (#1068)
- Fix auth_provider when relaunching coworkers during auth switch (#1076)

#### Channel System
- Seed channels in project config (#1095)
- Auto-archive channels when tasks complete (#1071, #1073)
- Toggle archived channels in TUI and web UI (#1074)
- Manual channel creation in TUI (#1091)
- TUI posts to selected channel (#1069)

#### Web UI
- Desktop UI improvements: load channels on page load, remove duplicate controls (#1094)
- Instant channel switching (#1097)
- Autocomplete alignment with TUI prefix matching (#1084)
- Clear widget for autocomplete background (#1080)
- Source task IDs in sidebar (#1087, #1090)

#### TUI
- Ctrl+K quick channel switcher (#1092)
- Improved focus indicators and simplified sidebar (#1088)
- Chat autocomplete and shift+enter support (#1077)

#### Daemon
- KANBAN_CACHE invalidation fix: include coworker state in cache key (#1096)
- Prevent duplicate work after daemon restarts (#1089)
- Correct exec-restart RPC response format (#1093, #1085)
- Fix worktree path detection from worktree directories (#1099)
- Clean up stale review branches (#1081)
- Prevent orphaned branches with clearer guidance (#1072)

## Test plan
- [x] Version bumped in Cargo.toml and Cargo.lock
- [ ] CI passes
- [ ] After merge: tag and publish release

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)