### PR TITLE
feat: Add channel-lead.md system prompt template [Midtown !1464]

### DIFF
--- a/agents/channel-lead.md
+++ b/agents/channel-lead.md
@@ -73,6 +73,8 @@ Use this awareness to keep your domain context current and surface relevant info
 You have read-only access to the codebase:
 - **Read, Glob, Grep** — explore code for context
 - **WebSearch, WebFetch** — research external topics
-- **midtown channel post** — post to #{channel_name}
+
+CLI commands available via Bash:
+- `midtown channel post "..." --channel {channel_name}` — post to #{channel_name}
 
 Do NOT use Edit, Write, or Bash to modify files. You are a brainstorming partner and domain expert, not an implementer.

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -385,6 +385,9 @@ pub fn clusterer_system_prompt() -> String {
 /// the embedded default. The `{channel_name}` placeholder is replaced with the
 /// actual channel name, and `{domain_context}` is replaced with daemon-injected
 /// context (channel description, active tasks, recent PRs).
+///
+/// Note: `channel_name` is embedded into bash command examples in the template,
+/// so it must be a shell-safe identifier (alphanumeric + hyphens).
 pub fn channel_lead_system_prompt(channel_name: &str, domain_context: &str) -> String {
     let template = load_prompt_file("channel-lead.md")
         .unwrap_or_else(|| DEFAULT_CHANNEL_LEAD_PROMPT.to_string());


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary

- Adds `agents/channel-lead.md` — the system prompt template for channel lead sessions
- Adds `channel_lead_system_prompt(channel_name, domain_context)` to `src/agents.rs`
- Adds 4 tests verifying template substitution and required content

## What this enables

Each topic channel can now have its own headless Claude session (channel lead) that acts as a domain expert. The template defines:

- **Identity**: Channel lead identifies itself as `#web-interface`, `#daemon-core`, etc.
- **Role**: Brainstorming, living documents, domain Q&A — not implementation
- **Channel posting**: `midtown channel post "..." --channel {channel_name}`
- **Escalation rules**: Domain questions stay in channel; cross-cutting questions go to @lead in #midtown
- **Read-only constraint**: No Edit/Write/Bash tools
- **Domain context**: `{domain_context}` placeholder for daemon-injected task/PR summaries

## Test plan

- [x] `cargo test --lib agents` — all 39 tests pass (4 new)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)