### PR TITLE
fix: Route review feedback to task owner instead of PR owner [Midtown !1271]

### DIFF
--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -2644,10 +2644,44 @@ pub(super) async fn handle_pr_comment_nudge(
         None => get_pr_owner_coworker_async(pr_number).await,
     };
 
-    let Some(owner) = owner else {
+    let Some(mut owner) = owner else {
         debug!("PR #{} has no coworker owner, skipping nudge", pr_number);
         return;
     };
+
+    // Check if this PR is linked to a task with an active owner.
+    // If so, route the review feedback to the task owner instead of the PR owner.
+    // This handles cases where a task was reassigned (e.g., via orphan recovery)
+    // and the PR metadata still shows the original author.
+    if let Some(task_id) = {
+        let ps = state.persistent_state.lock().await;
+        ps.github
+            .pr_author_sessions
+            .get(&pr_number)
+            .and_then(|session| session.task_id.as_ref())
+            .cloned()
+    } {
+        // Check if the task has an active owner in_progress
+        if let Some(task) = crate::tasks::read_task(&task_id)
+            && task.status == crate::tasks::TaskStatus::InProgress
+            && let Some(task_owner) = task.owner
+        {
+            // Check if the task owner is active
+            let task_owner_active = state
+                .coworkers
+                .list()
+                .iter()
+                .any(|c| c.name.eq_ignore_ascii_case(&task_owner));
+
+            if task_owner_active {
+                debug!(
+                    "PR #{} linked to task !{} with active owner {} — routing review feedback to task owner instead of PR owner {}",
+                    pr_number, task_id, task_owner, owner
+                );
+                owner = task_owner;
+            }
+        }
+    }
 
     // Author posted a comment on their own PR — notify the reviewer
     // (e.g., author is asking a follow-up question about review feedback)
@@ -3337,3 +3371,7 @@ pub(super) fn collect_merged_pr_cleanup_effects(snap: &WorldSnapshot) -> Vec<Eff
 #[path = "pr_tests.rs"]
 #[cfg(test)]
 mod tests;
+
+#[path = "pr_review_feedback_tests.rs"]
+#[cfg(test)]
+mod review_feedback_tests;

--- a/src/daemon/pr_review_feedback_tests.rs
+++ b/src/daemon/pr_review_feedback_tests.rs
@@ -1,0 +1,115 @@
+// Unit tests for review feedback handling logic (task 1271)
+//
+// Bug: When review feedback arrives on a PR that's linked to a task,
+// the daemon should check if that task has an active owner and nudge them,
+// rather than spawning based on the PR's git metadata owner.
+//
+// NOTE: This bug requires integration-level testing because it involves
+// checking task state from the filesystem. The actual fix is in
+// `handle_pr_comment_nudge` which needs to resolve the task owner
+// before calling the decision function.
+//
+// These tests document the expected behavior at the decision function level,
+// assuming the correct owner is passed in.
+
+#[cfg(test)]
+mod tests {
+    use crate::rules::{PrAction, decide_pr_comment_action_with_handoff};
+
+    /// Test that when the correct task owner is passed to the decision function,
+    /// it correctly nudges them when they're active and idle.
+    ///
+    /// This documents the expected behavior: when the upstream caller
+    /// (handle_pr_comment_nudge) correctly resolves the task owner,
+    /// the decision function should nudge them.
+    #[test]
+    fn test_decision_function_nudges_active_idle_owner() {
+        let task_owner = "york"; // Task !1260 owner (correctly resolved by caller)
+        let reviewer = "park";
+        let active_coworkers = vec!["york".to_string()];
+        let idle_coworkers = vec!["york".to_string()];
+        let at_dev_limit = false;
+        let session_context = None;
+        let message = "Review feedback";
+
+        let action = decide_pr_comment_action_with_handoff(
+            task_owner,
+            reviewer,
+            &active_coworkers,
+            &idle_coworkers,
+            at_dev_limit,
+            session_context,
+            message,
+        );
+
+        // Should nudge york (the task owner who is active and idle)
+        match action {
+            PrAction::NudgeOwner { owner, .. } => {
+                assert_eq!(owner, "york");
+            }
+            _ => panic!("Expected NudgeOwner, got {:?}", action),
+        }
+    }
+
+    /// Test that when the task owner is active but busy, the decision
+    /// function still nudges them (spawning an active coworker fails).
+    #[test]
+    fn test_decision_function_nudges_active_busy_owner() {
+        let task_owner = "york";
+        let reviewer = "park";
+        let active_coworkers = vec!["york".to_string()];
+        let idle_coworkers = vec![]; // york is busy
+        let at_dev_limit = false;
+        let session_context = None;
+        let message = "Review feedback";
+
+        let action = decide_pr_comment_action_with_handoff(
+            task_owner,
+            reviewer,
+            &active_coworkers,
+            &idle_coworkers,
+            at_dev_limit,
+            session_context,
+            message,
+        );
+
+        // Should still nudge york even though busy
+        match action {
+            PrAction::NudgeOwner { owner, .. } => {
+                assert_eq!(owner, "york");
+            }
+            _ => panic!("Expected NudgeOwner for busy owner, got {:?}", action),
+        }
+    }
+
+    /// Test that when the task owner is inactive, the decision function
+    /// spawns them (assuming dev limit allows).
+    #[test]
+    fn test_decision_function_spawns_inactive_owner() {
+        let task_owner = "york";
+        let reviewer = "park";
+        let active_coworkers = vec![]; // york is not active
+        let idle_coworkers = vec![];
+        let at_dev_limit = false;
+        let session_context = None;
+        let message = "Review feedback";
+
+        let action = decide_pr_comment_action_with_handoff(
+            task_owner,
+            reviewer,
+            &active_coworkers,
+            &idle_coworkers,
+            at_dev_limit,
+            session_context,
+            message,
+        );
+
+        // Should spawn york since they're inactive
+        match action {
+            PrAction::SpawnOwner { owner, .. } => {
+                assert_eq!(owner, "york");
+            }
+            _ => panic!("Expected SpawnOwner for inactive owner, got {:?}", action),
+        }
+    }
+}


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Fixed bug where review feedback on PRs linked to reassigned tasks was routed to the wrong coworker
- Added task owner resolution logic in `handle_pr_comment_nudge` to check if the PR is linked to an in_progress task with an active owner
- When found, routes feedback to the task owner instead of the PR's git metadata owner

## Bug Scenario
PR #1106 was authored by "madison" (in git metadata), but task !1260 (linked to that PR) was reassigned to "york" who was actively working on it. When review feedback arrived on PR #1106, the daemon spawned "riverside" to address it, even though "york" was the active task owner and should have been nudged instead.

## Fix
Added logic in `handle_pr_comment_nudge` to:
1. Check if the PR is linked to a task via `pr_author_sessions`
2. If yes, check if that task is `in_progress` with an active owner
3. If so, route feedback to the task owner instead of PR owner

This handles cases where tasks are reassigned (e.g., via orphan recovery) but the PR metadata still shows the original author.

## Test Plan
- [x] Added unit tests documenting expected behavior at the decision function level
- [x] All existing PR-related tests pass
- [x] All rules tests pass
- [x] Full library test suite passes (except pre-existing flaky sandbox test)

Fixes #1271

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)