### PR TITLE
fix: Move NamePool/reverse-map cleanup into cleanup_coworker_state [Midtown !1562]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -700,6 +700,11 @@ impl DaemonState {
     /// shared function, the two paths can drift out of sync — e.g., session death
     /// missing cooldown/nudge/assignment cleanup that shutdown handles. See PR #1268.
     ///
+    /// Handles: coworker deregistration, stop-time recording, coworker records,
+    /// cooldowns, pending nudges, task assignments, recent tool activity,
+    /// NamePool release, and session reverse-map cleanup (name_to_session,
+    /// session_to_name, task_to_session).
+    ///
     /// Does NOT handle session-specific operations (session_manager.shutdown vs
     /// session_manager.remove) or worktree unbinding — those differ between the
     /// intentional shutdown and session death paths.

--- a/src/daemon/mod_tests.rs
+++ b/src/daemon/mod_tests.rs
@@ -2150,3 +2150,86 @@ async fn test_task_to_session_cleanup_removes_all_tasks_for_session() {
     assert_eq!(t2s.len(), 1);
     assert_eq!(t2s.get("44"), Some(&"sid-park".to_string()));
 }
+
+/// Regression test: repeated shutdown/spawn cycles must not exhaust the NamePool.
+///
+/// Before this fix, cleanup_coworker_state didn't release names back to the pool
+/// or clear reverse maps. After enough shutdown/spawn cycles, the pool would have
+/// no names left even though no coworkers were active. This test simulates 3 full
+/// cycles of allocate → register → cleanup, then verifies the name is still
+/// available for reuse.
+#[tokio::test]
+async fn test_repeated_shutdown_spawn_cycles_do_not_exhaust_name_pool() {
+    let state = make_cleanup_test_state();
+
+    for cycle in 0..3 {
+        let session_id = format!("sid-madison-{cycle}");
+        let task_id = format!("{}", 100 + cycle);
+
+        // Simulate spawn: allocate name + populate reverse maps
+        {
+            state
+                .name_pool
+                .lock()
+                .unwrap()
+                .allocate(Some("madison"))
+                .unwrap();
+        }
+        {
+            state
+                .name_to_session
+                .lock()
+                .unwrap()
+                .insert("madison".to_string(), session_id.clone());
+            state
+                .session_to_name
+                .lock()
+                .unwrap()
+                .insert(session_id.clone(), "madison".to_string());
+            state
+                .task_to_session
+                .lock()
+                .unwrap()
+                .insert(task_id.clone(), session_id.clone());
+        }
+
+        // Verify name is allocated before cleanup
+        assert!(
+            state.name_pool.lock().unwrap().is_allocated("madison"),
+            "cycle {cycle}: madison should be allocated before cleanup"
+        );
+
+        // Simulate shutdown/session-death: cleanup_coworker_state
+        state.cleanup_coworker_state("madison").await;
+
+        // Verify cleanup released everything
+        assert!(
+            !state.name_pool.lock().unwrap().is_allocated("madison"),
+            "cycle {cycle}: madison should be released after cleanup"
+        );
+        assert_eq!(
+            state.session_for_name("madison"),
+            None,
+            "cycle {cycle}: name_to_session should be cleared"
+        );
+        assert_eq!(
+            state.name_for_session(&session_id),
+            None,
+            "cycle {cycle}: session_to_name should be cleared"
+        );
+        assert_eq!(
+            state.session_for_task(&task_id),
+            None,
+            "cycle {cycle}: task_to_session should be cleared"
+        );
+    }
+
+    // After 3 full cycles, the pool should be fully available (no leaked names)
+    let pool = state.name_pool.lock().unwrap();
+    let total = crate::coworker::AVENUE_NAMES.len() + crate::coworker::OVERFLOW_NAMES.len();
+    assert_eq!(
+        pool.available_count(),
+        total,
+        "all names should be available after repeated cleanup cycles"
+    );
+}


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Follow-up to PR #1286 — addresses review feedback from vernon
- Moved NamePool release and reverse-map cleanup (`name_to_session`, `session_to_name`, `task_to_session`) into `cleanup_coworker_state()` so both the intentional shutdown path and session-death path get identical cleanup
- Without this fix, intentional shutdowns via `Effect::ShutdownCoworker` would leave stale entries in all three maps and never release names back to `NamePool`, causing name exhaustion on repeated shutdown/spawn cycles
- Updated existing tests to exercise `cleanup_coworker_state()` directly instead of duplicating the cleanup logic inline

## Test plan
- [x] All 1552 library tests pass
- [x] Clippy clean with `-D warnings`
- [x] `test_cleanup_releases_name_from_pool` — verifies cleanup_coworker_state releases name and clears all maps
- [x] `test_cleanup_preserves_other_sessions_reverse_maps` — verifies other coworkers' state is untouched
- [x] `test_cleanup_with_no_session_id_is_noop_for_reverse_maps` — verifies no panic when reverse maps unpopulated
- [x] `test_task_to_session_cleanup_removes_all_tasks_for_session` — verifies multi-task cleanup via shared function

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)