### PR TITLE
fix: TUI shift key regression from kitty keyboard protocol

### DIFF
--- a/src/bin/midtown/cli/chat/keyboard_protocol_tests.rs
+++ b/src/bin/midtown/cli/chat/keyboard_protocol_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for keyboard protocol configuration.
 //!
 //! Verifies that the KEYBOARD_ENHANCEMENT_FLAGS constant includes the
-//! required flags for proper Shift+Enter detection via the kitty protocol.
+//! required flags for proper key decoding via the kitty protocol.
 
 use crossterm::event::KeyboardEnhancementFlags;
 
@@ -18,15 +18,18 @@ fn test_enhancement_flags_include_disambiguate() {
     );
 }
 
-/// Verify that the enhancement flags constant includes REPORT_ALL_KEYS_AS_ESCAPE_CODES.
+/// Verify that REPORT_ALL_KEYS_AS_ESCAPE_CODES is NOT enabled.
 ///
-/// Without this flag, modifier state (Shift, Ctrl, etc.) is not reliably
-/// reported for all key combinations.
+/// This flag causes the kitty protocol to report ALL keys as escape codes
+/// with the base (lowercase/unshifted) key plus modifier flags. This breaks
+/// shifted character input: Shift+A reports 'a'+SHIFT instead of 'A', and
+/// Shift+1 reports '1'+SHIFT instead of '!'. The terminal can no longer
+/// perform keyboard-layout-aware character translation.
 #[test]
-fn test_enhancement_flags_include_report_all_keys() {
+fn test_enhancement_flags_exclude_report_all_keys() {
     assert!(
-        super::KEYBOARD_ENHANCEMENT_FLAGS
+        !super::KEYBOARD_ENHANCEMENT_FLAGS
             .contains(KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES),
-        "KEYBOARD_ENHANCEMENT_FLAGS must include REPORT_ALL_KEYS_AS_ESCAPE_CODES"
+        "KEYBOARD_ENHANCEMENT_FLAGS must NOT include REPORT_ALL_KEYS_AS_ESCAPE_CODES"
     );
 }

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -34,15 +34,17 @@ use ui::Hyperlink;
 
 /// Keyboard enhancement flags for the kitty keyboard protocol.
 ///
-/// These flags enable unambiguous decoding of modifier key combinations
-/// like Shift+Enter. Without them, terminals send ambiguous escape sequences
+/// `DISAMBIGUATE_ESCAPE_CODES` ensures special keys (Enter, Esc, etc.) use
+/// unique CSI u sequences so crossterm can reliably decode modifier combinations
+/// like Shift+Enter. Without this flag, terminals send ambiguous escape sequences
 /// that crossterm may decode as incorrect characters (e.g., 'j' for Shift+Enter).
 ///
-/// - `DISAMBIGUATE_ESCAPE_CODES`: Ensures special keys use unique codes
-/// - `REPORT_ALL_KEYS_AS_ESCAPE_CODES`: Ensures modifier state is reported
+/// Note: `REPORT_ALL_KEYS_AS_ESCAPE_CODES` was intentionally removed because it
+/// causes ALL keys (including regular text) to report as escape codes with the
+/// base (lowercase) key plus modifier flags. This breaks shifted character input
+/// (capitals, symbols) since the terminal no longer performs character translation.
 const KEYBOARD_ENHANCEMENT_FLAGS: KeyboardEnhancementFlags =
-    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-        .union(KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES);
+    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES;
 
 /// Convert a character index to a byte index in a UTF-8 string.
 ///
@@ -607,6 +609,14 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                 // All other character input: if channel switcher is showing, input to it
                 // Otherwise auto-focus InputBar and insert
                 KeyCode::Char(c) => {
+                    // With the kitty keyboard protocol, Shift+letter reports the
+                    // lowercase base key plus a SHIFT modifier. Convert alphabetic
+                    // chars to uppercase when SHIFT is the only modifier held.
+                    let c = if key.modifiers == KeyModifiers::SHIFT && c.is_ascii_lowercase() {
+                        c.to_ascii_uppercase()
+                    } else {
+                        c
+                    };
                     if app.channel_switcher.show {
                         app.channel_switcher_input(c);
                         EventResult::Continue
@@ -1552,6 +1562,33 @@ mod tests {
             app.input_cursor, original_cursor,
             "Input cursor should be preserved on creation failure"
         );
+    }
+
+    /// Regression test: Shift+letter should insert uppercase character.
+    ///
+    /// With the kitty keyboard protocol (REPORT_ALL_KEYS_AS_ESCAPE_CODES),
+    /// Shift+A is reported as KeyCode::Char('a') + KeyModifiers::SHIFT.
+    /// The handler must convert to uppercase rather than inserting lowercase.
+    #[test]
+    fn test_shift_letter_inserts_uppercase() {
+        let mut app = test_app();
+
+        // Simulate kitty protocol: Shift+A = lowercase 'a' + SHIFT modifier
+        let event = Event::Key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::SHIFT));
+        handle_event(&mut app, event);
+
+        assert_eq!(app.input_text, "A", "Shift+a should insert uppercase 'A'");
+    }
+
+    /// Regression test: plain letter without Shift should insert lowercase.
+    #[test]
+    fn test_plain_letter_inserts_lowercase() {
+        let mut app = test_app();
+
+        let event = key_press(KeyCode::Char('a'));
+        handle_event(&mut app, event);
+
+        assert_eq!(app.input_text, "a", "Plain 'a' should insert lowercase 'a'");
     }
 }
 


### PR DESCRIPTION
## Summary

- Removed `REPORT_ALL_KEYS_AS_ESCAPE_CODES` from keyboard enhancement flags — it caused the kitty protocol to report all keys as their base (lowercase/unshifted) form plus modifier flags, breaking capital letters and shifted symbols (e.g., Shift+A → `'a'` instead of `'A'`)
- Added defense-in-depth Shift+letter handling in `handle_event` to convert lowercase chars to uppercase when SHIFT is the only modifier
- Updated keyboard protocol tests to assert the flag is excluded and added regression tests for Shift+letter input

## Test plan

- [x] `test_shift_letter_inserts_uppercase` — verifies Shift+Char('a') inserts 'A'
- [x] `test_plain_letter_inserts_lowercase` — verifies plain Char('a') inserts 'a'
- [x] `test_enhancement_flags_exclude_report_all_keys` — verifies flag is not set
- [x] `test_enhancement_flags_include_disambiguate` — verifies DISAMBIGUATE is still set
- [ ] Manual: verify capital letters work in TUI chat input
- [ ] Manual: verify Shift+Enter inserts newline (terminal-dependent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)