### PR TITLE
docs: Document and scope channel leads feature [Midtown !1494]

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,21 +231,7 @@ zellij_chat_pane_size = 40      # Wider chat for this project
 
 [daemon]
 webhook_port = 47023              # Auto-assigned if not set
-
-[channel_leads]
-default_model = "sonnet"          # Default model for all channel leads
-
-[channel_leads.overrides]
-"daemon-architecture" = "opus"    # Per-channel model override
-"web-interface" = "sonnet"
 ```
-
-The `[channel_leads]` section configures channel lead sessions:
-
-- `default_model` — Model used for all channel leads unless overridden (defaults to `"sonnet"`)
-- `[channel_leads.overrides]` — Per-channel model selection; override keys are channel names
-
-Model resolution priority: per-channel override → `default_model` → `"sonnet"`.
 
 The `[project]` section defines:
 
@@ -443,15 +429,15 @@ Coworkers are named after Manhattan avenues: lexington, park, madison, broadway,
 
 ### Channel Leads
 
-Each topic channel can have a **channel lead** — a persistent headless Claude Code session that acts as a domain expert for that channel. Channel leads are long-lived: they accumulate context across conversations, survive daemon restarts via session resume, and are created/destroyed automatically when channels are created or archived.
+Each topic channel can have a **channel lead** — a headless Claude Code session that acts as a domain expert for that channel. Channel leads accumulate context across conversations and are available to answer domain questions.
 
 **What channel leads do:**
 - Brainstorm with the user on domain topics in their channel
 - Maintain living design documents, architecture notes, and decision logs
-- Answer domain questions with accumulated context from their persistent session
-- Receive nudges about new tasks, opened/merged PRs, and CI failures in their channel
+- Answer domain questions with accumulated context
+- Receive user messages posted to their topic channel
 
-**What channel leads don't do:** Channel leads are read-only — they don't write code, open PRs, or create tasks. When implementation work is needed, they escalate to @lead.
+**What channel leads don't do:** Channel leads don't write code, open PRs, or create tasks. When implementation work is needed, they escalate to @lead.
 
 Coworkers use `@{channel-name}` for domain questions (e.g., `@auth-refactor can you explain the token expiry logic?`) and reserve `@lead` for coordination and priority questions.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,7 @@ The daemon handles:
 - GitHub webhook processing (PR events, CI status, reviews)
 - PR polling for merge conflicts and stuck conditions
 - @mention routing between team members
+- Topic channel message routing to channel leads
 - Headed wrapper intercom RPC endpoints (`headed.register/poll/ack/...`)
 
 ## Daemon Startup Sequence
@@ -36,8 +37,6 @@ When the daemon starts, it executes a careful cleanup and recovery sequence in `
 
 6. **Session recovery** — `recover_headless_sessions()` generates `ResumeCoworker` effects for each resumable session. The old process is NOT killed here — it dies naturally from the broken pipe when its previous daemon's handles are closed. A fresh `claude --resume <session_id>` process is spawned to continue the session.
 
-7. **Channel lead recovery** — `recover_channel_lead_sessions()` resumes or spawns channel leads for all active (non-archived) topic channels. Channel leads with saved session IDs are resumed; channels without a saved ID get a fresh lead spawned. The main "midtown" channel is excluded.
-
 ## Coworkers
 
 Each coworker runs as:
@@ -51,28 +50,13 @@ Coworkers are named after Manhattan avenues: lexington, park, madison, broadway,
 
 ## Channel Leads
 
-Channel leads are persistent headless Claude Code sessions attached to individual topic channels. Where coworkers are temporary implementers that come and go with tasks, channel leads are long-lived domain experts that accumulate context across conversations.
+Channel leads are headless Claude Code sessions attached to individual topic channels. Where coworkers are temporary implementers that come and go with tasks, channel leads are long-lived domain experts that accumulate context across conversations.
 
-**Role:** A channel lead is read-only — it brainstorms, maintains living design documents, answers domain questions, and tracks awareness of active tasks and PRs in its channel. It does not write code, open PRs, or create tasks. When implementation work is needed, it escalates to @lead.
+**Role:** A channel lead brainstorms, maintains living design documents, answers domain questions, and tracks awareness of active tasks and PRs in its channel. It does not write code, open PRs, or create tasks. When implementation work is needed, it escalates to @lead.
 
-**Session lifecycle:**
-- Created automatically when a new topic channel is created (`CreateChannel` effect)
-- Shut down automatically when a channel is archived (`ArchiveChannel` effect)
-- Session IDs are persisted in `DaemonPersistentState.channel_lead_sessions` (channel_name → session_id), so channel leads survive daemon restarts
-- On startup, `recover_channel_lead_sessions()` resumes sessions with saved IDs or spawns fresh leads for active topic channels (excluding the "midtown" main channel and archived channels)
+**Message routing:** When a user posts to a topic channel (any non-main channel), `handle_channel_post` in `src/daemon/mod.rs` nudges the channel lead for that channel via `SessionManager::send_message`. If no channel lead session is alive for that channel, the message is silently skipped — it remains in the channel log and is available when the channel lead next starts up. Main channel behavior is unchanged. Note: `route_mentions()` is intentionally disabled for topic channels — user `@coworker` and `@all` mentions in topic channels are silently dropped; only the channel lead nudge path is active.
 
-**Session naming:** A channel lead's session name equals its channel name (e.g., channel `auth-refactor` → session `auth-refactor`). This allows the daemon to address nudges to the correct lead without a separate lookup table.
-
-**Nudges:** The daemon nudges channel leads for events in their domain:
-- A user posts to the topic channel → `handle_channel_post` routes the message to the channel lead via `SessionManager::send_message`
-- A new task is assigned to the channel → `resolve_channel_lead_for_task()` identifies the lead and nudges it
-- A PR is opened, merged, or fails CI for a channel's task → the daemon nudges the channel lead alongside the coworker
-
-**Persistent effects:**
-- `SaveChannelLeadSession` — writes session ID to persistent state after initial spawn
-- `RemoveChannelLeadSession` — removes the session entry when a channel is archived
-
-**System prompt:** Channel leads use the `agents/channel-lead.md` template, which is instantiated with `{channel_name}` and `{domain_context}` substitutions via `channel_lead_system_prompt()` in `src/agents.rs`.
+**System prompt:** Channel leads use the `agents/channel-lead.md` template, instantiated with `{channel_name}` and `{domain_context}` via `channel_lead_system_prompt()` in `src/agents.rs`.
 
 **Coworker guidance:** Coworkers are instructed to `@{channel-name}` for domain questions (e.g., architecture, design decisions) and to reserve `@lead` for coordination, task, and priority questions.
 


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Documents the channel leads feature in `docs/architecture.md` and `README.md`
- Scopes documentation to features actually on main (removes documentation for per-channel model selection which is pending in PR #1241)

## Notes
PR #1241 (per-channel model selection for channel leads) was reviewed and CI-green — it has since merged. This PR documents the channel leads baseline that is on main.

## Test plan
- [x] Docs only — no code changes

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)