### PR TITLE
refactor: Extract shared worktree creation helper [Midtown !1270]

### DIFF
--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -717,18 +717,7 @@ pub fn handle_start(
         // Create lead worktree (or reuse existing one) so the lead session
         // starts in the worktree instead of the main repo.
         emit_startup_progress(90, "creating lead worktree");
-        let worktree_manager = midtown::worktree::WorktreeManager::new(primary_repo.clone())
-            .map_err(|e| format!("Failed to initialize worktree manager: {}", e))?;
-        let lead_workdir = worktree_manager
-            .create_lead_worktree()
-            .map_err(|e| {
-                eprintln!(
-                    "Warning: Failed to create lead worktree, falling back to main repo: {}",
-                    e
-                );
-                e
-            })
-            .unwrap_or_else(|_| primary_repo.clone());
+        let lead_workdir = create_or_reuse_lead_worktree(&primary_repo)?;
 
         // Use spawn_lead() to create the Lead window with proper config,
         // auth profile, settings, and system prompt.
@@ -1539,18 +1528,7 @@ fn ensure_lead_has_settings(session: &str, repo: &Path) -> Result<(), String> {
 
     // Create lead worktree (or reuse existing one) so the lead session
     // starts in the worktree instead of the main repo.
-    let worktree_manager = midtown::worktree::WorktreeManager::new(repo.to_path_buf())
-        .map_err(|e| format!("Failed to initialize worktree manager: {}", e))?;
-    let lead_workdir = worktree_manager
-        .create_lead_worktree()
-        .map_err(|e| {
-            eprintln!(
-                "Warning: Failed to create lead worktree, falling back to main repo: {}",
-                e
-            );
-            e
-        })
-        .unwrap_or_else(|_| repo.to_path_buf());
+    let lead_workdir = create_or_reuse_lead_worktree(repo)?;
 
     // spawn_lead kills existing lead windows and creates a fresh one
     midtown::tmux::spawn_lead(session, &lead_workdir.to_string_lossy(), &repo_name, &[])


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Extracted `create_or_reuse_lead_worktree()` helper function
- Eliminated ~15 lines of duplicate code from `handle_start()` and `ensure_lead_has_settings()`
- Added unit tests for success and fallback scenarios

## Problem
Per Vernon's review of PR #1106, worktree creation logic was duplicated in two locations:
1. `handle_start()` - when starting midtown
2. `ensure_lead_has_settings()` - when re-initializing lead

Both contained nearly identical code (~15 lines each) for creating a WorktreeManager, calling create_lead_worktree(), handling errors, and falling back to the main repo path.

## Solution
Created `create_or_reuse_lead_worktree(&Path)` helper that encapsulates this pattern:
- Takes a repo path
- Creates WorktreeManager  
- Calls create_lead_worktree()
- Handles errors with warning messages
- Falls back to original repo path on error
- Returns Result<PathBuf, String>

Both callsites now use the single-line helper instead of duplicating the logic.

## Test plan
- [x] Added unit test for successful worktree creation
- [x] Added unit test for fallback behavior on error
- [x] All tests pass (1284 passed, 1 unrelated sandbox failure)
- [x] No clippy warnings
- [x] Code formatted with rustfmt

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)