### PR TITLE
fix: Task worktrees branch from default branch, not HEAD

### DIFF
--- a/src/bin/midtown/cli/session.rs
+++ b/src/bin/midtown/cli/session.rs
@@ -395,6 +395,7 @@ pub(crate) fn ensure_attach_worktree(name: &str, daemon_cwd: &str) -> Result<Str
         // For coworkers, ensure their worktree exists
         let wt_path = manager.worktree_path(name);
         if !wt_path.exists() {
+            #[allow(deprecated)] // Legacy worktree layout for CLI session
             match manager.create(name) {
                 Ok(path) => return Ok(path.to_string_lossy().to_string()),
                 Err(e) => {
@@ -698,8 +699,8 @@ pub(crate) fn build_attach_shell_command(
     session_id: &str,
     coworker_type: Option<&str>,
 ) -> Result<String, String> {
-    let repo_name =
-        midtown::paths::detect_repo_name().ok_or_else(|| "Not in a git repository".to_string())?;
+    let repo_name = midtown::paths::detect_repo_name_from_dir(Path::new(cwd))
+        .ok_or_else(|| "Not in a git repository".to_string())?;
 
     let profile_dir =
         midtown::auth::active_profile_dir_for_project_with_provider(&repo_name, provider);

--- a/src/bin/midtown/cli/session_tests.rs
+++ b/src/bin/midtown/cli/session_tests.rs
@@ -1,33 +1,13 @@
 //! Tests for session commands (attach, detach, target parsing, CLI arg construction).
 
 use super::*;
-use std::sync::Mutex;
 
-// Mutex to serialize tests that depend on CWD being in a git repo.
-// Other tests (like daemon tests) may change CWD, so we need to serialize
-// to prevent interference. We use unwrap_or_else to recover from poisoned mutex.
-static SESSION_CWD_MUTEX: Mutex<()> = Mutex::new(());
-
-/// Ensure we're in a git repository before running a test.
-/// If not, try to cd to the project root (which is a git repo).
-fn ensure_in_git_repo() {
-    if midtown::paths::detect_repo_name().is_none() {
-        // Not in a repo - try to find the project root by looking for Cargo.toml
-        let current = std::env::current_dir().ok();
-        if let Some(mut path) = current {
-            // Walk up until we find Cargo.toml or run out of parents
-            while !path.join("Cargo.toml").exists() {
-                if !path.pop() {
-                    // Reached root without finding Cargo.toml - skip this approach
-                    break;
-                }
-            }
-            // If we found Cargo.toml, cd there
-            if path.join("Cargo.toml").exists() {
-                let _ = std::env::set_current_dir(&path);
-            }
-        }
-    }
+/// Return the project root directory (a git repo).
+///
+/// Uses CARGO_MANIFEST_DIR which is set at compile time, making this
+/// independent of the process CWD (which other tests may change).
+fn find_project_root() -> String {
+    env!("CARGO_MANIFEST_DIR").to_string()
 }
 
 fn git_head(dir: &std::path::Path) -> String {
@@ -350,10 +330,9 @@ fn test_to_cli_args_coworker_restricts_settings() {
 
 #[test]
 fn test_lead_attach_includes_system_prompt() {
-    let _lock = SESSION_CWD_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-    ensure_in_git_repo();
+    let cwd = find_project_root();
     let result = build_attach_shell_command(
-        "/tmp/test-cwd",
+        &cwd,
         "lead",
         midtown::auth::AuthProvider::Claude,
         "session-123",
@@ -379,10 +358,9 @@ fn test_lead_attach_includes_system_prompt() {
 
 #[test]
 fn test_coworker_attach_includes_system_prompt() {
-    let _lock = SESSION_CWD_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-    ensure_in_git_repo();
+    let cwd = find_project_root();
     let result = build_attach_shell_command(
-        "/tmp/test-cwd",
+        &cwd,
         "park",
         midtown::auth::AuthProvider::Claude,
         "session-456",
@@ -408,10 +386,9 @@ fn test_coworker_attach_includes_system_prompt() {
 
 #[test]
 fn test_lead_attach_sets_task_list_id() {
-    let _lock = SESSION_CWD_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-    ensure_in_git_repo();
+    let cwd = find_project_root();
     let result = build_attach_shell_command(
-        "/tmp/test-cwd",
+        &cwd,
         "lead",
         midtown::auth::AuthProvider::Claude,
         "session-123",
@@ -431,10 +408,9 @@ fn test_lead_attach_sets_task_list_id() {
 
 #[test]
 fn test_coworker_attach_no_task_list_id() {
-    let _lock = SESSION_CWD_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-    ensure_in_git_repo();
+    let cwd = find_project_root();
     let result = build_attach_shell_command(
-        "/tmp/test-cwd",
+        &cwd,
         "park",
         midtown::auth::AuthProvider::Claude,
         "session-456",
@@ -454,10 +430,9 @@ fn test_coworker_attach_no_task_list_id() {
 
 #[test]
 fn test_lead_attach_includes_agent_teams_flags() {
-    let _lock = SESSION_CWD_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-    ensure_in_git_repo();
+    let cwd = find_project_root();
     let result = build_attach_shell_command(
-        "/tmp/test-cwd",
+        &cwd,
         "lead",
         midtown::auth::AuthProvider::Claude,
         "session-123",
@@ -563,10 +538,9 @@ fn test_to_cli_args_coworker_gets_sonnet_model() {
 
 #[test]
 fn test_reviewer_attach_gets_reviewer_system_prompt() {
-    let _lock = SESSION_CWD_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-    ensure_in_git_repo();
+    let cwd = find_project_root();
     let result = build_attach_shell_command(
-        "/tmp/test-cwd",
+        &cwd,
         "york",
         midtown::auth::AuthProvider::Claude,
         "session-789",
@@ -585,10 +559,9 @@ fn test_reviewer_attach_gets_reviewer_system_prompt() {
 
 #[test]
 fn test_lead_attach_gets_opus_model() {
-    let _lock = SESSION_CWD_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-    ensure_in_git_repo();
+    let cwd = find_project_root();
     let result = build_attach_shell_command(
-        "/tmp/test-cwd",
+        &cwd,
         "lead",
         midtown::auth::AuthProvider::Claude,
         "session-123",

--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -231,6 +231,7 @@ impl CoworkerManager {
     ///
     /// Returns the list of additional worktree paths to pass as --add-dir to Claude.
     /// Failures in additional repos are logged but don't prevent coworker spawn.
+    #[allow(deprecated)] // Legacy worktree layout for additional repos
     fn create_additional_worktrees(&self, coworker_name: &str) -> Vec<std::path::PathBuf> {
         let mut additional_dirs = Vec::new();
         for mgr in &self.additional_worktree_managers {
@@ -525,6 +526,7 @@ impl CoworkerManager {
     /// - Ensures the worktree is not on the default branch
     ///
     /// Returns `(working_dir, augmented_config)` on success.
+    #[allow(deprecated)] // Legacy worktree layout when no working_dir override
     pub fn prepare_spawn(
         &self,
         config: &crate::launch::LaunchConfig,
@@ -790,6 +792,7 @@ fn is_valid_git_worktree(path: &std::path::Path) -> bool {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use std::process::Command;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -69,9 +69,16 @@ pub fn set_test_midtown_base_dir(path: PathBuf) -> TestMidtownBaseDirGuard {
 ///
 /// Returns `None` if not in a git repository.
 pub fn detect_repo_name() -> Option<String> {
+    let cwd = std::env::current_dir().ok()?;
+    detect_repo_name_from_dir(&cwd)
+}
+
+/// Detect the repository name from a specific directory (CWD-independent).
+pub fn detect_repo_name_from_dir(dir: &std::path::Path) -> Option<String> {
     // First try git-common-dir which works correctly for worktrees
     let common_dir = std::process::Command::new("git")
         .args(["rev-parse", "--git-common-dir"])
+        .current_dir(dir)
         .output()
         .ok()
         .and_then(|output| {
@@ -90,6 +97,7 @@ pub fn detect_repo_name() -> Option<String> {
             if git_dir == ".git" {
                 return std::process::Command::new("git")
                     .args(["rev-parse", "--show-toplevel"])
+                    .current_dir(dir)
                     .output()
                     .ok()
                     .and_then(|output| {
@@ -111,6 +119,7 @@ pub fn detect_repo_name() -> Option<String> {
     // Fallback: try show-toplevel for regular repos
     std::process::Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
+        .current_dir(dir)
         .output()
         .ok()
         .and_then(|output| {

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -97,14 +97,16 @@ impl WorktreeManager {
     /// Create a worktree for a coworker.
     ///
     /// Creates a new worktree at `~/.midtown/coworkers/<repo>/<name>/`
-    /// detached at the current HEAD. The coworker should immediately create
+    /// detached at the default branch. The coworker should immediately create
     /// a feature branch for their task.
     ///
     /// Exception: When reusing an existing worktree that's on the default branch
     /// (main/master), the spawn system creates a recovery branch to prevent
     /// working on main. See `checkout_new_branch` for the recovery mechanism.
+    #[deprecated(note = "Use create_task_worktree instead")]
     pub fn create(&self, coworker_name: &str) -> WorktreeResult<PathBuf> {
         let worktree_path = self.worktree_path(coworker_name);
+        let start_point = self.resolve_default_start_point();
 
         // Check if worktree already exists and is valid (idempotent)
         if worktree_path.exists() && self.is_worktree_registered(&worktree_path) {
@@ -121,7 +123,7 @@ impl WorktreeManager {
             std::fs::create_dir_all(parent)?;
         }
 
-        // Create the worktree detached at HEAD
+        // Create the worktree detached at the default branch
         // Coworker will create their own feature branch for each task
         let output = Command::new("git")
             .current_dir(&self.repo_root)
@@ -130,6 +132,7 @@ impl WorktreeManager {
                 "add",
                 "--detach",
                 worktree_path.to_str().unwrap(),
+                &start_point,
             ])
             .output()?;
 
@@ -152,6 +155,7 @@ impl WorktreeManager {
                         "add",
                         "--detach",
                         worktree_path.to_str().unwrap(),
+                        &start_point,
                     ])
                     .output()?;
 
@@ -479,6 +483,34 @@ impl WorktreeManager {
     /// Get the repository name.
     pub fn repo_name(&self) -> &str {
         &self.repo_name
+    }
+
+    /// Resolve the start-point for new worktree branches.
+    ///
+    /// Prefers `origin/<default>` (tracks remote), falls back to local
+    /// `<default>`, ultimate fallback `"main"`.
+    fn resolve_default_start_point(&self) -> String {
+        let default_branch =
+            detect_default_branch(&self.repo_root).unwrap_or_else(|| "main".to_string());
+
+        // Prefer origin/<default> so branches track the remote tip
+        let remote_ref = format!("origin/{}", default_branch);
+        let has_remote = Command::new("git")
+            .current_dir(&self.repo_root)
+            .args([
+                "rev-parse",
+                "--verify",
+                &format!("refs/remotes/{}", remote_ref),
+            ])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+
+        if has_remote {
+            remote_ref
+        } else {
+            default_branch
+        }
     }
 
     /// Get the branch name checked out in a coworker's worktree.
@@ -934,11 +966,12 @@ impl WorktreeManager {
 
     /// Create a task-based worktree at `~/.midtown/worktrees/<repo>/<worktree_id>/`.
     ///
-    /// The worktree is created detached at HEAD, then checked out on a branch
-    /// matching the worktree_id. This is the preferred path for new task
-    /// assignments.
+    /// The worktree is created on a branch matching the worktree_id, starting
+    /// from the default branch (not HEAD). This prevents cross-PR contamination
+    /// when the lead's HEAD is on an unrelated feature branch.
     pub fn create_task_worktree(&self, worktree_id: &str) -> WorktreeResult<PathBuf> {
         let worktree_path = self.task_worktree_path(worktree_id);
+        let start_point = self.resolve_default_start_point();
 
         // Check if worktree already exists and is valid (idempotent)
         if worktree_path.exists() && self.is_worktree_registered(&worktree_path) {
@@ -1013,6 +1046,7 @@ impl WorktreeManager {
                 "-b",
                 worktree_id,
                 worktree_path.to_str().unwrap(),
+                &start_point,
             ])
             .output()?;
 
@@ -1055,6 +1089,7 @@ impl WorktreeManager {
                         "-b",
                         worktree_id,
                         worktree_path.to_str().unwrap(),
+                        &start_point,
                     ])
                     .output()?;
 
@@ -1078,6 +1113,7 @@ impl WorktreeManager {
                         "-b",
                         worktree_id,
                         worktree_path.to_str().unwrap(),
+                        &start_point,
                     ])
                     .output()?;
                 if !retry.status.success() {
@@ -1516,6 +1552,7 @@ fn check_coworker_worktree(path: &Path, worktrees_base: &Path) -> (bool, Option<
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
 

--- a/src/worktree_stale_branch_tests.rs
+++ b/src/worktree_stale_branch_tests.rs
@@ -3,10 +3,27 @@
 //! These tests reproduce the bug where `create_task_worktree` fails when
 //! a branch already exists but is linked to a stale (deleted) worktree.
 
+use std::path::Path;
 use std::process::Command as TestCommand;
 use tempfile::TempDir;
 
 use crate::worktree::WorktreeManager;
+
+/// Helper to run `git rev-parse <rev>` and return the commit SHA.
+fn git_rev_parse(repo_path: &Path, rev: &str) -> String {
+    let output = TestCommand::new("git")
+        .current_dir(repo_path)
+        .args(["rev-parse", rev])
+        .output()
+        .expect("git rev-parse");
+    assert!(
+        output.status.success(),
+        "git rev-parse {} failed: {}",
+        rev,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
 
 /// Create a temp git repo with an initial commit
 fn create_test_repo() -> (WorktreeManager, TempDir) {
@@ -350,4 +367,100 @@ fn test_create_task_worktree_path_exists_but_not_registered() {
         .trim()
         .to_string();
     assert_eq!(branch, worktree_id);
+}
+
+#[test]
+fn test_create_task_worktree_branches_from_default_not_head() {
+    let (manager, _temp_dir) = create_test_repo();
+
+    // Record the default branch commit SHA (the initial commit)
+    let default_commit = git_rev_parse(manager.repo_root(), "HEAD");
+
+    // Move the repo HEAD to a feature branch with an extra commit
+    let output = TestCommand::new("git")
+        .current_dir(manager.repo_root())
+        .args(["checkout", "-b", "unrelated-feature"])
+        .output()
+        .expect("create feature branch");
+    assert!(output.status.success());
+
+    let output = TestCommand::new("git")
+        .current_dir(manager.repo_root())
+        .args(["commit", "--allow-empty", "-m", "unrelated feature commit"])
+        .output()
+        .expect("commit on feature branch");
+    assert!(output.status.success());
+
+    let feature_commit = git_rev_parse(manager.repo_root(), "HEAD");
+    assert_ne!(
+        default_commit, feature_commit,
+        "Feature commit should differ from default branch"
+    );
+
+    // Create a task worktree — it should branch from the default branch commit,
+    // NOT from the current HEAD (which is on unrelated-feature)
+    let worktree_id = "review-pr-999";
+    let result = manager.create_task_worktree(worktree_id);
+    assert!(
+        result.is_ok(),
+        "create_task_worktree should succeed, got: {:?}",
+        result.err()
+    );
+
+    let wt_path = manager.task_worktree_path(worktree_id);
+    let wt_commit = git_rev_parse(&wt_path, "HEAD");
+    assert_eq!(
+        wt_commit, default_commit,
+        "Task worktree should branch from the default branch commit, not HEAD"
+    );
+    assert_ne!(
+        wt_commit, feature_commit,
+        "Task worktree should NOT contain the unrelated feature commit"
+    );
+}
+
+#[test]
+fn test_create_worktree_detaches_at_default_not_head() {
+    let (manager, _temp_dir) = create_test_repo();
+
+    // Record the default branch commit
+    let default_commit = git_rev_parse(manager.repo_root(), "HEAD");
+
+    // Move HEAD to a feature branch with an extra commit
+    let output = TestCommand::new("git")
+        .current_dir(manager.repo_root())
+        .args(["checkout", "-b", "unrelated-feature-2"])
+        .output()
+        .expect("create feature branch");
+    assert!(output.status.success());
+
+    let output = TestCommand::new("git")
+        .current_dir(manager.repo_root())
+        .args(["commit", "--allow-empty", "-m", "unrelated commit 2"])
+        .output()
+        .expect("commit on feature branch");
+    assert!(output.status.success());
+
+    let feature_commit = git_rev_parse(manager.repo_root(), "HEAD");
+    assert_ne!(default_commit, feature_commit);
+
+    // Legacy create should detach at the default branch, not HEAD
+    #[allow(deprecated)]
+    let result = manager.create("testworker-default");
+    assert!(
+        result.is_ok(),
+        "create should succeed, got: {:?}",
+        result.err()
+    );
+
+    let wt_path = manager.worktree_path("testworker-default");
+    let wt_commit = git_rev_parse(&wt_path, "HEAD");
+    assert_eq!(
+        wt_commit, default_commit,
+        "Legacy create should detach at default branch commit, not HEAD"
+    );
+    assert_ne!(
+        wt_commit, feature_commit,
+        "Legacy create should NOT contain the unrelated feature commit"
+    );
 }


### PR DESCRIPTION
## Summary

- **Fix cross-PR contamination**: `create_task_worktree` and legacy `create` now branch from the default branch (`origin/main`) instead of HEAD, preventing unrelated commits from leaking into coworker branches when the lead is on a feature branch
- **Add `resolve_default_start_point()` helper** that prefers `origin/<default>` over local `<default>` as the git start-point
- **Deprecate legacy `create` method** with `#[deprecated(note = "Use create_task_worktree instead")]`
- **Fix flaky `test_coworker_attach_includes_system_prompt`**: Extract `detect_repo_name_from_dir(path)` from `detect_repo_name()` so `build_attach_shell_command` no longer depends on the process CWD, eliminating the race condition with daemon tests

## Test plan

- [x] TDD: wrote two failing tests first (`test_create_task_worktree_branches_from_default_not_head`, `test_create_worktree_detaches_at_default_not_head`), confirmed they fail, then fixed the code
- [x] All 9 stale branch tests pass (7 existing + 2 new)
- [x] All 1358 library tests pass
- [x] All 290 binary tests pass (including previously flaky test)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)