### PR TITLE
fix: Exclude lead from coworker cap and fix REVIEW_HEADROOM semantics [Midtown !1429]

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -1398,16 +1398,17 @@ pub(super) fn spawn_for_pending_tasks(
     // Spawns to already-running coworkers (grouped tasks) don't count — only fresh spawns
     // that will create new coworker processes.
     let mut spawns_queued_this_tick: usize = 0;
-    // Dev cap: max_coworkers - REVIEW_HEADROOM, but always allow at least 1 dev.
-    // With max=8 and REVIEW_HEADROOM=2, dev cap is 6.
-    let dev_cap = state.max_coworkers.saturating_sub(REVIEW_HEADROOM).max(1);
+    // Dev cap = max_coworkers (REVIEW_HEADROOM does NOT reduce dev slots).
+    // Reviewers may exceed max_coworkers by up to REVIEW_HEADROOM via is_at_coworker_limit().
+    // With max=8 and REVIEW_HEADROOM=2: dev_cap=8, reviewer_cap=10.
+    let dev_cap = state.max_coworkers;
     // Use running coworkers from snapshot, not all coworkers from internal map.
     // The internal map includes stopped coworkers until they're cleaned up, which
     // incorrectly blocks task dispatch when all coworkers are stopped.
     // Exclude the lead: a headless lead session counts as "running" in the
     // CoworkerManager but is not a dev/reviewer slot. Including it would consume
-    // one of the 6 dev slots (dev_cap = max_coworkers - REVIEW_HEADROOM), causing
-    // the daemon to under-spawn by one coworker whenever the lead runs headless.
+    // one of the dev slots, causing the daemon to under-spawn whenever the lead
+    // runs headless.
     let current_coworker_count = snap
         .running_coworkers
         .iter()

--- a/src/daemon/dispatch_dev_limit_tests.rs
+++ b/src/daemon/dispatch_dev_limit_tests.rs
@@ -1,19 +1,27 @@
 //! Tests for dev limit enforcement in task dispatch.
 //!
-//! These tests verify that the dev spawn cap (max_coworkers - REVIEW_HEADROOM)
-//! is correctly enforced even when multiple tasks are processed in a single tick.
+//! These tests verify that the dev spawn cap equals max_coworkers and that
+//! REVIEW_HEADROOM allows reviewers to exceed max_coworkers (not reduce dev slots).
 
 use crate::daemon::constants::REVIEW_HEADROOM;
 
 #[test]
-fn test_review_headroom_computation() {
-    // With max_coworkers=8 and REVIEW_HEADROOM=2, dev cap should be 6.
+fn test_review_headroom_semantics() {
+    // REVIEW_HEADROOM allows reviewers to EXCEED max_coworkers — it does NOT reduce dev slots.
+    // With max_coworkers=8 and REVIEW_HEADROOM=2:
+    //   - dev_cap = max_coworkers = 8  (no subtraction)
+    //   - reviewer_cap = max_coworkers + REVIEW_HEADROOM = 10
     let max_coworkers: usize = 8;
-    let dev_cap = max_coworkers.saturating_sub(REVIEW_HEADROOM).max(1);
+    let dev_cap = max_coworkers; // new semantics: no subtraction
+    let reviewer_cap = max_coworkers + REVIEW_HEADROOM;
 
     assert_eq!(
-        dev_cap, 6,
-        "Dev cap should be max_coworkers - REVIEW_HEADROOM"
+        dev_cap, 8,
+        "Dev cap should equal max_coworkers (REVIEW_HEADROOM no longer reduces dev slots)"
+    );
+    assert_eq!(
+        reviewer_cap, 10,
+        "Reviewer cap should be max_coworkers + REVIEW_HEADROOM"
     );
     assert_eq!(REVIEW_HEADROOM, 2, "REVIEW_HEADROOM should be 2");
 }
@@ -22,44 +30,52 @@ fn test_review_headroom_computation() {
 fn test_spawn_count_within_tick() {
     // This test documents the expected behavior for spawn limiting within a tick.
     //
-    // Scenario: 5 active dev coworkers, 3 pending unowned tasks.
-    // - Snapshot shows is_at_dev_limit = false (5 < 6)
+    // Scenario: 7 active dev coworkers, 3 pending unowned tasks.
+    // With max_coworkers=8, dev_cap=8 (no REVIEW_HEADROOM subtraction).
+    // - Snapshot shows is_at_dev_limit = false (7 < 8)
     // - Loop processes tasks one by one
     //
-    // Bug: Loop checks is_at_dev_limit ONCE at the start, then spawns all 3 tasks.
-    // Result: 5 + 3 = 8 coworkers, exceeding dev cap of 6.
+    // Without per-spawn counter: Loop checks is_at_dev_limit ONCE, spawns all 3 tasks.
+    // Result: 7 + 3 = 10 coworkers, exceeding dev cap of 8.
     //
-    // Fix: After each spawn decision, increment a counter and re-check:
+    // With per-spawn counter: after each spawn decision, re-check:
     //   - spawns_this_tick = 0
-    //   - Process task 1: spawns_this_tick = 1, total = 6 (at cap, STOP)
+    //   - Process task 1: spawns_this_tick = 1, total = 8 (at cap, STOP)
     //   - Tasks 2 and 3 deferred to next tick
 
-    let active_count = 5;
+    let active_count = 7;
     let pending_count = 3;
-    let dev_cap = 6;
+    let dev_cap = 8; // = max_coworkers (no REVIEW_HEADROOM subtraction)
 
-    // Current behavior: all tasks spawn
-    let spawned_without_fix = pending_count; // 3
-    let total_without_fix = active_count + spawned_without_fix; // 8
-    assert!(total_without_fix > dev_cap, "Bug: spawning exceeds dev cap");
+    // Without per-spawn counter: all tasks spawn
+    let spawned_without_counter = pending_count; // 3
+    let total_without_counter = active_count + spawned_without_counter; // 10
+    assert!(
+        total_without_counter > dev_cap,
+        "Bug: spawning exceeds dev cap"
+    );
 
-    // Expected behavior after fix: only spawn until cap
-    let spawned_with_fix = (dev_cap - active_count).min(pending_count); // 1
-    let total_with_fix = active_count + spawned_with_fix; // 6
-    assert_eq!(total_with_fix, dev_cap, "Fix: spawning stops at dev cap");
+    // With per-spawn counter: only spawn until cap
+    let spawned_with_counter = (dev_cap - active_count).min(pending_count); // 1
+    let total_with_counter = active_count + spawned_with_counter; // 8
+    assert_eq!(
+        total_with_counter, dev_cap,
+        "Fix: spawning stops at dev cap"
+    );
 }
 
 #[test]
 fn test_spawn_limit_edge_cases() {
-    let dev_cap = 6;
+    // dev_cap = max_coworkers (8), no REVIEW_HEADROOM subtraction
+    let dev_cap = 8;
 
     // Edge case 1: Already at cap
-    let active = 6;
+    let active = 8;
     let allowed = (dev_cap - active).max(0);
     assert_eq!(allowed, 0, "No spawns allowed when at cap");
 
     // Edge case 2: One below cap
-    let active = 5;
+    let active = 7;
     let allowed = (dev_cap - active).max(0);
     assert_eq!(allowed, 1, "Exactly 1 spawn allowed when 1 below cap");
 
@@ -67,7 +83,7 @@ fn test_spawn_limit_edge_cases() {
     let active = 0;
     let allowed = (dev_cap - active).max(0);
     assert_eq!(
-        allowed, 6,
+        allowed, 8,
         "Up to dev_cap spawns allowed when starting from 0"
     );
 }
@@ -225,24 +241,32 @@ fn make_test_state_with_max(max_coworkers: usize) -> crate::daemon::DaemonState 
 
 /// When a headless lead is running, it should NOT consume a dev slot.
 ///
-/// Scenario: max_coworkers=8, REVIEW_HEADROOM=2 → dev_cap=6.
-/// Lead (headless) + 5 real coworkers = 6 in running_coworkers.
-/// Bug: running_coworkers.len()=6 ≥ dev_cap=6 → no task effects dispatched.
-/// Fix: lead excluded → effective_count=5 < 6 → task effect IS emitted.
+/// Scenario: max_coworkers=8 → dev_cap=8 (no REVIEW_HEADROOM subtraction).
+/// Lead (headless) + 7 real coworkers = 8 in running_coworkers.
+/// Bug: running_coworkers.len()=8 ≥ dev_cap=8 → no task effects dispatched.
+/// Fix: lead excluded → effective_count=7 < 8 → task effect IS emitted.
 #[test]
 fn test_lead_does_not_count_against_dev_cap() {
     let state = make_test_state_with_max(8);
 
-    // Register 5 real coworkers in CoworkerManager so next_available_name()
-    // skips them and returns the 6th available name (columbus) for the new task.
+    // Register 7 real coworkers in CoworkerManager so next_available_name()
+    // skips them and returns the 8th available name for the new task.
     // This ensures the dispatch loop hits the "fresh spawn" code path.
-    for name in &["lexington", "park", "madison", "broadway", "amsterdam"] {
+    for name in &[
+        "lexington",
+        "park",
+        "madison",
+        "broadway",
+        "amsterdam",
+        "columbus",
+        "riverside",
+    ] {
         state
             .coworkers
             .insert_for_testing(make_running_coworker(name));
     }
 
-    // 5 real coworkers + 1 headless lead = 6 total in running_coworkers
+    // 7 real coworkers + 1 headless lead = 8 total in running_coworkers
     let running = vec![
         make_running_coworker("lead"),
         make_running_coworker("lexington"),
@@ -250,17 +274,19 @@ fn test_lead_does_not_count_against_dev_cap() {
         make_running_coworker("madison"),
         make_running_coworker("broadway"),
         make_running_coworker("amsterdam"),
+        make_running_coworker("columbus"),
+        make_running_coworker("riverside"),
     ];
 
     let pending = vec![make_pending_task("99")];
 
-    // is_at_dev_limit=false because lead doesn't count (5 real coworkers < dev_cap=6)
+    // is_at_dev_limit=false because lead doesn't count (7 real coworkers < dev_cap=8)
     let snap = make_dev_limit_snapshot(running, pending, false);
 
     let effects = crate::daemon::dispatch::spawn_for_pending_tasks(&snap, &state);
 
-    // With the bug: current_coworker_count=6 (includes lead) ≥ dev_cap=6 → no effects.
-    // After the fix: lead excluded → effective_count=5 < 6 → AssignAndSpawn IS emitted.
+    // With the bug: current_coworker_count=8 (includes lead) ≥ dev_cap=8 → no effects.
+    // After the fix: lead excluded → effective_count=7 < 8 → AssignAndSpawn IS emitted.
     let has_task_effect = effects.iter().any(|e| {
         matches!(
             e,
@@ -277,12 +303,12 @@ fn test_lead_does_not_count_against_dev_cap() {
     );
 }
 
-/// When the lead is NOT in running_coworkers, dev cap behaves normally.
+/// When the lead is NOT in running_coworkers, dev cap (= max_coworkers) behaves normally.
 #[test]
 fn test_dev_cap_without_lead_unaffected() {
     let state = make_test_state_with_max(8);
 
-    // Register 6 real coworkers — all slots at dev_cap=6 are consumed.
+    // Register 8 real coworkers — all slots at dev_cap=8 are consumed.
     for name in &[
         "lexington",
         "park",
@@ -290,13 +316,15 @@ fn test_dev_cap_without_lead_unaffected() {
         "broadway",
         "amsterdam",
         "columbus",
+        "riverside",
+        "york",
     ] {
         state
             .coworkers
             .insert_for_testing(make_running_coworker(name));
     }
 
-    // 6 real coworkers, no lead → at dev_cap=6
+    // 8 real coworkers, no lead → at dev_cap=8
     let running = vec![
         make_running_coworker("lexington"),
         make_running_coworker("park"),
@@ -304,11 +332,13 @@ fn test_dev_cap_without_lead_unaffected() {
         make_running_coworker("broadway"),
         make_running_coworker("amsterdam"),
         make_running_coworker("columbus"),
+        make_running_coworker("riverside"),
+        make_running_coworker("york"),
     ];
 
     let pending = vec![make_pending_task("99")];
 
-    // is_at_dev_limit=true: 6 real coworkers ≥ dev_cap=6
+    // is_at_dev_limit=true: 8 real coworkers ≥ dev_cap=8
     let snap = make_dev_limit_snapshot(running, pending, true);
 
     let effects = crate::daemon::dispatch::spawn_for_pending_tasks(&snap, &state);
@@ -324,7 +354,7 @@ fn test_dev_cap_without_lead_unaffected() {
     });
     assert!(
         !has_task_effect,
-        "Expected no task dispatch when truly at dev cap (6 real coworkers, no lead). \
+        "Expected no task dispatch when truly at dev cap (8 real coworkers, no lead). \
          Effects: {:?}",
         effects
     );

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -657,7 +657,11 @@ impl DaemonState {
         self.kanban_cache.cleanup();
     }
 
-    /// Check if the daemon is at the maximum coworker limit (absolute cap).
+    /// Check if the daemon is at the absolute coworker limit (including reviewer headroom).
+    ///
+    /// Reviewers may exceed `max_coworkers` by up to `REVIEW_HEADROOM` slots,
+    /// so the absolute cap is `max_coworkers + REVIEW_HEADROOM`. This allows
+    /// reviewer spawning to proceed even when the dev cap is fully used.
     ///
     /// The lead is excluded: a headless lead session registers in CoworkerManager
     /// but is not a dev/reviewer slot and must not consume capacity.
@@ -668,23 +672,25 @@ impl DaemonState {
             .iter()
             .filter(|cw| !cw.name.eq_ignore_ascii_case("lead"))
             .count();
-        non_lead_count >= self.max_coworkers
+        non_lead_count >= self.max_coworkers + REVIEW_HEADROOM
     }
 
     /// Check if the daemon is at the dev coworker limit.
-    /// Reserves `REVIEW_HEADROOM` slots for reviewers, but always allows at least 1 dev slot.
+    ///
+    /// Dev cap equals `max_coworkers` — REVIEW_HEADROOM is NOT subtracted here.
+    /// Instead, `is_at_coworker_limit()` uses `max_coworkers + REVIEW_HEADROOM`
+    /// so reviewers can exceed the normal dev cap by up to REVIEW_HEADROOM slots.
     ///
     /// The lead is excluded: a headless lead session registers in CoworkerManager
     /// but is not a dev/reviewer slot and must not consume capacity.
     fn is_at_dev_limit(&self) -> bool {
-        let dev_cap = self.max_coworkers.saturating_sub(REVIEW_HEADROOM).max(1);
         let non_lead_count = self
             .coworkers
             .list_running()
             .iter()
             .filter(|cw| !cw.name.eq_ignore_ascii_case("lead"))
             .count();
-        non_lead_count >= dev_cap
+        non_lead_count >= self.max_coworkers
     }
 
     /// Check if a coworker slot is available for spawning.
@@ -2322,10 +2328,10 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
         shutdown_tx.clone(),
     )?);
     info!(
-        "Max coworkers limit: {} (dev: {}, reserving {} for reviewers)",
+        "Max coworkers limit: {} dev slots, {} reviewer headroom (absolute cap: {})",
         config.max_coworkers,
-        config.max_coworkers.saturating_sub(REVIEW_HEADROOM).max(1),
-        REVIEW_HEADROOM
+        REVIEW_HEADROOM,
+        config.max_coworkers + REVIEW_HEADROOM
     );
 
     // Recover coworker workflow state from their state files across daemon restarts.


### PR DESCRIPTION
<!-- midtown: park -->

## Summary

Fixes two bugs in dispatch accounting:

1. **Lead counted against dev cap**: A headless lead session registered in CoworkerManager and counted against the dev cap (running_coworkers included it). Excluded by filtering `name == "lead"` in all cap checks.

2. **REVIEW_HEADROOM reduced dev slots instead of extending reviewer capacity**: Old: `dev_cap = max_coworkers - REVIEW_HEADROOM`. New semantics:
   - `dev_cap = max_coworkers` (devs get all slots)
   - `reviewer_cap = max_coworkers + REVIEW_HEADROOM` (reviewers can exceed normal cap)

With `max_coworkers=8` and `REVIEW_HEADROOM=2`, the old code gave 6 dev slots. Now devs get 8, and reviewers can use up to 10 total.

## Changes

- `mod.rs` `is_at_dev_limit()`: `non_lead_count >= max_coworkers` (removed `-REVIEW_HEADROOM`)
- `mod.rs` `is_at_coworker_limit()`: `non_lead_count >= max_coworkers + REVIEW_HEADROOM` (reviewers can exceed)
- `dispatch.rs` `spawn_for_pending_tasks()`: `dev_cap = state.max_coworkers` (same fix)
- Startup log updated to show new semantics
- Tests updated and extended to verify both fixes

## Test plan

- [x] `cargo test dispatch_dev_limit` — 5 unit tests covering lead exclusion and new REVIEW_HEADROOM semantics
- [x] `cargo test` — full suite passes
- [x] `cargo clippy -- -D warnings` — clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)