### PR TITLE
fix: Reset ownerless in_progress tasks to pending [Midtown !1474]

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -1907,11 +1907,19 @@ pub fn should_recover_task_test_helper(
 // Task reset for orphaned tasks (owner on break, no PR)
 // ============================================================================
 
-/// Reset tasks that are orphaned because their owner went on break.
+/// Reset tasks that are orphaned — either ownerless or their owner went on break.
 ///
-/// A task is orphaned when:
+/// A task is reset to pending when:
+///
+/// **Ownerless tasks** (no owner field):
+/// 1. It's in_progress with no owner
+/// 2. It does NOT have an open PR (no entry in `tasks_with_open_prs` or `github_open_pr_task_ids`)
+///
+/// These are reset immediately — no grace period since there's no owner to recover.
+///
+/// **Owned tasks** (owner went on break):
 /// 1. It's in_progress with an owner
-/// 2. It does NOT have an open PR (no entry in `tasks_with_open_prs`)
+/// 2. It does NOT have an open PR
 /// 3. The owner is NOT active (not in active_names)
 /// 4. Grace period has expired since owner stopped (respects `coworker_stop_times`)
 ///
@@ -1953,23 +1961,11 @@ pub fn reset_orphaned_tasks(snap: &snapshot::WorldSnapshot) -> Vec<Effect> {
             continue;
         }
 
-        // Ownerless in_progress tasks have no active worker — reset immediately.
-        // No grace period needed since there is no owner to recover.
-        if owner_clean.is_empty() {
-            debug!(
-                "Task !{} is in_progress with no owner — resetting to pending",
-                task_id
-            );
-            effects.push(Effect::ResetTaskToPending {
-                task_id: task_id.clone(),
-                repo_name: snap.repo_name.clone(),
-            });
-            continue;
-        }
-
-        // Also protect tasks that REFERENCE an open PR in their subject
+        // Protect tasks that REFERENCE an open PR in their subject
         // (e.g., "Address review feedback on PR #1032") — these don't own
         // the PR but shouldn't be reset while the PR is still open.
+        // This check runs before the ownerless check so that ownerless review
+        // tasks (e.g., owner cleared on break) are also protected.
         if let Some(pr_num_str) = crate::tasks::extract_pr_number(subject)
             && let Ok(pr_num) = pr_num_str.parse::<u64>()
         {
@@ -1984,6 +1980,21 @@ pub fn reset_orphaned_tasks(snap: &snapshot::WorldSnapshot) -> Vec<Effect> {
                 );
                 continue;
             }
+        }
+
+        // Ownerless in_progress tasks have no active worker — reset to pending
+        // so they can be re-dispatched. No grace period needed since there is
+        // no owner to recover.
+        if owner_clean.is_empty() {
+            debug!(
+                "Task !{} is in_progress with no owner — resetting to pending",
+                task_id
+            );
+            effects.push(Effect::ResetTaskToPending {
+                task_id: task_id.clone(),
+                repo_name: snap.repo_name.clone(),
+            });
+            continue;
         }
 
         // Only reset if the owner is NOT active (already shut down / on break)

