### PR TITLE
feat: TUI sidebar polish - clickable channels, compact spacing, aligned bullets [Midtown !1406]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -306,6 +306,9 @@ pub struct App {
     /// Mapping of board panel line numbers to tasks (for click-to-attach)
     /// Maps (line_number) -> (task_id, task_owner) where line_number is relative to board content area
     pub task_line_map: HashMap<u16, (String, Option<String>)>,
+    /// Mapping of board panel line numbers to channel headers (for click-to-select)
+    /// Maps line_number -> channel_name where line_number is relative to board content area
+    pub channel_line_map: HashMap<u16, String>,
 }
 
 /// Autocomplete state for @mentions, #channels, and !task-ids
@@ -437,6 +440,7 @@ impl App {
             board_area: None,
             input_area: None,
             task_line_map: HashMap::new(),
+            channel_line_map: HashMap::new(),
         };
 
         // Initial load
@@ -900,7 +904,7 @@ impl App {
     }
 
     /// Update the selected channel when a board selection changes
-    fn update_selected_channel(&mut self) {
+    pub fn update_selected_channel(&mut self) {
         if let Some(ref selection) = self.board_selection {
             let new_channel = match selection {
                 BoardSelection::Channel(ch) => ch.clone(),
@@ -2566,6 +2570,7 @@ pub(super) mod tests {
             board_area: None,
             input_area: None,
             task_line_map: HashMap::new(),
+            channel_line_map: HashMap::new(),
         }
     }
 

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -682,9 +682,19 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                     && y >= board_rect.y
                     && y < board_rect.y + board_rect.height
                 {
-                    // Check if click is on a task line (for attach)
                     // Board rect includes border (1 line), so subtract 1 to get content-relative line
                     let content_y = y.saturating_sub(board_rect.y + 1);
+
+                    // Check if click is on a channel header (for selection)
+                    if let Some(channel_name) = app.channel_line_map.get(&content_y) {
+                        // Update board selection to this channel
+                        app.board_selection =
+                            Some(app::BoardSelection::Channel(channel_name.clone()));
+                        app.update_selected_channel();
+                        return EventResult::Continue;
+                    }
+
+                    // Check if click is on a task line (for attach)
                     if let Some((_task_id, task_owner)) = app.task_line_map.get(&content_y)
                         && let Some(owner) = task_owner
                     {

--- a/src/bin/midtown/cli/chat/ui/board.rs
+++ b/src/bin/midtown/cli/chat/ui/board.rs
@@ -19,8 +19,9 @@ use super::text::wrap_content;
 /// Returns (hyperlinks, tasks_area) where tasks_area is the rect containing the task list
 /// (excluding the coworker status section). This is used for click detection.
 pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> (Vec<Hyperlink>, Rect) {
-    // Clear task line map for new render
+    // Clear line maps for new render
     app.task_line_map.clear();
+    app.channel_line_map.clear();
 
     // Split board area vertically: tasks at top, coworkers at bottom
     let active_coworker_count = app.coworkers.len();
@@ -104,21 +105,18 @@ pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> (Vec<Hyperl
         }
     }
 
-    // Build task_line_map before rendering (to avoid borrow conflicts)
-    // This maps line numbers to (task_id, owner) for click-to-attach
+    // Build task_line_map and channel_line_map before rendering (to avoid borrow conflicts)
+    // task_line_map: maps line numbers to (task_id, owner) for click-to-attach
+    // channel_line_map: maps line numbers to channel_name for click-to-select
     let mut task_line_map: HashMap<u16, (String, Option<String>)> = HashMap::new();
+    let mut channel_line_map: HashMap<u16, String> = HashMap::new();
     let mut current_line: u16 = 0;
-    let mut first_channel = true;
 
     // First pass: calculate line positions
-    for tasks in channels_to_display.values() {
-        if !first_channel {
-            current_line += 1; // Blank line between channels
-        }
-        first_channel = false;
-
+    for (channel_name, tasks) in &channels_to_display {
+        // Record channel header line for click-to-select
+        channel_line_map.insert(current_line, channel_name.clone());
         current_line += 1; // Channel header
-        current_line += 1; // Blank line after header
 
         for task in tasks {
             // Record the first line of this task for click-to-attach
@@ -132,19 +130,13 @@ pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> (Vec<Hyperl
         }
     }
 
-    // Store task_line_map in app for mouse click handler
+    // Store line maps in app for mouse click handler
     app.task_line_map = task_line_map;
+    app.channel_line_map = channel_line_map;
 
     // Render each channel as a swimlane
-    first_channel = true;
     for (channel_name, tasks) in &channels_to_display {
-        if !first_channel {
-            lines.push(Line::from(""));
-        }
-        first_channel = false;
-
         render_channel_header(app, channel_name, tasks, &prs_by_channel, &mut lines);
-        lines.push(Line::from("")); // Blank line after header
 
         let task_indentation = compute_task_indentation(tasks);
 
@@ -266,7 +258,7 @@ fn render_task_item(
     };
 
     let prefix = format!("!{} ", task.id);
-    let prefix_width = task_indent.len() + 2 + prefix.len(); // indent + "● " + prefix
+    let prefix_width = 2 + task_indent.len() + 2 + prefix.len(); // "  " + indent + "● " + prefix
     let task_line = format!("{}{}", prefix, task.subject);
 
     let is_task_selected = app.board_selection.as_ref().is_some_and(|sel| match sel {
@@ -278,8 +270,9 @@ fn render_task_item(
     for (i, wrapped) in wrapped_lines.iter().enumerate() {
         if i == 0 {
             // First line: render indent + bullet + text as separate spans
+            // Add 2-space indent to align bullet with channel # (channel header uses "  #")
             let bullet_span = Span::styled(
-                format!("{}● ", task_indent),
+                format!("  {}● ", task_indent),
                 Style::default().fg(bullet_color),
             );
             let mut text_style = Style::default().fg(text_color);
@@ -578,8 +571,8 @@ mod tests {
         assert_eq!(lines.len(), 1);
         let spans = &lines[0].spans;
         assert_eq!(spans.len(), 2);
-        // Bullet span: no indent (level 0), just "● "
-        assert_eq!(spans[0].content.as_ref(), "● ");
+        // Bullet span: 2-space alignment + no indent (level 0) = "  ● "
+        assert_eq!(spans[0].content.as_ref(), "  ● ");
         // Text span: "!42 Task 42"
         assert_eq!(spans[1].content.as_ref(), "!42 Task 42");
     }
@@ -597,8 +590,8 @@ mod tests {
         assert_eq!(lines.len(), 1);
         let spans = &lines[0].spans;
         assert_eq!(spans.len(), 2);
-        // Bullet span includes indent: "  ● "
-        assert_eq!(spans[0].content.as_ref(), "  ● ");
+        // Bullet span: 2-space alignment + 2-space indent (level 1) = "    ● "
+        assert_eq!(spans[0].content.as_ref(), "    ● ");
         // Text span: "!7 Task 7"
         assert_eq!(spans[1].content.as_ref(), "!7 Task 7");
     }
@@ -615,8 +608,8 @@ mod tests {
 
         assert_eq!(lines.len(), 1);
         let spans = &lines[0].spans;
-        // Bullet span includes 6-space indent: "      ● "
-        assert_eq!(spans[0].content.as_ref(), "      ● ");
+        // Bullet span: 2-space alignment + 6-space indent (level 3) = "        ● "
+        assert_eq!(spans[0].content.as_ref(), "        ● ");
         assert_eq!(spans[1].content.as_ref(), "!99 Task 99");
     }
 


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
Three improvements to the TUI board sidebar:

1. **Clickable channel names**: Mouse clicks on channel headers now select that channel and load its messages (via new `channel_line_map` similar to `task_line_map`)

2. **Compact spacing**: Removed 2 blank lines (one between channels, one after header) so channels and tasks appear on consecutive lines

3. **Aligned task bullets**: Added 2-space indent before task bullets so the ● aligns with the # in channel headers (both at column 2)

## Test plan
- [x] All board module tests pass
- [x] Clippy passes with no warnings
- [x] Updated render_task_item tests to expect new indentation

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)