### PR TITLE
Fix test_orphan_recovery_marks_task_in_flight by using non-existent task ID [Midtown !1295]

### DIFF
--- a/src/daemon/dispatch_tests.rs
+++ b/src/daemon/dispatch_tests.rs
@@ -3411,11 +3411,11 @@ fn test_orphan_recovery_marks_task_in_flight() {
     // coworker is spawning.
     //
     // Timeline without the fix:
-    // 1. Coworker crashes, task !1264 is in_progress with owner=lexington
+    // 1. Coworker crashes, task !999999 is in_progress with owner=lexington
     // 2. Orphan recovery spawns lexington (tick 0s)
     // 3. Task dispatch runs (tick 10s) before lexington claims via RPC
     // 4. Task dispatch sees task as in_progress but lexington not active → spawns another coworker
-    // 5. Result: double assignment (lexington + madison both working on !1264)
+    // 5. Result: double assignment (lexington + madison both working on !999999)
     let snap = snapshot::WorldSnapshot {
         active_coworkers: vec![],
         running_coworkers: vec![],
@@ -3428,7 +3428,7 @@ fn test_orphan_recovery_marks_task_in_flight() {
         headless_process_health: HashMap::new(),
         attached_coworkers: HashSet::new(),
         in_progress_tasks: vec![(
-            "1264".to_string(),
+            "999999".to_string(),
             "Test task".to_string(),
             "lexington".to_string(),
         )],
@@ -3499,7 +3499,7 @@ fn test_orphan_recovery_marks_task_in_flight() {
     // Should include RecordTaskAssignment in on_success
     let has_record_assignment = on_success.iter().any(|e| {
         matches!(e, Effect::RecordTaskAssignment { task_id, coworker }
-            if task_id == "1264" && coworker == "lexington")
+            if task_id == "999999" && coworker == "lexington")
     });
 
     assert!(
@@ -3510,7 +3510,7 @@ fn test_orphan_recovery_marks_task_in_flight() {
     // Verify that mark_in_flight_spawns_from_effects would mark this task
     state.mark_in_flight_spawns_from_effects(&effects);
     assert!(
-        state.is_task_spawn_in_flight("1264"),
-        "Task !1264 should be marked in-flight after orphan recovery"
+        state.is_task_spawn_in_flight("999999"),
+        "Task !999999 should be marked in-flight after orphan recovery"
     );
 }


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary

Fixed `test_orphan_recovery_marks_task_in_flight` which was failing because it used task ID "1264" that exists in the real `~/.claude/tasks/` directory and is marked as completed.

## Root Cause

The test creates a `WorldSnapshot` with `in_progress_tasks` containing task "1264", but when `check_and_recover_orphans()` filters tasks, it calls `crate::tasks::read_task("1264")` which reads from the actual Claude tasks directory on disk. Task 1264 exists and is completed, so `should_recover_task()` returns `false`, resulting in 0 tasks available for orphan recovery.

## Solution

Changed all references from task ID "1264" to "999999" (a task ID unlikely to exist in the real tasks directory). Now when `read_task("999999")` returns `None`, the filter correctly keeps the task for recovery.

## Test Results

Both test failures mentioned in the task description are now resolved:
1. ✅ `auth::tests::test_directory_replaced_with_symlink` - was already passing
2. ✅ `daemon::dispatch::tests::test_orphan_recovery_marks_task_in_flight` - now passes

Full test suite: 1327 passed, 0 failed, 1 ignored

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)