### PR TITLE
fix: omit session detach from midtown view pane to prevent dual-lead [Midtown !1428]

### DIFF
--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -824,6 +824,7 @@ fn attach_session_split(session_name: &str) {
         provider,
         session_id,
         coworker_type.as_deref(),
+        false, // include_detach: midtown view calls session_detach explicitly on exit
     ) {
         Ok(cmd) => cmd,
         Err(_) => {

--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -1815,8 +1815,10 @@ pub fn handle_view(project: Option<&str>, skip_auto_split: bool) -> Result<Respo
     }
 
     let cwd = super::session::ensure_attach_worktree("lead", cwd)?;
-    let lead_shell_command =
-        super::session::build_attach_shell_command(&cwd, "lead", provider, session_id, None)?;
+    let lead_shell_command = super::session::build_attach_shell_command(
+        &cwd, "lead", provider, session_id, None,
+        false, // include_detach: midtown view calls session_detach explicitly on exit
+    )?;
 
     let host = AttachHost::detect();
 

--- a/src/bin/midtown/cli/session.rs
+++ b/src/bin/midtown/cli/session.rs
@@ -309,8 +309,14 @@ fn handle_attach(target: &AttachArgs, client: &DaemonClient) -> Result<Response,
         // For coworkers, this ensures the worktree directory exists.
         let cwd = ensure_attach_worktree(name, cwd)?;
 
-        let shell_command =
-            build_attach_shell_command(&cwd, name, provider, session_id, coworker_type.as_deref())?;
+        let shell_command = build_attach_shell_command(
+            &cwd,
+            name,
+            provider,
+            session_id,
+            coworker_type.as_deref(),
+            true, // include_detach: standalone attach resumes headless when pane closes
+        )?;
         let launcher = PaneLauncher::detect();
 
         // Step 3: Launch interactive session in a pane for the current terminal host.
@@ -692,12 +698,22 @@ fn usage_attach() -> &'static str {
        midtown session attach park"
 }
 
