### PR TITLE
feat: Restore task display below channels in TUI Board sidebar [Midtown !1261]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -150,6 +150,8 @@ pub struct KanbanPr {
     pub task_id: Option<u64>,
     /// Task name/subject looked up from task list
     pub task_name: Option<String>,
+    /// Whether the PR has merge conflicts
+    pub has_conflicts: bool,
 }
 
 /// A merged PR item for the Done column
@@ -1853,6 +1855,7 @@ fn fetch_prs() -> Vec<KanbanPr> {
                         repo: None,
                         task_id,
                         task_name,
+                        has_conflicts: false, // Local fetch doesn't check mergeable status
                     });
                 }
             }
@@ -2120,6 +2123,11 @@ fn fetch_kanban_data_via_rpc() -> Option<(
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
 
+            let has_conflicts = pr
+                .get("has_conflicts")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
             Some(KanbanPr {
                 number,
                 title,
@@ -2132,6 +2140,7 @@ fn fetch_kanban_data_via_rpc() -> Option<(
                 repo,
                 task_id,
                 task_name,
+                has_conflicts,
             })
         })
         .collect();

--- a/src/bin/midtown/cli/chat/ui/board.rs
+++ b/src/bin/midtown/cli/chat/ui/board.rs
@@ -168,16 +168,23 @@ fn render_task_item(
 
     // Determine bullet color based on task and PR status
     let (bullet_color, text_color) = match task_pr {
-        // PR exists - use CI status
-        Some(pr) => match pr.ci_status {
-            super::super::app::CiStatus::Passed => (Color::Green, Color::Green),
-            super::super::app::CiStatus::Failed => (Color::Red, Color::Red),
-            super::super::app::CiStatus::Running => (Color::Yellow, Color::Yellow),
-            super::super::app::CiStatus::Unknown => {
-                // PR exists but CI status unknown - treat as in-progress
-                (Color::Yellow, Color::Green)
+        // PR exists - check for conflicts or CI status
+        Some(pr) => {
+            if pr.has_conflicts {
+                // Merge conflict takes priority - show red
+                (Color::Red, Color::Red)
+            } else {
+                match pr.ci_status {
+                    super::super::app::CiStatus::Passed => (Color::Green, Color::Green),
+                    super::super::app::CiStatus::Failed => (Color::Red, Color::Red),
+                    super::super::app::CiStatus::Running => (Color::Yellow, Color::Yellow),
+                    super::super::app::CiStatus::Unknown => {
+                        // PR exists but CI status unknown - treat as in-progress
+                        (Color::Yellow, Color::Green)
+                    }
+                }
             }
-        },
+        }
         // No PR - use task status
         None => {
             if task.status == TaskStatus::InProgress {

--- a/src/daemon/rpc_kanban.rs
+++ b/src/daemon/rpc_kanban.rs
@@ -398,6 +398,7 @@ query($owner: String!, $repo: String!) {
         author { login }
         createdAt
         body
+        mergeable
         commits(last: 1) {
           nodes {
             commit {
@@ -531,6 +532,13 @@ fn fetch_kanban_all_prs(
 
                     let created_at = pr.get("createdAt").and_then(|v| v.as_str()).unwrap_or("");
 
+                    // Check for merge conflicts
+                    let has_conflicts = pr
+                        .get("mergeable")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s == "CONFLICTING")
+                        .unwrap_or(false);
+
                     // Extract CI status from the last commit's statusCheckRollup
                     let check_contexts: Vec<serde_json::Value> = pr
                         .pointer("/commits/nodes")
@@ -576,6 +584,7 @@ fn fetch_kanban_all_prs(
                         "reviewed_at": reviewer_assigned_at,
                         "review_posted": review_posted,
                         "repo": repo_label,
+                        "has_conflicts": has_conflicts,
                     }))
                 })
                 .collect()


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Restored task rendering loop that calls `render_task_item` for each task under each channel
- Added back `wrap_width` computation for text wrapping
- Restored blank line separators between channels and after channel headers
- Removed `#[allow(dead_code)]` annotations from `render_task_item`, `compute_task_indentation`, and `compute_indentation_recursive`
- Preserved yellow border focus indicator from PR #1088
- Changed task bullets to colored unicode circles (● ●) based on PR/CI state:
  - Gray ● — pending (no PR exists yet)
  - Yellow ● — in progress (task active or PR with unknown CI)
  - Green ● — PR with passing CI checks
  - Red ● — PR with failed CI checks OR merge conflicts

## Test plan
- [x] Code compiles successfully
- [x] Clippy passes with no warnings
- [x] Test suite passes (1270/1271 tests pass - 1 failure is pre-existing sandbox environment issue unrelated to changes)

This reverts the task display removal from PR #1088 while keeping the improved focus indicators, and adds colored status indicators for tasks.

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)