### PR TITLE
test: Add tests for RecordTaskAssignment in PR spawn paths [Midtown !1377]

### DIFF
--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -152,6 +152,26 @@ impl PrContext {
     }
 }
 
+/// Add RecordTaskAssignment to on_success for cross-tick spawn deduplication.
+///
+/// When spawning a coworker for a PR that's associated with a task, we must include
+/// RecordTaskAssignment in the on_success callback so mark_in_flight_spawns_from_effects()
+/// can track the spawn and prevent task dispatch from double-spawning the same task
+/// in the next tick. See bug !1377.
+fn add_task_assignment_to_on_success(
+    on_success: &mut Vec<Effect>,
+    pr_number: u64,
+    coworker: &str,
+    ctx: &PrContext,
+) {
+    if let Some(task_id) = ctx.pr_task_associations.get(&pr_number) {
+        on_success.push(Effect::RecordTaskAssignment {
+            coworker: coworker.to_string(),
+            task_id: task_id.clone(),
+        });
+    }
+}
+
 /// How often to re-fetch merged PRs (5 minutes). Merges aren't urgent so
 /// polling less frequently saves significant API calls.
 const MERGED_PRS_FETCH_INTERVAL_SECS: u64 = 300;
@@ -1091,15 +1111,7 @@ fn pr_action_to_effects(
                 },
             ];
 
