### PR TITLE
fix: Handle terminal resize events in headed wrapper PTY [Midtown !1315]

### DIFF
--- a/src/bin/midtown/cli/headed_wrapper.rs
+++ b/src/bin/midtown/cli/headed_wrapper.rs
@@ -764,6 +764,22 @@ pub fn handle(cmd: &HeadedWrapperCommand, client: &DaemonClient) -> Result<Respo
                     }
                 }
 
+                // Check for terminal resize events
+                if crossterm::event::poll(Duration::from_millis(0)).unwrap_or(false)
+                    && let Ok(crossterm::event::Event::Resize(new_cols, new_rows)) =
+                        crossterm::event::read()
+                {
+                    let new_size = portable_pty::PtySize {
+                        rows: new_rows,
+                        cols: new_cols,
+                        pixel_width: 0,
+                        pixel_height: 0,
+                    };
+                    if let Err(e) = pty_pair.master.resize(new_size) {
+                        debug!("Failed to resize PTY: {}", e);
+                    }
+                }
+
                 // Poll daemon for nudges. Tolerate transient connection failures
                 // (e.g., daemon restart) — just skip the poll cycle and retry next
                 // iteration. The interactive session should survive daemon restarts.


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Added terminal resize event handling to the RunAgent handler in headed_wrapper.rs
- The PTY now properly resizes when the terminal window is resized
- Uses crossterm's non-blocking event polling to detect resize events

## Technical Details
The RunAgent handler creates a PTY with the initial terminal size but never updated it when the terminal window changed. This caused display issues with long lines and corrupted output in the embedded Claude CLI.

The fix adds crossterm event polling in the main loop to detect `Event::Resize` events. When a resize is detected, it calls `pty_pair.master.resize()` with the new dimensions. The check uses a zero-duration poll so it doesn't block the existing daemon polling logic.

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo clippy -- -D warnings` passes
- [x] Pre-existing test failures are unrelated to this change
- Manual testing: resize terminal window while `midtown headed-wrapper run-agent` is running

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)