### PR TITLE
fix: Trim leading/trailing whitespace from channel messages [Midtown !1527]

### DIFF
--- a/src/daemon/rpc_channel.rs
+++ b/src/daemon/rpc_channel.rs
@@ -96,7 +96,8 @@ pub(super) async fn handle_channel_post(
     state: &DaemonState,
 ) -> Response {
     // Clean up shell escaping artifacts (e.g. "\!" from bash history expansion escaping)
-    let message = unescape_shell_artifacts(message);
+    // and trim leading/trailing whitespace so channel messages don't start with blank lines.
+    let message = unescape_shell_artifacts(message.trim());
 
     // Check for /me prefix (IRC-style action)
     let (content, msg_type) = if let Some(action) = message.strip_prefix("/me ") {

--- a/src/daemon/stream.rs
+++ b/src/daemon/stream.rs
@@ -44,10 +44,11 @@ pub fn process_lead_output(events: &HashMap<String, Vec<StreamEvent>>) -> Vec<Ef
 
     if let Some(lead_events) = events.get("lead") {
         let aggregated = extract_lead_text(lead_events);
-        if !aggregated.is_empty() {
+        let trimmed = aggregated.trim().to_string();
+        if !trimmed.is_empty() {
             effects.push(Effect::PostToChannel {
                 sender: "lead".to_string(),
-                message: aggregated,
+                message: trimmed,
                 channel: None, // Posts to main channel
             });
         }

--- a/src/daemon/stream_tests.rs
+++ b/src/daemon/stream_tests.rs
@@ -193,6 +193,77 @@ fn test_process_lead_output_empty_text_not_posted() {
     );
 }
 
+// ── leading newline trimming tests ──────────────────────────────────
+
+#[test]
+fn test_process_lead_output_trims_leading_newlines() {
+    let mut events = HashMap::new();
+    events.insert(
+        "lead".to_string(),
+        vec![StreamEvent::Assistant {
+            message: json!({
+                "content": [{"type": "text", "text": "\n\nGood, amsterdam confirmed."}]
+            }),
+            session_id: None,
+            extra: json!(null),
+        }],
+    );
+
+    let effects = process_lead_output(&events);
+    assert_eq!(effects.len(), 1);
+    match &effects[0] {
+        Effect::PostToChannel { message, .. } => {
+            assert_eq!(message, "Good, amsterdam confirmed.");
+        }
+        _ => panic!("Expected PostToChannel effect"),
+    }
+}
+
+#[test]
+fn test_process_lead_output_trims_trailing_newlines() {
+    let mut events = HashMap::new();
+    events.insert(
+        "lead".to_string(),
+        vec![StreamEvent::Assistant {
+            message: json!({
+                "content": [{"type": "text", "text": "Done.\n\n"}]
+            }),
+            session_id: None,
+            extra: json!(null),
+        }],
+    );
+
+    let effects = process_lead_output(&events);
+    assert_eq!(effects.len(), 1);
+    match &effects[0] {
+        Effect::PostToChannel { message, .. } => {
+            assert_eq!(message, "Done.");
+        }
+        _ => panic!("Expected PostToChannel effect"),
+    }
+}
+
+#[test]
+fn test_process_lead_output_whitespace_only_not_posted() {
+    let mut events = HashMap::new();
+    events.insert(
+        "lead".to_string(),
+        vec![StreamEvent::Assistant {
+            message: json!({
+                "content": [{"type": "text", "text": "\n\n  \n"}]
+            }),
+            session_id: None,
+            extra: json!(null),
+        }],
+    );
+
+    let effects = process_lead_output(&events);
+    assert!(
+        effects.is_empty(),
+        "Should not post a message that is only whitespace after trimming"
+    );
+}
+
 // ── process_universal_events tests ───────────────────────────────────
 
 #[test]

--- a/web-app/src/lib/markdown.js
+++ b/web-app/src/lib/markdown.js
@@ -57,6 +57,8 @@ export function hasMermaid(text) {
  * Converts !N task references to clickable task-detail links.
  */
 export function renderContent(text) {
+  // Trim leading/trailing whitespace so messages don't render with blank lines at the top.
+  text = text.trim()
   // Escape &, <, and > for XSS defense-in-depth.
   let safe = text
     .replace(/&/g, '&amp;')


### PR DESCRIPTION
## Summary

- Lead messages posted via headless session streaming were sometimes prefixed with blank lines because Claude's API responses can start with `\n\n`
- `process_lead_output` now trims the aggregated text before generating a `PostToChannel` effect
- `handle_channel_post` trims the incoming message at the RPC layer (defensive, catches all callers including `midtown channel post`)
- `renderContent` in the web app adds a defensive `text.trim()` before markdown processing

## Test plan

- [x] 3 new unit tests: `test_process_lead_output_trims_leading_newlines`, `test_process_lead_output_trims_trailing_newlines`, `test_process_lead_output_whitespace_only_not_posted`
- [x] All tests verified failing before fix, passing after
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)