### PR TITLE
Fix race condition: deduplicate spawns by task ID [Midtown !1307]

### DIFF
--- a/src/daemon/events.rs
+++ b/src/daemon/events.rs
@@ -213,7 +213,7 @@ pub async fn evaluate_tick(
     }
 }
 
-/// Deduplicate spawn effects by coworker name.
+/// Deduplicate spawn effects by coworker name and task ID.
 ///
 /// Multiple independent decision functions (orphan recovery, pending task spawn,
 /// dead process respawn, PR call-in) can each decide to spawn the same coworker
@@ -221,12 +221,17 @@ pub async fn evaluate_tick(
 /// ones trigger `on_success` callbacks (since the idempotent guard returns Ok),
 /// posting duplicate "Called in" messages.
 ///
+/// Also prevents double-spawn for the same task: orphan recovery might spawn
+/// "amsterdam" for task 123, while task dispatch spawns "york" for the same task
+/// in the same tick. This function deduplicates by BOTH coworker name AND task ID.
+///
 /// Handles all spawn-like effect variants: `SpawnCoworker`,
 /// `SpawnCoworkerWithCallbacks`, `AssignAndSpawn`, and `ResumeCoworker`.
-/// Keeps the first spawn effect for each coworker name, drops duplicates.
+/// Keeps the first spawn effect for each coworker name and task ID, drops duplicates.
 /// Non-spawn effects are always preserved.
 fn dedup_spawn_effects(effects: Vec<Effect>) -> Vec<Effect> {
-    let mut seen_spawns: HashSet<String> = HashSet::new();
+    let mut seen_coworker_names: HashSet<String> = HashSet::new();
+    let mut seen_task_ids: HashSet<String> = HashSet::new();
     let mut result: Vec<Effect> = Vec::new();
     let mut registry_effects: Vec<Effect> = Vec::new();
 
@@ -239,9 +244,43 @@ fn dedup_spawn_effects(effects: Vec<Effect>) -> Vec<Effect> {
             _ => None,
         };
 
+        // Extract task ID if this is a task-related spawn
+        let task_id = match &effect {
+            Effect::AssignAndSpawn { task_id, .. } => Some(task_id.clone()),
+            Effect::SpawnCoworkerWithCallbacks { on_success, .. } => {
+                // Look for RecordTaskAssignment in on_success callbacks
+                on_success.iter().find_map(|e| {
+                    if let Effect::RecordTaskAssignment { task_id, .. } = e {
+                        Some(task_id.clone())
+                    } else {
+                        None
+                    }
+                })
+            }
+            _ => None,
+        };
+
         if let Some(name) = spawn_name {
-            if seen_spawns.contains(&name) {
-                tracing::debug!("Deduplicated duplicate spawn effect for '{}'", name);
+            // Check if we've already seen this coworker name
+            let duplicate_by_name = seen_coworker_names.contains(&name);
+            // Check if we've already seen this task ID (if task-related)
+            let duplicate_by_task = task_id
+                .as_ref()
+                .is_some_and(|tid| seen_task_ids.contains(tid));
+
+            if duplicate_by_name || duplicate_by_task {
+                let reason = if duplicate_by_name && duplicate_by_task {
+                    format!(
+                        "coworker '{}' and task '{}'",
+                        name,
+                        task_id.as_ref().unwrap()
+                    )
+                } else if duplicate_by_name {
+                    format!("coworker '{}'", name)
+                } else {
+                    format!("task '{}'", task_id.as_ref().unwrap())
+                };
+                tracing::debug!("Deduplicated duplicate spawn effect for {}", reason);
 
                 // Extract and preserve registry effects from the dropped spawn
                 let on_success_effects = match effect {
@@ -304,7 +343,10 @@ fn dedup_spawn_effects(effects: Vec<Effect>) -> Vec<Effect> {
 
             registry_effects.extend(extracted_registry);
             result.push(modified_effect);
-            seen_spawns.insert(name);
+            seen_coworker_names.insert(name);
+            if let Some(tid) = task_id {
+                seen_task_ids.insert(tid);
+            }
         } else {
             result.push(effect);
         }

--- a/src/daemon/events_tests.rs
+++ b/src/daemon/events_tests.rs
@@ -264,3 +264,143 @@ fn dedup_preserves_registry_effects_from_dropped_spawns() {
         "Second task's worktree should be registered"
     );
 }
+
+#[test]
+fn dedup_prevents_double_spawn_for_same_task() {
+    // Bug: Orphan recovery spawns "amsterdam" for task 123, then task dispatch
+    // spawns "york" for the same task in the same tick. Dedup only checks coworker
+    // name, so both spawns go through.
+    use crate::worktree_registry::WorktreeAssignment;
+
+    let config_amsterdam = LaunchConfig {
+        name: "amsterdam".to_string(),
+        session_mode: SessionMode::Fresh,
+        role: CoworkerRole::Coworker,
+        initial_prompt: None,
+        additional_dirs: vec![],
+        restrict_setting_sources: false,
+        pr_number: None,
+        team_name: None,
+        working_dir: None,
+        model: "sonnet".to_string(),
+        channel: None,
+        auth_profile_dir: None,
+        auth_provider: crate::auth::AuthProvider::Claude,
+    };
+
+    let config_york = LaunchConfig {
+        name: "york".to_string(),
+        session_mode: SessionMode::Fresh,
+        role: CoworkerRole::Coworker,
+        initial_prompt: None,
+        additional_dirs: vec![],
+        restrict_setting_sources: false,
+        pr_number: None,
+        team_name: None,
+        working_dir: None,
+        model: "sonnet".to_string(),
+        channel: None,
+        auth_profile_dir: None,
+        auth_provider: crate::auth::AuthProvider::Claude,
+    };
+
+    // Orphan recovery spawns amsterdam for task 123
+    let orphan_spawn = Effect::SpawnCoworkerWithCallbacks {
+        config: config_amsterdam,
+        on_success: vec![
+            Effect::RecordTaskAssignment {
+                coworker: "amsterdam".to_string(),
+                task_id: "123".to_string(),
+            },
+            Effect::RegisterWorktreeAssignment {
+                assignment: WorktreeAssignment {
+                    worktree_id: "task-123-foo".to_string(),
+                    branch_name: "task-123-foo".to_string(),
+                    task_id: Some("123".to_string()),
+                    current_coworker: None,
+                    pr_number: None,
+                    created_at: chrono::Utc::now(),
+                    completed_at: None,
+                },
+            },
+        ],
+        on_failure: vec![],
+    };
+
+    // Task dispatch spawns york for task 123 (same task, different coworker)
+    let dispatch_spawn = Effect::AssignAndSpawn {
+        task_id: "123".to_string(),
+        owner: "york".to_string(),
+        repo_name: "test".to_string(),
+        config: config_york,
+        on_success: vec![Effect::RegisterWorktreeAssignment {
+            assignment: WorktreeAssignment {
+                worktree_id: "task-123-bar".to_string(),
+                branch_name: "task-123-bar".to_string(),
+                task_id: Some("123".to_string()),
+                current_coworker: None,
+                pr_number: None,
+                created_at: chrono::Utc::now(),
+                completed_at: None,
+            },
+        }],
+        on_failure: vec![],
+    };
+
+    let effects = vec![orphan_spawn, dispatch_spawn];
+    let deduped = dedup_spawn_effects(effects);
+
+    // EXPECTED: Only ONE spawn effect should remain (the first one)
+    let spawn_count = deduped
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                Effect::AssignAndSpawn { .. }
+                    | Effect::SpawnCoworker(_)
+                    | Effect::SpawnCoworkerWithCallbacks { .. }
+            )
+        })
+        .count();
+    assert_eq!(
+        spawn_count, 1,
+        "Should have only one spawn for task 123 (got {} spawns)",
+        spawn_count
+    );
+
+    // Both worktree assignments should be preserved
+    let registry_count = deduped
+        .iter()
+        .filter(|e| matches!(e, Effect::RegisterWorktreeAssignment { .. }))
+        .count();
+    assert_eq!(
+        registry_count, 2,
+        "Both worktree registrations should be preserved"
+    );
+
+    // The task assignment from the kept spawn should be preserved (in its on_success callbacks)
+    let task_assignments: Vec<&str> = deduped
+        .iter()
+        .flat_map(|e| match e {
+            Effect::RecordTaskAssignment { task_id, .. } => vec![task_id.as_str()],
+            Effect::SpawnCoworkerWithCallbacks { on_success, .. }
+            | Effect::AssignAndSpawn { on_success, .. } => on_success
+                .iter()
+                .filter_map(|sub| {
+                    if let Effect::RecordTaskAssignment { task_id, .. } = sub {
+                        Some(task_id.as_str())
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            _ => vec![],
+        })
+        .collect();
+    assert_eq!(
+        task_assignments.len(),
+        1,
+        "Should have exactly one task assignment for task 123 (from the kept spawn's callbacks)"
+    );
+    assert_eq!(task_assignments[0], "123");
+}


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Fixed same-tick double-spawn race between orphan recovery and task dispatch
- Modified `dedup_spawn_effects` to track task IDs in addition to coworker names
- Added test coverage for the bug scenario

## Problem
When the daemon restarts with orphaned tasks, both `check_and_recover_orphans` and `spawn_for_pending_tasks` run in the same tick. Previously, `dedup_spawn_effects` only checked coworker names, so if orphan recovery spawned "amsterdam" for task 123 and task dispatch spawned "york" for the same task, both spawns would execute.

This caused:
- Two coworkers working on the same task
- Worktree collision warnings (but not full prevention)
- Potential for duplicate PRs

## Solution
Modified `dedup_spawn_effects` in `src/daemon/events.rs` to:
1. Extract task IDs from spawn effects (from `AssignAndSpawn` field or `RecordTaskAssignment` callbacks)
2. Track both coworker names AND task IDs in seen sets
3. Drop duplicates based on either criterion
4. Preserve registry effects from dropped spawns

## Test plan
- [x] Added `dedup_prevents_double_spawn_for_same_task` test that verifies the fix
- [x] All existing dedup tests pass
- [x] Full unit test suite passes (1268 tests)
- [x] Clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)