### PR TITLE
feat: Improve table rendering in minimad-ratatui crate [Midtown !1438]

### DIFF
--- a/crates/minimad-ratatui/src/lib.rs
+++ b/crates/minimad-ratatui/src/lib.rs
@@ -170,7 +170,12 @@ fn mad_line_to_line(mad_line: &MadLine<'_>, base_style: Style) -> Line<'static> 
             }
             Line::from(spans)
         }
-        MadLine::TableRule(_) => Line::from(Span::styled("\u{2500}".repeat(40), base_style)),
+        MadLine::TableRule(rule) => {
+            // Fallback: estimate width from column count (3 chars per cell + separators)
+            let n = rule.cells.len().max(1);
+            let width = n * 3 + n.saturating_sub(1) * 3;
+            Line::from(Span::styled("\u{2500}".repeat(width), base_style))
+        }
         MadLine::HorizontalRule => Line::from(Span::styled("\u{2500}".repeat(40), base_style)),
     }
 }

--- a/crates/minimad-ratatui/src/tests.rs
+++ b/crates/minimad-ratatui/src/tests.rs
@@ -415,3 +415,40 @@ fn test_table_alignment_center() {
         data_content
     );
 }
+
+#[test]
+fn test_inline_table_rule_width_scales_with_columns() {
+    // The fallback path in mad_line_to_line() should produce a rule width
+    // proportional to the column count, not a hardcoded value.
+    use super::mad_line_to_line;
+    use minimad::Text as MadText;
+
+    let md = "|---|---|---|";
+    let mad_text = MadText::from(md);
+    let mad_line = &mad_text.lines[0];
+    let line = mad_line_to_line(mad_line, base());
+    let content = line_content(&line);
+
+    // 3 columns → 3*3 + 2*3 = 15 chars of ─
+    assert_eq!(
+        content.chars().count(),
+        15,
+        "TableRule with 3 columns should produce 15-char rule, got: {:?}",
+        content
+    );
+
+    // Verify it scales: 2-column table rule should be shorter
+    let md2 = "|---|---|";
+    let mad_text2 = MadText::from(md2);
+    let mad_line2 = &mad_text2.lines[0];
+    let line2 = mad_line_to_line(mad_line2, base());
+    let content2 = line_content(&line2);
+
+    // 2 columns → 2*3 + 1*3 = 9 chars of ─
+    assert_eq!(
+        content2.chars().count(),
+        9,
+        "TableRule with 2 columns should produce 9-char rule, got: {:?}",
+        content2
+    );
+}


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Two-pass table rendering: collects all rows first to compute max column widths, then renders with padding so all rows align
- Header row (first `TableRow`) is now rendered **bold** to visually distinguish it from data rows
- Alignment markers from the separator row (`|---|:---:|---:|`) are respected (left/center/right padding)
- `TableRule` width now matches the actual rendered table width instead of a hardcoded 40 chars

## Before / After

Before:
```
Feature │ Status │ Owner
────────────────────────────────────────
Universal events pipeline │ In progress │ riverside
```

After:
```
Feature                   │ Status      │ Owner    
──────────────────────────────────────────────────
Universal events pipeline │ In progress │ riverside
```

## Implementation

`from_str()` now detects contiguous table blocks (consecutive `TableRow`/`TableRule` lines), runs `compute_table_layout()` to find per-column max widths and alignments, then renders each row with proper padding via `render_table_row()`.

## Test plan
- [x] 5 new tests added: column padding, rule width, header bold, right alignment, center alignment
- [x] All 21 tests pass (`cargo test --package minimad-ratatui`)
- [x] Clippy clean (`cargo clippy --package minimad-ratatui -- -D warnings`)
- [x] Existing tests unchanged and passing

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)