### PR TITLE
fix: Include RecordTaskAssignment in PR spawn callbacks for cross-tick dedup [Midtown !1377]

### DIFF
--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -1090,6 +1090,17 @@ fn pr_action_to_effects(
                     issue_type,
                 },
             ];
+
+            // Cross-tick spawn deduplication (!1377): Include RecordTaskAssignment
+            // so mark_in_flight_spawns_from_effects() tracks this spawn and prevents
+            // task dispatch from double-spawning for the same task in the next tick.
+            if let Some(task_id) = ctx.pr_task_associations.get(&pr_number) {
+                on_success.push(Effect::RecordTaskAssignment {
+                    coworker: owner.clone(),
+                    task_id: task_id.clone(),
+                });
+            }
+
             if saved_session.is_some() {
                 on_success.push(Effect::ClearPrBreakSession {
                     name: owner.clone(),
@@ -1750,6 +1761,17 @@ fn comment_action_to_effects(
                     issue_type,
                 },
             ];
+
+            // Cross-tick spawn deduplication (!1377): Include RecordTaskAssignment
+            // so mark_in_flight_spawns_from_effects() tracks this spawn and prevents
+            // task dispatch from double-spawning for the same task in the next tick.
+            if let Some(task_id) = ctx.pr_task_associations.get(&pr_number) {
+                on_success.push(Effect::RecordTaskAssignment {
+                    coworker: owner.clone(),
+                    task_id: task_id.clone(),
+                });
+            }
+
             if saved_session.is_some() {
                 on_success.push(Effect::ClearPrBreakSession {
                     name: owner.clone(),
@@ -1853,7 +1875,7 @@ fn handoff_to_coworker_effects(
         original_author,
     );
 
-    let on_success = vec![
+    let mut on_success = vec![
         Effect::BroadcastCoworkerUpdate {
             name: assignee.to_string(),
             status: "running".to_string(),
@@ -1872,6 +1894,16 @@ fn handoff_to_coworker_effects(
             issue_type,
         },
     ];
+
+    // Cross-tick spawn deduplication (!1377): Include RecordTaskAssignment
+    // so mark_in_flight_spawns_from_effects() tracks this spawn and prevents
+    // task dispatch from double-spawning for the same task in the next tick.
+    if let Some(task_id) = ctx.pr_task_associations.get(&pr_number) {
+        on_success.push(Effect::RecordTaskAssignment {
+            coworker: assignee.to_string(),
+            task_id: task_id.clone(),
+        });
+    }
 
     let on_failure = vec![
         Effect::PostToChannel {
@@ -2327,6 +2359,17 @@ fn review_complete_action_to_effects(
                     issue_type,
                 },
             ];
+
+            // Cross-tick spawn deduplication (!1377): Include RecordTaskAssignment
+            // so mark_in_flight_spawns_from_effects() tracks this spawn and prevents
+            // task dispatch from double-spawning for the same task in the next tick.
+            if let Some(task_id) = ctx.pr_task_associations.get(&pr_number) {
+                on_success.push(Effect::RecordTaskAssignment {
+                    coworker: owner.clone(),
+                    task_id: task_id.clone(),
+                });
+            }
+
             if saved_session.is_some() {
                 on_success.push(Effect::ClearPrBreakSession {
                     name: owner.clone(),


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary

Fixes cross-tick duplicate spawn bug where review feedback spawns bypassed the in-flight deduplication mechanism, causing multiple coworkers to be assigned to the same task.

**Root Cause:**
- Review feedback spawn paths (comment_action_to_effects, review_complete_action_to_effects, pr_action_to_effects, handoff_to_coworker_effects) did NOT include `RecordTaskAssignment` in their `on_success` callbacks
- Without `RecordTaskAssignment`, `mark_in_flight_spawns_from_effects()` couldn't track these spawns
- Task dispatch in the next tick would see the task as unassigned and spawn another coworker

**Observed Bug (task !1376):**
- Tick 1: columbus spawned for task !1376 (task dispatch)
- Tick 2: lexington spawned for task !1376 (review feedback)
- Tick 3: york spawned for review feedback on the same PR
- Result: Three coworkers working on the same task

**Fix:**
Add `RecordTaskAssignment` to `on_success` callbacks in all PR spawn paths when the PR has an associated task_id (via `ctx.pr_task_associations`). This enables the existing cross-tick deduplication mechanism to work correctly for ALL spawn paths.

## Changes

### src/daemon/pr.rs
- `comment_action_to_effects`: Add `RecordTaskAssignment` to `SpawnOwner` branch (lines 1755-1761)
- `review_complete_action_to_effects`: Add `RecordTaskAssignment` to `SpawnOwner` branch (lines 2340-2346)  
- `pr_action_to_effects`: Add `RecordTaskAssignment` to `SpawnOwner` branch (lines 1103-1109)
- `handoff_to_coworker_effects`: Add `RecordTaskAssignment` (lines 1906-1912)

All changes follow the same pattern: conditionally add `RecordTaskAssignment` if the PR has an associated task_id.

## Test plan

- [x] All existing tests pass (cargo test --lib daemon::)
- [x] Clippy passes with -D warnings
- [x] The fix enables existing cross-tick dedup checks in spawn_for_pending_tasks (dispatch.rs:1191, 1426)

The fix leverages the existing `is_task_spawn_in_flight()` infrastructure that was already protecting task dispatch - it now protects ALL spawn paths.

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)