### PR TITLE
fix: Set CARGO_HOME to sandbox-writable path [Midtown !1273]

### DIFF
--- a/src/launch.rs
+++ b/src/launch.rs
@@ -256,6 +256,13 @@ impl LaunchConfig {
         let mut env = std::collections::HashMap::new();
         env.insert("MIDTOWN_AGENT".to_string(), self.name.clone());
 
+        // Set CARGO_HOME to a sandbox-writable path to avoid permission errors.
+        // Cargo's default ~/.cargo/registry/src/ isn't writable in the sandbox,
+        // but ~/.midtown/ is (see sandbox.rs writable_dirs).
+        let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/root"));
+        let cargo_home = home.join(".midtown/cargo");
+        env.insert("CARGO_HOME".to_string(), cargo_home.to_string_lossy().to_string());
+
         // Set auth-provider-specific env vars
         let config_dir = self
             .auth_profile_dir
@@ -334,9 +341,16 @@ impl LaunchConfig {
         primary_repo: &std::path::Path,
     ) -> LaunchCommand {
         // -- Environment variables --
+        // Set CARGO_HOME to a sandbox-writable path to avoid permission errors.
+        // Cargo's default ~/.cargo/registry/src/ isn't writable in the sandbox,
+        // but ~/.midtown/ is (see sandbox.rs writable_dirs).
+        let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/root"));
+        let cargo_home = home.join(".midtown/cargo");
+
         let mut env_parts = vec![
             format!("MIDTOWN_AGENT='{}'", self.name),
             "DISABLE_AUTOUPDATER=1".to_string(),
+            format!("CARGO_HOME='{}'", cargo_home.display()),
         ];
 
         // Set auth-provider-specific env vars
@@ -527,6 +541,10 @@ fn parse_task_model(full_model: &str) -> Option<(crate::auth::AuthProvider, &str
     let provider = provider_str.parse::<crate::auth::AuthProvider>().ok()?;
     Some((provider, model_alias))
 }
+
+#[path = "launch_tests.rs"]
+#[cfg(test)]
+mod launch_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/launch_tests.rs
+++ b/src/launch_tests.rs
@@ -1,0 +1,40 @@
+//! Tests for LaunchConfig
+
+use super::*;
+
+#[test]
+fn test_to_headless_config_sets_cargo_home() {
+    let config = LaunchConfig::coworker("park", "myrepo", SessionMode::Fresh, None);
+    let headless = config.to_headless_config();
+
+    // CARGO_HOME should be set to ~/.midtown/cargo to avoid sandbox violations
+    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/root"));
+    let expected_cargo_home = home.join(".midtown/cargo").to_string_lossy().to_string();
+
+    assert_eq!(
+        headless.env.get("CARGO_HOME"),
+        Some(&expected_cargo_home),
+        "CARGO_HOME should be set to ~/.midtown/cargo for sandboxed coworkers"
+    );
+}
+
+#[test]
+fn test_shell_command_sets_cargo_home() {
+    let config = LaunchConfig::coworker("park", "myrepo", SessionMode::Fresh, None);
+    let result = config.to_shell_command(
+        std::path::Path::new("/tmp/settings.json"),
+        std::path::Path::new("/tmp/prompt.md"),
+        None,
+        std::path::Path::new("/tmp/test-repo"),
+    );
+
+    // CARGO_HOME should be set in the environment
+    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/root"));
+    let expected_cargo_home = home.join(".midtown/cargo").to_string_lossy().to_string();
+
+    assert!(
+        result.shell_command.contains(&format!("CARGO_HOME='{}'", expected_cargo_home)),
+        "CARGO_HOME should be set in shell command environment: {}",
+        result.shell_command
+    );
+}


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Set `CARGO_HOME=~/.midtown/cargo` for all coworker sessions to avoid sandbox permission errors
- Applied to both headless and tmux launch paths
- Added test coverage for both code paths

## Background
Coworkers running in the macOS sandbox can't write to `~/.cargo/registry/src/` because `~/.cargo` isn't in the sandbox's writable directories list. This causes permission errors when building Rust dependencies.

The fix redirects Cargo's cache to `~/.midtown/cargo`, which is already writable (see `sandbox.rs:68`). All coworkers share this cache, which is efficient and safe.

## Test plan
- [x] Unit tests pass (`cargo test launch_tests`)
- [x] Full test suite passes (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Formatting correct (`cargo fmt -- --check`)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)