### PR TITLE
fix: Use explicit task.pr field for stale task cleanup [Midtown !1312]

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -1151,12 +1151,25 @@ pub(super) fn spawn_for_pending_tasks(
     // with pre-existing tasks or tasks where the Lead manually set an owner.
     let pending_with_owners = &snap.pending_tasks_with_owners;
     for (task_id, task_subject, owner) in pending_with_owners.iter() {
-        // Skip tasks whose referenced PR is already merged. These are stale —
-        // the work is done (PR merged) but the task wasn't auto-completed.
-        if let Some(pr_num_str) = crate::tasks::extract_pr_number(task_subject)
-            && let Ok(pr_num) = pr_num_str.parse::<u64>()
-            && snap.merged_pr_numbers.contains(&pr_num)
-        {
+        // Skip tasks whose explicit PR field references a merged PR.
+        // This indicates the task's work is IN that PR (not just about it).
+        // Pattern matching task descriptions would cause false positives when
+        // tasks reference merged PRs for context (e.g., "Fix bug from PR #123").
+        let task_pr_merged = snap
+            .all_tasks
+            .iter()
+            .find(|t| &t.id == task_id)
+            .and_then(|t| t.pr)
+            .map(|pr_num| snap.merged_pr_numbers.contains(&pr_num))
+            .unwrap_or(false);
+
+        if task_pr_merged {
+            let pr_num = snap
+                .all_tasks
+                .iter()
+                .find(|t| &t.id == task_id)
+                .and_then(|t| t.pr)
+                .unwrap(); // Safe: we just checked it exists
             info!(
                 "Auto-completing stale task !{}: PR #{} has been merged",
                 task_id, pr_num
@@ -1418,9 +1431,11 @@ pub(super) fn spawn_for_pending_tasks(
             continue;
         }
 
-        // Skip tasks whose referenced PR is already merged.
-        if let Some(pr_num_str) = crate::tasks::extract_pr_number_from_task(task)
-            && let Ok(pr_num) = pr_num_str.parse::<u64>()
+        // Skip tasks whose explicit PR field references a merged PR.
+        // This indicates the task's work is IN that PR (not just about it).
+        // Pattern matching task descriptions would cause false positives when
+        // tasks reference merged PRs for context (e.g., "Fix bug from PR #123").
+        if let Some(pr_num) = task.pr
             && snap.merged_pr_numbers.contains(&pr_num)
         {
             info!(

--- a/src/daemon/dispatch_tests.rs
+++ b/src/daemon/dispatch_tests.rs
@@ -3558,3 +3558,213 @@ fn test_orphan_recovery_marks_task_in_flight() {
         "Task !999999 should be marked in-flight after orphan recovery"
     );
 }
+
+// ======================================================================
+// Stale task cleanup tests
+// ======================================================================
+
+#[test]
+fn test_stale_task_cleanup_false_positive_task_about_merged_pr() {
+    // Reproduces the false positive where a task ABOUT a merged PR (e.g., analyzing a bug
+    // that occurred during that PR) gets auto-completed because the PR number appears in
+    // the task description.
+    //
+    // Expected: Task should NOT be auto-completed (it has no explicit pr field set)
+    // Actual (before fix): Task gets auto-completed because description mentions "PR #1153"
+
+    use crate::tasks::{Task, TaskStatus};
+    use std::time::SystemTime;
+
+    let task = Task {
+        id: "1310".to_string(),
+        subject: "Fix bug from PR #1153".to_string(), // PR number in subject to trigger pattern matching
+        description: Some(
+            "Bug: When PR #1153 opened, the daemon queued a reviewer to spawn 45s later. \
+             But when it tried, CI was still running so no reviewer spawned. When CI went \
+             green, the daemon never re-evaluated the PR. The fix is to re-evaluate when \
+             CI status changes."
+                .to_string(),
+        ),
+        status: TaskStatus::Pending,
+        owner: Some("pleasant".to_string()),
+        blocked_by: vec![],
+        channel: None,
+        pr: None, // No explicit pr field - this task is ABOUT PR #1153, not FOR it
+        created_at: Some(SystemTime::now()),
+    };
+
+    let snap = snapshot::WorldSnapshot {
+        pending_tasks_with_owners: vec![(
+            task.id.clone(),
+            task.subject.clone(),
+            task.owner.clone().unwrap(),
+        )],
+        pending_tasks_without_owners: vec![],
+        all_tasks: vec![task],
+        merged_pr_numbers: [1153u64].into_iter().collect(), // PR #1153 is merged
+        is_at_dev_limit: false,
+        active_names: HashSet::new(),
+        active_session_ids: HashSet::new(),
+        running_coworkers: vec![],
+        active_coworkers: vec![],
+        coworker_snapshots: vec![],
+        session_name: "midtown-test".to_string(),
+        coworker_start_times: HashMap::new(),
+        coworker_stop_times: HashMap::new(),
+        headless_process_health: HashMap::new(),
+        attached_coworkers: HashSet::new(),
+        in_progress_tasks: vec![],
+        busy_coworkers: HashSet::new(),
+        coworker_task_assignments: HashMap::new(),
+        task_channel: HashMap::new(),
+        task_model_map: HashMap::new(),
+        task_plan_map: HashMap::new(),
+        task_execution_skill_map: HashMap::new(),
+        coworkers_with_open_prs: HashSet::new(),
+        coworkers_with_merged_prs: HashSet::new(),
+        ci_passed_pr_coworkers: HashSet::new(),
+        review_feedback_pr_coworkers: HashSet::new(),
+        open_prs_data: vec![],
+        github_open_pr_task_ids: HashMap::new(),
+        pending_task_owners: HashSet::new(),
+        tasks_with_open_prs: HashMap::new(),
+        pr_task_associations: HashMap::new(),
+        active_reviewers: HashSet::new(),
+        reviewer_pr_assignments: HashMap::new(),
+        reviewed_prs: HashSet::new(),
+        prs_needing_review: 0,
+        reviewer_restart_counts: HashMap::new(),
+        reviewer_escalations_posted: HashSet::new(),
+        coworkers_with_unblocked_deps: HashSet::new(),
+        usage_limit_nudge_scheduled: false,
+        usage_limit_nudge_at: None,
+        usage_limited_coworkers: HashSet::new(),
+        api_error_coworkers: HashSet::new(),
+        auth_error_coworkers: HashSet::new(),
+        tool_name_conflict_coworkers: HashSet::new(),
+        channel_messages: vec![],
+        archived_channels: HashSet::new(),
+        daemon_logs: vec![],
+        tasks_with_worktrees: HashSet::new(),
+        task_worktree_map: HashMap::new(),
+        worktree_registry: crate::worktree_registry::WorktreeRegistry::default(),
+        worktree_branch_owners: HashMap::new(),
+        merged_pr_branches: HashMap::new(),
+        is_at_coworker_limit: false,
+        now_utc: chrono::Utc::now(),
+        repo_name: "test-repo".to_string(),
+        github_rate_limit: crate::github_rate_limit::GitHubRateLimit::default(),
+        freshly_fetched_rate_limit: None,
+    };
+
+    let state = make_test_state();
+    let effects = spawn_for_pending_tasks(&snap, &state);
+
+    // Should NOT auto-complete the task. The task is about a bug that occurred during
+    // PR #1153, not a task whose work is in PR #1153.
+    let has_complete = effects
+        .iter()
+        .any(|e| matches!(e, Effect::CompleteTask { task_id, .. } if task_id == "1310"));
+
+    assert!(
+        !has_complete,
+        "Task !1310 should NOT be auto-completed - it's about PR #1153, not for it"
+    );
+}
+
+#[test]
+fn test_stale_task_cleanup_correct_behavior_with_explicit_pr_field() {
+    // Task with explicit pr field set should be auto-completed when that PR merges.
+
+    use crate::tasks::{Task, TaskStatus};
+    use std::time::SystemTime;
+
+    let task = Task {
+        id: "42".to_string(),
+        subject: "Add auth endpoint".to_string(),
+        description: None,
+        status: TaskStatus::Pending,
+        owner: Some("park".to_string()),
+        blocked_by: vec![],
+        channel: None,
+        pr: Some(123), // Explicit pr field - this task's work is IN PR #123
+        created_at: Some(SystemTime::now()),
+    };
+
+    let snap = snapshot::WorldSnapshot {
+        pending_tasks_with_owners: vec![(
+            task.id.clone(),
+            task.subject.clone(),
+            task.owner.clone().unwrap(),
+        )],
+        pending_tasks_without_owners: vec![],
+        all_tasks: vec![task],
+        merged_pr_numbers: [123u64].into_iter().collect(), // PR #123 is merged
+        is_at_dev_limit: false,
+        active_names: HashSet::new(),
+        active_session_ids: HashSet::new(),
+        running_coworkers: vec![],
+        active_coworkers: vec![],
+        coworker_snapshots: vec![],
+        session_name: "midtown-test".to_string(),
+        coworker_start_times: HashMap::new(),
+        coworker_stop_times: HashMap::new(),
+        headless_process_health: HashMap::new(),
+        attached_coworkers: HashSet::new(),
+        in_progress_tasks: vec![],
+        busy_coworkers: HashSet::new(),
+        coworker_task_assignments: HashMap::new(),
+        task_channel: HashMap::new(),
+        task_model_map: HashMap::new(),
+        task_plan_map: HashMap::new(),
+        task_execution_skill_map: HashMap::new(),
+        coworkers_with_open_prs: HashSet::new(),
+        coworkers_with_merged_prs: HashSet::new(),
+        ci_passed_pr_coworkers: HashSet::new(),
+        review_feedback_pr_coworkers: HashSet::new(),
+        open_prs_data: vec![],
+        github_open_pr_task_ids: HashMap::new(),
+        pending_task_owners: HashSet::new(),
+        tasks_with_open_prs: HashMap::new(),
+        pr_task_associations: HashMap::new(),
+        active_reviewers: HashSet::new(),
+        reviewer_pr_assignments: HashMap::new(),
+        reviewed_prs: HashSet::new(),
+        prs_needing_review: 0,
+        reviewer_restart_counts: HashMap::new(),
+        reviewer_escalations_posted: HashSet::new(),
+        coworkers_with_unblocked_deps: HashSet::new(),
+        usage_limit_nudge_scheduled: false,
+        usage_limit_nudge_at: None,
+        usage_limited_coworkers: HashSet::new(),
+        api_error_coworkers: HashSet::new(),
+        auth_error_coworkers: HashSet::new(),
+        tool_name_conflict_coworkers: HashSet::new(),
+        channel_messages: vec![],
+        archived_channels: HashSet::new(),
+        daemon_logs: vec![],
+        tasks_with_worktrees: HashSet::new(),
+        task_worktree_map: HashMap::new(),
+        worktree_registry: crate::worktree_registry::WorktreeRegistry::default(),
+        worktree_branch_owners: HashMap::new(),
+        merged_pr_branches: HashMap::new(),
+        is_at_coworker_limit: false,
+        now_utc: chrono::Utc::now(),
+        repo_name: "test-repo".to_string(),
+        github_rate_limit: crate::github_rate_limit::GitHubRateLimit::default(),
+        freshly_fetched_rate_limit: None,
+    };
+
+    let state = make_test_state();
+    let effects = spawn_for_pending_tasks(&snap, &state);
+
+    // SHOULD auto-complete the task because task.pr == 123 and PR #123 is merged
+    let has_complete = effects
+        .iter()
+        .any(|e| matches!(e, Effect::CompleteTask { task_id, .. } if task_id == "42"));
+
+    assert!(
+        has_complete,
+        "Task !42 should be auto-completed - its explicit pr field matches merged PR #123"
+    );
+}


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Fixed false positive in daemon's stale task cleanup where tasks ABOUT a merged PR were incorrectly auto-completed
- Replaced pattern matching (`extract_pr_number`) with explicit `task.pr` field checks
- Pattern matching can't distinguish "task FOR PR #123" vs "task ABOUT PR #123"
- The `task.pr` field represents "this task's work is IN this PR" and is the correct signal

## Root Cause
The daemon was pattern-matching "PR #NNN" anywhere in task subject/description and auto-completing when that PR merged. This caused false positives when tasks referenced merged PRs for context.

Example:
- Task: "Fix bug from PR #1153" (investigating why #1153 merged without review)
- Daemon auto-completed it 46 seconds later because PR #1153 was merged
- But the task was about FIXING THE BUG, not about PR #1153's changes

## Changes
**dispatch.rs:**
- Case 1 (pending tasks with owners): Check `task.pr` field instead of `extract_pr_number(task_subject)`
- Case 2 (pending tasks without owners): Check `task.pr` field instead of `extract_pr_number_from_task(task)`
- Pattern matching still used for PR-based task grouping (assigning sub-tasks to same coworker), not auto-completion

**dispatch_tests.rs:**
- `test_stale_task_cleanup_false_positive_task_about_merged_pr`: Verifies task with "PR #1153" in subject but no `pr` field is NOT auto-completed
- `test_stale_task_cleanup_correct_behavior_with_explicit_pr_field`: Verifies task with `pr=123` IS auto-completed when PR #123 merges

## Test plan
- [x] Unit tests pass (both new tests added)
- [x] Full test suite passes (1269 tests)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Formatting checked (`cargo fmt -- --check`)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)