### PR TITLE
fix: Add warning logs for auth profile setup failures [Midtown !1257]

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -43,6 +43,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+use tracing::warn;
+
 use crate::paths::midtown_base_dir;
 
 /// Default profile name used when none is specified.
@@ -560,8 +562,13 @@ pub fn current_profile_dir_for(provider: AuthProvider) -> PathBuf {
     let profile_name = current_profile_for(provider);
 
     // For Claude, ensure the profile is set up before use
-    if provider == AuthProvider::Claude {
-        let _ = ensure_profile_dir_for(provider, &profile_name);
+    if provider == AuthProvider::Claude
+        && let Err(e) = ensure_profile_dir_for(provider, &profile_name)
+    {
+        warn!(
+            "Failed to set up {} profile '{}': {}. Profile directory may be misconfigured.",
+            provider, profile_name, e
+        );
     }
 
     profile_dir_for(provider, &profile_name)
@@ -612,8 +619,13 @@ pub fn active_profile_dir_for_project_with_provider(
     let profile_name = active_profile_for_project_with_provider(project, provider);
 
     // For Claude, ensure the profile is set up before use
-    if provider == AuthProvider::Claude {
-        let _ = ensure_profile_dir_for(provider, &profile_name);
+    if provider == AuthProvider::Claude
+        && let Err(e) = ensure_profile_dir_for(provider, &profile_name)
+    {
+        warn!(
+            "Failed to set up {} profile '{}' for project '{}': {}. Profile directory may be misconfigured.",
+            provider, profile_name, project, e
+        );
     }
 
     profile_dir_for(provider, &profile_name)


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Replace silent `let _ = ensure_profile_dir_for(...)` with `tracing::warn!` logging when profile directory setup fails
- Surfaces permission errors, disk-full conditions, and migration/symlink failures that would otherwise leave Claude Code with a misconfigured profile directory
- Two call sites updated: `current_profile_dir_for()` and `active_profile_dir_for_project_with_provider()`

**Depends on:** PR #1104 (must merge first). The silent `ensure_profile_dir_for` calls were introduced by that PR.

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] All auth tests pass (28/28)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)