### PR TITLE
fix: Add retry logic to channel read operations [Midtown !1397]

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -488,9 +488,35 @@ impl Channel {
         let mut cursor = Cursor::load_or_create(&self.base_dir, &self.channel_name, agent)?;
 
         let file = File::open(&self.channel_file)?;
-        // Try to acquire shared lock without blocking
-        file.try_lock_shared()
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::WouldBlock, e.to_string()))?;
+
+        // Try to acquire shared lock with bounded retries to handle lock contention.
+        let mut acquired = false;
+        for attempt in 0..10 {
+            match file.try_lock_shared() {
+                Ok(()) => {
+                    acquired = true;
+                    break;
+                }
+                Err(_) if attempt < 9 => {
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+                Err(e) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::WouldBlock,
+                        format!("Failed to acquire shared lock after 500ms: {}", e),
+                    )
+                    .into());
+                }
+            }
+        }
+
+        if !acquired {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "Failed to acquire shared lock after 500ms",
+            )
+            .into());
+        }
 
         let mut reader = BufReader::new(file);
 
@@ -596,8 +622,36 @@ impl Channel {
         }
 
         let file = File::open(&self.channel_file)?;
-        file.try_lock_shared()
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::WouldBlock, e.to_string()))?;
+
+        // Try to acquire shared lock with bounded retries to handle lock contention.
+        // This prevents failures when a writer is still releasing its exclusive lock.
+        let mut acquired = false;
+        for attempt in 0..10 {
+            match file.try_lock_shared() {
+                Ok(()) => {
+                    acquired = true;
+                    break;
+                }
+                Err(_) if attempt < 9 => {
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+                Err(e) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::WouldBlock,
+                        format!("Failed to acquire shared lock after 500ms: {}", e),
+                    )
+                    .into());
+                }
+            }
+        }
+
+        if !acquired {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "Failed to acquire shared lock after 500ms",
+            )
+            .into());
+        }
 
         let file_size = file.metadata()?.len();
         if file_size == 0 {
@@ -671,8 +725,35 @@ impl Channel {
         }
 
         let file = File::open(&self.channel_file)?;
-        file.try_lock_shared()
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::WouldBlock, e.to_string()))?;
+
+        // Try to acquire shared lock with bounded retries to handle lock contention.
+        let mut acquired = false;
+        for attempt in 0..10 {
+            match file.try_lock_shared() {
+                Ok(()) => {
+                    acquired = true;
+                    break;
+                }
+                Err(_) if attempt < 9 => {
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+                Err(e) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::WouldBlock,
+                        format!("Failed to acquire shared lock after 500ms: {}", e),
+                    )
+                    .into());
+                }
+            }
+        }
+
+        if !acquired {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "Failed to acquire shared lock after 500ms",
+            )
+            .into());
+        }
 
         // Estimate where to start reading
         let estimated_bytes = (n as u64) * 300;


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Fixed CI test failure: `test_channel_read_with_last_parameter` was failing with exit code 101
- Added bounded retry logic (10 attempts, 50ms delays) to three channel read methods
- Prevents `WouldBlock` errors when reads happen immediately after async writes

## Root Cause
The test `test_channel_read_with_last_parameter` was failing in CI because:
1. `handle_channel_post()` is async and uses `spawn_blocking` to write to the channel file
2. After awaiting the write, the test immediately calls `handle_channel_read()`
3. `read_last_n_messages()` used `try_lock_shared()` with no retries
4. In CI (heavily loaded), the exclusive write lock might not be fully released yet
5. This caused the read to fail with `WouldBlock`

## Fix Details
Added retry logic to three read methods in `src/channel.rs`:
- `read_last_n_messages()` - line 593
- `read_since_cursor()` - line 490
- `read_messages_before_position()` - line 727

Each now retries up to 10 times with 50ms delays (500ms total) when encountering lock contention, matching the existing pattern in `read_all()`.

## Test Plan
- [x] Local tests pass: `cargo test`
- [x] Clippy clean: `cargo clippy -- -D warnings`
- [x] Formatting clean: `cargo fmt -- --check`
- [x] Failing test now passes: `cargo test test_channel_read_with_last_parameter`
- [ ] CI tests pass on GitHub Actions

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)