### PR TITLE
Add worktree collision guard at spawn time [Midtown !1291]

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -1233,7 +1233,51 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 coworker,
             } => {
                 let mut ps = state.persistent_state.lock().await;
-                if let Err(e) = ps.worktree_registry.bind_coworker(&worktree_id, &coworker) {
+
+                // Collision guard: check if worktree is bound to a different ACTIVE coworker
+                let needs_force_rebind = if let Some(assignment) =
+                    ps.worktree_registry.get(&worktree_id)
+                {
+                    if let Some(ref current_coworker) = assignment.current_coworker {
+                        if current_coworker != &coworker {
+                            // Worktree is bound to a different coworker - check if they're active
+                            if state.session_manager.is_alive(current_coworker).await {
+                                warn!(
+                                    "WORKTREE COLLISION BLOCKED: Refusing to bind {} to worktree {} - already bound to ACTIVE coworker {}",
+                                    coworker, worktree_id, current_coworker
+                                );
+                                // Do NOT bind - this would crash both Claude Code sessions
+                                return;
+                            } else {
+                                debug!(
+                                    "Worktree {} was bound to {} but they're not active - allowing rebind to {}",
+                                    worktree_id, current_coworker, coworker
+                                );
+                                // Old coworker is dead - need force rebind
+                                true
+                            }
+                        } else {
+                            // Same coworker - idempotent, use normal bind
+                            false
+                        }
+                    } else {
+                        // No current coworker - use normal bind
+                        false
+                    }
+                } else {
+                    // Worktree doesn't exist in registry - will fail with normal bind
+                    false
+                };
+
+                // Perform the bind operation
+                let bind_result = if needs_force_rebind {
+                    ps.worktree_registry
+                        .force_rebind_coworker(&worktree_id, &coworker)
+                } else {
+                    ps.worktree_registry.bind_coworker(&worktree_id, &coworker)
+                };
+
+                if let Err(e) = bind_result {
                     warn!(
                         "Failed to bind {} to worktree {}: {}",
                         coworker, worktree_id, e

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,9 @@ pub mod github_rate_limit;
 
 // Task-based worktree registry
 pub mod worktree_registry;
+#[path = "worktree_registry_tests.rs"]
+#[cfg(test)]
+mod worktree_registry_tests;
 
 // CI check duration statistics (for auto-retry of stale checks)
 pub mod ci_stats;

--- a/src/worktree_registry.rs
+++ b/src/worktree_registry.rs
@@ -96,9 +96,45 @@ impl WorktreeRegistry {
 
     /// Bind a coworker to an existing worktree.
     ///
-    /// Enforces single-coworker-per-worktree: the old binding (if any) is
-    /// removed before the new one is set.
+    /// Enforces single-coworker-per-worktree: fails if the worktree is already
+    /// bound to a different coworker. Idempotent for the same coworker.
+    ///
+    /// This is the collision-guarded version. Use this for spawning new coworkers
+    /// to prevent double-assignment races.
     pub fn bind_coworker(&mut self, worktree_id: &str, coworker: &str) -> Result<(), String> {
+        let assignment = self
+            .assignments
+            .get_mut(worktree_id)
+            .ok_or_else(|| format!("Worktree {} not found in registry", worktree_id))?;
+
+        // Check for collision: if already bound to a different coworker, fail
+        if let Some(ref current) = assignment.current_coworker {
+            if current.to_lowercase() != coworker.to_lowercase() {
+                return Err(format!(
+                    "Worktree {} is already bound to coworker {}",
+                    worktree_id, current
+                ));
+            }
+            // Same coworker — idempotent, nothing to do
+            return Ok(());
+        }
+
+        assignment.current_coworker = Some(coworker.to_string());
+        self.coworker_index
+            .insert(coworker.to_lowercase(), worktree_id.to_string());
+        Ok(())
+    }
+
+    /// Forcibly rebind a coworker to a worktree, removing the old binding.
+    ///
+    /// Use this only when you've explicitly verified the old coworker is no longer
+    /// active. For spawn-time binding, use `bind_coworker()` which enforces
+    /// collision detection.
+    pub fn force_rebind_coworker(
+        &mut self,
+        worktree_id: &str,
+        coworker: &str,
+    ) -> Result<(), String> {
         let assignment = self
             .assignments
             .get_mut(worktree_id)
@@ -432,7 +468,7 @@ mod tests {
     }
 
     #[test]
-    fn test_registry_bind_replaces_old_coworker() {
+    fn test_registry_bind_prevents_collision() {
         let mut registry = WorktreeRegistry::new();
 
         let assignment = WorktreeAssignment {
@@ -447,8 +483,33 @@ mod tests {
 
         registry.assign_worktree(assignment).unwrap();
 
-        // Bind a different coworker — should replace
-        registry.bind_coworker("task-42-add-auth", "park").unwrap();
+        // Bind a different coworker — should fail (collision guard)
+        assert!(registry.bind_coworker("task-42-add-auth", "park").is_err());
+        // Original binding still intact
+        assert!(registry.get_by_coworker("lexington").is_some());
+        assert!(registry.get_by_coworker("park").is_none());
+    }
+
+    #[test]
+    fn test_registry_force_rebind_replaces_old_coworker() {
+        let mut registry = WorktreeRegistry::new();
+
+        let assignment = WorktreeAssignment {
+            worktree_id: "task-42-add-auth".to_string(),
+            branch_name: "task-42-add-auth".to_string(),
+            task_id: Some("42".to_string()),
+            current_coworker: Some("lexington".to_string()),
+            pr_number: None,
+            created_at: Utc::now(),
+            completed_at: None,
+        };
+
+        registry.assign_worktree(assignment).unwrap();
+
+        // Force rebind to a different coworker — should replace
+        registry
+            .force_rebind_coworker("task-42-add-auth", "park")
+            .unwrap();
         assert!(registry.get_by_coworker("lexington").is_none());
         assert!(registry.get_by_coworker("park").is_some());
     }

--- a/src/worktree_registry_tests.rs
+++ b/src/worktree_registry_tests.rs
@@ -1,0 +1,116 @@
+use chrono::Utc;
+
+use crate::worktree_registry::{WorktreeAssignment, WorktreeRegistry};
+
+/// Test that bind_coworker prevents binding a coworker to a worktree that's
+/// already bound to another coworker (collision guard).
+///
+/// This test simulates the scenario where:
+/// 1. Coworker A is bound to a worktree
+/// 2. An attempt is made to bind Coworker B to the same worktree
+/// 3. The bind should fail with an error indicating the collision
+#[test]
+fn test_bind_coworker_prevents_collision() {
+    let mut registry = WorktreeRegistry::new();
+
+    let assignment = WorktreeAssignment {
+        worktree_id: "task-42-add-auth".to_string(),
+        branch_name: "task-42-add-auth".to_string(),
+        task_id: Some("42".to_string()),
+        current_coworker: None,
+        pr_number: None,
+        created_at: Utc::now(),
+        completed_at: None,
+    };
+
+    registry.assign_worktree(assignment).unwrap();
+
+    // Bind first coworker
+    registry
+        .bind_coworker("task-42-add-auth", "lexington")
+        .unwrap();
+
+    // Attempt to bind second coworker to the same worktree should fail
+    let result = registry.bind_coworker("task-42-add-auth", "park");
+    assert!(
+        result.is_err(),
+        "Expected bind_coworker to fail when worktree is already bound"
+    );
+
+    // The error message should indicate the collision
+    let err_msg = result.unwrap_err();
+    assert!(
+        err_msg.contains("lexington"),
+        "Error message should mention the existing coworker: {}",
+        err_msg
+    );
+    assert!(
+        err_msg.contains("task-42-add-auth"),
+        "Error message should mention the worktree: {}",
+        err_msg
+    );
+}
+
+/// Test that bind_coworker allows rebinding when the worktree is unbound.
+#[test]
+fn test_bind_coworker_allows_rebind_after_unbind() {
+    let mut registry = WorktreeRegistry::new();
+
+    let assignment = WorktreeAssignment {
+        worktree_id: "task-42-add-auth".to_string(),
+        branch_name: "task-42-add-auth".to_string(),
+        task_id: Some("42".to_string()),
+        current_coworker: None,
+        pr_number: None,
+        created_at: Utc::now(),
+        completed_at: None,
+    };
+
+    registry.assign_worktree(assignment).unwrap();
+
+    // Bind first coworker
+    registry
+        .bind_coworker("task-42-add-auth", "lexington")
+        .unwrap();
+
+    // Unbind
+    registry.unbind_coworker("lexington");
+
+    // Binding a different coworker should now succeed
+    let result = registry.bind_coworker("task-42-add-auth", "park");
+    assert!(
+        result.is_ok(),
+        "Expected bind_coworker to succeed after unbind"
+    );
+}
+
+/// Test that bind_coworker allows the same coworker to rebind to the same worktree
+/// (idempotent operation).
+#[test]
+fn test_bind_coworker_is_idempotent() {
+    let mut registry = WorktreeRegistry::new();
+
+    let assignment = WorktreeAssignment {
+        worktree_id: "task-42-add-auth".to_string(),
+        branch_name: "task-42-add-auth".to_string(),
+        task_id: Some("42".to_string()),
+        current_coworker: None,
+        pr_number: None,
+        created_at: Utc::now(),
+        completed_at: None,
+    };
+
+    registry.assign_worktree(assignment).unwrap();
+
+    // Bind coworker
+    registry
+        .bind_coworker("task-42-add-auth", "lexington")
+        .unwrap();
+
+    // Binding the same coworker again should succeed (idempotent)
+    let result = registry.bind_coworker("task-42-add-auth", "lexington");
+    assert!(
+        result.is_ok(),
+        "Expected bind_coworker to be idempotent for the same coworker"
+    );
+}


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
Prevents the double-assignment race that allowed two Claude Code sessions to occupy the same worktree directory, causing cargo lock file conflicts and immediate crashes.

This adds a defensive guard below the dispatch layer: when binding a coworker to a worktree, we check if another ACTIVE coworker is already bound. If so, we refuse to bind and log a warning instead of silently rebinding.

## Changes

### 1. `worktree_registry.rs`
- **Modified `bind_coworker()`** to enforce collision detection
  - Fails if worktree is already bound to a different coworker
  - Idempotent for the same coworker
- **Added `force_rebind_coworker()`** for explicit rebinding when the old coworker is verified to be inactive
- Updated existing test `test_registry_bind_replaces_old_coworker` → `test_registry_bind_prevents_collision`

### 2. `daemon/effects.rs`
Enhanced `Effect::BindCoworkerToWorktree` handler to check if the currently-bound coworker is ACTIVE:
- **If active**: refuse to bind (log warning and return)
- **If inactive**: use `force_rebind_coworker()` to reclaim the worktree
- **If unbound**: use normal `bind_coworker()`

### 3. New tests (`worktree_registry_tests.rs`)
- `test_bind_coworker_prevents_collision` - verifies collision detection
- `test_bind_coworker_allows_rebind_after_unbind` - verifies rebinding after unbind
- `test_bind_coworker_is_idempotent` - verifies same-coworker binding is idempotent
- `test_registry_force_rebind_replaces_old_coworker` - verifies force rebind behavior

## Test plan
- [x] All existing tests pass (`cargo test --lib`)
- [x] New collision guard tests pass
- [x] Clippy passes with `-D warnings`
- [x] Code formatted with `cargo fmt`

## Related
- !1289 (fixes the assignment race at the dispatch level)
- This task adds a safety net below the dispatch layer

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)