### PR TITLE
refactor: Rename channel leads from ch-<name> to <name> [Midtown !1515]

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -1440,14 +1440,20 @@ pub(super) fn spawn_for_pending_tasks_excluding(
     // Use running coworkers from snapshot, not all coworkers from internal map.
     // The internal map includes stopped coworkers until they're cleaned up, which
     // incorrectly blocks task dispatch when all coworkers are stopped.
-    // Exclude the lead: a headless lead session counts as "running" in the
-    // CoworkerManager but is not a dev/reviewer slot. Including it would consume
-    // one of the dev slots, causing the daemon to under-spawn whenever the lead
-    // runs headless.
+    // Exclude the lead and channel leads: headless lead and channel lead sessions
+    // register in CoworkerManager but are not dev/reviewer slots. Including them
+    // would incorrectly consume dev slots and cause under-spawning.
+    let channel_lead_names: std::collections::HashSet<&str> = snap
+        .channel_lead_sessions
+        .keys()
+        .map(|s| s.as_str())
+        .collect();
     let current_coworker_count = snap
         .running_coworkers
         .iter()
-        .filter(|cw| !cw.name.eq_ignore_ascii_case("lead"))
+        .filter(|cw| {
+            !cw.name.eq_ignore_ascii_case("lead") && !channel_lead_names.contains(cw.name.as_str())
+        })
         .count();
 
     for task in pending_unowned.iter() {

--- a/src/daemon/dispatch_dev_limit_tests.rs
+++ b/src/daemon/dispatch_dev_limit_tests.rs
@@ -469,3 +469,54 @@ fn test_dev_cap_without_lead_unaffected() {
         effects
     );
 }
+
+/// Channel leads should not consume dev slots in the dispatch coworker count.
+///
+/// Scenario: max_coworkers=2, 3 running sessions: "lexington" (dev), "auth" (channel lead),
+/// "web" (channel lead). The dispatch loop's `current_coworker_count` must only count
+/// lexington → 1 dev < dev_cap=2 → task dispatch IS emitted.
+#[test]
+fn test_dispatch_excludes_channel_leads_from_dev_count() {
+    let state = make_test_state_with_max(2);
+
+    // Register the dev coworker in CoworkerManager so next_available_name()
+    // skips "lexington" and returns another name for the new task.
+    state
+        .coworkers
+        .insert_for_testing(make_running_coworker("lexington"));
+
+    // 3 running sessions: 1 dev + 2 channel leads
+    let running = vec![
+        make_running_coworker("lexington"),
+        make_running_coworker("auth"),
+        make_running_coworker("web"),
+    ];
+
+    let pending = vec![make_pending_task("99")];
+
+    // Build snapshot with channel_lead_sessions populated so dispatch excludes them
+    let mut snap = make_dev_limit_snapshot(running, pending, false);
+    snap.channel_lead_sessions
+        .insert("auth".to_string(), "session-auth-123".to_string());
+    snap.channel_lead_sessions
+        .insert("web".to_string(), "session-web-456".to_string());
+
+    let effects = crate::daemon::dispatch::spawn_for_pending_tasks(&snap, &state);
+
+    // Only 1 dev coworker (lexington) < dev_cap=2 → task dispatch IS emitted.
+    // Without the fix, channel leads would inflate the count to 3 ≥ 2 → no dispatch.
+    let has_task_effect = effects.iter().any(|e| {
+        matches!(
+            e,
+            crate::daemon::effects::Effect::AssignAndSpawn { .. }
+                | crate::daemon::effects::Effect::SpawnCoworkerWithCallbacks { .. }
+                | crate::daemon::effects::Effect::NudgeCoworkerWithCallbacks { .. }
+        )
+    });
+    assert!(
+        has_task_effect,
+        "Expected task dispatch effect: channel leads must not count toward dev cap. \
+         Effects: {:?}",
+        effects
+    );
+}

--- a/src/daemon/rpc_kanban.rs
+++ b/src/daemon/rpc_kanban.rs
@@ -36,19 +36,19 @@ pub(crate) async fn handle_kanban_data(id: RequestId, state: &DaemonState) -> Re
     // Clone data needed for cache key computation
     let all_repo_paths = state.all_repo_paths.clone();
 
-    // Compute a hash of all repo paths for cache keying
-    let mut hasher = DefaultHasher::new();
-    for path in &all_repo_paths {
-        path.hash(&mut hasher);
-    }
-    let repo_hash = hasher.finish();
-
     // Extract channel lead names early for cache key computation (best-effort)
     let cache_channel_lead_names: std::collections::HashSet<String> = state
         .persistent_state
         .try_lock()
         .map(|ps| ps.channel_lead_sessions.keys().cloned().collect())
         .unwrap_or_default();
+
+    // Compute a hash of all repo paths for cache keying
+    let mut hasher = DefaultHasher::new();
+    for path in &all_repo_paths {
+        path.hash(&mut hasher);
+    }
+    let repo_hash = hasher.finish();
 
     // Compute a hash of coworker state for cache invalidation
     let coworker_state_hash = {

--- a/src/daemon/rpc_kanban_tests.rs
+++ b/src/daemon/rpc_kanban_tests.rs
@@ -348,11 +348,10 @@ fn test_cache_key_stable_on_progress_update() {
         make_record(Some(WorkflowPhase::Developing), Some(1234), Some(60)),
     );
 
+    let empty_cl: std::collections::HashSet<String> = std::collections::HashSet::new();
     // Use the real function from the parent module (not the local test helper below)
-    let hash_before =
-        super::compute_coworker_state_hash(&records_before, &std::collections::HashSet::new());
-    let hash_after =
-        super::compute_coworker_state_hash(&records_after, &std::collections::HashSet::new());
+    let hash_before = super::compute_coworker_state_hash(&records_before, &empty_cl);
+    let hash_after = super::compute_coworker_state_hash(&records_after, &empty_cl);
 
     assert_eq!(
         hash_before, hash_after,
@@ -376,10 +375,9 @@ fn test_cache_key_changes_on_phase_transition() {
         make_record(Some(WorkflowPhase::PullRequest), Some(1500), Some(90)),
     );
 
-    let hash_dev =
-        super::compute_coworker_state_hash(&records_dev, &std::collections::HashSet::new());
-    let hash_pr =
-        super::compute_coworker_state_hash(&records_pr, &std::collections::HashSet::new());
+    let empty_cl: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let hash_dev = super::compute_coworker_state_hash(&records_dev, &empty_cl);
+    let hash_pr = super::compute_coworker_state_hash(&records_pr, &empty_cl);
 
     assert_ne!(
         hash_dev, hash_pr,
@@ -403,10 +401,9 @@ fn test_cache_key_changes_on_task_assignment() {
         make_record(Some(WorkflowPhase::Developing), Some(999), None),
     );
 
-    let hash_no_task =
-        super::compute_coworker_state_hash(&records_no_task, &std::collections::HashSet::new());
-    let hash_with_task =
-        super::compute_coworker_state_hash(&records_with_task, &std::collections::HashSet::new());
+    let empty_cl: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let hash_no_task = super::compute_coworker_state_hash(&records_no_task, &empty_cl);
+    let hash_with_task = super::compute_coworker_state_hash(&records_with_task, &empty_cl);
 
     assert_ne!(
         hash_no_task, hash_with_task,
@@ -428,10 +425,9 @@ fn test_cache_key_changes_on_coworker_spawn() {
         make_record(Some(WorkflowPhase::Developing), Some(1200), None),
     );
 
-    let hash_empty =
-        super::compute_coworker_state_hash(&records_empty, &std::collections::HashSet::new());
-    let hash_one =
-        super::compute_coworker_state_hash(&records_one, &std::collections::HashSet::new());
+    let empty_cl: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let hash_empty = super::compute_coworker_state_hash(&records_empty, &empty_cl);
+    let hash_one = super::compute_coworker_state_hash(&records_one, &empty_cl);
 
     assert_ne!(
         hash_empty, hash_one,
@@ -457,14 +453,10 @@ fn test_cache_key_stable_when_idle_coworker_updates_progress() {
         make_record(Some(WorkflowPhase::Idle), Some(1400), Some(100)),
     );
 
-    let hash_no_progress = super::compute_coworker_state_hash(
-        &records_idle_no_progress,
-        &std::collections::HashSet::new(),
-    );
-    let hash_with_progress = super::compute_coworker_state_hash(
-        &records_idle_with_progress,
-        &std::collections::HashSet::new(),
-    );
+    let empty_cl: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let hash_no_progress = super::compute_coworker_state_hash(&records_idle_no_progress, &empty_cl);
+    let hash_with_progress =
+        super::compute_coworker_state_hash(&records_idle_with_progress, &empty_cl);
 
     assert_eq!(
         hash_no_progress, hash_with_progress,
@@ -479,6 +471,7 @@ fn test_cache_key_stable_when_channel_lead_phase_changes() {
     // a channel lead's phase or task change must NOT change the cache key.
     use crate::coworker_state::WorkflowPhase;
 
+    // Channel leads use bare channel names (e.g. "auth", not "ch-auth")
     let channel_leads: std::collections::HashSet<String> =
         ["auth"].iter().map(|s| s.to_string()).collect();
 
@@ -490,33 +483,31 @@ fn test_cache_key_stable_when_channel_lead_phase_changes() {
     );
 
     // Same regular coworker + a channel lead in Developing phase
-    let mut records_with_ch_lead_dev = base_records.clone();
-    records_with_ch_lead_dev.insert(
+    let mut records_with_cl_dev = base_records.clone();
+    records_with_cl_dev.insert(
         "auth".to_string(),
         make_record(Some(WorkflowPhase::Developing), Some(777), None),
     );
 
     // Same regular coworker + the same channel lead, now in PullRequest phase
-    let mut records_with_ch_lead_pr = base_records.clone();
-    records_with_ch_lead_pr.insert(
+    let mut records_with_cl_pr = base_records.clone();
+    records_with_cl_pr.insert(
         "auth".to_string(),
         make_record(Some(WorkflowPhase::PullRequest), Some(777), None),
     );
 
     let hash_base = super::compute_coworker_state_hash(&base_records, &channel_leads);
-    let hash_with_ch_dev =
-        super::compute_coworker_state_hash(&records_with_ch_lead_dev, &channel_leads);
-    let hash_with_ch_pr =
-        super::compute_coworker_state_hash(&records_with_ch_lead_pr, &channel_leads);
+    let hash_with_cl_dev = super::compute_coworker_state_hash(&records_with_cl_dev, &channel_leads);
+    let hash_with_cl_pr = super::compute_coworker_state_hash(&records_with_cl_pr, &channel_leads);
 
     // Channel leads must be invisible to the hash — adding one or changing its
     // phase/task must not change the cache key.
     assert_eq!(
-        hash_base, hash_with_ch_dev,
+        hash_base, hash_with_cl_dev,
         "Adding a channel lead must NOT change the cache key"
     );
     assert_eq!(
-        hash_with_ch_dev, hash_with_ch_pr,
+        hash_with_cl_dev, hash_with_cl_pr,
         "Channel lead phase change (Developing→PullRequest) must NOT change the cache key"
     );
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -694,7 +694,6 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
     let persistent_state =
         crate::daemon::state::DaemonPersistentState::load_for_repo(&state.config.repo)
             .unwrap_or_default();
-
     // Channel lead names for filtering (channel leads must not appear in coworker status)
     let channel_lead_names: std::collections::HashSet<String> = persistent_state
         .channel_lead_sessions


### PR DESCRIPTION
## Summary

- Removes the `ch-` prefix from channel lead session names throughout the codebase — channel leads are now named after their channel directly (e.g. `@web` instead of `@ch-web`)
- Replaces all `ch-` prefix string checks with proper `channel_lead_sessions` lookup, eliminating fragile pattern matching
- Fixes `is_channel_lead` function and dispatch count logic based on review feedback
- Adds test coverage for channel lead exclusion from dispatch dev limits

## Changes

- **`src/coworker.rs`**: Channel lead sessions spawned with bare channel name (no `ch-` prefix)
- **`src/daemon/dispatch.rs`**: Uses `channel_lead_sessions` lookup instead of `ch-` prefix check; fixes dispatch count to exclude channel leads
- **`src/daemon/dispatch_dev_limit_tests.rs`**: New tests for channel lead exclusion from limit checks
- **`src/daemon/rpc_kanban.rs`**: `is_channel_lead` now checks `channel_lead_names` set instead of string prefix
- **`src/daemon/rpc_kanban_tests.rs`**: Updated tests to use bare channel names
- **`src/web.rs`**: Channel lead filtering updated to use set lookup

## Test plan
- [x] All 1482 unit tests pass (`cargo test --lib`)
- [x] Channel leads no longer appear in coworker status panel
- [x] Channel leads excluded from dispatch dev limits
- [x] `is_channel_lead` correctly identifies leads by name lookup (not prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)