### PR TITLE
docs: Update Lead Maintenance to use cargo install [Midtown !1275]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,13 +184,13 @@ Each concern has a primary owner. The non-owner path only acts as reconciliation
 If you are the Lead, whenever a PR is merged into main, pull, rebuild, and restart so the running daemon and coworkers pick up the changes:
 
 ```bash
-git pull && cargo build --release && midtown restart
+git pull && cargo install --path . && midtown restart
 ```
 
 Post to the channel when done so the team knows the new code is live:
 
 ```bash
-midtown channel post "Pulled main, rebuilt release, and restarted midtown."
+midtown channel post "Pulled main, installed updated binary, and restarted midtown."
 ```
 
 ## Debugging & Test Fixtures


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Updated Lead Maintenance section to use `cargo install --path .` instead of `cargo build --release`
- Updated the channel post message to reflect the new command

## Context
The `cargo install --path .` command handles binary installation directly without requiring manual symlink setup. This is already the documented standard in the Build & Development Commands section, so this change makes the Lead Maintenance section consistent with that.

## Test plan
- [x] Verified Build & Development Commands section already documents `cargo install --path .`
- [x] Confirmed the change is consistent with existing documentation

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)