### PR TITLE
fix: Task-level click detection for board panel [Midtown !1326]

### DIFF
--- a/src/bin/midtown/cli/chat/ui/board.rs
+++ b/src/bin/midtown/cli/chat/ui/board.rs
@@ -15,7 +15,10 @@ use super::Hyperlink;
 use super::text::wrap_content;
 
 /// Draw the board panel (left side) with channel list
-pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> Vec<Hyperlink> {
+///
+/// Returns (hyperlinks, tasks_area) where tasks_area is the rect containing the task list
+/// (excluding the coworker status section). This is used for click detection.
+pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> (Vec<Hyperlink>, Rect) {
     // Clear task line map for new render
     app.task_line_map.clear();
 
@@ -178,7 +181,7 @@ pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> Vec<Hyperli
         draw_coworker_status(f, app, chunks[1]);
     }
 
-    hyperlinks
+    (hyperlinks, tasks_area)
 }
 
 /// Render a channel header line with task count and unread count.
@@ -646,5 +649,113 @@ mod tests {
         let text_style = lines[0].spans[1].style;
         assert_eq!(bullet_style.fg, Some(Color::Yellow));
         assert_eq!(text_style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn test_draw_board_panel_populates_task_line_map() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let backend = TestBackend::new(80, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        let mut app = test_app();
+        app.tasks = vec![
+            KanbanTask {
+                id: "42".to_string(),
+                subject: "First task".to_string(),
+                owner: Some("york".to_string()),
+                status: TaskStatus::InProgress,
+                modified_at: None,
+                channel: None,
+                blocked_by: vec![],
+            },
+            KanbanTask {
+                id: "43".to_string(),
+                subject: "Second task".to_string(),
+                owner: Some("lexington".to_string()),
+                status: TaskStatus::Pending,
+                modified_at: None,
+                channel: None,
+                blocked_by: vec![],
+            },
+        ];
+
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                let (_hyperlinks, tasks_area) = draw_board_panel(f, &mut app, area);
+
+                // Verify tasks_area is returned correctly
+                assert!(tasks_area.width > 0);
+                assert!(tasks_area.height > 0);
+            })
+            .unwrap();
+
+        // Verify task_line_map is populated
+        assert!(
+            !app.task_line_map.is_empty(),
+            "task_line_map should be populated"
+        );
+
+        // Verify both tasks are in the map
+        let task_42_found = app
+            .task_line_map
+            .values()
+            .any(|(id, owner)| id == "42" && owner.as_deref() == Some("york"));
+        let task_43_found = app
+            .task_line_map
+            .values()
+            .any(|(id, owner)| id == "43" && owner.as_deref() == Some("lexington"));
+
+        assert!(task_42_found, "Task 42 should be in task_line_map");
+        assert!(task_43_found, "Task 43 should be in task_line_map");
+    }
+
+    #[test]
+    fn test_draw_board_panel_returns_correct_tasks_area() {
+        use super::super::super::app::CoworkerInfo;
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let backend = TestBackend::new(80, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        let mut app = test_app();
+        // Add a coworker to trigger the split
+        app.coworkers = vec![CoworkerInfo {
+            name: "york".to_string(),
+            task_id: Some(42),
+            phase: Some("developing".to_string()),
+            pr_number: None,
+            health: "green".to_string(),
+            provider: "claude".to_string(),
+            profile: "test".to_string(),
+            progress: None,
+        }];
+
+        let mut returned_tasks_area = None;
+
+        terminal
+            .draw(|f| {
+                let area = Rect {
+                    x: 0,
+                    y: 0,
+                    width: 80,
+                    height: 40,
+                };
+                let (_hyperlinks, tasks_area) = draw_board_panel(f, &mut app, area);
+                returned_tasks_area = Some(tasks_area);
+            })
+            .unwrap();
+
+        let tasks_area = returned_tasks_area.unwrap();
+
+        // When coworkers exist, tasks_area should be smaller than the input area
+        // because the coworker status section takes up space at the bottom
+        assert!(
+            tasks_area.height < 40,
+            "tasks_area should exclude coworker section"
+        );
     }
 }

--- a/src/bin/midtown/cli/chat/ui/mod.rs
+++ b/src/bin/midtown/cli/chat/ui/mod.rs
@@ -92,10 +92,9 @@ pub fn draw(f: &mut Frame, app: &mut App) -> Vec<Hyperlink> {
         .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
         .split(vertical_chunks[1]);
 
-    // Store board area for click detection
-    app.board_area = Some(horizontal_chunks[0]);
-
-    let hyperlinks = board::draw_board_panel(f, app, horizontal_chunks[0]);
+    let (hyperlinks, tasks_area) = board::draw_board_panel(f, app, horizontal_chunks[0]);
+    // Store tasks area for click detection (task_line_map line numbers are relative to this area)
+    app.board_area = Some(tasks_area);
     chat::draw_chat_panel(f, app, horizontal_chunks[1]);
 
     if !app.usage_data.is_empty() {


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Fixed mouse click detection for tasks in the board panel by correctly setting `app.board_area` to the tasks area (excluding coworker status section)
- Added comprehensive tests for task_line_map population and tasks_area correctness

## Problem
The task-level click-to-attach feature from PR #1158 wasn't working correctly. When clicking on a task in the board panel, the click handler couldn't find the task in `task_line_map` because the line number calculation was off.

Root cause: `app.board_area` was set to the entire left panel area, but `task_line_map` line numbers are relative to the tasks section only (which excludes the coworker status table at the bottom). When coworkers were displayed, the offset mismatch caused clicks to miss their targets.

## Solution
- Changed `draw_board_panel` to return `(Vec<Hyperlink>, Rect)` tuple, where the second element is the tasks area rect
- Updated `ui/mod.rs` to store the returned tasks_area as `app.board_area` instead of the full panel area
- Added doc comment explaining the return value
- Added two tests:
  - `test_draw_board_panel_populates_task_line_map`: Verifies task_line_map is populated correctly
  - `test_draw_board_panel_returns_correct_tasks_area`: Verifies tasks_area excludes coworker section

## Test plan
- [x] Code compiles without warnings (cargo clippy passes)
- [x] Code is formatted correctly (cargo fmt passes)
- [x] All existing tests pass (1284 tests)
- [x] New tests pass and verify the fix
- [ ] Manual testing: Click on a task in the board panel with coworkers displayed, verify it attaches to the correct coworker session

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)