### PR TITLE
feat: Add lead working indicator line to chat TUI [Midtown !1450]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -49,6 +49,8 @@ struct KanbanData {
     coworkers: Vec<CoworkerInfo>,
     /// Maximum number of coworkers from daemon config
     max_coworkers: usize,
+    /// Whether the headless lead session is actively working
+    lead_working: bool,
 }
 
 /// Coworker status information for the TUI board sidebar
@@ -226,6 +228,8 @@ pub struct App {
     pub merged_prs: Vec<MergedPr>,
     /// Active coworkers with their current status
     pub coworkers: Vec<CoworkerInfo>,
+    /// Whether the headless lead session is actively working
+    pub lead_working: bool,
     /// Maximum number of coworkers allowed
     pub max_coworkers: usize,
     /// Repository name with owner (e.g., "btucker/midtown")
@@ -420,6 +424,7 @@ impl App {
             prs: Vec::new(),
             merged_prs: Vec::new(),
             coworkers: Vec::new(),
+            lead_working: false,
             max_coworkers: 10, // Default, will be updated from daemon
             repo_name,
             kanban_last_refresh: Instant::now() - KANBAN_REFRESH_INTERVAL, // Force initial refresh
@@ -524,6 +529,7 @@ impl App {
                     self.prs = data.prs;
                     self.merged_prs = data.merged_prs;
                     self.coworkers = data.coworkers;
+                    self.lead_working = data.lead_working;
                     self.max_coworkers = data.max_coworkers;
                     // Update repo info from daemon if available
                     if !data.repos.is_empty() {
@@ -685,8 +691,17 @@ impl App {
         self.kanban_receiver = Some(rx);
 
         thread::spawn(move || {
-            let (prs, merged_prs, repos, coworkers, max_coworkers) = fetch_kanban_data_via_rpc()
-                .unwrap_or_else(|| (fetch_prs(), fetch_merged_prs(), Vec::new(), Vec::new(), 10));
+            let (prs, merged_prs, repos, coworkers, max_coworkers, lead_working) =
+                fetch_kanban_data_via_rpc().unwrap_or_else(|| {
+                    (
+                        fetch_prs(),
+                        fetch_merged_prs(),
+                        Vec::new(),
+                        Vec::new(),
+                        10,
+                        false,
+                    )
+                });
             // Ignore send error if receiver dropped (app closed)
             let _ = tx.send(KanbanData {
                 prs,
@@ -694,6 +709,7 @@ impl App {
                 repos,
                 coworkers,
                 max_coworkers,
+                lead_working,
             });
         });
     }
@@ -2165,6 +2181,7 @@ fn fetch_kanban_data_via_rpc() -> Option<(
     Vec<(String, String)>,
     Vec<CoworkerInfo>,
     usize,
+    bool,
 )> {
     use crate::client::DaemonClient;
 
@@ -2360,7 +2377,19 @@ fn fetch_kanban_data_via_rpc() -> Option<(
         })
         .unwrap_or_default();
 
-    Some((prs, merged_prs, repos, coworkers, max_coworkers))
+    let lead_working = data
+        .get("lead_working")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    Some((
+        prs,
+        merged_prs,
+        repos,
+        coworkers,
+        max_coworkers,
+        lead_working,
+    ))
 }
 
 /// Cache for default branch names, keyed by repo full name (or empty string for current repo).
@@ -2591,6 +2620,7 @@ pub(super) mod tests {
             prs: Vec::new(),
             merged_prs: Vec::new(),
             coworkers: Vec::new(),
+            lead_working: false,
             max_coworkers: 10, // Test default
             repo_name: "test".to_string(),
             kanban_last_refresh: Instant::now(),

--- a/src/bin/midtown/cli/chat/ui/chat.rs
+++ b/src/bin/midtown/cli/chat/ui/chat.rs
@@ -21,18 +21,41 @@ pub fn draw_chat_panel(f: &mut Frame, app: &mut App, area: Rect) {
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(5), Constraint::Length(input_bar_height)])
+        .constraints([
+            Constraint::Min(5),
+            Constraint::Length(1),
+            Constraint::Length(input_bar_height),
+        ])
         .split(area);
 
     // Store input area for click detection
-    app.input_area = Some(chunks[1]);
+    app.input_area = Some(chunks[2]);
 
     draw_chat_messages(f, app, chunks[0]);
-    draw_input_bar(f, app, chunks[1]);
+    draw_lead_indicator(f, app, chunks[1]);
+    draw_input_bar(f, app, chunks[2]);
 
     if app.autocomplete.show {
-        draw_autocomplete_dropdown(f, app, chunks[1]);
+        draw_autocomplete_dropdown(f, app, chunks[2]);
     }
+}
+
+/// Draw the lead working indicator line between chat messages and input bar.
+///
+/// Shows a braille spinner with "lead..." when the headless lead session is
+/// actively working. Always reserves the space to prevent layout jitter.
+fn draw_lead_indicator(f: &mut Frame, app: &mut App, area: Rect) {
+    let line = if app.lead_working {
+        let spinner = app.spinner_char();
+        Line::from(vec![Span::styled(
+            format!(" {} lead...", spinner),
+            Style::default().fg(Color::DarkGray),
+        )])
+    } else {
+        Line::from("")
+    };
+    let paragraph = Paragraph::new(line);
+    f.render_widget(paragraph, area);
 }
 
 /// Draw the chat messages area (top of chat panel)

--- a/src/daemon/rpc_kanban.rs
+++ b/src/daemon/rpc_kanban.rs
@@ -55,11 +55,16 @@ pub(crate) async fn handle_kanban_data(id: RequestId, state: &DaemonState) -> Re
     let cache_key = cache_key_hasher.finish();
 
     // Check cache first
-    if let Some(cached) = state.kanban_cache.get(cache_key) {
+    if let Some(mut cached) = state.kanban_cache.get(cache_key) {
         debug!(
             "Returning cached kanban data (TTL: {}s)",
             KANBAN_CACHE_TTL.as_secs()
         );
+        // lead_working is not cached — it's live session state
+        let lead_working = state.session_manager.is_alive("lead").await;
+        if let Some(obj) = cached.as_object_mut() {
+            obj.insert("lead_working".to_string(), serde_json::json!(lead_working));
+        }
         return Response::success(id, cached);
     }
 
@@ -248,6 +253,9 @@ pub(crate) async fn handle_kanban_data(id: RequestId, state: &DaemonState) -> Re
             .collect::<Vec<_>>()
     };
 
+    // Check if the headless lead session is actively working
+    let lead_working = state.session_manager.is_alive("lead").await;
+
     // Build response and cache it
     let response_data = serde_json::json!({
         "prs": prs,
@@ -255,6 +263,7 @@ pub(crate) async fn handle_kanban_data(id: RequestId, state: &DaemonState) -> Re
         "repos": repos,
         "coworkers": coworkers_data,
         "max_coworkers": state.max_coworkers,
+        "lead_working": lead_working,
     });
 
     state.kanban_cache.set(response_data.clone(), cache_key);


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Adds a 1-line status area between the chat messages and input bar showing a braille spinner with "lead..." when the headless lead session is actively working
- Lead status is fetched from the daemon's `kanban.data` RPC response as a live (non-cached) field
- Space is always reserved to prevent layout jitter when the indicator toggles on/off

## Implementation

**Daemon (`rpc_kanban.rs`):** Added `lead_working` to the `kanban.data` RPC response. This field is populated dynamically via `session_manager.is_alive("lead")` — on both cache hits and misses — so it always reflects the current session state rather than the 30s cached data.

**TUI App (`app.rs`):** Added `lead_working: bool` to `App` state and `KanbanData`. Updated `fetch_kanban_data_via_rpc` to parse the new field from the RPC response, and propagated it through `refresh_kanban` → `KanbanData` → `App::lead_working`.

**Chat UI (`chat.rs`):** Added `draw_lead_indicator` function and a `Constraint::Length(1)` slot in `draw_chat_panel`'s vertical layout. The indicator renders `"⠹ lead..."` in `DarkGray` when active, or an empty line when idle. Reuses the existing `app.spinner_char()` animation infrastructure.

## Test plan
- [x] `cargo test --bin midtown` — 326 tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt -- --check` — no formatting issues
- [ ] Manual: verify spinner appears when lead is working and disappears when idle

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)