### PR TITLE
Fix web interface channel routing - messages now go to active channel [Midtown !1309]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -2632,12 +2632,13 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
                 }
             } => {
                 let content = &mobile_post.content;
+                let channel = mobile_post.channel.as_deref();
                 let sender = state.user_display_name.as_deref().unwrap_or("user");
                 rpc_channel::handle_channel_post(
                     RequestId::Null,
                     sender,
                     content,
-                    None, // No channel specified - use default
+                    channel,
                     &state,
                 ).await;
             }

--- a/src/web.rs
+++ b/src/web.rs
@@ -133,6 +133,7 @@ impl Default for WebConfig {
 /// A mobile channel post to be forwarded to the daemon for processing.
 pub struct MobileChannelPost {
     pub content: String,
+    pub channel: Option<String>,
 }
 
 /// Shared state for WebSocket connections
@@ -259,7 +260,11 @@ pub struct ErrorData {
 pub enum ClientMessage {
     /// Send a message to the channel (to lead)
     #[serde(rename = "send_message")]
-    SendMessage { content: String },
+    SendMessage {
+        content: String,
+        #[serde(default)]
+        channel: Option<String>,
+    },
     /// Request full channel history
     #[serde(rename = "get_history")]
     GetHistory,
@@ -1512,13 +1517,14 @@ async fn handle_client_message(text: &str, state: &Arc<WebState>) -> Result<(), 
         serde_json::from_str(text).map_err(|e| format!("Invalid message format: {}", e))?;
 
     match msg {
-        ClientMessage::SendMessage { content } => {
+        ClientMessage::SendMessage { content, channel } => {
             // Forward to the daemon for processing (handles channel write,
             // WebSocket broadcast, and side-effects like nudging the Lead)
             state
                 .channel_post_tx
                 .send(MobileChannelPost {
                     content: content.clone(),
+                    channel: channel.clone(),
                 })
                 .await
                 .map_err(|e| format!("Failed to forward message to daemon: {}", e))?;
@@ -1648,8 +1654,22 @@ mod tests {
         let json = r#"{"type": "send_message", "content": "Hello world"}"#;
         let msg: ClientMessage = serde_json::from_str(json).unwrap();
         match msg {
-            ClientMessage::SendMessage { content } => {
+            ClientMessage::SendMessage { content, channel } => {
                 assert_eq!(content, "Hello world");
+                assert_eq!(channel, None); // No channel specified
+            }
+            _ => panic!("Expected SendMessage"),
+        }
+    }
+
+    #[test]
+    fn test_client_message_parsing_with_channel() {
+        let json = r#"{"type": "send_message", "content": "Hello", "channel": "auth-refactor"}"#;
+        let msg: ClientMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            ClientMessage::SendMessage { content, channel } => {
+                assert_eq!(content, "Hello");
+                assert_eq!(channel, Some("auth-refactor".to_string()));
             }
             _ => panic!("Expected SendMessage"),
         }
@@ -1682,6 +1702,7 @@ mod tests {
             .try_recv()
             .expect("expected a mobile channel post");
         assert_eq!(post.content, "hello from mobile");
+        assert_eq!(post.channel, None); // No channel specified, should default to None
     }
 
     #[test]

--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -424,7 +424,7 @@
           ? `${inputText.trim()}\n\n[Attached: ${result.path}]`
           : `[Attached file: ${result.filename}]\nPlease read: ${result.path}`
 
-        sendMessage(message)
+        sendMessage(message, $activeChannel)
         inputText = ''
         pendingFile = null
       } else {
@@ -432,7 +432,7 @@
         return
       }
     } else if (inputText.trim()) {
-      sendMessage(inputText.trim())
+      sendMessage(inputText.trim(), $activeChannel)
       inputText = ''
     }
   }

--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -441,14 +441,17 @@ function handleUpdate(update) {
 }
 
 // Send a message to the lead via WebSocket
-export function sendMessage(content) {
+export function sendMessage(content, channel = null) {
   if (ws && ws.readyState === WebSocket.OPEN) {
-    ws.send(
-      JSON.stringify({
-        type: 'send_message',
-        content,
-      })
-    )
+    const message = {
+      type: 'send_message',
+      content,
+    }
+    // Include channel if specified (null/undefined means use default)
+    if (channel) {
+      message.channel = channel
+    }
+    ws.send(JSON.stringify(message))
   } else {
     console.error('WebSocket not connected')
   }


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
Fixed web interface channel routing so messages are posted to the active channel instead of always going to the main 'midtown' channel.

## Root Cause
The web interface was always posting messages to the main 'midtown' channel regardless of which channel was active in the UI. This happened because:
1. The WebSocket message from the frontend didn't include channel info
2. The backend `ClientMessage::SendMessage` struct had no channel field
3. The daemon defaulted to the main channel when no channel was specified

## Changes
1. Added `channel` field to `MobileChannelPost` struct in `src/web.rs`
2. Added `channel` field to `ClientMessage::SendMessage` in `src/web.rs` (optional, defaults to None)
3. Updated `handle_client_message` to forward the channel to the daemon
4. Updated daemon's `mobile_rx` handler to pass channel to `handle_channel_post`
5. Updated `sendMessage()` in `web-app/src/lib/api.js` to accept and include active channel
6. Updated `Channel.svelte` to pass `$activeChannel` when sending messages
7. Added test for channel parameter parsing

## Data Flow
Web UI → WebSocket (with channel) → Daemon → `handle_channel_post` → Channel file

The fix allows the active channel to flow through the entire stack, ensuring messages are written to the correct channel file.

## Test Plan
- [x] Existing web tests pass
- [x] Added test for channel parameter parsing
- [x] Build succeeds with no warnings

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)