### PR TITLE
docs: Update coworker.md to reference channel leads [Midtown !1482]

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -440,7 +440,7 @@ When unsure about something, **ask in the channel** using @mentions. Follow this
 2. **@lead** - Ask the Lead for project-wide coordination, priority decisions, and cross-channel blockers. **Only @lead for genuine questions, decisions, or blockers** — not for routine status updates like "PR is ready" or "task complete" (the daemon handles those automatically).
 3. **@coworker** - Ask a specific coworker if they're actively working on something directly related to your task.
 
-If your task has no channel (no `MIDTOWN_CHANNEL` set), go directly to @lead for questions.
+If your task has no channel (no `MIDTOWN_CHANNEL` set), or if no channel lead responds after a reasonable wait, go directly to `@lead` for questions.
 
 Collaboration is encouraged! Don't make assumptions - it's better to ask than to build the wrong thing.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,10 @@ Coworkers are named after Manhattan avenues: lexington, park, madison, broadway,
 
 Coworkers stay synchronized via a Claude Code Stop hook. When Claude pauses, the hook reads new channel messages and checks for unclaimed tasks. This means coworkers automatically receive updates at natural pause points.
 
+## Channel Leads
+
+Topic channels can have a dedicated channel lead — a headless Claude Code session with persistent context for a specific area of the codebase. Channel leads are spawned from the `agents/channel-lead.md` system prompt template and provide domain expertise to coworkers working in their channel. Coworkers are instructed to ask `@channel-lead` for domain questions before escalating to `@lead`, forming a three-tier question hierarchy: channel lead → lead → peer coworker.
+
 ## Mailbox Messaging
 
 In addition to the shared channel, the daemon can deliver targeted messages to individual coworkers via the Claude Code agent teams mailbox protocol. Messages are written as JSON to `~/.claude/teams/{team-name}/inboxes/{agent-name}.json` using atomic file operations with mkdir-based locking for safe concurrent access.


### PR DESCRIPTION
<!-- midtown: spring -->

## Summary
- Introduce channel leads concept in the Channel Usage section, near the `MIDTOWN_CHANNEL` explanation
- Add numbered escalation hierarchy in "Asking Questions": channel lead → @lead → peer coworker
- Update "Other Updates" quick examples to distinguish domain questions (channel lead) from coordination questions (@lead)
- Add fallback guidance: if no `MIDTOWN_CHANNEL` is set, go directly to @lead

## Test plan
- [x] Existing agent tests pass (39/39)
- [x] `cargo clippy` and `cargo fmt` pass (pre-commit hooks)
- [x] Text changes are documentation only — no code changes

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)