### PR TITLE
docs: Document sccache setup for shared Rust build cache [Midtown !1532]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ cargo fmt -- --check
 
 **Shared build cache (sccache)**: Midtown uses many worktrees simultaneously. sccache shares compiled dependency artifacts across all of them, so new worktrees build in ~15-30s instead of ~2-4min (only the `midtown` crate recompiles).
 
-One-time setup:
+**One-time setup** (modifies `~/.cargo/config.toml`, which applies globally to all Rust projects on this machine):
 ```bash
 cargo install sccache
 
@@ -40,12 +40,12 @@ cargo install sccache
 # rustc-wrapper = "sccache"
 # [env]
 # CARGO_INCREMENTAL = "0"
-# SCCACHE_DIR = "/Users/<you>/.midtown/sccache"
+# SCCACHE_DIR = "/Users/<you>/.midtown/sccache"  # absolute path required (~ not expanded in TOML)
 
 sccache --show-stats   # verify cache hits after a second build
 ```
 
-The cache lives at `~/.midtown/sccache` (writable in the midtown sandboxed environment). `CARGO_INCREMENTAL=0` is required — incremental compilation and sccache are competing strategies, and disabling incremental enables cross-worktree sharing.
+The cache lives at `~/.midtown/sccache` (writable in the midtown sandboxed environment). `CARGO_INCREMENTAL=0` is required — incremental compilation and sccache are competing strategies, and disabling incremental enables cross-worktree sharing. Note: this also disables incremental compilation for single-worktree `cargo test` iterations, but sccache's cross-worktree sharing more than compensates when running multiple worktrees.
 
 **Test file placement**: Put unit tests in separate files (`src/daemon/pr_tests.rs`) rather than inline `#[cfg(test)] mod tests` blocks. Use `#[path = "pr_tests.rs"] #[cfg(test)] mod tests;` in the source file to maintain private access. This keeps PR diffs focused — reviewers can see how much is test vs. implementation at a glance. Integration/E2E tests go in `tests/` as usual.
 


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Installs `sccache` via `cargo install sccache` (Homebrew cache dirs had permission issues in the sandboxed environment)
- Configures `~/.cargo/config.toml` with `rustc-wrapper = "sccache"`, `CARGO_INCREMENTAL = "0"`, and `SCCACHE_DIR = "~/.midtown/sccache"`
- Pre-warmed the cache with a full build (161 MiB cached)
- Verified **52% cache hit rate** on a fresh-directory build — cross-worktree sharing confirmed
- Documents the setup in `AGENTS.md` so future coworkers can reproduce it

## Test plan
- [x] `sccache --show-stats` shows 52% cache hit rate after second build
- [x] `cargo build` completes in ~28s on a fresh directory vs ~33s cold
- [x] Cache stored at `~/.midtown/sccache` (writable in sandboxed env)
- [x] `cargo clippy` and `cargo fmt` pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)