+/// Build the shell command to run in a pane for an interactive attach session.
+///
+/// When `include_detach` is `true`, the shell command ends with
+/// `midtown session detach <name>`, which resumes the headless session when the
+/// interactive pane closes.  Set this to `true` for `midtown session attach`
+/// (standalone interactive use) and `false` for `midtown view`, which calls
+/// `session_detach` explicitly when the chat UI exits — avoiding a race where
+/// the pane's claude process exits before the chat UI and triggers an early
+/// headless respawn that creates a dual-lead situation.
 pub(crate) fn build_attach_shell_command(
     cwd: &str,
     name: &str,
     provider: midtown::auth::AuthProvider,
     session_id: &str,
     coworker_type: Option<&str>,
+    include_detach: bool,
 ) -> Result<String, String> {
     let repo_name = midtown::paths::detect_repo_name_from_dir(Path::new(cwd))
         .ok_or_else(|| "Not in a git repository".to_string())?;
@@ -824,14 +840,22 @@ pub(crate) fn build_attach_shell_command(
         shell_quote(cwd),
         shell_quote(&provider_cmd),
     );
-    let detach_cmd = format!("{} session detach {}", bin_command, shell_quote(name));
 
-    Ok(format!(
-        "export {}; {}; _midtown_rc=$?; {} >/dev/null 2>&1 || true; exit $_midtown_rc",
-        env_parts.join(" "),
-        wrapped_attach_cmd,
-        detach_cmd
-    ))
+    if include_detach {
+        let detach_cmd = format!("{} session detach {}", bin_command, shell_quote(name));
+        Ok(format!(
+            "export {}; {}; _midtown_rc=$?; {} >/dev/null 2>&1 || true; exit $_midtown_rc",
+            env_parts.join(" "),
+            wrapped_attach_cmd,
+            detach_cmd
+        ))
+    } else {
+        Ok(format!(
+            "export {}; {}",
+            env_parts.join(" "),
+            wrapped_attach_cmd,
+        ))
+    }
 }
 
 fn parse_provider(raw: &str) -> midtown::auth::AuthProvider {

--- a/src/bin/midtown/cli/session_tests.rs
+++ b/src/bin/midtown/cli/session_tests.rs
@@ -361,6 +361,7 @@ fn test_lead_attach_includes_system_prompt() {
         midtown::auth::AuthProvider::Claude,
         "session-123",
         None,
+        true,
     );
 
     let command = result.expect("build_attach_shell_command should succeed");
@@ -389,6 +390,7 @@ fn test_coworker_attach_includes_system_prompt() {
         midtown::auth::AuthProvider::Claude,
         "session-456",
         None,
+        true,
     );
 
     let command = result.expect("build_attach_shell_command should succeed");
@@ -417,6 +419,7 @@ fn test_lead_attach_sets_task_list_id() {
         midtown::auth::AuthProvider::Claude,
         "session-123",
         None,
+        true,
     );
 
     assert!(result.is_ok(), "build_attach_shell_command should succeed");
@@ -439,6 +442,7 @@ fn test_coworker_attach_no_task_list_id() {
         midtown::auth::AuthProvider::Claude,
         "session-456",
         None,
+        true,
     );
 
     assert!(result.is_ok(), "build_attach_shell_command should succeed");
@@ -461,6 +465,7 @@ fn test_lead_attach_includes_agent_teams_flags() {
         midtown::auth::AuthProvider::Claude,
         "session-123",
         None,
+        true,
     );
 
     let command = result.expect("build_attach_shell_command should succeed");
@@ -569,6 +574,7 @@ fn test_reviewer_attach_gets_reviewer_system_prompt() {
         midtown::auth::AuthProvider::Claude,
         "session-789",
         Some("reviewer"),
+        true,
     );
 
     let command = result.expect("build_attach_shell_command should succeed");
@@ -590,6 +596,7 @@ fn test_lead_attach_gets_opus_model() {
         midtown::auth::AuthProvider::Claude,
         "session-123",
         None,
+        true,
     );
 
     let command = result.expect("build_attach_shell_command should succeed");
@@ -641,6 +648,7 @@ fn test_build_attach_command_uses_shell_command_substitution() {
         midtown::auth::AuthProvider::Claude,
         "session-123",
         None,
+        true,
     );
 
     let command = result.expect("build_attach_shell_command should succeed");
@@ -726,6 +734,7 @@ fn test_build_attach_command_no_double_quoting() {
         midtown::auth::AuthProvider::Claude,
         "session-123",
         None,
+        true,
     );
 
     let command = result.expect("build_attach_shell_command should succeed");
@@ -771,6 +780,7 @@ fn test_build_attach_command_shell_parseable() {
         midtown::auth::AuthProvider::Claude,
         "session-123",
         None,
+        true,
     );
 
     let command = result.expect("build_attach_shell_command should succeed");
@@ -784,6 +794,53 @@ fn test_build_attach_command_shell_parseable() {
     assert!(
         parse_result.is_ok() && parse_result.unwrap().success(),
         "Command should be parseable by shell, got error for: {}",
+        command
+    );
+}
+
+// ── include_detach flag (fix for dual-lead bug #1428) ────────────────
+
+#[test]
+fn test_view_attach_command_omits_session_detach() {
+    // midtown view passes include_detach=false so the split pane's shell command
+    // does NOT call `session detach` when claude exits — preventing the dual-lead
+    // bug where the pane's claude process exits before the chat UI exits, causing
+    // the headless lead to be re-spawned while the headed session is still active.
+    let cwd = find_project_root();
+    let result = build_attach_shell_command(
+        &cwd,
+        "lead",
+        midtown::auth::AuthProvider::Claude,
+        "session-123",
+        None,
+        false, // include_detach=false: midtown view manages detach explicitly on exit
+    );
+    let command = result.expect("build_attach_shell_command should succeed");
+    assert!(
+        !command.contains("session detach"),
+        "midtown view shell command must NOT contain `session detach` (dual-lead bug #1428), got: {}",
+        command
+    );
+}
+
+#[test]
+fn test_standalone_attach_command_includes_session_detach() {
+    // midtown session attach passes include_detach=true so the pane's shell
+    // command calls `session detach` when the interactive session ends, resuming
+    // the headless lead automatically.
+    let cwd = find_project_root();
+    let result = build_attach_shell_command(
+        &cwd,
+        "lead",
+        midtown::auth::AuthProvider::Claude,
+        "session-123",
+        None,
+        true, // include_detach=true: standalone attach needs auto-detach
+    );
+    let command = result.expect("build_attach_shell_command should succeed");
+    assert!(
+        command.contains("session detach"),
+        "standalone attach shell command must contain `session detach`, got: {}",
         command
     );
 }


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary

- **Bug**: After `midtown view` attaches the headed lead session, the daemon pauses the headless lead correctly. But ~43 seconds later, it re-spawns the headless lead, resulting in two simultaneous lead sessions.
- **Root cause**: `build_attach_shell_command()` always appended `; midtown session detach <name>` to the shell command run in the split pane. When the pane's claude process exits (before the `midtown view` chat UI exits), the detach fires prematurely and re-spawns the headless lead.
- **Fix**: Added `include_detach: bool` parameter to `build_attach_shell_command()`. `midtown view` passes `false` because the chat UI already calls `session_detach()` explicitly when it exits. `midtown session attach` (standalone) continues to pass `true`.

## Files changed

- `session.rs`: Added `include_detach` param with doc comment explaining the race
- `daemon.rs`: Updated `midtown view` call site to pass `false`  
- `chat/mod.rs`: Updated `attach_session_split` call site to pass `false`
- `session_tests.rs`: Updated all existing tests + added two new regression tests

## Test plan

- [x] New test `test_view_attach_command_omits_session_detach` verifies `include_detach=false` omits `session detach`
- [x] New test `test_standalone_attach_command_includes_session_detach` verifies `include_detach=true` includes `session detach`
- [x] All 39 session tests pass
- [x] Full test suite: 0 failures
- [x] `cargo clippy -- -D warnings`: clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)