--- a/src/daemon/dispatch_tests.rs
+++ b/src/daemon/dispatch_tests.rs
@@ -4029,12 +4029,12 @@ fn test_reset_orphaned_tasks_resets_ownerless_in_progress_task() {
     // Bug: When a coworker goes on break and the task owner is cleared,
     // the task becomes in_progress with no owner. reset_orphaned_tasks() was
     // skipping these via `continue` on empty owner, leaving them stuck forever.
-    let mut snap = snapshot::minimal_snapshot_for_test();
-    snap.in_progress_tasks = vec![(
+    let in_progress = vec![(
         "1474".to_string(),
         "Fix orphaned tasks".to_string(),
         "".to_string(),
     )];
+    let snap = make_reconcile_snapshot(in_progress, HashMap::new(), HashSet::new());
 
     let effects = reset_orphaned_tasks(&snap);
 
@@ -4055,18 +4055,62 @@ fn test_reset_orphaned_tasks_resets_ownerless_in_progress_task() {
 fn test_reset_orphaned_tasks_ownerless_task_with_open_pr_is_skipped() {
     // Ownerless in_progress tasks that have an open PR should NOT be reset —
     // they're being managed by reconcile_tasks_in_review.
-    let mut snap = snapshot::minimal_snapshot_for_test();
-    snap.in_progress_tasks = vec![(
+    let in_progress = vec![(
         "1474".to_string(),
         "Fix orphaned tasks".to_string(),
         "".to_string(),
     )];
-    snap.tasks_with_open_prs.insert("1474".to_string(), 999u64);
+    let mut tasks_with_open_prs = HashMap::new();
+    tasks_with_open_prs.insert("1474".to_string(), 999u64);
+    let snap = make_reconcile_snapshot(in_progress, tasks_with_open_prs, HashSet::new());
 
     let effects = reset_orphaned_tasks(&snap);
 
     assert!(
         effects.is_empty(),
         "Ownerless in_progress task with open PR should not be reset"
+    );
+}
+
+#[test]
+fn test_reset_orphaned_tasks_ownerless_task_with_github_open_pr_is_skipped() {
+    // Defense-in-depth: ownerless tasks should also be protected when the PR
+    // is only in github_open_pr_task_ids (e.g., after daemon restart when
+    // tasks_with_open_prs is empty).
+    let in_progress = vec![(
+        "1474".to_string(),
+        "Fix orphaned tasks".to_string(),
+        "".to_string(),
+    )];
+    let mut snap = make_reconcile_snapshot(in_progress, HashMap::new(), HashSet::new());
+    snap.github_open_pr_task_ids
+        .insert("1474".to_string(), 999u64);
+
+    let effects = reset_orphaned_tasks(&snap);
+
+    assert!(
+        effects.is_empty(),
+        "Ownerless in_progress task with open PR via github_open_pr_task_ids should not be reset"
+    );
+}
+
+#[test]
+fn test_reset_orphaned_tasks_ownerless_task_with_subject_pr_reference_is_skipped() {
+    // Ownerless tasks whose subject references an open PR should NOT be reset.
+    // E.g., "Address review feedback on PR #42" — the PR is still open, so
+    // the review task should remain in_progress for re-dispatch, not reset.
+    let in_progress = vec![(
+        "1474".to_string(),
+        "Address review feedback on PR #42".to_string(),
+        "".to_string(),
+    )];
+    let mut snap = make_reconcile_snapshot(in_progress, HashMap::new(), HashSet::new());
+    snap.open_prs_data = vec![serde_json::json!({"number": 42})];
+
+    let effects = reset_orphaned_tasks(&snap);
+
+    assert!(
+        effects.is_empty(),
+        "Ownerless task referencing open PR #42 in subject should not be reset"
     );
 }


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary

- Fixed `reset_orphaned_tasks()` in `dispatch.rs` to reset in_progress tasks with no owner to pending status
- Previously, a `continue` on empty owner caused these tasks to be silently skipped forever, never dispatched
- Added PR-protection: ownerless tasks with an open PR are still skipped (handled by `reconcile_tasks_in_review`)

## Root Cause

When a coworker goes on break and the task owner is cleared, `reset_orphaned_tasks()` hit this early exit:

```rust
if owner_clean.is_empty() {
    continue;  // skipped ownerless in_progress tasks entirely
}
```

The task stayed `in_progress` with no owner forever — the pending-tasks dispatcher doesn't look at in_progress tasks, and the orphan reset skipped them.

## Fix

Move the open-PR check before the owner check, then emit `ResetTaskToPending` for ownerless tasks immediately (no grace period needed since there's no owner to recover):

```rust
// Open-PR check first (protects both owned and ownerless tasks)
if snap.tasks_with_open_prs.contains_key(task_id) || ... { continue; }

// Ownerless: reset immediately, no owner-activity check needed
if owner_clean.is_empty() {
    effects.push(Effect::ResetTaskToPending { ... });
    continue;
}
```

## Test Plan

- [x] `test_reset_orphaned_tasks_resets_ownerless_in_progress_task` — fails before fix, passes after
- [x] `test_reset_orphaned_tasks_ownerless_task_with_open_pr_is_skipped` — protects PR-tracked tasks
- [x] All 9 `test_reset_orphaned_tasks_*` tests pass
- [x] Full test suite: 1394 tests pass, 0 failures
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)