### PR TITLE
feat: Enable bracketed paste and add Alt+Enter for newline input [Midtown !1458]

### DIFF
--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -740,25 +740,37 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
             _ => EventResult::Continue,
         },
         Event::Paste(text) => {
-            // Bracketed paste: insert the entire pasted string at cursor position.
-            // Newlines in the pasted text are preserved as-is (they display as
-            // line breaks in the multi-line input and are sent as part of the message).
-            auto_focus_and_insert_str(app, &text);
+            // Normalize line endings: clipboard content from Windows or web browsers
+            // may contain \r\n or bare \r — convert to \n before insertion.
+            let text = text.replace("\r\n", "\n").replace('\r', "\n");
+
+            if app.channel_switcher.show {
+                // Route pasted text to channel switcher filter
+                for c in text.chars() {
+                    app.channel_switcher_input(c);
+                }
+            } else {
+                // Bracketed paste: insert the entire pasted string at cursor position.
+                // Newlines in the pasted text are preserved as-is (they display as
+                // line breaks in the multi-line input and are sent as part of the message).
+                auto_focus_and_insert_str(app, &text);
+            }
             EventResult::Continue
         }
         _ => EventResult::Continue,
     }
 }
 
-/// Toggle mouse capture for text selection mode.
-/// When selection mode is on, mouse capture is disabled so the terminal handles
-/// text selection natively. Scrollwheel won't work in the TUI during selection mode.
+/// Toggle mouse capture and bracketed paste for text selection mode.
+/// When selection mode is on, mouse capture and bracketed paste are disabled so
+/// the terminal handles text selection and paste natively. Scrollwheel won't
+/// work in the TUI during selection mode.
 fn toggle_mouse_capture(app: &mut App, backend: &mut CrosstermBackend<io::Stdout>) {
     app.selection_mode = !app.selection_mode;
     if app.selection_mode {
-        let _ = execute!(backend, DisableMouseCapture);
+        let _ = execute!(backend, DisableMouseCapture, DisableBracketedPaste);
     } else {
-        let _ = execute!(backend, EnableMouseCapture);
+        let _ = execute!(backend, EnableMouseCapture, EnableBracketedPaste);
     }
 }
 
@@ -787,14 +799,17 @@ fn auto_focus_and_insert_char(app: &mut App, c: char) {
 fn auto_focus_and_insert_str(app: &mut App, s: &str) {
     use app::FocusedPane;
 
+    // Switch focus to InputBar if not already there
     if app.focused_pane != FocusedPane::InputBar {
         app.focused_pane = FocusedPane::InputBar;
     }
 
+    // Insert string at cursor position
     let byte_idx = char_index_to_byte_index(&app.input_text, app.input_cursor);
     app.input_text.insert_str(byte_idx, s);
     app.input_cursor += s.chars().count();
 
+    // Detect autocomplete trigger
     app.detect_autocomplete_trigger();
 }
 
@@ -1717,88 +1732,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_paste_inserts_text_at_cursor() {
-        let mut app = test_app();
-
-        let event = Event::Paste("hello world".to_string());
-        handle_event(&mut app, event);
-
-        assert_eq!(app.input_text, "hello world");
-        assert_eq!(app.input_cursor, 11);
-    }
-
-    #[test]
-    fn test_paste_preserves_newlines() {
-        let mut app = test_app();
-
-        let event = Event::Paste("line1\nline2\nline3".to_string());
-        handle_event(&mut app, event);
-
-        assert_eq!(app.input_text, "line1\nline2\nline3");
-        assert_eq!(app.input_cursor, 17);
-    }
-
-    #[test]
-    fn test_paste_inserts_at_middle_of_existing_text() {
-        use app::FocusedPane;
-        let mut app = test_app();
-        app.focused_pane = FocusedPane::InputBar;
-        app.input_text = "helo".to_string();
-        app.input_cursor = 2; // cursor between 'he' and 'lo'
-
-        let event = Event::Paste("l".to_string());
-        handle_event(&mut app, event);
-
-        assert_eq!(app.input_text, "hello");
-        assert_eq!(app.input_cursor, 3);
-    }
-
-    #[test]
-    fn test_paste_auto_focuses_input_bar() {
-        use app::FocusedPane;
-        let mut app = test_app();
-        app.focused_pane = FocusedPane::Chat;
-
-        let event = Event::Paste("hello".to_string());
-        handle_event(&mut app, event);
-
-        assert_eq!(app.focused_pane, FocusedPane::InputBar);
-    }
-
-    #[test]
-    fn test_paste_empty_string_is_noop() {
-        let mut app = test_app();
-
-        let event = Event::Paste(String::new());
-        handle_event(&mut app, event);
-
-        assert_eq!(app.input_text, "");
-        assert_eq!(app.input_cursor, 0);
-    }
-
-    #[test]
-    fn test_alt_enter_inserts_newline() {
-        let mut app = test_app();
-
-        let event = Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT));
-        handle_event(&mut app, event);
-
-        assert_eq!(app.input_text, "\n");
-        assert_eq!(app.input_cursor, 1);
-    }
-
-    #[test]
-    fn test_shift_enter_inserts_newline() {
-        let mut app = test_app();
-
-        let event = Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT));
-        handle_event(&mut app, event);
-
-        assert_eq!(app.input_text, "\n");
-        assert_eq!(app.input_cursor, 1);
-    }
-
     /// Regression test: Shift+letter should insert uppercase character.
     ///
     /// With the kitty keyboard protocol (REPORT_ALL_KEYS_AS_ESCAPE_CODES),
