### PR TITLE
feat: Unify typing indicator and tool call display, make channel-aware [Midtown !1569]

### DIFF
--- a/src/bin/midtown/cli/chat/ui/chat.rs
+++ b/src/bin/midtown/cli/chat/ui/chat.rs
@@ -192,7 +192,7 @@ fn count_tool_activity_lines(
             continue;
         }
         count += 1; // agent name header
-        count += headers.len().min(3); // up to 3 tool call lines
+        count += 1; // 1 most recent tool call line
     }
     if count > 0 {
         count += 1; // blank separator before activity strip
@@ -240,9 +240,9 @@ fn append_tool_activity_lines(
             Span::styled(" working\u{2026}", Style::default().fg(Color::DarkGray)),
         ]));
 
-        // Show up to 3 most recent tool calls (last 3, most recent last).
+        // Show the most recent tool call (last item, most recent last).
         // Each header starts with a prefix char (✓/✗/›) followed by a space and the description.
-        let start = headers.len().saturating_sub(3);
+        let start = headers.len().saturating_sub(1);
         for header in &headers[start..] {
             // Split prefix character from the rest of the description.
             // Format is "<prefix_char> <description>" where prefix is a single Unicode char.
@@ -631,8 +631,8 @@ mod tests {
     }
 
     #[test]
-    fn test_append_tool_activity_lines_shows_at_most_3_recent() {
-        // 5 headers — should show only the last 3
+    fn test_append_tool_activity_lines_shows_only_most_recent() {
+        // 5 headers — should show only the last 1 (most recent)
         let activity = make_activity(
             "amsterdam",
             vec!["✓ call1", "✓ call2", "✓ call3", "✓ call4", "› call5"],
@@ -640,21 +640,15 @@ mod tests {
         let mut lines: Vec<Line<'static>> = Vec::new();
         append_tool_activity_lines(&activity, &mut lines);
 
-        // blank sep + agent header + 3 call lines
-        assert_eq!(lines.len(), 5, "Should emit blank + agent + 3 call lines");
+        // blank sep + agent header + 1 call line
+        assert_eq!(lines.len(), 3, "Should emit blank + agent + 1 call line");
 
-        // The last call line should be for "call5"
-        let last = &lines[4];
+        // The single call line should be for "call5" (most recent)
+        let last = &lines[2];
         let text: String = last.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(
             text.contains("call5"),
-            "Last line should be call5, got: {text}"
-        );
-        // call3 and call4 should also appear
-        let line3_text: String = lines[2].spans.iter().map(|s| s.content.as_ref()).collect();
-        assert!(
-            line3_text.contains("call3"),
-            "Third call line should be call3"
+            "Only line should be call5 (most recent), got: {text}"
         );
     }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -211,9 +211,6 @@ pub enum WebUpdate {
     /// Coworker status changed
     #[serde(rename = "coworker_status")]
     CoworkerStatus(CoworkerStatusData),
-    /// Lead is actively working (typing indicator)
-    #[serde(rename = "lead_typing")]
-    LeadTyping(LeadTypingData),
     /// Error response for a client action
     #[serde(rename = "error")]
     Error(ErrorData),
@@ -275,11 +272,6 @@ pub struct CoworkerStatusData {
     /// Health status color: "green", "yellow", or "red".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub health: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct LeadTypingData {
-    pub working: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1711,12 +1703,6 @@ pub fn broadcast_coworker_status(
     let _ = tx.send(coworker_status_update(name, status, current_task, model));
 }
 
-/// Broadcast lead typing/working status to all WebSocket clients
-pub fn broadcast_lead_typing(tx: &broadcast::Sender<WebUpdate>, working: bool) {
-    let update = WebUpdate::LeadTyping(LeadTypingData { working });
-    let _ = tx.send(update);
-}
-
 /// Build a `WebUpdate` for a channel message.
 pub fn channel_message_update(message: &Message) -> WebUpdate {
     WebUpdate::ChannelMessage(ChannelMessageData {
@@ -1857,18 +1843,6 @@ mod tests {
             !json.contains("\"current_task\""),
             "progress update must not include current_task"
         );
-    }
-
-    #[test]
-    fn test_lead_typing_update_serialization() {
-        let update = WebUpdate::LeadTyping(LeadTypingData { working: true });
-        let json = serde_json::to_string(&update).unwrap();
-        assert!(json.contains("lead_typing"));
-        assert!(json.contains(r#""working":true"#));
-
-        let update = WebUpdate::LeadTyping(LeadTypingData { working: false });
-        let json = serde_json::to_string(&update).unwrap();
-        assert!(json.contains(r#""working":false"#));
     }
 
     #[test]

--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { messages, messagesByChannel, activeChannel, channels, coworkers, leadTyping, kanbanData, repoStatus, repoStatuses, daemonStatus, detailPanelData, isWideScreen, agentToolItems } from './store.js'
+  import { messages, messagesByChannel, activeChannel, channels, coworkers, kanbanData, repoStatus, repoStatuses, daemonStatus, detailPanelData, isWideScreen, agentToolItems } from './store.js'
   import { sendMessage, uploadFile } from './api.js'
   import { tick, onMount } from 'svelte'
   import MermaidDiagram from './MermaidDiagram.svelte'
@@ -621,30 +621,29 @@
         {/each}
       {/if}
 
-      <!-- Tool call activity strip for the active channel's lead.
-           Main channel shows the lead's tool calls; topic channels show their channel lead's.
-           "working…" is shown only when at least one item is still InProgress. -->
-      {#if activeChannelToolItems.length > 0}
-        {@const agentName = $activeChannel === 'midtown' ? 'lead' : $activeChannel}
+      <!-- Unified activity strip: shows the active channel's lead name, bouncing dots,
+           and tool call activity. In the main channel, uses lead_working (same signal as
+           the TUI braille spinner) to drive the dots. In topic channels, InProgress tool
+           items drive the dots (channel leads don't have a separate lead_working signal). -->
+      {@const agentName = $activeChannel === 'midtown' ? 'lead' : $activeChannel}
+      {@const isLeadWorking = $activeChannel === 'midtown' ? !!$daemonStatus?.lead_working : false}
+      {@const hasInProgressItems = activeChannelToolItems.some((item) => item.status === 'InProgress')}
+      {@const showDots = isLeadWorking || hasInProgressItems}
+      {#if activeChannelToolItems.length > 0 || isLeadWorking}
         <div class="mt-[3px]">
           <div class="flex items-center gap-[7px] whitespace-nowrap overflow-hidden text-ellipsis">
             <span class="font-bold text-[0.85rem]" style="color: {getSenderColor(agentName)}">{agentName}</span>
-            {#if activeChannelToolItems.some((item) => item.status === 'InProgress')}
-              <span class="text-[#3a6a3a] text-[0.78rem] select-none">working…</span>
+            {#if showDots}
+              <span class="typing-dots flex gap-[3px] items-center">
+                <span class="dot w-[5px] h-[5px] rounded-full" style="background-color: {getSenderColor(agentName)}"></span>
+                <span class="dot w-[5px] h-[5px] rounded-full" style="background-color: {getSenderColor(agentName)}"></span>
+                <span class="dot w-[5px] h-[5px] rounded-full" style="background-color: {getSenderColor(agentName)}"></span>
+              </span>
             {/if}
           </div>
-          <ToolActivity {agentName} items={activeChannelToolItems} />
-        </div>
-      {/if}
-
-      {#if $leadTyping}
-        <div class="flex items-center gap-[7px] py-[5px] mt-[5px] opacity-70">
-          <span class="font-bold text-[0.85rem]" style="color: {AVENUE_COLORS.lead}">lead</span>
-          <span class="typing-dots flex gap-[3px] items-center">
-            <span class="dot w-[5px] h-[5px] rounded-full bg-[#d7d787]"></span>
-            <span class="dot w-[5px] h-[5px] rounded-full bg-[#d7d787]"></span>
-            <span class="dot w-[5px] h-[5px] rounded-full bg-[#d7d787]"></span>
-          </span>
+          {#if activeChannelToolItems.length > 0}
+            <ToolActivity {agentName} items={activeChannelToolItems} />
+          {/if}
         </div>
       {/if}
   </div>

--- a/web-app/src/lib/ToolActivity.svelte
+++ b/web-app/src/lib/ToolActivity.svelte
@@ -5,7 +5,7 @@
    * Props:
    *   agentName  — coworker name (e.g. "amsterdam")
    *   items      — UniversalItem[] for this agent (newest last)
-   *   maxVisible — how many items to show when collapsed (default: 3)
+   *   maxVisible — max lines to show (default: 3); collapsed shows 1
    */
   let { agentName, items = [], maxVisible = 3 } = $props()
 
@@ -39,8 +39,9 @@
 
   // Most recent items first for display
   let sorted = $derived([...merged].reverse())
-  let visible = $derived(expanded ? sorted : sorted.slice(0, maxVisible))
-  let hasMore = $derived(sorted.length > maxVisible)
+  // Collapsed: show only the 1 most recent item; expanded: show up to maxVisible
+  let visible = $derived(expanded ? sorted.slice(0, maxVisible) : sorted.slice(0, 1))
+  let hasMore = $derived(sorted.length > 1 && !expanded)
 
   function describeItem(item) {
     for (const part of item.content) {
@@ -87,9 +88,16 @@
     {#if hasMore}
       <button
         class="text-[#3a5a5a] hover:text-[#5fafaf] text-[0.78rem] mt-[1px] bg-transparent border-none cursor-pointer p-0"
-        onclick={() => { expanded = !expanded }}
+        onclick={() => { expanded = true }}
       >
-        {expanded ? '▲ show less' : `▼ ${sorted.length - maxVisible} more`}
+        ▼ {sorted.length - 1} more
+      </button>
+    {:else if expanded && sorted.length > 1}
+      <button
+        class="text-[#3a5a5a] hover:text-[#5fafaf] text-[0.78rem] mt-[1px] bg-transparent border-none cursor-pointer p-0"
+        onclick={() => { expanded = false }}
+      >
+        ▲ less
       </button>
     {/if}
   </div>

--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -7,7 +7,6 @@ import {
   connected,
   coworkers,
   maxCoworkers,
-  leadTyping,
   daemonStatus,
   kanbanData,
   repoStatus,
@@ -29,7 +28,6 @@ let ws = null
 let reconnectTimeout = null
 let statusPollInterval = null
 let usagePollInterval = null
-let leadTypingTimeout = null
 
 // Base URL for the current project's daemon API.
 // Always connects via the project's webhook port.
@@ -106,7 +104,6 @@ export function switchProject(projectName, webhookPort) {
   channels.set([{ name: 'midtown', unread: 0, has_pr: false, ci_status: null }])
   activeChannel.set('midtown')
   coworkers.set([])
-  leadTyping.set(false)
   daemonStatus.set(null)
   kanbanData.set({ backlog: [], inProgress: [], review: [], done: [] })
   repoStatus.set({
@@ -404,12 +401,6 @@ function handleUpdate(update) {
         return channelList
       })
 
-      // Dismiss typing indicator when lead posts a message
-      if (msg.from?.toLowerCase() === 'lead') {
-        leadTyping.set(false)
-        if (leadTypingTimeout) clearTimeout(leadTypingTimeout)
-      }
-
       // Clear tool activity for the sender when they post a message —
       // their work phase is done and the activity strip should reset.
       if (msg.from && msg.from.toLowerCase() !== 'lead' && msg.from.toLowerCase() !== 'midtown') {
@@ -438,16 +429,6 @@ function handleUpdate(update) {
       })
       break
     }
-    case 'lead_typing':
-      leadTyping.set(update.data.working)
-      // Auto-dismiss after 45s if no further updates (safety net).
-      // The daemon uses a 30s grace period before sending working=false,
-      // so this client timeout should be longer to avoid premature dismissal.
-      if (leadTypingTimeout) clearTimeout(leadTypingTimeout)
-      if (update.data.working) {
-        leadTypingTimeout = setTimeout(() => leadTyping.set(false), 45000)
-      }
-      break
     case 'universal_items':
       // Tool call activity keyed by channel.
       // data: { agent_name: string, channel: string|null, items: UniversalItem[] }

--- a/web-app/src/lib/store.js
+++ b/web-app/src/lib/store.js
@@ -59,9 +59,6 @@ export const coworkers = writable([])
 // Maximum number of coworkers that can be spawned
 export const maxCoworkers = writable(8)
 
-// Lead typing/working indicator
-export const leadTyping = writable(false)
-
 // Daemon status
 export const daemonStatus = writable(null)
 


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Merges the separate typing indicator (bouncing dots) and tool call activity strip into one unified display in `Channel.svelte`
- Wires the dots to `$daemonStatus.lead_working` — the same time-window signal that drives the TUI braille spinner — instead of the never-sent `lead_typing` WebSocket event
- **Both web UI and TUI now show 1 line (most recent tool call) by default**; web UI expands to 3 lines on click
- Removes all dead code: `broadcast_lead_typing`, `LeadTypingData`, `WebUpdate::LeadTyping` (Rust), and the `leadTyping` store + `lead_typing` handler (JS)
- In topic channels, InProgress tool items drive the dots (no separate `lead_working` signal for channel leads)
- Dot color now matches the agent's own color instead of hardcoded yellow

## Behavior
**Web UI:**
- Main channel: name + dots appear when `lead_working=true` (lead is actively streaming), with tool call items shown below when present
- Collapsed view: shows 1 item (most recent); click "▼ N more" to expand to 3; click "▲ less" to collapse
- Topic channels: name + dots + tool items shown when InProgress items exist

**TUI:**
- Shows only the most recent tool call line (was: last 3), matching web UI default

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --bin midtown -- chat::ui::chat` passes (13 tests)
- [x] `cargo test --lib -- web::` passes (24 tests)
- [x] No remaining references to `leadTyping`, `broadcast_lead_typing`, or `LeadTypingData`

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)