### PR TITLE
fix: view detach lifecycle, unified nudge delivery, lead initial prompt

### DIFF
--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -1616,9 +1616,10 @@ pub fn handle_view(project: Option<&str>, skip_auto_split: bool) -> Result<Respo
                 continue;
             }
             Err(e) if e.contains("already attached") => {
-                // Lead is already attached somewhere else — build a fresh attach command
-                // by resolving session info without pausing.
-                break;
+                // Previous view session exited without detaching — clean up and retry
+                let _ = client.session_detach("lead");
+                std::thread::sleep(std::time::Duration::from_millis(200));
+                continue;
             }
             Err(e) => {
                 if let Some(cwd) = original_cwd {
@@ -1684,6 +1685,11 @@ If you want chat without automatic split creation, run:\n  midtown view --skip-a
     }
 
     let chat_result = super::chat::run();
+
+    // Always detach on exit so the daemon resumes headless mode.
+    // Without this, a normal exit leaves the lead in `attached_coworkers`
+    // and subsequent `midtown view` calls fail with "already attached".
+    let _ = client.session_detach("lead");
 
     if let Some(cwd) = original_cwd {
         let _ = std::env::set_current_dir(cwd);

--- a/src/bin/midtown/cli/headed_wrapper.rs
+++ b/src/bin/midtown/cli/headed_wrapper.rs
@@ -13,13 +13,13 @@ use crate::cli::Response;
 use crate::client::DaemonClient;
 use tracing::{debug, info};
 
-const LEAD_INPUT_WAIT_TIMEOUT: Duration = Duration::from_secs(90);
 const COWORKER_INPUT_MAX_WAIT: Duration = Duration::from_secs(120);
 const COWORKER_INPUT_STABLE_DURATION: Duration = Duration::from_secs(20);
 const NUDGE_POLL_INTERVAL: Duration = Duration::from_secs(3);
 const SUBMIT_RETRY_ATTEMPTS: usize = 3;
 const SUBMIT_RETRY_DELAY: Duration = Duration::from_millis(200);
 const SUBMIT_PROCESS_DELAY: Duration = Duration::from_millis(120);
+const PAYLOAD_SETTLE_DELAY: Duration = Duration::from_millis(80);
 const OUTPUT_MIRROR_MAX_BYTES: usize = 256 * 1024;
 const OUTPUT_MIRROR_MAX_LINES: usize = 500;
 
@@ -161,6 +161,7 @@ type SharedWriter = Arc<Mutex<Box<dyn std::io::Write + Send>>>;
 type SharedInputState = Arc<Mutex<InputState>>;
 type SharedOutputMirror = Arc<Mutex<OutputMirror>>;
 
+#[cfg(test)]
 #[derive(Debug, Clone)]
 struct InputSnapshot {
     current_input: String,
@@ -277,6 +278,7 @@ fn update_input_state(state: &SharedInputState, bytes: &[u8]) {
     }
 }
 
+#[cfg(test)]
 fn snapshot_input_state(state: &SharedInputState) -> InputSnapshot {
     match state.lock() {
         Ok(guard) => InputSnapshot {
@@ -451,6 +453,7 @@ fn is_nudge_stuck(content: &str, nudge_text: &str) -> bool {
     false
 }
 
+#[cfg(test)]
 fn wait_for_empty_input(input_state: &SharedInputState, timeout: Duration) -> bool {
     let start = Instant::now();
 
@@ -780,28 +783,21 @@ pub fn handle(cmd: &HeadedWrapperCommand, client: &DaemonClient) -> Result<Respo
                     };
 
                 for msg in parsed.messages {
-                    let safe = if session.eq_ignore_ascii_case("lead") {
-                        wait_for_empty_input(&input_state, LEAD_INPUT_WAIT_TIMEOUT)
-                    } else {
-                        wait_for_nudge_safe(
-                            &output_mirror,
-                            last_nudge_text.as_deref(),
-                            COWORKER_INPUT_STABLE_DURATION,
-                            COWORKER_INPUT_MAX_WAIT,
-                        )
-                    };
+                    // For all sessions (lead and coworkers), check the PTY output
+                    // for the ❯ prompt to know when Claude is ready for input.
+                    // Without this, nudges get injected while Claude is thinking
+                    // and the submit fails because there's no active input field.
+                    let safe = wait_for_nudge_safe(
+                        &output_mirror,
+                        last_nudge_text.as_deref(),
+                        COWORKER_INPUT_STABLE_DURATION,
+                        COWORKER_INPUT_MAX_WAIT,
+                    );
                     if !safe {
-                        if session.eq_ignore_ascii_case("lead") {
-                            info!(
-                                "Lead input still active after {}s, nudging anyway",
-                                LEAD_INPUT_WAIT_TIMEOUT.as_secs()
-                            );
-                        } else {
-                            info!(
-                                "Coworker input still active after {}s, nudging anyway",
-                                COWORKER_INPUT_MAX_WAIT.as_secs()
-                            );
-                        }
+                        info!(
+                            "Input still active after {}s, nudging anyway",
+                            COWORKER_INPUT_MAX_WAIT.as_secs()
+                        );
                     }
 
                     let payload =
@@ -810,6 +806,13 @@ pub fn handle(cmd: &HeadedWrapperCommand, client: &DaemonClient) -> Result<Respo
                     if let Err(e) = write_payload_to_pty(&shared_writer, &payload) {
                         run_result = Err(e);
                         break;
+                    }
+                    // Give Claude Code's TUI time to process the text before
+                    // sending Enter — without this, \r arrives in the same
+                    // read buffer as the payload and is treated as a newline
+                    // character in the input rather than a submit action.
+                    if msg.submit {
+                        std::thread::sleep(PAYLOAD_SETTLE_DELAY);
                     }
                     if msg.submit
                         && let Err(e) =

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -189,7 +189,7 @@ impl LaunchConfig {
             name: "lead".to_string(),
             session_mode: SessionMode::Fresh,
             role: CoworkerRole::Lead,
-            initial_prompt: None,
+            initial_prompt: Some("Read the channel for context, then post to the channel that you're online and ready.".to_string()),
             additional_dirs: vec![],
             restrict_setting_sources: false,
             pr_number: None,
@@ -317,6 +317,13 @@ impl LaunchConfig {
             env.insert("MIDTOWN_CHANNEL".to_string(), ch.clone());
         }
 
+        // Lead shares the project task list with coworkers via this env var
+        if self.role == CoworkerRole::Lead
+            && let Some(ref team) = self.team_name
+        {
+            env.insert("CLAUDE_CODE_TASK_LIST_ID".to_string(), team.clone());
+        }
+
         HeadlessConfig {
             model: self.model.clone(),
             system_prompt,
@@ -399,6 +406,12 @@ impl LaunchConfig {
         // Must be a real shell env var — Claude Code blocklists this from settings.json
         if self.team_name.is_some() {
             env_parts.push("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1".to_string());
+        }
+        // Lead shares the project task list with coworkers via this env var
+        if self.role == CoworkerRole::Lead
+            && let Some(ref team) = self.team_name
+        {
+            env_parts.push(format!("CLAUDE_CODE_TASK_LIST_ID='{}'", team));
         }
         // Set default channel for routing coworker messages
         if let Some(ref ch) = self.channel {
@@ -976,7 +989,10 @@ mod tests {
         assert_eq!(config.name, "lead");
         assert_eq!(config.role, CoworkerRole::Lead);
         assert!(!config.restrict_setting_sources);
-        assert!(config.initial_prompt.is_none());
+        assert!(
+            config.initial_prompt.is_some(),
+            "Lead should have an initial prompt for session_id init"
+        );
         assert!(config.pr_number.is_none());
         assert_eq!(config.team_name, Some("midtown-myrepo".to_string()));
         assert_eq!(config.model, "sonnet");


### PR DESCRIPTION
## Summary
- **View detach lifecycle**: Always detach lead session on exit so subsequent `midtown view` calls don't fail with "already attached". Retry with detach when hitting stale attach state.
- **Unified nudge delivery**: Both lead and coworker nudges now use output-based prompt detection (`wait_for_nudge_safe`) instead of the lead using input-state polling. Adds `PAYLOAD_SETTLE_DELAY` (80ms) before sending Enter so payload text and submit aren't batched together. Marks now-unused `InputSnapshot`, `snapshot_input_state`, `wait_for_empty_input`, and `LEAD_INPUT_WAIT_TIMEOUT` as `#[cfg(test)]`.
- **Lead initial prompt**: Gives the lead a default initial prompt ("Read the channel for context, then post to the channel that you're online and ready.") so it has a session_id from startup.
- **Shared task list for lead**: Sets `CLAUDE_CODE_TASK_LIST_ID` env var for the lead (both headed and headless) so it shares the project task list with coworkers.

## Test plan
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes
- [ ] `midtown view` exits cleanly and can be re-entered without "already attached" error
- [ ] Lead nudges delivered correctly using output-based prompt detection
- [ ] Lead starts with initial prompt and posts to channel on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)