@@ -2220,3 +2153,7 @@ mod channel_switcher_tests;
 #[path = "keyboard_protocol_tests.rs"]
 #[cfg(test)]
 mod keyboard_protocol_tests;
+
+#[path = "paste_tests.rs"]
+#[cfg(test)]
+mod paste_tests;

--- a/src/bin/midtown/cli/chat/paste_tests.rs
+++ b/src/bin/midtown/cli/chat/paste_tests.rs
@@ -1,0 +1,165 @@
+//! Tests for bracketed paste and Alt+Enter newline input.
+//!
+//! Covers paste event handling (text insertion, cursor positioning, line ending
+//! normalization, channel switcher routing) and modifier+Enter newline insertion.
+
+use super::app::FocusedPane;
+use super::app::tests::test_app;
+use crate::cli::chat::{EventResult, handle_event};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+
+#[test]
+fn test_paste_inserts_text_at_cursor() {
+    let mut app = test_app();
+
+    let event = Event::Paste("hello world".to_string());
+    handle_event(&mut app, event);
+
+    assert_eq!(app.input_text, "hello world");
+    assert_eq!(app.input_cursor, 11);
+}
+
+#[test]
+fn test_paste_preserves_newlines() {
+    let mut app = test_app();
+
+    let event = Event::Paste("line1\nline2\nline3".to_string());
+    handle_event(&mut app, event);
+
+    assert_eq!(app.input_text, "line1\nline2\nline3");
+    assert_eq!(app.input_cursor, 17);
+}
+
+#[test]
+fn test_paste_inserts_at_middle_of_existing_text() {
+    let mut app = test_app();
+    app.focused_pane = FocusedPane::InputBar;
+    app.input_text = "helo".to_string();
+    app.input_cursor = 2; // cursor between 'he' and 'lo'
+
+    let event = Event::Paste("l".to_string());
+    handle_event(&mut app, event);
+
+    assert_eq!(app.input_text, "hello");
+    assert_eq!(app.input_cursor, 3);
+}
+
+#[test]
+fn test_paste_auto_focuses_input_bar() {
+    let mut app = test_app();
+    app.focused_pane = FocusedPane::Chat;
+
+    let event = Event::Paste("hello".to_string());
+    handle_event(&mut app, event);
+
+    assert_eq!(app.focused_pane, FocusedPane::InputBar);
+}
+
+#[test]
+fn test_paste_empty_string_preserves_existing_state() {
+    let mut app = test_app();
+    app.focused_pane = FocusedPane::InputBar;
+    app.input_text = "existing".to_string();
+    app.input_cursor = 3;
+
+    let event = Event::Paste(String::new());
+    handle_event(&mut app, event);
+
+    assert_eq!(
+        app.input_text, "existing",
+        "Existing text should be preserved on empty paste"
+    );
+    assert_eq!(app.input_cursor, 3, "Cursor position should be unchanged");
+}
+
+#[test]
+fn test_paste_normalizes_crlf_line_endings() {
+    let mut app = test_app();
+
+    let event = Event::Paste("line1\r\nline2\r\nline3".to_string());
+    handle_event(&mut app, event);
+
+    assert_eq!(
+        app.input_text, "line1\nline2\nline3",
+        "\\r\\n should be normalized to \\n"
+    );
+    assert!(
+        !app.input_text.contains('\r'),
+        "No \\r characters should remain"
+    );
+}
+
+#[test]
+fn test_paste_normalizes_bare_cr_line_endings() {
+    let mut app = test_app();
+
+    let event = Event::Paste("line1\rline2\rline3".to_string());
+    handle_event(&mut app, event);
+
+    assert_eq!(
+        app.input_text, "line1\nline2\nline3",
+        "Bare \\r should be normalized to \\n"
+    );
+}
+
+#[test]
+fn test_paste_routes_to_channel_switcher_when_open() {
+    let mut app = test_app();
+    app.channel_switcher.show = true;
+
+    let event = Event::Paste("test".to_string());
+    handle_event(&mut app, event);
+
+    assert_eq!(
+        app.channel_switcher.input, "test",
+        "Pasted text should go to channel switcher filter"
+    );
+    assert_eq!(
+        app.input_text, "",
+        "Main input should remain empty when channel switcher is open"
+    );
+}
+
+#[test]
+fn test_alt_enter_inserts_newline() {
+    let mut app = test_app();
+
+    let event = Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT));
+    handle_event(&mut app, event);
+
+    assert_eq!(app.input_text, "\n");
+    assert_eq!(app.input_cursor, 1);
+}
+
+#[test]
+fn test_shift_enter_inserts_newline() {
+    let mut app = test_app();
+
+    let event = Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT));
+    handle_event(&mut app, event);
+
+    assert_eq!(app.input_text, "\n");
+    assert_eq!(app.input_cursor, 1);
+}
+
+#[test]
+fn test_alt_enter_with_autocomplete_shown() {
+    // Alt+Enter should insert newline even if autocomplete is showing,
+    // matching Shift+Enter precedence (see test_shift_enter_with_autocomplete_shown
+    // in autocomplete_tests.rs)
+    let mut app = test_app();
+    app.input_text = "@p".to_string();
+    app.input_cursor = 2;
+    app.autocomplete.show = true;
+    app.autocomplete.selected_index = 0;
+
+    let event = Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT));
+    let result = handle_event(&mut app, event);
+
+    assert!(matches!(result, EventResult::Continue));
+    assert_eq!(
+        app.input_text, "@p\n",
+        "Alt+Enter should insert newline, not select autocomplete"
+    );
+    assert_eq!(app.input_cursor, 3);
+}


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Enable `EnableBracketedPaste` in terminal setup so pasted text arrives as `Event::Paste(String)` rather than individual characters — newlines in pasted text are now preserved instead of triggering message send
- Handle `Event::Paste` events by inserting the full pasted string at the cursor position (via new `auto_focus_and_insert_str` helper)
- Add `Alt+Enter` as a universal fallback for newline insertion alongside `Shift+Enter` — Alt+Enter works in all terminals, while Shift+Enter requires kitty keyboard protocol support
- Add `DisableBracketedPaste` to terminal cleanup

## Test plan
- [x] `test_paste_inserts_text_at_cursor` — paste inserts text and advances cursor
- [x] `test_paste_preserves_newlines` — newlines in pasted text are preserved
- [x] `test_paste_inserts_at_middle_of_existing_text` — paste respects cursor position
- [x] `test_paste_auto_focuses_input_bar` — paste auto-focuses InputBar
- [x] `test_paste_empty_string_is_noop` — empty paste is a no-op
- [x] `test_alt_enter_inserts_newline` — Alt+Enter inserts newline
- [x] `test_shift_enter_inserts_newline` — Shift+Enter still inserts newline
- [x] All 1381 existing tests pass
- [x] Clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)