### PR TITLE
fix: Address review feedback for lead working indicator [Midtown !1450]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,10 +243,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "binstring"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0669d5a35b64fdb5ab7fb19cae13148b6b5cbdf4b8247faf54ece47f699c8cef"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -518,6 +548,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +705,15 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -837,6 +885,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +927,22 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1555,6 +1630,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,6 +1799,17 @@ version = "0.1.0"
 dependencies = [
  "minimad",
  "ratatui",
+ "syntect",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1820,6 +1912,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -2038,6 +2136,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2078,6 +2189,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2123,6 +2240,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2505,6 +2631,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2767,6 +2902,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2914,6 +3055,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "tailf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2992,6 +3154,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -3433,6 +3626,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3585,6 +3788,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -3845,6 +4057,15 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "yoke"

--- a/src/bin/midtown/cli/chat/ui/chat.rs
+++ b/src/bin/midtown/cli/chat/ui/chat.rs
@@ -250,7 +250,7 @@ fn draw_autocomplete_dropdown(f: &mut Frame, app: &App, input_area: Rect) {
     let dropdown_height = (item_count * 2) as u16;
     let dropdown_width = 40u16.min(input_area.width.saturating_sub(4));
 
-    // saturating_sub(2): skip past the 1-row lead indicator + 1-row visual gap
+    // saturating_sub(2): skip past the 1-row lead indicator + 1-row original spacing
     let dropdown_y = input_area
         .y
         .saturating_sub(dropdown_height)

--- a/src/daemon/rpc_kanban.rs
+++ b/src/daemon/rpc_kanban.rs
@@ -308,8 +308,10 @@ fn is_session_actively_working(health: Option<&ProcessHealth>) -> bool {
     if !h.is_alive {
         return false;
     }
-    h.last_event_at
-        .is_some_and(|ts| (Utc::now() - ts).num_seconds() < LEAD_ACTIVITY_TIMEOUT.as_secs() as i64)
+    h.last_event_at.is_some_and(|ts| {
+        let elapsed = (Utc::now() - ts).num_seconds();
+        elapsed >= 0 && elapsed < LEAD_ACTIVITY_TIMEOUT.as_secs() as i64
+    })
 }
 
 /// Compute a hash representing coworker state for cache invalidation.
@@ -373,8 +375,10 @@ fn build_pr_task_map(prs: &[serde_json::Value]) -> HashMap<u32, u64> {
 
 /// Thread-safe TTL cache for kanban GraphQL data.
 ///
-/// Stores the full kanban response (PRs, merged PRs, repos, coworkers) keyed
-/// by a combined hash of repo paths AND coworker state (task assignments).
+/// Stores the kanban response (PRs, merged PRs, repos, coworkers) keyed by a
+/// combined hash of repo paths AND coworker state (task assignments).
+/// Note: `lead_working` is excluded from the cache and injected live on each
+/// read, since it changes on a sub-second cadence.
 /// The cache expires after KANBAN_CACHE_TTL and avoids expensive GraphQL
 /// queries on every RPC call.
 ///
@@ -837,54 +841,6 @@ mod tests {
             kanban_ci_status(&[serde_json::json!({"status": "IN_PROGRESS"})]),
             "running"
         );
-    }
-
-    #[test]
-    fn test_lead_activity_detection_no_health() {
-        assert!(!is_session_actively_working(None));
-    }
-
-    #[test]
-    fn test_lead_activity_detection_not_alive() {
-        let health = ProcessHealth {
-            is_alive: false,
-            last_event_at: Some(Utc::now()),
-            ..Default::default()
-        };
-        assert!(!is_session_actively_working(Some(&health)));
-    }
-
-    #[test]
-    fn test_lead_activity_detection_alive_recent_event() {
-        let health = ProcessHealth {
-            is_alive: true,
-            last_event_at: Some(Utc::now()),
-            ..Default::default()
-        };
-        assert!(is_session_actively_working(Some(&health)));
-    }
-
-    #[test]
-    fn test_lead_activity_detection_alive_stale_event() {
-        // Event older than LEAD_ACTIVITY_TIMEOUT — should be considered idle
-        let stale_ts = Utc::now() - chrono::Duration::seconds(10);
-        let health = ProcessHealth {
-            is_alive: true,
-            last_event_at: Some(stale_ts),
-            ..Default::default()
-        };
-        assert!(!is_session_actively_working(Some(&health)));
-    }
-
-    #[test]
-    fn test_lead_activity_detection_alive_no_events() {
-        // Alive but has never received any events
-        let health = ProcessHealth {
-            is_alive: true,
-            last_event_at: None,
-            ..Default::default()
-        };
-        assert!(!is_session_actively_working(Some(&health)));
     }
 
     #[test]

--- a/src/daemon/rpc_kanban_tests.rs
+++ b/src/daemon/rpc_kanban_tests.rs
@@ -134,3 +134,63 @@ fn test_coworker_state_hash_changes_on_assignment() {
     assert_ne!(hash_2, hash_3);
     assert_ne!(hash_3, hash_4);
 }
+
+#[test]
+fn test_lead_activity_detection_no_health() {
+    assert!(!is_session_actively_working(None));
+}
+
+#[test]
+fn test_lead_activity_detection_not_alive() {
+    let health = ProcessHealth {
+        is_alive: false,
+        last_event_at: Some(Utc::now()),
+        ..Default::default()
+    };
+    assert!(!is_session_actively_working(Some(&health)));
+}
+
+#[test]
+fn test_lead_activity_detection_alive_recent_event() {
+    let health = ProcessHealth {
+        is_alive: true,
+        last_event_at: Some(Utc::now()),
+        ..Default::default()
+    };
+    assert!(is_session_actively_working(Some(&health)));
+}
+
+#[test]
+fn test_lead_activity_detection_alive_stale_event() {
+    // Event older than LEAD_ACTIVITY_TIMEOUT — should be considered idle
+    let stale_ts = Utc::now() - chrono::Duration::seconds(10);
+    let health = ProcessHealth {
+        is_alive: true,
+        last_event_at: Some(stale_ts),
+        ..Default::default()
+    };
+    assert!(!is_session_actively_working(Some(&health)));
+}
+
+#[test]
+fn test_lead_activity_detection_alive_no_events() {
+    // Alive but has never received any events
+    let health = ProcessHealth {
+        is_alive: true,
+        last_event_at: None,
+        ..Default::default()
+    };
+    assert!(!is_session_actively_working(Some(&health)));
+}
+
+#[test]
+fn test_lead_activity_detection_future_timestamp() {
+    // Clock skew: last_event_at is in the future — should NOT report active
+    let future_ts = Utc::now() + chrono::Duration::seconds(60);
+    let health = ProcessHealth {
+        is_alive: true,
+        last_event_at: Some(future_ts),
+        ..Default::default()
+    };
+    assert!(!is_session_actively_working(Some(&health)));
+}


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
Follow-up to PR #1226 — addresses review feedback from pleasant.

- **Activity detection**: Replace `is_alive("lead")` with `last_event_at`-based timeout (5s) using `headless_health`. The spinner now shows only when the lead session is actively computing, not just when the process is alive.
- **Cache hygiene**: Strip `lead_working` from the cached kanban response. Live value is injected on every request, preventing stale values if the cache-hit injection is ever refactored away.
- **Autocomplete overlap**: Increase dropdown Y offset by 1 to account for the new indicator row between messages and input bar.
- **Tests**: 5 unit tests for `is_session_actively_working` covering: no health data, not alive, recent event (active), stale event (idle), no events (idle).

Item #4 (shared spinner frame) is cosmetic and deferred — both spinners animating in sync is not functionally wrong.

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --lib` — 1380 tests pass (5 new)
- [x] Pre-commit hooks pass (fmt + clippy)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)