### PR TITLE
fix: channel.read respects topic channel for channel leads [Midtown !1505]

### DIFF
--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -228,6 +228,11 @@ impl DaemonClient {
         if let Some(duration) = since {
             params["since"] = serde_json::json!(duration);
         }
+        // If MIDTOWN_CHANNEL is set (channel lead context), read from that channel.
+        // Mirrors how channel_post() respects MIDTOWN_CHANNEL.
+        if let Ok(ch) = std::env::var("MIDTOWN_CHANNEL") {
+            params["channel"] = serde_json::json!(ch);
+        }
         self.send("channel.read", Some(params))
     }
 

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -399,7 +399,8 @@ async fn dispatch_request(request: Request, state: &DaemonState) -> Response {
             let all = params.bool_or("all", false);
             let last = params.usize_param("last");
             let since = params.str_param("since");
-            super::rpc_channel::handle_channel_read(request.id, all, last, since, state)
+            let channel = params.str_param("channel");
+            super::rpc_channel::handle_channel_read(request.id, all, last, since, channel, state)
         }
 
         "channel.list" => {

--- a/src/daemon/rpc_channel.rs
+++ b/src/daemon/rpc_channel.rs
@@ -294,31 +294,45 @@ pub(super) fn handle_channel_list(
 }
 
 /// Handle channel.read RPC method.
+///
+/// Accepts an optional `channel` parameter to read from a topic channel.
+/// If not provided, defaults to the main channel. Respects `MIDTOWN_CHANNEL`
+/// when called via the CLI client.
 pub(super) fn handle_channel_read(
     id: RequestId,
     all: bool,
     last: Option<usize>,
     since: Option<&str>,
+    channel: Option<&str>,
     state: &DaemonState,
 ) -> Response {
     info!(
-        "channel.read called with all={}, last={:?}, since={:?}",
-        all, last, since
+        "channel.read called with all={}, last={:?}, since={:?}, channel={:?}",
+        all, last, since, channel
     );
 
-    // Read from the default (main) channel
-    let default_channel = match state.channel_router.default_channel() {
-        Ok(ch) => ch,
-        Err(e) => {
-            error!("Failed to get default channel: {}", e);
-            return Response::error(id, RpcError::new(-32603, e.to_string()));
-        }
+    // Read from the specified channel, or fall back to the default (main) channel
+    let target_channel = match channel {
+        Some(name) => match state.channel_router.get_channel(name) {
+            Ok(ch) => ch,
+            Err(e) => {
+                error!("Failed to get channel '{}': {}", name, e);
+                return Response::error(id, RpcError::new(-32603, e.to_string()));
+            }
+        },
+        None => match state.channel_router.default_channel() {
+            Ok(ch) => ch,
+            Err(e) => {
+                error!("Failed to get default channel: {}", e);
+                return Response::error(id, RpcError::new(-32603, e.to_string()));
+            }
+        },
     };
 
     let messages = if let Some(n) = last {
         // Use --last flag: read last N messages
         info!("Reading last {} messages", n);
-        match default_channel.read_last_n_messages(n) {
+        match target_channel.read_last_n_messages(n) {
             Ok((msgs, _)) => {
                 info!(
                     "read_last_n_messages({}) returned {} messages",
@@ -352,7 +366,7 @@ pub(super) fn handle_channel_read(
 
         let cutoff = chrono::Utc::now() - chrono::Duration::from_std(duration).unwrap();
 
-        match default_channel.read_all() {
+        match target_channel.read_all() {
             Ok(msgs) => msgs.into_iter().filter(|m| m.timestamp >= cutoff).collect(),
             Err(e) => {
                 error!("Failed to read channel: {}", e);
@@ -361,7 +375,7 @@ pub(super) fn handle_channel_read(
         }
     } else if all {
         // Read all messages
-        match default_channel.read_all() {
+        match target_channel.read_all() {
             Ok(msgs) => msgs,
             Err(e) => {
                 error!("Failed to read channel: {}", e);
@@ -370,7 +384,7 @@ pub(super) fn handle_channel_read(
         }
     } else {
         // Read recent messages (last 20)
-        match default_channel.read_all() {
+        match target_channel.read_all() {
             Ok(msgs) => {
                 let total = msgs.len();
                 if total > 20 {
@@ -664,6 +678,39 @@ mod tests {
         assert_eq!(messages[0].text, "user: hello main");
     }
 
+    /// Verify that channel.read with a channel parameter reads from the specified
+    /// topic channel, not the main channel.
+    ///
+    /// Regression test for: channel leads calling `midtown channel read` always
+    /// got main channel messages instead of their topic channel messages.
+    #[tokio::test]
+    async fn test_channel_read_with_channel_parameter() {
+        let state = make_test_state("midtown-test-channel-read-channel");
+
+        // Post a message to the topic channel
+        let _r =
+            handle_channel_post(1_i64.into(), "user", "hello topic", Some("auth"), &state).await;
+
+        // Post a different message to the main channel
+        let _r = handle_channel_post(2_i64.into(), "user", "hello main", None, &state).await;
+
+        // Reading from the topic channel should return only the topic message
+        let response = handle_channel_read(999.into(), true, None, None, Some("auth"), &state);
+
+        assert!(response.error.is_none(), "channel.read should succeed");
+        let result = response.result.unwrap();
+        let messages = result["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 1, "Expected 1 message from topic channel");
+        assert!(
+            messages[0]["message"]
+                .as_str()
+                .unwrap()
+                .contains("hello topic"),
+            "Expected topic channel message, got: {:?}",
+            messages[0]["message"]
+        );
+    }
+
     #[tokio::test]
     async fn test_channel_read_with_last_parameter() {
         let state = make_test_state("midtown-test-channel-read-last");
@@ -675,7 +722,7 @@ mod tests {
         }
 
         // Request last 3 messages
-        let response = handle_channel_read(999.into(), false, Some(3), None, &state);
+        let response = handle_channel_read(999.into(), false, Some(3), None, None, &state);
 
         // Verify we got exactly 3 messages
         assert!(response.error.is_none(), "channel.read should succeed");

--- a/tests/channel_rpc_routing_test.rs
+++ b/tests/channel_rpc_routing_test.rs
@@ -1,0 +1,294 @@
+//! E2E tests for channel RPC routing — specifically that channel.read respects
+//! the `channel` parameter so that channel leads read from their topic channel
+//! instead of the main channel.
+//!
+//! Regression tests for: user messages sent to topic channels from the web UI
+//! not being visible to channel leads because channel.read always read from the
+//! main channel.
+//!
+//! Run with `cargo test --test channel_rpc_routing_test -- --ignored` as these
+//! spawn a real daemon.
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::Duration;
+
+static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn test_repo_name() -> String {
+    let counter = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+    format!("channel-rpc-test-{}-{}", std::process::id(), counter)
+}
+
+struct DaemonFixture {
+    temp_dir: PathBuf,
+    project_dir: PathBuf,
+    socket_path: PathBuf,
+    daemon_process: Option<Child>,
+}
+
+impl DaemonFixture {
+    fn new() -> Self {
+        let repo_name = test_repo_name();
+        let temp_dir = std::env::temp_dir().join(&repo_name);
+        fs::create_dir_all(&temp_dir).expect("Failed to create temp dir");
+
+        for (args, desc) in [
+            (vec!["init"], "init"),
+            (vec!["config", "user.name", "Test User"], "config name"),
+            (
+                vec!["config", "user.email", "test@example.com"],
+                "config email",
+            ),
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&temp_dir)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .unwrap_or_else(|_| panic!("Failed to git {}", desc));
+        }
+
+        fs::write(temp_dir.join("README.md"), "test").expect("Failed to write README");
+        Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(&temp_dir)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("Failed to git add");
+        Command::new("git")
+            .args(["commit", "-m", "Initial commit"])
+            .current_dir(&temp_dir)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("Failed to git commit");
+        Command::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                &format!("git@github.com:test/{}.git", repo_name),
+            ])
+            .current_dir(&temp_dir)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("Failed to set git remote");
+
+        let project_dir = dirs::home_dir()
+            .expect("home dir")
+            .join(".midtown")
+            .join("projects")
+            .join(&repo_name);
+
+        let state_dir = std::env::var("XDG_STATE_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                dirs::home_dir()
+                    .expect("home dir")
+                    .join(".local")
+                    .join("state")
+            });
+        let socket_path = state_dir
+            .join("midtown")
+            .join(&repo_name)
+            .join("daemon.sock");
+
+        Self {
+            temp_dir,
+            project_dir,
+            socket_path,
+            daemon_process: None,
+        }
+    }
+
+    fn start_daemon(&mut self) {
+        let binary_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("debug")
+            .join("midtown");
+
+        assert!(
+            binary_path.exists(),
+            "Debug binary not found at {:?}. Run `cargo build` first.",
+            binary_path
+        );
+
+        let _ = fs::remove_file(&self.socket_path);
+
+        let daemon = Command::new(&binary_path)
+            .args(["daemon", "--workdir", self.temp_dir.to_str().unwrap()])
+            .current_dir(&self.temp_dir)
+            .env("MIDTOWN_WEBHOOK_PORT", "0")
+            .env("MIDTOWN_CHAT_MONITOR", "0")
+            .env("RUST_LOG", "warn")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Failed to start daemon");
+
+        self.daemon_process = Some(daemon);
+
+        for _ in 0..300 {
+            thread::sleep(Duration::from_millis(200));
+            if self.socket_path.exists() && UnixStream::connect(&self.socket_path).is_ok() {
+                return;
+            }
+        }
+        panic!("Daemon socket did not become available within 60 seconds");
+    }
+
+    fn rpc_call(&self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        let mut stream =
+            UnixStream::connect(&self.socket_path).expect("Failed to connect to daemon");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("set read timeout");
+        stream
+            .set_write_timeout(Some(Duration::from_secs(5)))
+            .expect("set write timeout");
+
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": 1
+        });
+
+        writeln!(stream, "{}", request).expect("Failed to write request");
+
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .expect("Failed to read response");
+        serde_json::from_str(&line).expect("Failed to parse response")
+    }
+}
+
+impl Drop for DaemonFixture {
+    fn drop(&mut self) {
+        if let Some(mut daemon) = self.daemon_process.take() {
+            let _ = daemon.kill();
+            let _ = daemon.wait();
+        }
+        let _ = fs::remove_dir_all(&self.temp_dir);
+        let _ = fs::remove_dir_all(&self.project_dir);
+        if let Some(parent) = self.socket_path.parent() {
+            let _ = fs::remove_dir_all(parent);
+        }
+    }
+}
+
+/// Verify that channel.read with a channel parameter returns messages from
+/// the topic channel, not the main channel.
+///
+/// Regression test: channel leads calling `midtown channel read` always got
+/// main channel messages instead of their topic channel messages, causing them
+/// to miss user messages posted to their topic channel from the web UI.
+#[test]
+#[ignore] // E2E test - requires daemon
+fn test_channel_read_topic_channel_routing() {
+    let mut fixture = DaemonFixture::new();
+    fixture.start_daemon();
+
+    // Post a message to the topic channel (simulating a web UI user message)
+    let post_topic = fixture.rpc_call(
+        "channel.post",
+        serde_json::json!({
+            "message": "hello from topic channel",
+            "from": "user",
+            "channel": "auth"
+        }),
+    );
+    assert!(
+        post_topic.get("error").is_none(),
+        "channel.post to topic channel should succeed: {:?}",
+        post_topic
+    );
+
+    // Post a different message to the main channel
+    let post_main = fixture.rpc_call(
+        "channel.post",
+        serde_json::json!({
+            "message": "hello from main channel",
+            "from": "user"
+        }),
+    );
+    assert!(
+        post_main.get("error").is_none(),
+        "channel.post to main channel should succeed: {:?}",
+        post_main
+    );
+
+    // Read from the topic channel — should return only the topic message
+    let read_topic = fixture.rpc_call(
+        "channel.read",
+        serde_json::json!({
+            "all": true,
+            "channel": "auth"
+        }),
+    );
+    assert!(
+        read_topic.get("error").is_none(),
+        "channel.read from topic channel should succeed: {:?}",
+        read_topic
+    );
+
+    let topic_messages = read_topic["result"]["messages"]
+        .as_array()
+        .expect("messages should be an array");
+    assert_eq!(
+        topic_messages.len(),
+        1,
+        "Topic channel should have exactly 1 message, got: {:?}",
+        topic_messages
+    );
+    assert!(
+        topic_messages[0]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("hello from topic channel"),
+        "Topic channel message should be the one posted to 'auth', got: {:?}",
+        topic_messages[0]
+    );
+
+    // Read from the main channel (no channel param) — should return only the main message
+    let read_main = fixture.rpc_call(
+        "channel.read",
+        serde_json::json!({
+            "all": true
+        }),
+    );
+    assert!(
+        read_main.get("error").is_none(),
+        "channel.read from main channel should succeed: {:?}",
+        read_main
+    );
+
+    let main_messages = read_main["result"]["messages"]
+        .as_array()
+        .expect("messages should be an array");
+    assert_eq!(
+        main_messages.len(),
+        1,
+        "Main channel should have exactly 1 message, got: {:?}",
+        main_messages
+    );
+    assert!(
+        main_messages[0]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("hello from main channel"),
+        "Main channel message should be the one posted without channel param, got: {:?}",
+        main_messages[0]
+    );
+}


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary

- `channel.read` RPC always read from the main channel, ignoring the `channel` parameter entirely
- Channel leads running in a topic channel (with `MIDTOWN_CHANNEL` set) missed user messages posted to their topic channel from the web UI
- `channel_post()` in the CLI client already respected `MIDTOWN_CHANNEL`; `channel_read()` did not

## Root Cause

The asymmetry between `channel.post` and `channel.read`:

| Method | Supported `channel` param | Respected `MIDTOWN_CHANNEL` |
|--------|--------------------------|----------------------------|
| `channel.post` | ✅ | ✅ |
| `channel.read` | ❌ (before this fix) | ❌ (before this fix) |

When a channel lead ran `midtown channel read`, the RPC handler ignored any channel parameter and always opened `state.channel_router.default_channel()` (the main channel). The CLI client also never forwarded `MIDTOWN_CHANNEL` in the request params.

## Fix

Three changes, mirroring the existing `channel.post` pattern:

1. **`handle_channel_read`** — Added `channel: Option<&str>` parameter; reads from the named channel or falls back to the default
2. **RPC dispatch (`rpc.rs`)** — Extracts `channel` param from request and passes it to the handler
3. **CLI client (`client/mod.rs`)** — `channel_read()` now checks `MIDTOWN_CHANNEL` env var and includes it in the RPC params

## Test Plan

- [x] Unit test: `test_channel_read_with_channel_parameter` in `rpc_channel.rs` — posts to topic channel and main channel separately, verifies `channel.read` with `channel: "auth"` returns only the topic channel message
- [x] E2E test: `tests/channel_rpc_routing_test.rs` — full RPC path via a running daemon (run with `--ignored`)
- [x] All 1471 existing unit tests pass
- [x] `cargo clippy -- -D warnings` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)