### PR TITLE
fix: Filter invalid channel names in Channel::list() and web UI [Midtown !1285]

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -95,17 +95,25 @@ impl Channel {
     ///
     /// For backward compatibility, if `channel.jsonl` exists, it's treated as the
     /// "midtown" channel. New channels always use the `channels/` directory.
+    /// Validates a channel name.
+    ///
+    /// Channel names must be non-empty and contain only alphanumeric characters,
+    /// hyphens, and underscores. This prevents path traversal attacks and ensures
+    /// filesystem compatibility.
+    fn is_valid_channel_name(name: &str) -> bool {
+        !name.is_empty()
+            && name
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    }
+
     pub fn new(base_dir: impl Into<PathBuf>, channel_name: impl Into<String>) -> Result<Self> {
         let base_dir = base_dir.into();
         let channel_name = channel_name.into();
 
         // Validate channel name: must be non-empty and contain only
         // alphanumeric characters, hyphens, and underscores.
-        if channel_name.is_empty()
-            || !channel_name
-                .chars()
-                .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
-        {
+        if !Self::is_valid_channel_name(&channel_name) {
             return Err(crate::Error::InvalidMessage(format!(
                 "Invalid channel name '{}': must be non-empty and contain only alphanumeric characters, hyphens, and underscores",
                 channel_name
@@ -231,6 +239,12 @@ impl Channel {
                     } else {
                         stem
                     };
+
+                    // Validate channel name - skip files with invalid names
+                    // (could be created by filesystem bugs, manual edits, etc.)
+                    if !Self::is_valid_channel_name(channel_name) {
+                        continue;
+                    }
 
                     // Don't duplicate "midtown" if we already found channel.jsonl
                     let channel_info = ChannelInfo {
@@ -1790,6 +1804,48 @@ mod tests {
             archived_path.exists(),
             "Archived file should exist at {:?}",
             archived_path
+        );
+    }
+
+    #[test]
+    fn test_list_skips_invalid_channel_names() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create valid channels
+        Channel::new(temp_dir.path(), "valid-channel").unwrap();
+        Channel::new(temp_dir.path(), "feature_123").unwrap();
+
+        // Manually create files with invalid names in channels/ directory
+        // (these could be created by filesystem bugs, manual edits, etc.)
+        let channels_dir = temp_dir.path().join("channels");
+        fs::create_dir_all(&channels_dir).unwrap();
+        File::create(channels_dir.join("test extra text.jsonl")).unwrap(); // spaces
+        File::create(channels_dir.join("has\nnewline.jsonl")).unwrap(); // newline (if filesystem allows)
+        File::create(channels_dir.join(".hidden.jsonl")).unwrap(); // leading dot
+
+        // List should only return valid channel names
+        let channels = Channel::list(temp_dir.path(), false).unwrap();
+        let channel_names: Vec<&str> = channels.iter().map(|c| c.name.as_str()).collect();
+
+        assert!(
+            channel_names.contains(&"valid-channel"),
+            "valid-channel should be in the list"
+        );
+        assert!(
+            channel_names.contains(&"feature_123"),
+            "feature_123 should be in the list"
+        );
+        assert!(
+            !channel_names.contains(&"test extra text"),
+            "Channel with spaces should be filtered out"
+        );
+        assert!(
+            !channel_names.contains(&"has\nnewline"),
+            "Channel with newline should be filtered out"
+        );
+        assert!(
+            !channel_names.contains(&".hidden"),
+            "Channel with leading dot should be filtered out"
         );
     }
 

--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -178,40 +178,19 @@ export async function fetchHistory(channelName = null) {
         messages.set(data)
 
         const byChannel = {}
-        const channelSet = new Set()
         for (const msg of data) {
           const name = msg.channel || 'midtown'
           if (!byChannel[name]) {
             byChannel[name] = []
           }
           byChannel[name].push(msg)
-          channelSet.add(name)
         }
 
         messagesByChannel.set(byChannel)
 
-        // Merge message-derived channels with existing channel list (preserves
-        // channels loaded from GET /api/channels that may have no messages yet).
-        channels.update((existingChannels) => {
-          const existingNames = new Set(existingChannels.map((ch) => ch.name))
-          const newChannels = Array.from(channelSet)
-            .filter((name) => !existingNames.has(name))
-            .map((name) => ({
-              name,
-              unread: 0,
-              has_pr: false,
-              ci_status: null,
-            }))
-
-          const merged = [...existingChannels, ...newChannels]
-          // Ensure midtown is first
-          merged.sort((a, b) => {
-            if (a.name === 'midtown') return -1
-            if (b.name === 'midtown') return 1
-            return a.name.localeCompare(b.name)
-          })
-          return merged
-        })
+        // Channels are already populated by fetchChannels() which calls the
+        // backend's Channel::list(). We no longer derive channels from message
+        // content to avoid showing ghost channels for invalid/deleted .jsonl files.
       }
     }
   } catch (err) {
@@ -410,28 +389,19 @@ function handleUpdate(update) {
       // Update channel list - increment unread if not viewing this channel
       const currentActiveChannel = get(activeChannel)
 
+      // Only update unread counts for channels that already exist in the list.
+      // We no longer auto-add channels from message content to prevent ghost
+      // channels. New channels will appear after the next fetchChannels() call
+      // (triggered by status polling or manual refresh).
       channels.update((channelList) => {
         const existingChannel = channelList.find((ch) => ch.name === channelName)
-        if (existingChannel) {
+        if (existingChannel && channelName !== currentActiveChannel) {
           // Channel exists - increment unread if it's not the active channel
-          if (channelName !== currentActiveChannel) {
-            return channelList.map((ch) =>
-              ch.name === channelName ? { ...ch, unread: ch.unread + 1 } : ch
-            )
-          }
-          return channelList
-        } else {
-          // New channel - add it with unread count if not active
-          return [
-            ...channelList,
-            {
-              name: channelName,
-              unread: channelName === currentActiveChannel ? 0 : 1,
-              has_pr: false,
-              ci_status: null,
-            },
-          ]
+          return channelList.map((ch) =>
+            ch.name === channelName ? { ...ch, unread: ch.unread + 1 } : ch
+          )
         }
+        return channelList
       })
 
       // Dismiss typing indicator when lead posts a message


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Fixed ghost channels appearing in web UI but not in TUI
- Added validation to Channel::list() to skip invalid filenames (spaces, newlines, etc.)
- Removed message-derived channel discovery in web UI
- Added test coverage for invalid channel name filtering

## Root Causes
1. **Channel::list() didn't validate filenames** - Files like `test extra text.jsonl` (with spaces) were returned as valid channels
2. **Web UI derived channels from messages** - `fetchHistory()` scanned message metadata and added any channel name found, even if no `.jsonl` file existed

## Changes
**Backend (src/channel.rs):**
- Extracted `Channel::is_valid_channel_name()` helper for consistent validation
- Updated `Channel::list()` to filter out files with invalid channel names
- Added test: `test_list_skips_invalid_channel_names`

**Frontend (web-app/src/lib/api.js):**
- Removed channel discovery from `fetchHistory()` - channels now only come from backend's `Channel::list()`
- WebSocket handler only updates unread counts for existing channels, doesn't auto-add new ones

**Cleanup:**
- Removed invalid channel file on disk (`test extra text.jsonl`)

## Test Plan
- [x] New test `test_list_skips_invalid_channel_names` passes
- [x] All 41 channel tests pass
- [x] Clippy passes with no warnings
- [x] Pre-commit hooks (fmt + clippy) pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)