### PR TITLE
TUI: Increase coworker refresh to 5s and hide idle coworkers [Midtown !1272]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -340,8 +340,8 @@ pub struct ChannelSwitcherItem {
     pub unread_count: usize,
 }
 
-/// Interval between kanban data refreshes (30 seconds)
-const KANBAN_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+/// Interval between kanban data refreshes (5 seconds)
+const KANBAN_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Interval between repo status refreshes (60 seconds)
 const REPO_STATUS_REFRESH_INTERVAL: Duration = Duration::from_secs(60);

--- a/src/bin/midtown/cli/chat/ui/board.rs
+++ b/src/bin/midtown/cli/chat/ui/board.rs
@@ -222,7 +222,17 @@ fn draw_coworker_status(f: &mut Frame, app: &App, area: Rect) {
         ])
         .split(area);
 
-    let active_count = app.coworkers.len();
+    // Filter out idle coworkers - only show those actively working
+    let active_coworkers: Vec<_> = app
+        .coworkers
+        .iter()
+        .filter(|cw| {
+            // Show coworker if they have a phase and it's not "idle"
+            cw.phase.as_deref() != Some("idle") && cw.phase.is_some()
+        })
+        .collect();
+
+    let active_count = active_coworkers.len();
     let header = format!("  Coworkers ({}/{})", active_count, app.max_coworkers);
     let header_paragraph = Paragraph::new(Line::from(vec![Span::styled(
         header,
@@ -232,8 +242,7 @@ fn draw_coworker_status(f: &mut Frame, app: &App, area: Rect) {
     )]));
     f.render_widget(header_paragraph, chunks[0]);
 
-    let rows: Vec<Row> = app
-        .coworkers
+    let rows: Vec<Row> = active_coworkers
         .iter()
         .map(|cw| {
             let health_dot = "●";


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Reduced `KANBAN_REFRESH_INTERVAL` from 30s to 5s for more responsive status updates
- Filter idle coworkers from the status table to reduce visual clutter

## Details

**Refresh rate increase (30s → 5s):**
- The RPC call to fetch kanban data is cheap (reads in-memory daemon state)
- More frequent updates improve UX without performance impact

**Hide idle coworkers:**
- Only coworkers actively working on tasks are shown
- Filters out coworkers with `phase == "idle"` or no phase
- Keeps the coworker count in the header accurate (shows active/max)

## Test plan
- [x] Code compiles
- [x] Clippy passes with `-D warnings`
- [ ] Manual testing: Verify TUI updates more quickly
- [ ] Manual testing: Verify idle coworkers are hidden from status table

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)