-            // Cross-tick spawn deduplication (!1377): Include RecordTaskAssignment
-            // so mark_in_flight_spawns_from_effects() tracks this spawn and prevents
-            // task dispatch from double-spawning for the same task in the next tick.
-            if let Some(task_id) = ctx.pr_task_associations.get(&pr_number) {
-                on_success.push(Effect::RecordTaskAssignment {
-                    coworker: owner.clone(),
-                    task_id: task_id.clone(),
-                });
-            }
+            add_task_assignment_to_on_success(&mut on_success, pr_number, &owner, ctx);
 
             if saved_session.is_some() {
                 on_success.push(Effect::ClearPrBreakSession {
@@ -1762,15 +1774,7 @@ fn comment_action_to_effects(
                 },
             ];
 
-            // Cross-tick spawn deduplication (!1377): Include RecordTaskAssignment
-            // so mark_in_flight_spawns_from_effects() tracks this spawn and prevents
-            // task dispatch from double-spawning for the same task in the next tick.
-            if let Some(task_id) = ctx.pr_task_associations.get(&pr_number) {
-                on_success.push(Effect::RecordTaskAssignment {
-                    coworker: owner.clone(),
-                    task_id: task_id.clone(),
-                });
-            }
+            add_task_assignment_to_on_success(&mut on_success, pr_number, &owner, ctx);
 
             if saved_session.is_some() {
                 on_success.push(Effect::ClearPrBreakSession {
@@ -1895,15 +1899,7 @@ fn handoff_to_coworker_effects(
         },
     ];
 
-    // Cross-tick spawn deduplication (!1377): Include RecordTaskAssignment
-    // so mark_in_flight_spawns_from_effects() tracks this spawn and prevents
-    // task dispatch from double-spawning for the same task in the next tick.
-    if let Some(task_id) = ctx.pr_task_associations.get(&pr_number) {
-        on_success.push(Effect::RecordTaskAssignment {
-            coworker: assignee.to_string(),
-            task_id: task_id.clone(),
-        });
-    }
+    add_task_assignment_to_on_success(&mut on_success, pr_number, assignee, ctx);
 
     let on_failure = vec![
         Effect::PostToChannel {
@@ -2360,15 +2356,7 @@ fn review_complete_action_to_effects(
                 },
             ];
 
-            // Cross-tick spawn deduplication (!1377): Include RecordTaskAssignment
-            // so mark_in_flight_spawns_from_effects() tracks this spawn and prevents
-            // task dispatch from double-spawning for the same task in the next tick.
-            if let Some(task_id) = ctx.pr_task_associations.get(&pr_number) {
-                on_success.push(Effect::RecordTaskAssignment {
-                    coworker: owner.clone(),
-                    task_id: task_id.clone(),
-                });
-            }
+            add_task_assignment_to_on_success(&mut on_success, pr_number, &owner, ctx);
 
             if saved_session.is_some() {
                 on_success.push(Effect::ClearPrBreakSession {

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -951,3 +951,208 @@ fn test_reconcile_orphaned_prs_ignores_completed_merge_tasks() {
          leaving the PR stuck without an active merge task."
     );
 }
+
+/// Bug !1377: pr_action_to_effects was missing RecordTaskAssignment in on_success,
+/// allowing cross-tick duplicate spawns for the same task.
+#[test]
+fn pr_action_to_effects_includes_record_task_assignment() {
+    let state = make_test_state("test-repo");
+
+    // Build PrContext with a PR→task association
+    let mut pr_task_associations = HashMap::new();
+    pr_task_associations.insert(123, "42".to_string());
+
+    let ctx = PrContext {
+        pr_task_associations,
+        task_channel: HashMap::new(),
+        session_context: None,
+    };
+
+    // Call pr_action_to_effects with SpawnOwner action
+    let effects = pr_action_to_effects(
+        crate::rules::PrAction::SpawnOwner {
+            owner: "broadway".to_string(),
+            message: "CI failed".to_string(),
+        },
+        123,
+        "Fix auth bug [Midtown !42]",
+        PrIssueType::CiFailed,
+        &state,
+        &ctx,
+    );
+
+    // Find the SpawnCoworkerWithCallbacks effect
+    let spawn_effect = effects
+        .iter()
+        .find_map(|e| {
+            if let Effect::SpawnCoworkerWithCallbacks { on_success, .. } = e {
+                Some(on_success)
+            } else {
+                None
+            }
+        })
+        .expect("Should have SpawnCoworkerWithCallbacks");
+
+    // Verify RecordTaskAssignment is in on_success
+    let has_record = spawn_effect.iter().any(|e| {
+        matches!(
+            e,
+            Effect::RecordTaskAssignment { coworker, task_id }
+                if coworker == "broadway" && task_id == "42"
+        )
+    });
+    assert!(
+        has_record,
+        "pr_action_to_effects on_success must include RecordTaskAssignment for cross-tick dedup"
+    );
+}
+
+/// Bug !1377: comment_action_to_effects was missing RecordTaskAssignment in on_success.
+#[test]
+fn comment_action_to_effects_includes_record_task_assignment() {
+    let state = make_test_state("test-repo");
+
+    let mut pr_task_associations = HashMap::new();
+    pr_task_associations.insert(456, "99".to_string());
+
+    let ctx = PrContext {
+        pr_task_associations,
+        task_channel: HashMap::new(),
+        session_context: None,
+    };
+
+    let effects = comment_action_to_effects(
+        crate::rules::PrAction::SpawnOwner {
+            owner: "park".to_string(),
+            message: "Review comment received".to_string(),
+        },
+        456,
+        "Add feature [Midtown !99]",
+        &state,
+        &ctx,
+    );
+
+    let spawn_effect = effects
+        .iter()
+        .find_map(|e| {
+            if let Effect::SpawnCoworkerWithCallbacks { on_success, .. } = e {
+                Some(on_success)
+            } else {
+                None
+            }
+        })
+        .expect("Should have SpawnCoworkerWithCallbacks");
+
+    let has_record = spawn_effect.iter().any(|e| {
+        matches!(
+            e,
+            Effect::RecordTaskAssignment { coworker, task_id }
+                if coworker == "park" && task_id == "99"
+        )
+    });
+    assert!(
+        has_record,
+        "comment_action_to_effects on_success must include RecordTaskAssignment for cross-tick dedup"
+    );
+}
+
+/// Bug !1377: handoff_to_coworker_effects was missing RecordTaskAssignment in on_success.
+#[test]
+fn handoff_to_coworker_effects_includes_record_task_assignment() {
+    let state = make_test_state("test-repo");
+
+    let mut pr_task_associations = HashMap::new();
+    pr_task_associations.insert(789, "17".to_string());
+
+    let ctx = PrContext {
+        pr_task_associations,
+        task_channel: HashMap::new(),
+        session_context: None,
+    };
+
+    let effects = handoff_to_coworker_effects(
+        "york",
+        "broadway",
+        789,
+        "york/task-17-fix",
+        "test-session-id".to_string(),
+        "Handoff message",
+        "context",
+        "Refactor module [Midtown !17]",
+        PrIssueType::ReviewComment,
+        &state,
+        &ctx,
+    );
+
+    let spawn_effect = effects
+        .iter()
+        .find_map(|e| {
+            if let Effect::SpawnCoworkerWithCallbacks { on_success, .. } = e {
+                Some(on_success)
+            } else {
+                None
+            }
+        })
+        .expect("Should have SpawnCoworkerWithCallbacks");
+
+    let has_record = spawn_effect.iter().any(|e| {
+        matches!(
+            e,
+            Effect::RecordTaskAssignment { coworker, task_id }
+                if coworker == "york" && task_id == "17"
+        )
+    });
+    assert!(
+        has_record,
+        "handoff_to_coworker_effects on_success must include RecordTaskAssignment for cross-tick dedup"
+    );
+}
+
+/// Bug !1377: review_complete_action_to_effects was missing RecordTaskAssignment in on_success.
+#[test]
+fn review_complete_action_to_effects_includes_record_task_assignment() {
+    let state = make_test_state("test-repo");
+
+    let mut pr_task_associations = HashMap::new();
+    pr_task_associations.insert(321, "55".to_string());
+
+    let ctx = PrContext {
+        pr_task_associations,
+        task_channel: HashMap::new(),
+        session_context: None,
+    };
+
+    let effects = review_complete_action_to_effects(
+        crate::rules::PrAction::SpawnOwner {
+            owner: "amsterdam".to_string(),
+            message: "Review complete".to_string(),
+        },
+        321,
+        "Update docs [Midtown !55]",
+        &state,
+        &ctx,
+    );
+
+    let spawn_effect = effects
+        .iter()
+        .find_map(|e| {
+            if let Effect::SpawnCoworkerWithCallbacks { on_success, .. } = e {
+                Some(on_success)
+            } else {
+                None
+            }
+        })
+        .expect("Should have SpawnCoworkerWithCallbacks");
+
+    let has_record = spawn_effect.iter().any(|e| {
+        matches!(
+            e,
+            Effect::RecordTaskAssignment { coworker, task_id }
+                if coworker == "amsterdam" && task_id == "55"
+        )
+    });
+    assert!(
+        has_record,
+        "review_complete_action_to_effects on_success must include RecordTaskAssignment for cross-tick dedup"
+    );
+}


### PR DESCRIPTION
<!-- midtown: park -->

## Summary

Follow-up to PR #1179 — addresses review feedback from columbus:

1. **Tests added** — Four new tests in `pr_tests.rs` verify that RecordTaskAssignment is included in on_success callbacks for all PR-driven spawn paths:
   - pr_action_to_effects
   - comment_action_to_effects
   - handoff_to_coworker_effects
   - review_complete_action_to_effects

2. **Reduced duplication** — Extracted the repeated RecordTaskAssignment block to a helper function (`add_task_assignment_to_on_success`). This ensures future spawn paths don't miss the dedup logic.

## Test plan

- [x] All new tests pass
- [x] Existing pr tests still pass
- [x] Clippy and cargo fmt pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)