### PR TITLE
fix: Don't orphan active coworker's PR when worktree is missing [Midtown !1499]

### DIFF
--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -1957,6 +1957,7 @@ async fn collect_reviewer_effects(
     collect_reviewer_effects_with_source(
         Some(&snap.worktree_branch_owners),
         &snap.worktree_registry,
+        &snap.active_names,
         state,
         prs,
         crate::github_state::AssignmentSource::PollingFallback,
@@ -1967,6 +1968,7 @@ async fn collect_reviewer_effects(
 pub(crate) async fn collect_reviewer_effects_with_source(
     branch_owners_map: Option<&std::collections::HashMap<String, String>>,
     worktree_registry: &crate::worktree_registry::WorktreeRegistry,
+    active_names: &std::collections::HashSet<String>,
     state: &DaemonState,
     prs: &[serde_json::Value],
     source: crate::github_state::AssignmentSource,
@@ -2172,15 +2174,12 @@ pub(crate) async fn collect_reviewer_effects_with_source(
                     coworker_from_branch_with_map(head_ref, branch_owners_map)
                 {
                     // The branch identifies a coworker owner. Only treat as orphaned if
-                    // the coworker is NOT currently running — an active coworker can always
+                    // the coworker is NOT currently active — an active coworker can always
                     // address review feedback regardless of whether a worktree is registered.
-                    let running_names: std::collections::HashSet<String> = state
-                        .coworkers
-                        .list_running()
-                        .into_iter()
-                        .map(|cw| cw.name.to_lowercase())
-                        .collect();
-                    let is_active = running_names.contains(&owner.to_lowercase());
+                    // Uses the caller-provided active_names (from WorldSnapshot) which includes
+                    // both pane-based and headless sessions, unlike list_running() which only
+                    // tracks pane-based coworkers.
+                    let is_active = active_names.contains(&owner.to_lowercase());
                     if is_active {
                         debug!(
                             "PR #{} has no worktree for owner {} but coworker is active, not orphaned",
@@ -2581,6 +2580,7 @@ pub(super) async fn process_pending_review_spawns(
         let effects = collect_reviewer_effects_with_source(
             Some(&branch_owners),
             &snap.worktree_registry,
+            &snap.active_names,
             state,
             &[pr],
             crate::github_state::AssignmentSource::Webhook,
@@ -2647,6 +2647,20 @@ pub(super) async fn handle_ci_completion_for_review_spawn(
         (branch_owners, ps.worktree_registry.clone())
     };
 
+    // Build active_names including both pane-based and headless sessions,
+    // matching the WorldSnapshot construction in snapshot.rs
+    let mut active_names: std::collections::HashSet<String> = state
+        .coworkers
+        .list_running()
+        .into_iter()
+        .map(|cw| cw.name.to_lowercase())
+        .collect();
+    for name in state.session_manager.list_names().await {
+        if state.session_manager.is_alive(&name).await {
+            active_names.insert(name.to_lowercase());
+        }
+    }
+
     // Fetch PR data to check if it needs review
     let output = match tokio::process::Command::new("gh")
         .args([
@@ -2705,6 +2719,7 @@ pub(super) async fn handle_ci_completion_for_review_spawn(
     let effects = collect_reviewer_effects_with_source(
         Some(&branch_owners),
         &worktree_registry,
+        &active_names,
         state,
         &[pr],
         crate::github_state::AssignmentSource::Webhook,

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -378,10 +378,12 @@ async fn test_lead_pr_without_task_id_should_not_be_orphaned() {
 
     // Important: The lead's worktree exists, but NOT indexed by this branch name
     // (it's the main "lead" worktree in a different location)
+    let active_names = std::collections::HashSet::new();
 
     let effects = collect_reviewer_effects_with_source(
         None, // No branch_owners_map (simulating empty worktree map)
         &registry,
+        &active_names,
         &state,
         &[pr],
         crate::github_state::AssignmentSource::PollingFallback,
@@ -711,10 +713,12 @@ async fn test_reviewer_spawns_when_worktree_exists_but_no_current_coworker() {
     let branch_owners: std::collections::HashMap<String, String> = std::collections::HashMap::new();
 
     let state = make_test_state("test-repo");
+    let active_names = std::collections::HashSet::new();
 
     let effects = collect_reviewer_effects_with_source(
         Some(&branch_owners),
         &registry,
+        &active_names,
         &state,
         &[pr_json],
         crate::github_state::AssignmentSource::PollingFallback,
@@ -770,10 +774,12 @@ async fn test_completed_worktree_with_open_pr_gets_reviewer() {
 
     let branch_owners: std::collections::HashMap<String, String> = std::collections::HashMap::new();
     let state = make_test_state("test-repo");
+    let active_names = std::collections::HashSet::new();
 
     let effects = collect_reviewer_effects_with_source(
         Some(&branch_owners),
         &registry,
+        &active_names,
         &state,
         &[pr_json],
         crate::github_state::AssignmentSource::PollingFallback,
@@ -842,11 +848,13 @@ async fn test_completed_worktree_with_snapshot_data() {
 
     // Create minimal test state
     let state = make_test_state("midtown");
+    let active_names = std::collections::HashSet::new();
 
     // Call the function under test with snapshot's worktree registry and synthetic PR
     let effects = collect_reviewer_effects_with_source(
         Some(&branch_owners),
         &snap.worktree_registry, // Real snapshot data with task 1323's completed worktree
+        &active_names,
         &state,
         &[pr_json], // Synthetic PR that extracts task ID 1323 from title
         crate::github_state::AssignmentSource::PollingFallback,
@@ -918,11 +926,13 @@ async fn test_lead_pr_with_non_standard_branch_gets_reviewer() {
     // The repo_owner is extracted from git remote URL at daemon startup;
     // in tests we configure it via a fake origin remote.
     let state = make_test_state_with_owner("midtown", "btucker");
+    let active_names = std::collections::HashSet::new();
 
     // Call the function under test
     let effects = collect_reviewer_effects_with_source(
         Some(&branch_owners),
         &worktree_registry,
+        &active_names,
         &state,
         &[pr_json],
         crate::github_state::AssignmentSource::PollingFallback,
@@ -1564,15 +1574,13 @@ fn review_complete_action_to_effects_includes_record_task_assignment() {
 /// Expected: Active coworker's PR should NOT be marked as orphaned — the coworker
 /// can always address review feedback regardless of worktree status.
 ///
-/// Note: This test constructs synthetic state rather than loading the fixture directly.
-/// `collect_reviewer_effects_with_source` takes `&DaemonState`, not `&WorldSnapshot`,
-/// so the fixture (which serializes a `WorldSnapshot`) cannot be used without significant
-/// plumbing to reconstruct `DaemonState` from it. The fixture serves as documentation
-/// of the exact production scenario that triggered the bug.
+/// Note: The fixture's `active_names` and `worktree_registry` are used directly via
+/// the `active_names` parameter (following the WorldSnapshot architecture pattern).
+/// The fixture serves as documentation of the exact production scenario that triggered
+/// the bug.
 #[tokio::test]
 async fn test_active_coworker_pr_without_worktree_is_not_orphaned() {
     use super::super::snapshot::WorldSnapshot;
-    use crate::coworker::{Coworker, CoworkerStatus};
 
     // Load the captured snapshot that exhibits the bug scenario
     let fixture = include_str!(
@@ -1613,21 +1621,6 @@ async fn test_active_coworker_pr_without_worktree_is_not_orphaned() {
 
     let state = make_test_state("midtown");
 
-    // Add "park" as a running coworker — the key setup for this bug
-    let park = Coworker {
-        slot_id: uuid::Uuid::new_v4().to_string(),
-        name: "park".to_string(),
-        status: CoworkerStatus::Running,
-        working_dir: "/tmp/park-worktree".to_string(),
-        started_at: chrono::Utc::now(),
-        current_task: None,
-        session_id: None,
-        model: "sonnet".to_string(),
-        provider: crate::auth::AuthProvider::Claude,
-        profile: "claude@example.com".to_string(),
-    };
-    state.coworkers.insert_for_testing(park);
-
     // Empty branch_owners_map — the bug manifests because coworker_from_branch_with_map
     // still identifies "park" as the owner via the branch prefix
     let branch_owners: std::collections::HashMap<String, String> = std::collections::HashMap::new();
@@ -1635,6 +1628,7 @@ async fn test_active_coworker_pr_without_worktree_is_not_orphaned() {
     let effects = collect_reviewer_effects_with_source(
         Some(&branch_owners),
         &snap.worktree_registry, // Real snapshot registry: no task 1483 entry
+        &snap.active_names,      // Real snapshot active_names: includes "park"
         &state,
         &[pr],
         crate::github_state::AssignmentSource::PollingFallback,
@@ -1657,5 +1651,56 @@ async fn test_active_coworker_pr_without_worktree_is_not_orphaned() {
         has_reviewer_effect,
         "Expected reviewer spawn effect for PR #1246. Effects: {:#?}",
         effects
+    );
+}
+
+/// Headless-only coworker's PR should not be marked as orphaned.
+///
+/// This test verifies that a coworker running only as a headless session (no pane,
+/// not in CoworkerManager's list_running()) is still recognized as active via
+/// the active_names parameter. Before the fix, list_running() was called directly
+/// inside collect_reviewer_effects_with_source, which only tracked pane-based
+/// coworkers — missing headless-only sessions entirely.
+#[tokio::test]
+async fn test_headless_only_coworker_pr_is_not_orphaned() {
+    let pr = json!({
+        "number": 999,
+        "headRefName": "york/task-500-headless-feature",
+        "title": "feat: Headless feature [Midtown !500]",
+        "isDraft": false,
+        "createdAt": "2026-02-17T00:00:00Z",
+        "state": "OPEN",
+        "author": {"login": "btucker"},
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": null,
+        "reviewDecision": "",
+    });
+
+    let state = make_test_state("midtown");
+
+    // active_names includes "york" (as it would from WorldSnapshot which includes
+    // headless sessions), but we do NOT insert york into state.coworkers — simulating
+    // a headless-only coworker that list_running() would miss.
+    let active_names: std::collections::HashSet<String> =
+        ["york".to_string()].into_iter().collect();
+
+    let branch_owners: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let registry = crate::worktree_registry::WorktreeRegistry::new();
+
+    let effects = collect_reviewer_effects_with_source(
+        Some(&branch_owners),
+        &registry,
+        &active_names,
+        &state,
+        &[pr],
+        crate::github_state::AssignmentSource::PollingFallback,
+    )
+    .await;
+
+    // With active_names containing "york", the PR should NOT be orphaned
+    assert!(
+        !effects.is_empty(),
+        "Headless-only coworker's PR should spawn a reviewer, not be marked as orphaned. \
+         active_names includes 'york' but state.coworkers does not (headless-only session)."
     );
 }


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

- Fixes daemon bug where PR #1246 went 50+ minutes without a reviewer despite 4+ idle coworkers
- Root cause: orphan detection in `collect_reviewer_effects_with_source` checked for a registered worktree but not whether the coworker was still running
- When a coworker's worktree wasn't registered (e.g., task worktree cleaned up before PR link was established), the PR was incorrectly marked as orphaned and skipped for reviewer assignment
- Fix: check if the branch-identified coworker is currently running before declaring the PR orphaned — active coworkers can always address review feedback regardless of worktree registration

## Changes

- `src/daemon/pr.rs`: Added running-coworker check as fourth strategy in orphan detection (after worktree-by-PR, worktree-by-task, worktree-by-branch)
- `src/daemon/pr_tests.rs`: Added failing test `test_active_coworker_pr_without_worktree_is_not_orphaned` using the captured production snapshot
- `tests/fixtures/snapshot/snapshot-reviewer-not-assigned-pr-1246-20260218-001618.json`: Captured snapshot from the incident

## Test plan

- [x] `test_active_coworker_pr_without_worktree_is_not_orphaned` verifies PR gets reviewer spawned even without a worktree registry entry
- [x] All existing PR tests pass (`cargo test`)
- [x] Snapshot fixture documents exact production state at time of bug

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)