### PR TITLE
feat: Add multi-tick test harness for cross-tick bugs [Midtown !1387]

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -1757,9 +1757,7 @@ pub(super) fn build_task_completion_effects(
 /// This function skips those tasks to avoid double-completion.
 ///
 /// Returns effects to complete tasks whose description references only merged PRs.
-pub(super) fn build_description_based_completion_effects(
-    snap: &snapshot::WorldSnapshot,
-) -> Vec<Effect> {
+pub fn build_description_based_completion_effects(snap: &snapshot::WorldSnapshot) -> Vec<Effect> {
     let mut effects = Vec::new();
 
     for task in &snap.all_tasks {

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -552,7 +552,7 @@ pub fn check_for_usage_limits(snap: &snapshot::WorldSnapshot) -> Vec<Effect> {
 }
 
 /// Check if a scheduled usage limit nudge is due, and if so, nudge all running coworkers.
-pub(super) fn maybe_nudge_usage_limit_expiry(snap: &snapshot::WorldSnapshot) -> Vec<Effect> {
+pub fn maybe_nudge_usage_limit_expiry(snap: &snapshot::WorldSnapshot) -> Vec<Effect> {
     // Pure decision: should we nudge?
     let decision = crate::rules::decide_usage_limit_expiry(
         snap.usage_limit_nudge_at,
@@ -774,7 +774,7 @@ pub(super) fn check_and_nudge_api_errors(
 /// The primary fix is in `headless.rs` (skip `--settings` on resume), but this
 /// serves as defense in depth: detect the error via stderr, shut down the session,
 /// and let normal task dispatch respawn it.
-pub(super) fn check_and_restart_tool_name_conflicts(snap: &snapshot::WorldSnapshot) -> Vec<Effect> {
+pub fn check_and_restart_tool_name_conflicts(snap: &snapshot::WorldSnapshot) -> Vec<Effect> {
     if snap.tool_name_conflict_coworkers.is_empty() {
         return vec![];
     }
@@ -891,7 +891,7 @@ pub(super) async fn check_and_respawn_dead_processes(
 /// The lead is the human-facing session that should never be permanently down.
 /// If the lead is not in `active_coworkers` (dead and deregistered), respawn it.
 /// Uses `coworker_stop_times` as a cooldown to prevent rapid respawn loops.
-pub(super) fn ensure_lead_alive(snap: &snapshot::WorldSnapshot) -> Vec<Effect> {
+pub fn ensure_lead_alive(snap: &snapshot::WorldSnapshot) -> Vec<Effect> {
     // Check if lead is already registered (any status)
     let lead_registered = snap
         .active_coworkers

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -66,12 +66,17 @@ pub use effects::Effect;
 // 2. Those functions often mutate state, making them harder to test in isolation
 // 3. Pure functions are the gold standard for testing
 #[doc(hidden)]
-pub use dispatch::reset_orphaned_tasks;
+pub use dispatch::{
+    build_description_based_completion_effects, check_for_duplicate_task_workers,
+    reset_orphaned_tasks,
+};
 #[doc(hidden)]
 pub use events::DaemonEvent;
 #[doc(hidden)]
 pub use health::{
-    check_and_restart_stuck_reviewers, check_and_shutdown_idle_coworkers, check_for_usage_limits,
+    check_and_restart_stuck_reviewers, check_and_restart_tool_name_conflicts,
+    check_and_shutdown_idle_coworkers, check_for_usage_limits, ensure_lead_alive,
+    maybe_nudge_usage_limit_expiry,
 };
 #[doc(hidden)]
 pub use pr::{collect_merged_pr_cleanup_effects, reconcile_orphaned_prs};

--- a/tests/multi_tick_e2e.rs
+++ b/tests/multi_tick_e2e.rs
@@ -14,6 +14,7 @@ mod multi_tick_harness;
 
 use midtown::daemon::{DaemonEvent, Effect};
 use multi_tick_harness::MultiTickHarness;
+use serde_json::json;
 
 /// Test that reset_orphaned_tasks doesn't produce duplicate resets.
 ///
@@ -21,7 +22,6 @@ use multi_tick_harness::MultiTickHarness;
 /// On tick 2, the same task shouldn't be reset again.
 #[test]
 fn test_no_duplicate_orphan_resets() {
-    // Load a snapshot with orphaned tasks
     let fixture = include_str!(
         "fixtures/snapshot/snapshot-tool-names-must-be-unique-all-stuck-20260211-030435.json"
     );
@@ -30,7 +30,6 @@ fn test_no_duplicate_orphan_resets() {
     // Tick 1: Reset orphaned tasks
     let effects1 = harness.tick(&DaemonEvent::TaskDispatchTick);
 
-    // Count reset effects
     let reset_count_1 = effects1
         .iter()
         .filter(|e| matches!(e, Effect::ResetTaskToPending { .. }))
@@ -48,12 +47,6 @@ fn test_no_duplicate_orphan_resets() {
 
     println!("Tick 2: {} reset effects", reset_count_2);
 
-    // After effects are applied from tick 1, tick 2 should not re-reset the same tasks.
-    // The harness simulates applying resets, so tasks that were reset in tick 1
-    // should be pending (with no owner) in tick 2.
-    //
-    // If the decision function has a bug and doesn't check current state properly,
-    // it would try to reset the same task again.
     assert_eq!(
         reset_count_2, 0,
         "Tick 2 should not re-reset tasks that were already reset in tick 1"
@@ -100,90 +93,118 @@ fn test_no_duplicate_idle_shutdowns() {
 
     println!("Tick 2: {} shutdown effects", shutdown_count_2);
 
-    // The harness simulates removing coworkers from active_names when they're shut down.
-    // Tick 2 should not attempt to shut down coworkers that were already removed.
     assert_eq!(
         shutdown_count_2, 0,
         "Tick 2 should not re-shutdown coworkers that were already shut down in tick 1"
     );
 }
 
-/// Test that merged PR cleanup doesn't duplicate task completion effects.
+/// Test that merged PR cleanup doesn't repeat across ticks.
 ///
-/// Bug scenario: PR is merged → task completed on tick 1.
-/// On tick 2, the same task shouldn't be completed again.
+/// Bug scenario: PR is merged → cleanup on tick 1.
+/// On tick 2, the same PR shouldn't be cleaned up again.
+///
+/// Uses snapshot mutation to inject a merged PR with a matching branch entry,
+/// since `collect_merged_pr_cleanup_effects` requires both `merged_pr_numbers`
+/// and `merged_pr_branches` to produce `CleanupMergedWorktree` effects.
 #[test]
 fn test_no_duplicate_pr_cleanup() {
     let fixture =
         include_str!("fixtures/snapshot/snapshot-reviewer-not-spawning-20260214-003545.json");
     let mut harness = MultiTickHarness::from_json(fixture).unwrap();
 
+    // Inject a merged PR with a matching branch entry so
+    // collect_merged_pr_cleanup_effects produces effects
+    harness.snapshot_mut().merged_pr_numbers.insert(9999);
+    harness
+        .snapshot_mut()
+        .merged_pr_branches
+        .insert(9999, "test-branch".to_string());
+
     // Tick 1: Collect merged PR cleanup effects
     let effects1 = harness.tick(&DaemonEvent::PrPollTick);
 
-    let complete_count_1 = effects1
+    let cleanup_count_1 = effects1
         .iter()
-        .filter(|e| matches!(e, Effect::CompleteTask { .. }))
+        .filter(|e| matches!(e, Effect::CleanupMergedWorktree { .. }))
         .count();
 
-    println!("Tick 1: {} complete task effects", complete_count_1);
+    println!("Tick 1: {} CleanupMergedWorktree effects", cleanup_count_1);
+    assert!(
+        cleanup_count_1 > 0,
+        "Tick 1 should produce at least one CleanupMergedWorktree effect for the injected PR"
+    );
 
-    // Tick 2: Should not re-complete the same tasks
+    // Tick 2: Should not re-clean up the same PRs
     let effects2 = harness.tick(&DaemonEvent::PrPollTick);
 
-    let complete_count_2 = effects2
+    let cleanup_count_2 = effects2
         .iter()
-        .filter(|e| matches!(e, Effect::CompleteTask { .. }))
+        .filter(|e| matches!(e, Effect::CleanupMergedWorktree { .. }))
         .count();
 
-    println!("Tick 2: {} complete task effects", complete_count_2);
+    println!("Tick 2: {} CleanupMergedWorktree effects", cleanup_count_2);
 
-    // The harness marks tasks as completed when CompleteTask effects are applied.
-    // Tick 2 should not try to complete tasks that are already completed.
     assert_eq!(
-        complete_count_2, 0,
-        "Tick 2 should not re-complete tasks that were already completed in tick 1"
+        cleanup_count_2, 0,
+        "Tick 2 should not re-clean up PRs that were already cleaned up in tick 1"
     );
 }
 
-/// Test that reviewer spawn doesn't duplicate across ticks.
+/// Test that reconcile_orphaned_prs doesn't create duplicate tasks.
 ///
-/// Bug scenario: PR needs review → reviewer assigned on tick 1.
-/// On tick 2, another reviewer shouldn't be assigned to the same PR.
+/// Bug scenario: Orphaned PR found → task created on tick 1.
+/// On tick 2, the same PR shouldn't get another task.
+///
+/// Uses snapshot mutation to create an orphaned PR (reviewed, CI green,
+/// no task association) that `reconcile_orphaned_prs` will act on.
 #[test]
-fn test_no_duplicate_reviewer_spawns() {
+fn test_no_duplicate_orphaned_pr_tasks() {
     let fixture =
         include_str!("fixtures/snapshot/snapshot-reviewer-not-spawning-20260214-003545.json");
     let mut harness = MultiTickHarness::from_json(fixture).unwrap();
 
-    // Tick 1: Reconcile orphaned PRs (may spawn reviewers)
+    // Inject an orphaned PR: reviewed, CI green, has a coworker branch prefix, no task.
+    // open_prs_data is Vec<serde_json::Value> matching the GitHub API shape.
+    let orphan_pr = json!({
+        "number": 8888,
+        "title": "feat: Test orphan PR [Midtown !999]",
+        "headRefName": "broadway/test-orphan",
+        "isDraft": false,
+        "statusCheckRollup": [
+            {"conclusion": "SUCCESS"}
+        ]
+    });
+    harness.snapshot_mut().open_prs_data.push(orphan_pr);
+    harness.snapshot_mut().reviewed_prs.insert(8888);
+
+    // Tick 1: Reconcile should create a task for the orphaned PR
     let effects1 = harness.tick(&DaemonEvent::PrPollTick);
 
-    let assign_count_1 = effects1
+    let create_count_1 = effects1
         .iter()
-        .filter(|e| matches!(e, Effect::AssignReviewer { .. }))
+        .filter(|e| matches!(e, Effect::CreateTask { .. }))
         .count();
 
-    println!("Tick 1: {} reviewer assignments", assign_count_1);
+    println!("Tick 1: {} CreateTask effects", create_count_1);
+    assert!(
+        create_count_1 > 0,
+        "Tick 1 should create a task for the orphaned PR"
+    );
 
-    // Tick 2: Should not re-assign reviewers to the same PRs
+    // Tick 2: Should not create a duplicate task for the same PR
     let effects2 = harness.tick(&DaemonEvent::PrPollTick);
 
-    let assign_count_2 = effects2
+    let create_count_2 = effects2
         .iter()
-        .filter(|e| matches!(e, Effect::AssignReviewer { .. }))
+        .filter(|e| matches!(e, Effect::CreateTask { .. }))
         .count();
 
-    println!("Tick 2: {} reviewer assignments", assign_count_2);
+    println!("Tick 2: {} CreateTask effects", create_count_2);
 
-    // The harness tracks reviewer assignments. After tick 1 assigns a reviewer,
-    // tick 2 should see that the PR already has a reviewer and not assign another.
-    //
-    // Note: This depends on the decision function checking reviewer_pr_assignments.
-    // If it's buggy and doesn't check, it would assign again.
     assert_eq!(
-        assign_count_2, 0,
-        "Tick 2 should not re-assign reviewers to PRs that already have reviewers from tick 1"
+        create_count_2, 0,
+        "Tick 2 should not create duplicate tasks for PRs that already have tasks from tick 1"
     );
 }
 
@@ -229,22 +250,20 @@ fn test_stuck_reviewer_backoff() {
 
     println!("Tick 2: {} reviewer restarts", restart_count_2);
 
-    // The stuck reviewer logic includes cooldowns and restart count limits.
-    // Even if the reviewer is still stuck after tick 1, tick 2 should respect
-    // cooldowns and backoff instead of restarting immediately.
-    //
-    // Note: This test depends on the decision function tracking restart counts
-    // and implementing backoff. If buggy, it would restart every tick.
     assert_eq!(
         restart_count_2, 0,
         "Tick 2 should not immediately restart a stuck reviewer due to backoff"
     );
 }
 
-/// Test that usage limit nudges don't spam every tick.
+/// Test that usage limit nudges don't fire repeatedly.
 ///
 /// Bug scenario: Coworker hits usage limit → nudge scheduled on tick 1.
-/// On tick 2, the nudge shouldn't be scheduled again immediately.
+/// On tick 2, the nudge shouldn't be scheduled again because
+/// `usage_limit_nudge_scheduled` is now true.
+///
+/// Uses snapshot mutation to set `has_usage_limit: true` on a coworker,
+/// since the fixture doesn't have any coworkers with usage limits.
 #[test]
 fn test_usage_limit_nudge_dedup() {
     let fixture = include_str!(
@@ -252,7 +271,20 @@ fn test_usage_limit_nudge_dedup() {
     );
     let mut harness = MultiTickHarness::from_json(fixture).unwrap();
 
-    // Tick 1: Check for usage limits
+    // Inject a coworker with has_usage_limit: true so check_for_usage_limits
+    // will actually produce SetUsageLimitNudge
+    if let Some((_name, health)) = harness
+        .snapshot_mut()
+        .headless_process_health
+        .iter_mut()
+        .find(|(_, h)| h.is_alive)
+    {
+        health.has_usage_limit = true;
+    }
+    // Ensure the flag starts as false
+    harness.snapshot_mut().usage_limit_nudge_scheduled = false;
+
+    // Tick 1: Check for usage limits — should produce SetUsageLimitNudge
     let effects1 = harness.tick(&DaemonEvent::SessionMonitorTick);
 
     let nudge_count_1 = effects1
@@ -261,8 +293,18 @@ fn test_usage_limit_nudge_dedup() {
         .count();
 
     println!("Tick 1: {} usage limit nudge effects", nudge_count_1);
+    assert!(
+        nudge_count_1 > 0,
+        "Tick 1 should produce a SetUsageLimitNudge effect for the usage-limited coworker"
+    );
 
-    // Tick 2: Should not re-schedule the same nudge
+    // Verify the harness applied the effect
+    assert!(
+        harness.snapshot().usage_limit_nudge_scheduled,
+        "After tick 1, usage_limit_nudge_scheduled should be true"
+    );
+
+    // Tick 2: Should not re-schedule the nudge
     let effects2 = harness.tick(&DaemonEvent::SessionMonitorTick);
 
     let nudge_count_2 = effects2
@@ -272,15 +314,9 @@ fn test_usage_limit_nudge_dedup() {
 
     println!("Tick 2: {} usage limit nudge effects", nudge_count_2);
 
-    // The usage_limit_nudge_scheduled flag in WorldSnapshot tracks whether
-    // a nudge is already scheduled. Tick 2 should see this and not schedule again.
-    //
-    // Note: The harness doesn't currently mutate usage_limit_nudge_scheduled,
-    // so this test may pass trivially. To make it meaningful, we'd need to
-    // simulate the effect of SetUsageLimitNudge.
     assert_eq!(
         nudge_count_2, 0,
-        "Tick 2 should not re-schedule a usage limit nudge that's already scheduled"
+        "Tick 2 should not re-schedule a usage limit nudge — flag is already set"
     );
 }
 
@@ -302,10 +338,6 @@ fn test_multi_tick_stabilization() {
         println!("Tick {}: {} effects", i, effects.len());
     }
 
-    // After the first tick resolves issues, subsequent ticks should produce
-    // fewer effects. By tick 5, we should be stable (0 effects).
-    //
-    // If there's a bug causing an infinite loop, effect counts won't decrease.
     let last_count = effect_counts.last().unwrap();
     assert_eq!(
         *last_count, 0,

--- a/tests/multi_tick_harness.rs
+++ b/tests/multi_tick_harness.rs
@@ -29,9 +29,11 @@
 
 use chrono::Utc;
 
+use midtown::auth::AuthProvider;
+use midtown::coworker::{Coworker, CoworkerStatus};
 use midtown::daemon::Effect;
 use midtown::daemon::snapshot::{ProcessHealth, WorldSnapshot};
-use midtown::tasks::TaskStatus;
+use midtown::tasks::{Task, TaskStatus};
 
 /// A test harness for simulating multiple daemon ticks.
 ///
@@ -41,6 +43,33 @@ use midtown::tasks::TaskStatus;
 /// 3. Generate a new snapshot for the next tick
 ///
 /// This enables testing cross-tick behavior without running a full daemon.
+///
+/// ## Coverage
+///
+/// The harness calls only pure decision functions (those taking `&WorldSnapshot`
+/// and returning `Vec<Effect>` without I/O). Functions requiring `DaemonState`
+/// are skipped:
+///
+/// ### SessionMonitorTick
+/// - Called: `check_and_shutdown_idle_coworkers`, `check_and_restart_stuck_reviewers`,
+///   `check_for_usage_limits`, `maybe_nudge_usage_limit_expiry`,
+///   `check_and_restart_tool_name_conflicts`
+/// - Skipped (needs DaemonState): `check_and_handle_auth_errors`,
+///   `check_and_restart_stuck_coworkers`, `check_and_nudge_api_errors`
+///
+/// ### TaskDispatchTick
+/// - Called: `reset_orphaned_tasks`, `check_for_duplicate_task_workers`,
+///   `ensure_lead_alive`
+/// - Skipped (needs DaemonState): `check_and_recover_orphans`,
+///   `spawn_for_pending_tasks`, `check_and_respawn_dead_processes`,
+///   `check_and_fire_reminders`
+/// - Skipped (takes individual fields): `collect_auto_archive_effects`
+///
+/// ### PrPollTick
+/// - Called: `collect_merged_pr_cleanup_effects`, `reconcile_orphaned_prs`,
+///   `build_description_based_completion_effects`
+/// - Skipped (needs DaemonState): `poll_prs_for_issues`
+/// - Skipped (takes individual fields): `check_for_stale_worktrees`
 pub struct MultiTickHarness {
     /// Current snapshot state (mutated by effect application)
     snapshot: WorldSnapshot,
@@ -53,6 +82,12 @@ impl MultiTickHarness {
         Ok(Self { snapshot })
     }
 
+    /// Get a mutable reference to the current snapshot for test setup.
+    #[allow(dead_code)]
+    pub fn snapshot_mut(&mut self) -> &mut WorldSnapshot {
+        &mut self.snapshot
+    }
+
     /// Get a reference to the current snapshot.
     #[allow(dead_code)]
     pub fn snapshot(&self) -> &WorldSnapshot {
@@ -62,7 +97,7 @@ impl MultiTickHarness {
     /// Simulate a daemon tick by calling pure decision functions.
     ///
     /// This calls only the pure decision functions that don't require DaemonState.
-    /// Functions that need DaemonState are skipped for now.
+    /// See the struct-level documentation for the full list of called/skipped functions.
     ///
     /// Returns the effects produced by this tick.
     pub fn tick(&mut self, event: &midtown::daemon::DaemonEvent) -> Vec<Effect> {
@@ -71,7 +106,6 @@ impl MultiTickHarness {
         // Call pure decision functions based on event type
         let effects = match event {
             DaemonEvent::SessionMonitorTick => {
-                // Health checks that are pure
                 let mut effects = Vec::new();
                 effects.extend(midtown::daemon::check_and_shutdown_idle_coworkers(
                     &self.snapshot,
@@ -80,13 +114,25 @@ impl MultiTickHarness {
                     &self.snapshot,
                 ));
                 effects.extend(midtown::daemon::check_for_usage_limits(&self.snapshot));
+                effects.extend(midtown::daemon::maybe_nudge_usage_limit_expiry(
+                    &self.snapshot,
+                ));
+                effects.extend(midtown::daemon::check_and_restart_tool_name_conflicts(
+                    &self.snapshot,
+                ));
                 effects
             }
             DaemonEvent::TaskDispatchTick => {
                 let mut effects = Vec::new();
                 effects.extend(midtown::daemon::reset_orphaned_tasks(&self.snapshot));
-                // Note: check_and_recover_orphans requires DaemonState - skipped in harness
-                // Note: spawn_for_pending_tasks requires DaemonState - skipped in harness
+                effects.extend(midtown::daemon::check_for_duplicate_task_workers(
+                    &self.snapshot,
+                ));
+                effects.extend(midtown::daemon::ensure_lead_alive(&self.snapshot));
+                // Skipped (needs DaemonState): check_and_recover_orphans,
+                // spawn_for_pending_tasks, check_and_respawn_dead_processes,
+                // check_and_fire_reminders
+                // Skipped (takes individual fields): collect_auto_archive_effects
                 effects
             }
             DaemonEvent::PrPollTick => {
@@ -95,10 +141,16 @@ impl MultiTickHarness {
                     &self.snapshot,
                 ));
                 effects.extend(midtown::daemon::reconcile_orphaned_prs(&self.snapshot));
+                effects.extend(midtown::daemon::build_description_based_completion_effects(
+                    &self.snapshot,
+                ));
+                // Skipped (needs DaemonState): poll_prs_for_issues
+                // Skipped (takes individual fields): check_for_stale_worktrees
                 effects
             }
             DaemonEvent::RateLimitCheckTick => {
-                // Rate limit checks are mostly side effects - skip
+                // Rate limit checks are inline in evaluate_tick with no separate
+                // pure decision functions to call
                 vec![]
             }
         };
@@ -111,32 +163,28 @@ impl MultiTickHarness {
 
     /// Apply effects to the current snapshot, simulating their execution.
     ///
-    /// This is a simplified simulation that only handles the effects most
-    /// relevant to cross-tick testing. Many effects (channel posts, nudges)
-    /// don't affect the snapshot state and are ignored.
+    /// Handles all effects that modify WorldSnapshot state relevant to cross-tick
+    /// testing. Effects that only produce side effects (channel posts, nudges)
+    /// are ignored since they don't affect decision function inputs.
     fn apply_effects(&mut self, effects: &[Effect]) {
         for effect in effects {
             match effect {
                 Effect::AssignAndSpawn { task_id, owner, .. } => {
-                    // Mark task as in_progress with owner
                     self.assign_task(task_id, owner);
                 }
                 Effect::RecordTaskAssignment { coworker, task_id } => {
-                    // Track the assignment
                     self.snapshot
                         .coworker_task_assignments
                         .insert(coworker.to_lowercase(), task_id.clone());
                     self.snapshot.busy_coworkers.insert(coworker.to_lowercase());
                 }
                 Effect::SpawnCoworker(config) => {
-                    // Add coworker to active set
                     self.spawn_coworker(&config.name);
                 }
                 Effect::SpawnCoworkerWithCallbacks { config, .. } => {
                     self.spawn_coworker(&config.name);
                 }
                 Effect::ShutdownCoworker { name, .. } => {
-                    // Remove coworker from active set
                     self.remove_coworker(name);
                 }
                 Effect::ShutdownCoworkerWithCallbacks { name, .. } => {
@@ -147,7 +195,6 @@ impl MultiTickHarness {
                     reviewer_name,
                     ..
                 } => {
-                    // Track reviewer assignment
                     self.snapshot
                         .active_reviewers
                         .insert(reviewer_name.to_lowercase());
@@ -156,26 +203,33 @@ impl MultiTickHarness {
                         .insert(reviewer_name.to_lowercase(), *pr_number);
                 }
                 Effect::RemoveReviewerAssignment { pr_number } => {
-                    // Remove reviewer assignment
                     self.snapshot
                         .reviewer_pr_assignments
                         .retain(|_, pr| pr != pr_number);
                 }
                 Effect::CompleteTask { task_id, .. } => {
-                    // Mark task as completed
                     self.complete_task(task_id);
                 }
                 Effect::ResetTaskToPending { task_id, .. } => {
-                    // Reset task to pending (clear owner)
                     self.reset_task(task_id);
                 }
+                Effect::SetUsageLimitNudge { .. } => {
+                    self.snapshot.usage_limit_nudge_scheduled = true;
+                }
+                Effect::CleanupMergedWorktree { pr_number, .. } => {
+                    self.snapshot.merged_pr_numbers.remove(pr_number);
+                    self.snapshot.merged_pr_branches.remove(pr_number);
+                }
+                Effect::CreateTask { subject, pr, .. } => {
+                    self.create_task(subject, *pr);
+                }
                 Effect::RecordCooldown { .. } => {
-                    // Cooldowns are tracked in DaemonState, not WorldSnapshot
-                    // We can't simulate this without DaemonState
+                    // Cooldowns are tracked in DaemonState, not WorldSnapshot.
+                    // Cannot simulate without DaemonState.
                 }
                 _ => {
-                    // Other effects (PostToChannel, NudgeCoworker, etc.) don't affect
-                    // the snapshot state in ways that matter for cross-tick testing
+                    // Other effects (PostToChannel, PostSystemMessage, NudgeCoworker,
+                    // NudgeLead, etc.) don't affect WorldSnapshot state.
                 }
             }
         }
@@ -183,7 +237,6 @@ impl MultiTickHarness {
 
     /// Simulate assigning a task to a coworker.
     fn assign_task(&mut self, task_id: &str, owner: &str) {
-        // Find the task and update its status/owner
         for task in &mut self.snapshot.all_tasks {
             if task.id == task_id {
                 task.status = TaskStatus::InProgress;
@@ -192,7 +245,6 @@ impl MultiTickHarness {
             }
         }
 
-        // Update in_progress_tasks
         if let Some(task) = self.snapshot.all_tasks.iter().find(|t| t.id == task_id) {
             self.snapshot.in_progress_tasks.push((
                 task.id.clone(),
@@ -201,7 +253,6 @@ impl MultiTickHarness {
             ));
         }
 
-        // Remove from pending lists
         self.snapshot
             .pending_tasks_without_owners
             .retain(|t| t.id != task_id);
@@ -209,7 +260,6 @@ impl MultiTickHarness {
             .pending_tasks_with_owners
             .retain(|(id, _, _)| id != task_id);
 
-        // Mark coworker as busy
         self.snapshot.busy_coworkers.insert(owner.to_lowercase());
         self.snapshot
             .coworker_task_assignments
@@ -219,61 +269,69 @@ impl MultiTickHarness {
     /// Simulate spawning a coworker.
     fn spawn_coworker(&mut self, name: &str) {
         let name_lower = name.to_lowercase();
-
-        // Add to active sets
         self.snapshot.active_names.insert(name_lower.clone());
-
-        // Add start time
+        let now = Utc::now();
         self.snapshot
             .coworker_start_times
-            .insert(name_lower.clone(), Utc::now());
-
-        // Add process health (alive, no issues)
+            .insert(name_lower.clone(), now);
         self.snapshot.headless_process_health.insert(
-            name_lower,
+            name_lower.clone(),
             ProcessHealth {
                 is_alive: true,
-                last_event_at: Some(Utc::now()),
+                last_event_at: Some(now),
                 ..Default::default()
             },
         );
+
+        // Add to active_coworkers so ensure_lead_alive sees it
+        let coworker = Coworker {
+            slot_id: format!("test-slot-{}", name_lower),
+            name: name.to_string(),
+            status: CoworkerStatus::Running,
+            working_dir: format!("/test/worktree/{}", name_lower),
+            started_at: now,
+            current_task: None,
+            session_id: None,
+            model: "opus".to_string(),
+            provider: AuthProvider::Claude,
+            profile: "default".to_string(),
+        };
+        self.snapshot.active_coworkers.push(coworker.clone());
+        self.snapshot.running_coworkers.push(coworker);
     }
 
     /// Simulate removing a coworker.
     fn remove_coworker(&mut self, name: &str) {
         let name_lower = name.to_lowercase();
-
-        // Remove from active sets
         self.snapshot.active_names.remove(&name_lower);
         self.snapshot.busy_coworkers.remove(&name_lower);
-
-        // Add stop time
         self.snapshot
             .coworker_stop_times
             .insert(name_lower.clone(), Utc::now());
-
-        // Mark process as dead
         if let Some(health) = self.snapshot.headless_process_health.get_mut(&name_lower) {
             health.is_alive = false;
             health.exit_code = Some(0);
         }
-
-        // Clear task assignment
         self.snapshot.coworker_task_assignments.remove(&name_lower);
         self.snapshot.active_reviewers.remove(&name_lower);
+
+        // Remove from active_coworkers and running_coworkers
+        self.snapshot
+            .active_coworkers
+            .retain(|c| c.name.to_lowercase() != name_lower);
+        self.snapshot
+            .running_coworkers
+            .retain(|c| c.name.to_lowercase() != name_lower);
     }
 
     /// Simulate completing a task.
     fn complete_task(&mut self, task_id: &str) {
-        // Update task status
         for task in &mut self.snapshot.all_tasks {
             if task.id == task_id {
                 task.status = TaskStatus::Completed;
                 break;
             }
         }
-
-        // Remove from in_progress
         self.snapshot
             .in_progress_tasks
             .retain(|(id, _, _)| id != task_id);
@@ -281,24 +339,20 @@ impl MultiTickHarness {
 
     /// Simulate resetting a task to pending.
     fn reset_task(&mut self, task_id: &str) {
-        // Find the task and reset it
         for task in &mut self.snapshot.all_tasks {
             if task.id == task_id {
                 task.status = TaskStatus::Pending;
                 let owner = task.owner.clone();
                 task.owner = None;
 
-                // Move to pending_tasks_without_owners
                 self.snapshot
                     .pending_tasks_without_owners
                     .push(task.clone());
 
-                // Remove from in_progress
                 self.snapshot
                     .in_progress_tasks
                     .retain(|(id, _, _)| id != task_id);
 
-                // Clear busy state if this was the only task
                 if let Some(owner_name) = owner {
                     let owner_lower = owner_name.to_lowercase();
                     if !self
@@ -313,6 +367,33 @@ impl MultiTickHarness {
                 }
                 break;
             }
+        }
+    }
+
+    /// Simulate creating a task (from reconcile_orphaned_prs).
+    fn create_task(&mut self, subject: &str, pr: Option<u64>) {
+        let task_id = format!("harness-{}", self.snapshot.all_tasks.len() + 1);
+        let task = Task {
+            id: task_id,
+            subject: subject.to_string(),
+            status: TaskStatus::Pending,
+            owner: None,
+            description: None,
+            blocked_by: vec![],
+            channel: None,
+            pr,
+            created_at: None,
+        };
+        self.snapshot.all_tasks.push(task.clone());
+        self.snapshot.pending_tasks_without_owners.push(task);
+
+        // Track the PR → task association so reconcile_orphaned_prs
+        // won't create a duplicate task for the same PR on the next tick
+        if let Some(pr_number) = pr {
+            self.snapshot.pr_task_associations.insert(
+                pr_number,
+                format!("harness-{}", self.snapshot.all_tasks.len()),
+            );
         }
     }
 }


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Built a `MultiTickHarness` that loads WorldSnapshot fixtures and simulates multiple daemon ticks
- Added 8 E2E tests covering cross-tick bug scenarios (duplicate spawns, resets, shutdowns, etc.)
- Harness simulates effect application by mutating snapshot state between ticks

## Background

Cross-tick bugs (triple-spawn, double-assign, duplicate merge tasks) kept appearing because we could only test single ticks in isolation. This harness enables testing daemon behavior across multiple ticks by:

1. Loading an initial WorldSnapshot fixture
2. Calling pure decision functions to get Vec<Effect>
3. Simulating effect execution by mutating the snapshot
4. Calling decision functions again on the mutated snapshot
5. Asserting no duplicate effects are produced

## Test Coverage

1. **test_no_duplicate_orphan_resets**: Task reset on tick 1 → not reset again on tick 2
2. **test_no_duplicate_idle_shutdowns**: Coworker shutdown on tick 1 → not shutdown again on tick 2
3. **test_no_duplicate_pr_cleanup**: Task completed on tick 1 → not completed again on tick 2
4. **test_no_duplicate_reviewer_spawns**: Reviewer assigned on tick 1 → not re-assigned on tick 2
5. **test_stuck_reviewer_backoff**: Stuck reviewer restarted on tick 1 → backoff applied on tick 2
6. **test_usage_limit_nudge_dedup**: Usage limit nudge scheduled on tick 1 → not re-scheduled on tick 2
7. **test_multi_tick_stabilization**: Effects monotonically decrease over 5 ticks (catches infinite loops)

## Limitations

The harness only simulates pure decision functions (WorldSnapshot → Vec<Effect>). Functions requiring DaemonState (cooldown trackers, persistent state mutations) are skipped. This is sufficient to catch most cross-tick bugs since WorldSnapshot contains the majority of decision-relevant state.

## Test plan
- [x] All 8 multi-tick tests pass
- [x] Full test suite passes
- [x] No clippy warnings

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)