### PR TITLE
fix: Prevent duplicate merge task creation [Midtown !1339]

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -351,6 +351,8 @@ pub enum Effect {
         repo_name: String,
         subject: String,
         description: String,
+        /// Optional PR number to associate with the task (for deduplication).
+        pr: Option<u64>,
     },
 }
 
@@ -1540,6 +1542,7 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 repo_name,
                 subject,
                 description,
+                pr,
             } => {
                 // Derive active_form from subject (simple present progressive form)
                 let active_form = if subject.starts_with("Merge") {
@@ -1556,7 +1559,7 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                     &repo_name,
                     None, // blocked_by
                     None, // channel
-                    None, // pr
+                    pr,   // pr (from effect)
                 ) {
                     Ok(task_id) => {
                         info!("Created task !{}: {}", task_id, subject);

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -3460,6 +3460,12 @@ pub(super) fn reconcile_orphaned_prs(snap: &WorldSnapshot) -> Vec<Effect> {
             continue;
         }
 
+        // Skip if a merge task already exists for this PR (prevents duplicates)
+        // This checks all_tasks for any task with pr field matching pr_number
+        if snap.all_tasks.iter().any(|task| task.pr == Some(pr_number)) {
+            continue;
+        }
+
         // Check if PR has been reviewed (Claude review comment exists)
         if !snap.reviewed_prs.contains(&pr_number) {
             continue;
@@ -3496,6 +3502,7 @@ pub(super) fn reconcile_orphaned_prs(snap: &WorldSnapshot) -> Vec<Effect> {
                  Branch: {}",
                 pr_number, title, branch
             ),
+            pr: Some(pr_number),
         });
     }
 

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -606,3 +606,80 @@ async fn test_reviewer_spawns_when_worktree_exists_but_no_current_coworker() {
          Before fix: empty branch_owners_map caused all PRs to be treated as orphaned after restart.",
     );
 }
+
+/// Bug: reconcile_orphaned_prs creates duplicate "Merge PR #X" tasks every 30 seconds.
+///
+/// Root cause: The function only checks pr_task_associations (which tracks the *original*
+/// task that created the PR via pr_author_sessions). When a merge task is created, it's
+/// a new task not linked in pr_author_sessions, so pr_task_associations doesn't contain
+/// the PR. On the next tick, the function creates another duplicate merge task.
+///
+/// Expected: Only one "Merge PR #X" task should exist for each PR, even across multiple ticks.
+#[test]
+fn test_reconcile_orphaned_prs_does_not_create_duplicates() {
+    use super::super::snapshot::minimal_snapshot_for_test;
+    use crate::tasks::{Task, TaskStatus};
+
+    // Simulate PR #42 that meets all orphan criteria:
+    // - Has coworker branch prefix
+    // - Has been reviewed
+    // - CI is passing
+    // - Not a draft
+    let pr_data = json!({
+        "number": 42,
+        "title": "Fix authentication bug",
+        "headRefName": "york/fix-auth",
+        "isDraft": false,
+        "statusCheckRollup": {
+            "state": "SUCCESS"
+        }
+    });
+
+    let mut snap = minimal_snapshot_for_test();
+    snap.open_prs_data = vec![pr_data];
+    snap.reviewed_prs.insert(42);
+
+    // First tick: No existing merge task yet
+    let effects1 = reconcile_orphaned_prs(&snap);
+
+    // Should create one merge task
+    let create_task_count1 = effects1
+        .iter()
+        .filter(|e| matches!(e, Effect::CreateTask { .. }))
+        .count();
+    assert_eq!(
+        create_task_count1, 1,
+        "First tick should create exactly one merge task"
+    );
+
+    // Simulate the created task now exists in all_tasks as pending
+    let merge_task = Task {
+        id: "1001".to_string(),
+        subject: "Merge PR #42 — reviewed, CI green".to_string(),
+        status: TaskStatus::Pending,
+        owner: None,
+        description: Some("PR #42 (Fix authentication bug) has been reviewed...".to_string()),
+        blocked_by: vec![],
+        channel: None,
+        pr: Some(42), // This will be set after the fix
+        created_at: None,
+    };
+
+    snap.all_tasks = vec![merge_task];
+
+    // Second tick: Merge task now exists
+    let effects2 = reconcile_orphaned_prs(&snap);
+
+    // Should NOT create another merge task (bug: currently creates duplicate)
+    let create_task_count2 = effects2
+        .iter()
+        .filter(|e| matches!(e, Effect::CreateTask { .. }))
+        .count();
+    assert_eq!(
+        create_task_count2, 0,
+        "Second tick should NOT create duplicate merge task. BUG: reconcile_orphaned_prs \
+         only checks pr_task_associations (which tracks original PR author tasks), not \
+         existing merge tasks in all_tasks. This causes duplicate 'Merge PR #42' tasks \
+         to be created every 30 seconds."
+    );
+}


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Fixed bug where `reconcile_orphaned_prs()` created duplicate "Merge PR #X" tasks every ~30 seconds
- Added `pr` field to `Effect::CreateTask` to associate tasks with PRs
- Added deduplication check in `reconcile_orphaned_prs()` to prevent duplicate merge tasks

## Root Cause
The function only checked `pr_task_associations` (which tracks the original task that created the PR via `pr_author_sessions`). When a merge task is created, it's a new task not linked in `pr_author_sessions`, so `pr_task_associations` doesn't contain the PR. On the next tick, the function creates another duplicate merge task.

## Fix
1. Added `pr: Option<u64>` field to `Effect::CreateTask`
2. Set `pr: Some(pr_number)` when creating merge tasks in `reconcile_orphaned_prs()`
3. Check `snap.all_tasks` for any task with matching `pr` field before creating a new merge task

## Test plan
- [x] Added failing test `test_reconcile_orphaned_prs_does_not_create_duplicates`
- [x] Test passes after fix
- [x] All daemon tests pass
- [x] Clippy passes

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)