### PR TITLE
feat: Auto-install required Claude plugins at daemon start [Midtown !1375]

### DIFF
--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -631,19 +631,8 @@ fn ensure_required_plugins() {
         .filter_map(|p| p.get("id").and_then(|id| id.as_str()).map(String::from))
         .collect();
 
-    // Required plugins from daemon/mod.rs
-    let required = [
-        "superpowers@claude-plugins-official",
-        "code-review@claude-plugins-official",
-        "pr-review-toolkit@claude-plugins-official",
-        "commit-commands@claude-plugins-official",
-        "feature-dev@claude-plugins-official",
-        "explanatory-output-style@claude-plugins-official",
-        "code-simplifier@claude-plugins-official",
-    ];
-
-    // Find missing plugins
-    let missing: Vec<_> = required
+    // Find missing plugins (use canonical list from daemon)
+    let missing: Vec<_> = midtown::daemon::REQUIRED_PLUGINS
         .iter()
         .filter(|p| !installed.contains(**p))
         .collect();
@@ -652,9 +641,12 @@ fn ensure_required_plugins() {
         return;
     }
 
-    // Install missing plugins
-    for plugin_id in &missing {
-        emit_startup_progress(10, &format!("installing plugin {}", plugin_id));
+    // Install missing plugins with incremental progress indicators
+    let total_missing = missing.len();
+    for (i, plugin_id) in missing.iter().enumerate() {
+        // Spread progress from 10% to 60% based on plugin index
+        let progress = 10 + ((50 * (i + 1)) / total_missing.max(1)) as u16;
+        emit_startup_progress(progress, &format!("installing plugin {}", plugin_id));
         install_plugin(plugin_id);
     }
 }


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Ensures official marketplace is configured before plugin installation
- Checks for missing required plugins during `midtown start`
- Automatically installs missing plugins with progress indicators
- Non-blocking: logs errors but continues startup on failure

## Implementation Details
- Added `ensure_official_marketplace()` to check/add the official marketplace
- Added `install_plugin()` to install individual plugins via `claude plugin install`
- Added `ensure_required_plugins()` to orchestrate the full check-and-install flow
- Integrated into `handle_start()` after project validation (5%) and before daemon spawn (65%)
- Uses progress indicators at 8% (marketplace) and 10% (each plugin)

## Test Plan
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] Code formatted with `cargo fmt`

## Required Plugins
- superpowers@claude-plugins-official
- code-review@claude-plugins-official
- pr-review-toolkit@claude-plugins-official
- commit-commands@claude-plugins-official
- feature-dev@claude-plugins-official
- explanatory-output-style@claude-plugins-official
- code-simplifier@claude-plugins-official

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)