### PR TITLE
feat: Add click-and-drag resizing for sidebar/chat divider [Midtown !1420]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -323,6 +323,10 @@ pub struct App {
     pub dragging_divider: bool,
     /// Full width of the horizontal layout area (set each render pass, used for drag resize)
     pub layout_width: u16,
+    /// Y range of the main content area (set each render pass, used for divider Y bounds check)
+    pub main_area_y: u16,
+    /// Bottom Y (exclusive) of the main content area
+    pub main_area_bottom: u16,
 }
 
 /// Autocomplete state for @mentions, #channels, and !task-ids
@@ -460,6 +464,8 @@ impl App {
             divider_x: None,
             dragging_divider: false,
             layout_width: 0,
+            main_area_y: 0,
+            main_area_bottom: u16::MAX,
         };
 
         // Initial load
@@ -2621,6 +2627,8 @@ pub(super) mod tests {
             divider_x: None,
             dragging_divider: false,
             layout_width: 0,
+            main_area_y: 0,
+            main_area_bottom: u16::MAX,
         }
     }
 

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -666,6 +666,8 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                 // Check if click is on the sidebar/chat divider
                 if let Some(div_x) = app.divider_x
                     && x == div_x
+                    && y >= app.main_area_y
+                    && y < app.main_area_bottom
                 {
                     app.dragging_divider = true;
                     return EventResult::Continue;
@@ -724,7 +726,7 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                 }
                 EventResult::Continue
             }
-            MouseEventKind::Up(_) => {
+            MouseEventKind::Up(crossterm::event::MouseButton::Left) => {
                 app.dragging_divider = false;
                 EventResult::Continue
             }
@@ -1908,6 +1910,38 @@ mod tests {
         assert!(
             !app.dragging_divider,
             "Clicking adjacent to divider (right) should not start drag"
+        );
+    }
+
+    /// Test that clicking the divider X column outside the main content area (e.g., in the
+    /// status bar row at y=0) does not start a drag.
+    #[test]
+    fn test_click_divider_outside_main_area_does_not_start_drag() {
+        let mut app = test_app();
+        app.divider_x = Some(32);
+        // Status bar is at row 0; main content starts at row 1
+        app.main_area_y = 1;
+        app.main_area_bottom = 40;
+
+        // Click at (div_x, 0) — status bar row, above main content area
+        handle_event(&mut app, mouse_click(32, 0));
+        assert!(
+            !app.dragging_divider,
+            "Clicking divider in status bar row should not start drag"
+        );
+
+        // Click at (div_x, 40) — usage bar row, below main content area
+        handle_event(&mut app, mouse_click(32, 40));
+        assert!(
+            !app.dragging_divider,
+            "Clicking divider below main content area should not start drag"
+        );
+
+        // Click at (div_x, 1) — first row of main area — should start drag
+        handle_event(&mut app, mouse_click(32, 1));
+        assert!(
+            app.dragging_divider,
+            "Clicking divider within main content area should start drag"
         );
     }
 

--- a/src/bin/midtown/cli/chat/ui/mod.rs
+++ b/src/bin/midtown/cli/chat/ui/mod.rs
@@ -90,6 +90,8 @@ pub fn draw(f: &mut Frame, app: &mut App) -> Vec<Hyperlink> {
     let sidebar_pct = app.sidebar_width_pct;
     let main_area = vertical_chunks[1];
     app.layout_width = main_area.width;
+    app.main_area_y = main_area.y;
+    app.main_area_bottom = main_area.y + main_area.height;
     let horizontal_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Add `sidebar_width_pct` field to `App` state (default 40%, clamped 20–60%) replacing the hardcoded `Constraint::Percentage(40)` split
- Track `divider_x` and `layout_width` each render pass so mouse hit-testing and drag math use accurate coordinates
- Handle `MouseEventKind::Down` on the divider column to start drag, `Drag` to resize, and `Up` to stop

## Implementation details

The divider is detected by checking if the mouse column exactly matches `divider_x` (the last column of the sidebar panel). During a drag, `resize_sidebar_to(mouse_x, layout_width)` computes the percentage and clamps it to [20, 60] so both panels remain usable. The message render cache is invalidated on resize since the available width changes.

## Test plan
- [x] Unit tests for `resize_sidebar_to`: normal case, min clamp, max clamp, zero-width noop, cache invalidation
- [x] Integration tests: click divider starts drag, adjacent click doesn't start drag, full drag sequence (click → drag → release), min/max clamping via drag, drag without prior mousedown is no-op
- [x] `cargo clippy -- -D warnings` passes
- [x] All library tests pass (1360 tests)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)