### PR TITLE
feat: Display task progress percentage in mobile Status view [Midtown !1378]

### DIFF
--- a/web-app/src/lib/Status.svelte
+++ b/web-app/src/lib/Status.svelte
@@ -127,10 +127,25 @@
     {:else}
       <div class="flex flex-col gap-1">
         {#each $daemonStatus.tasks as task}
-          <div class="flex gap-2 px-3 py-2 bg-[#262626] rounded text-[0.85rem]">
-            <span class="text-[#585858] min-w-[30px]">!{task.id}</span>
-            <span class="flex-1 line-clamp-2 overflow-hidden">{task.subject}</span>
-            <span class="text-[#585858] capitalize">{task.status}</span>
+          {@const coworker = $coworkers.find(cw => cw.task_id === Number(task.id))}
+          {@const progress = coworker?.progress}
+          <div class="flex flex-col gap-1.5 px-3 py-2 bg-[#262626] rounded text-[0.85rem]">
+            <div class="flex gap-2">
+              <span class="text-[#585858] min-w-[30px]">!{task.id}</span>
+              <span class="flex-1 line-clamp-2 overflow-hidden">{task.subject}</span>
+              <span class="text-[#585858] capitalize">{task.status}</span>
+            </div>
+            {#if progress != null}
+              <div class="flex items-center gap-2 ml-[38px]">
+                <div class="flex-1 h-1.5 bg-[#3a3a3a] rounded-full overflow-hidden">
+                  <div
+                    class="h-full bg-[#5fafaf] rounded-full transition-all duration-300"
+                    style="width: {progress}%"
+                  ></div>
+                </div>
+                <span class="text-[#a8a8a8] font-mono text-[0.65rem] min-w-[32px] text-right">{progress}%</span>
+              </div>
+            {/if}
           </div>
         {/each}
       </div>


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Add progress bars to the Tasks section in mobile web UI Status.svelte
- Join task data with coworker progress based on task_id assignment
- Display progress percentage with visual progress bar matching existing styling

## Details

The mobile Status view displays a "Tasks" section showing all active tasks, but was not showing progress percentages even though the data is available from coworker records.

Tasks don't have progress data themselves - progress is reported by coworkers via `midtown state --progress` and stored in the CoworkerRecord. The fix joins tasks with coworker data to display the progress of whichever coworker is working on each task.

Implementation:
- Find the coworker assigned to each task by matching task_id
- Extract the progress value from the coworker record
- Render a progress bar (if progress is set) using the same styling as the Coworkers section

## Test plan
- [x] Built successfully
- [x] Pre-commit hooks passed (clippy + fmt)
- [ ] Visual verification on mobile viewport

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)