### PR TITLE
feat: Disallow creating channels with coworker avenue names [Midtown !1521]

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -120,6 +120,14 @@ impl Channel {
             )));
         }
 
+        // Reject names reserved for coworker sessions to prevent naming collisions.
+        if crate::coworker::AVENUE_NAMES.contains(&channel_name.as_str()) {
+            return Err(crate::Error::InvalidMessage(format!(
+                "Channel name '{}' is reserved for coworker sessions and cannot be used as a channel name",
+                channel_name
+            )));
+        }
+
         fs::create_dir_all(&base_dir)?;
         fs::create_dir_all(base_dir.join("cursors"))?;
 
@@ -1227,6 +1235,31 @@ mod tests {
         assert!(Channel::new(temp_dir.path(), "my-channel").is_ok());
         assert!(Channel::new(temp_dir.path(), "feature_123").is_ok());
         assert!(Channel::new(temp_dir.path(), "midtown").is_ok());
+    }
+
+    #[test]
+    fn test_channel_name_rejects_coworker_avenue_names() {
+        // These names are reserved for coworker sessions; creating a channel with
+        // the same name would collide with the channel lead session for that coworker.
+        let temp_dir = TempDir::new().unwrap();
+        for name in [
+            "lexington",
+            "park",
+            "madison",
+            "broadway",
+            "amsterdam",
+            "columbus",
+            "riverside",
+            "york",
+            "pleasant",
+            "vernon",
+        ] {
+            assert!(
+                Channel::new(temp_dir.path(), name).is_err(),
+                "Channel name '{}' should be rejected as a reserved coworker avenue name",
+                name
+            );
+        }
     }
 
     #[test]

--- a/src/coworker.rs
+++ b/src/coworker.rs
@@ -14,7 +14,10 @@ use crate::session_key::SessionKey;
 use crate::worktree::{WorktreeError, WorktreeManager};
 
 /// Primary Manhattan avenue names used for coworker naming.
-const AVENUE_NAMES: &[&str] = &[
+///
+/// Also used by channel validation to reject these reserved names
+/// (a channel named "park" would collide with the "park" channel lead session).
+pub const AVENUE_NAMES: &[&str] = &[
     "lexington",
     "park",
     "madison",


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Blocks creation of channels named after coworker avenue names (lexington, park, madison, broadway, amsterdam, columbus, riverside, york, pleasant, vernon)
- Fix is at `Channel::new()` — the single creation chokepoint for all paths (TUI, daemon RPC, ChannelRouter)
- Made `AVENUE_NAMES` public in `coworker.rs` so `channel.rs` can reference it directly (no duplication)
- Added test: `test_channel_name_rejects_coworker_avenue_names`

## Why
After the `ch-` prefix removal, a channel named `park` would collide with the `park` channel lead session. Blocking at creation time is cleaner than filtering in `next_available_name`.

## Test plan
- [x] `test_channel_name_rejects_coworker_avenue_names` — all 10 avenue names rejected
- [x] All existing channel tests pass (53 tests)
- [x] Full test suite passes (1482+ tests)
- [x] Clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)