### PR TITLE
test: Add E2E tests for daemon restart recovery [Midtown !1388]

### DIFF
--- a/tests/daemon_restart_recovery_e2e.rs
+++ b/tests/daemon_restart_recovery_e2e.rs
@@ -104,7 +104,7 @@ fn test_reviewer_assignments_preserved_after_restart() {
     // Create temporary test environment
     let temp_dir = TempDir::new().unwrap();
     let state_dir = temp_dir.path();
-    fs::create_dir_all(&state_dir).unwrap();
+    fs::create_dir_all(state_dir).unwrap();
 
     // Create daemon-state.json with reviewer assignments (using the actual JSON format)
     let now = Utc::now();
@@ -159,7 +159,7 @@ fn test_headless_sessions_preserved_after_restart() {
     // Create temporary test environment
     let temp_dir = TempDir::new().unwrap();
     let state_dir = temp_dir.path();
-    fs::create_dir_all(&state_dir).unwrap();
+    fs::create_dir_all(state_dir).unwrap();
 
     // Create daemon-state.json with headless sessions (using the actual JSON format)
     let now = Utc::now();
@@ -248,7 +248,7 @@ fn test_no_duplicate_spawns_after_restart() {
     let tasks_dir = temp_dir.path().join("tasks").join("midtown-test");
     let state_dir = temp_dir.path();
     fs::create_dir_all(&tasks_dir).unwrap();
-    fs::create_dir_all(&state_dir).unwrap();
+    fs::create_dir_all(state_dir).unwrap();
 
     // Set up pre-restart state:
     // - 3 in_progress tasks with owners


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
Added comprehensive E2E tests to verify daemon state persistence across restarts, ensuring:
- Task assignments are restored from disk
- Reviewer assignments survive restarts
- Headless sessions are preserved for recovery
- No duplicate spawns occur after restart

## Test Coverage
**Regression protection for captured bugs:**
- `snapshot-assignments-lost-after-restart-20260211-033718.json`
- `snapshot-duplicate-work-after-restart-20260212-231938.json`
- `snapshot-review-spawn-lost-after-restart-20260216-235656.json`
- `snapshot-review-spawn-lost-after-restart-20260217-001806.json`
- `snapshot-review-spawn-lost-after-restart-20260217-003046.json`

**Test approach:**
Uses JSON persistence format to verify the actual serialization/deserialization path. Tests simulate:
1. Pre-restart state (task files + daemon-state.json)
2. Restart recovery (load from disk, restore_task_assignments_from_disk)
3. Post-restart state verification (no orphans, no duplicates)

## Test Plan
- [x] All 4 new E2E tests pass
- [x] Full test suite passes (cargo test)
- [x] No clippy warnings

All tests pass with current code (fix already applied in production).

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)