### PR TITLE
refactor: Use Claude API call_id as item_id in universal events [Midtown !1440]

### DIFF
--- a/src/daemon/stream.rs
+++ b/src/daemon/stream.rs
@@ -61,9 +61,10 @@ pub fn process_lead_output(events: &HashMap<String, Vec<StreamEvent>>) -> Vec<Ef
 /// Iterates all agents' events, extracts tool calls using the Claude converter,
 /// and returns broadcast effects for any agents that produced tool calls.
 pub fn process_universal_events(events: &HashMap<String, Vec<StreamEvent>>) -> Vec<Effect> {
+    let timestamp = chrono::Utc::now();
     let mut effects = Vec::new();
     for (agent_name, agent_events) in events {
-        let items = crate::universal_events::claude::extract_tool_calls(agent_events);
+        let items = crate::universal_events::claude::extract_tool_calls(agent_events, timestamp);
         if !items.is_empty() {
             effects.push(Effect::BroadcastUniversalItems {
                 agent_name: agent_name.clone(),

--- a/src/universal_events/claude.rs
+++ b/src/universal_events/claude.rs
@@ -15,8 +15,14 @@ mod tests;
 /// Iterates over `StreamEvent::Assistant` events, inspects each content block,
 /// and produces a `UniversalItem` for every `tool_use` block found.
 ///
+/// Uses Claude's `call_id` as the `item_id` for deterministic output.
+/// The provided `timestamp` is applied to all extracted items.
+///
 /// Non-assistant events and non-tool-use content blocks are skipped.
-pub fn extract_tool_calls(events: &[StreamEvent]) -> Vec<UniversalItem> {
+pub fn extract_tool_calls(
+    events: &[StreamEvent],
+    timestamp: chrono::DateTime<chrono::Utc>,
+) -> Vec<UniversalItem> {
     let mut items = Vec::new();
 
     for event in events {
@@ -42,7 +48,7 @@ pub fn extract_tool_calls(events: &[StreamEvent]) -> Vec<UniversalItem> {
                         .to_string();
 
                     items.push(UniversalItem {
-                        item_id: uuid::Uuid::new_v4().to_string(),
+                        item_id: call_id.clone(),
                         kind: ItemKind::ToolCall,
                         content: vec![ContentPart::ToolCall {
                             name,
@@ -50,7 +56,7 @@ pub fn extract_tool_calls(events: &[StreamEvent]) -> Vec<UniversalItem> {
                             call_id,
                         }],
                         status: ItemStatus::Completed,
-                        timestamp: chrono::Utc::now(),
+                        timestamp,
                     });
                 }
             }

--- a/src/universal_events/claude_tests.rs
+++ b/src/universal_events/claude_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::headless::StreamEvent;
+use chrono::{TimeZone, Utc};
 use serde_json::json;
 
 // ── extract_tool_calls tests ────────────────────────────────────────────
@@ -19,12 +20,15 @@ fn test_extract_tool_calls_single_tool_use() {
         extra: json!(null),
     }];
 
-    let items = extract_tool_calls(&events);
+    let timestamp = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+    let items = extract_tool_calls(&events, timestamp);
     assert_eq!(items.len(), 1);
 
     let item = &items[0];
+    assert_eq!(item.item_id, "call_001");
     assert!(matches!(item.kind, ItemKind::ToolCall));
     assert!(matches!(item.status, ItemStatus::Completed));
+    assert_eq!(item.timestamp, timestamp);
     assert_eq!(item.content.len(), 1);
 
     match &item.content[0] {
@@ -64,8 +68,12 @@ fn test_extract_tool_calls_multiple_tool_uses() {
         extra: json!(null),
     }];
 
-    let items = extract_tool_calls(&events);
+    let timestamp = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+    let items = extract_tool_calls(&events, timestamp);
     assert_eq!(items.len(), 2);
+
+    assert_eq!(items[0].item_id, "call_001");
+    assert_eq!(items[1].item_id, "call_002");
 
     match &items[0].content[0] {
         ContentPart::ToolCall { name, call_id, .. } => {
@@ -97,7 +105,8 @@ fn test_extract_tool_calls_text_only_no_items() {
         extra: json!(null),
     }];
 
-    let items = extract_tool_calls(&events);
+    let timestamp = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+    let items = extract_tool_calls(&events, timestamp);
     assert!(items.is_empty());
 }
 
@@ -120,9 +129,11 @@ fn test_extract_tool_calls_mixed_content() {
         extra: json!(null),
     }];
 
-    let items = extract_tool_calls(&events);
+    let timestamp = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+    let items = extract_tool_calls(&events, timestamp);
     assert_eq!(items.len(), 1);
 
+    assert_eq!(items[0].item_id, "call_100");
     match &items[0].content[0] {
         ContentPart::ToolCall { name, .. } => {
             assert_eq!(name, "Bash");
@@ -155,7 +166,8 @@ fn test_extract_tool_calls_non_assistant_events() {
         },
     ];
 
-    let items = extract_tool_calls(&events);
+    let timestamp = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+    let items = extract_tool_calls(&events, timestamp);
     assert!(items.is_empty());
 }
 
@@ -163,6 +175,7 @@ fn test_extract_tool_calls_non_assistant_events() {
 fn test_extract_tool_calls_empty_events() {
     let events: Vec<StreamEvent> = vec![];
 
-    let items = extract_tool_calls(&events);
+    let timestamp = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+    let items = extract_tool_calls(&events, timestamp);
     assert!(items.is_empty());
 }


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary

- Use Claude's API `call_id` as `item_id` instead of generating random UUIDs
- Accept timestamp parameter to make `extract_tool_calls()` a pure function
- Tests now verify deterministic behavior (item_id matches call_id, timestamp is applied)

## Background

From PR #1214 review (madison): `extract_tool_calls()` generated random UUIDs and called `Utc::now()` internally, making the converter non-deterministic and harder to test.

## Changes

| File | Change |
|------|--------|
| `src/universal_events/claude.rs` | Use `call_id` as `item_id`, accept `timestamp` parameter |
| `src/universal_events/claude_tests.rs` | Updated tests to pass timestamp and verify item_id matches call_id |
| `src/daemon/stream.rs` | Updated `process_universal_events()` to pass `Utc::now()` to converter |

## Test plan

- [x] All 6 universal events converter tests pass
- [x] All 15 stream integration tests pass
- [x] Full test suite passes (1375 tests)
- [x] `cargo clippy -- -D warnings` — clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)