### PR TITLE
feat: Cap TUI sidebar width at 40 characters [Midtown !1449]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -313,7 +313,8 @@ pub struct App {
     /// Mapping of board panel line numbers to channel headers (for click-to-select)
     /// Maps line_number -> channel_name where line_number is relative to board content area
     pub channel_line_map: HashMap<u16, String>,
-    /// Sidebar width as a percentage of the total horizontal area (20–60)
+    /// Sidebar width as a percentage of the total horizontal area (20–60).
+    /// The rendered width is further capped at `MAX_SIDEBAR_WIDTH` columns.
     pub sidebar_width_pct: u16,
     /// X column of the divider between sidebar and chat (set each render pass)
     pub divider_x: Option<u16>,

--- a/src/bin/midtown/cli/chat/ui/mod.rs
+++ b/src/bin/midtown/cli/chat/ui/mod.rs
@@ -96,7 +96,17 @@ pub fn draw(f: &mut Frame, app: &mut App) -> Vec<Hyperlink> {
     app.main_area_y = main_area.y;
     app.main_area_bottom = main_area.y + main_area.height;
     // Cap sidebar at MAX_SIDEBAR_WIDTH columns; any remaining space goes to main content.
-    let sidebar_width = (main_area.width * sidebar_pct / 100).min(MAX_SIDEBAR_WIDTH);
+    // Use u32 arithmetic to avoid overflow on very wide terminals (u16 wraps at width > 1638).
+    let sidebar_width =
+        (main_area.width as u32 * sidebar_pct as u32 / 100).min(MAX_SIDEBAR_WIDTH as u32) as u16;
+    // Sync stored percentage when the cap is active, so drag-resize starts from the
+    // rendered divider position rather than the uncapped percentage (avoids dead zone).
+    if main_area.width > 0 {
+        let effective_pct = (sidebar_width as u32 * 100 / main_area.width as u32) as u16;
+        if effective_pct < sidebar_pct {
+            app.sidebar_width_pct = effective_pct.max(20);
+        }
+    }
     let horizontal_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Length(sidebar_width), Constraint::Min(0)])
@@ -238,6 +248,29 @@ fn build_repo_status_line(repo_label: &str, status: &RepoStatus, width: u16) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Mirrors the sidebar width calculation from `draw()`.
+    fn compute_sidebar_width(terminal_width: u16, sidebar_pct: u16) -> u16 {
+        (terminal_width as u32 * sidebar_pct as u32 / 100).min(MAX_SIDEBAR_WIDTH as u32) as u16
+    }
+
+    #[test]
+    fn test_sidebar_width_capped_at_max() {
+        // 120-column terminal at 40% → 48 columns, capped to 40
+        assert_eq!(compute_sidebar_width(120, 40), 40);
+        // 100-column terminal at 40% → exactly 40
+        assert_eq!(compute_sidebar_width(100, 40), 40);
+        // 80-column terminal at 40% → 32, under cap
+        assert_eq!(compute_sidebar_width(80, 40), 32);
+    }
+
+    #[test]
+    fn test_sidebar_width_no_u16_overflow_on_wide_terminal() {
+        // 2000 columns at 40% = 800, capped to 40 — should not panic or wrap
+        assert_eq!(compute_sidebar_width(2000, 40), 40);
+        // 5000 columns at 60% = 3000, capped to 40
+        assert_eq!(compute_sidebar_width(5000, 60), 40);
+    }
 
     #[test]
     fn test_format_relative_time() {


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Adds `MAX_SIDEBAR_WIDTH = 40` constant to `ui/mod.rs`
- Sidebar grows proportionally (via `sidebar_width_pct`) up to the 40-column cap
- At terminals wider than the cap threshold, all extra width goes to the main content area
- Switches sidebar layout constraint from `Percentage` to `Length` + `Min(0)` for the cleaner expression of this invariant

## Test plan
- [x] All 1375 unit tests pass (`cargo test --lib`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Build succeeds

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)