### PR TITLE
fix: Remove duplicate worktree cleanup log messages [Midtown !1293]

### DIFF
--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -1175,26 +1175,10 @@ pub(super) fn check_for_stale_worktrees(
             age.num_hours()
         );
 
-        // Schedule cleanup with channel notification
-        let message = if let Some(ref task_id) = assignment.task_id {
-            format!(
-                "🧹 Cleaned up stale worktree {} (task !{}, completed {}h ago)",
-                assignment.worktree_id,
-                task_id,
-                age.num_hours()
-            )
-        } else {
-            format!(
-                "🧹 Cleaned up stale worktree {} (completed {}h ago)",
-                assignment.worktree_id,
-                age.num_hours()
-            )
-        };
-
+        // Schedule cleanup (message posting happens in effects.rs when cleanup executes)
         effects.push(Effect::CleanupStaleWorktree {
             worktree_id: assignment.worktree_id.clone(),
         });
-        effects.push(Effect::PostSystemMessage { message });
     }
 
     if !effects.is_empty() {

--- a/src/daemon/health_tests.rs
+++ b/src/daemon/health_tests.rs
@@ -404,7 +404,7 @@ fn test_check_for_usage_limits_already_scheduled() {
 }
 
 #[test]
-fn check_for_stale_worktrees_generates_cleanup_and_channel_message() {
+fn check_for_stale_worktrees_generates_only_cleanup_effect() {
     use std::collections::HashSet;
 
     let mut registry = crate::worktree_registry::WorktreeRegistry::new();
@@ -438,18 +438,16 @@ fn check_for_stale_worktrees_generates_cleanup_and_channel_message() {
 
     let effects = check_for_stale_worktrees(&registry, &active_coworkers, retention);
 
-    // Only the 48h-old worktree should be cleaned up (2 effects: cleanup + message)
+    // Only the 48h-old worktree should be cleaned up.
+    // Decision function should only return CleanupStaleWorktree effect.
+    // The message posting is handled by effects.rs when executing the cleanup.
     assert_eq!(
         effects.len(),
-        2,
-        "should generate 1 cleanup + 1 channel message effect"
+        1,
+        "should generate only 1 CleanupStaleWorktree effect (message posting happens in effects.rs)"
     );
     assert!(
         matches!(&effects[0], Effect::CleanupStaleWorktree { worktree_id } if worktree_id == "task-99-fix-bug"),
         "first effect should be CleanupStaleWorktree"
-    );
-    assert!(
-        matches!(&effects[1], Effect::PostSystemMessage { message } if message.contains("task-99-fix-bug") && message.contains("task !99") && message.contains('🧹')),
-        "second effect should be PostSystemMessage with task ID"
     );
 }


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Fixed duplicate channel messages when daemon cleans up stale worktrees
- Previously posted two messages per cleanup (one from health.rs, one from effects.rs)
- Now posts only one message from effects.rs when cleanup executes

## Details
The daemon was posting duplicate messages because:
1. `health.rs` created both a `CleanupStaleWorktree` effect AND a `PostSystemMessage` effect
2. `effects.rs` also posted a message when executing the cleanup

Following the architecture principle that decision functions should be pure and side effects should only happen in `effects.rs`, removed the duplicate `PostSystemMessage` effect from `health.rs`.

## Test plan
- [x] Updated test to verify only one effect is generated
- [x] All unit tests pass
- [x] Clippy passes with no warnings

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)