### PR TITLE
feat: Display progress percentage in mobile coworker status [Midtown !1378]

### DIFF
--- a/web-app/src/lib/Status.svelte
+++ b/web-app/src/lib/Status.svelte
@@ -99,6 +99,20 @@
                   <span class="text-[#a8a8a8] font-mono">#{cw.pr_number}</span>
                 </div>
               {/if}
+              {#if cw.progress != null}
+                <div class="flex gap-2 text-[0.8rem] items-center">
+                  <span class="text-[#585858] min-w-[50px]">Progress:</span>
+                  <div class="flex-1 flex items-center gap-2">
+                    <div class="flex-1 h-1.5 bg-[#3a3a3a] rounded-full overflow-hidden">
+                      <div
+                        class="h-full bg-[#5fafaf] rounded-full transition-all duration-300"
+                        style="width: {cw.progress}%"
+                      ></div>
+                    </div>
+                    <span class="text-[#a8a8a8] font-mono text-[0.7rem] min-w-[32px] text-right">{cw.progress}%</span>
+                  </div>
+                </div>
+              {/if}
             </div>
           </div>
         {/each}


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Added progress bar to Status.svelte coworker status cards
- Backend already sends progress via RPC kanban endpoint (src/daemon/rpc_kanban.rs:244)
- Mobile UI now displays progress percentage with visual bar when available

## Test plan
- [x] Unit tests pass (npm test in web-app)
- [x] Pre-commit hooks pass (cargo clippy, cargo fmt)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)