### PR TITLE
fix: Deduplicate @lead in chat autocomplete [Midtown !1448]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -1491,8 +1491,12 @@ impl App {
         }
 
         // In test mode, use self.coworkers instead of daemon
+        // Skip "lead" since it's already added above
         if self.test_mode {
             for cw in &self.coworkers {
+                if cw.name.eq_ignore_ascii_case("lead") {
+                    continue;
+                }
                 if cw.name.to_lowercase().starts_with(query) {
                     // Look up current task from the tasks cache
                     let current_task = self
@@ -1507,7 +1511,11 @@ impl App {
             }
         } else {
             // Add coworkers from cached list (populated from daemon status)
+            // Skip "lead" since it's already added above
             for cw in &self.coworkers {
+                if cw.name.eq_ignore_ascii_case("lead") {
+                    continue;
+                }
                 if cw.name.to_lowercase().starts_with(query) {
                     // Look up current task from the tasks cache
                     let current_task = self


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary

- The `@mention` autocomplete was showing "lead" twice: once hardcoded as the first item and again when iterating the coworker list from the daemon
- Added a `eq_ignore_ascii_case("lead")` skip guard in both the test-mode and live-mode coworker iteration paths in `get_mention_items`
- Applies to both paths since the coworker list always includes the lead from the daemon's kanban response

## Root Cause

The daemon's kanban handler includes all coworkers with non-idle/non-completed phases. The lead is registered as a coworker named "lead" but with no `CoworkerRecord`, so its phase is `None` — which doesn't match `Idle` or `Completed`, causing it to pass the filter and appear in the coworker list. The autocomplete code hardcodes `@lead` first but didn't previously skip it when iterating the coworker list.

## Test plan

- [x] Build compiles cleanly
- [ ] Open chat with `midtown view` and type `@l` — "lead" should appear exactly once in the autocomplete

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)