### PR TITLE
fix: Include channel_lead_names in kanban cache key; fix tool activity strip colors [Midtown !1587] [Midtown !1588]

### DIFF
--- a/src/bin/midtown/cli/chat/ui/chat.rs
+++ b/src/bin/midtown/cli/chat/ui/chat.rs
@@ -148,7 +148,7 @@ fn draw_chat_messages(f: &mut Frame, app: &mut App, area: Rect) {
     {
         let mut lines = cache.lines.clone();
         lines.truncate(msg_height);
-        append_tool_activity_lines(&app.tool_activity, &mut lines);
+        append_tool_activity_lines(&app.tool_activity, &mut lines, &app.channel_lead_names);
         let paragraph = Paragraph::new(lines);
         f.render_widget(block, area);
         f.render_widget(paragraph, inner);
@@ -232,7 +232,11 @@ fn draw_chat_messages(f: &mut Frame, app: &mut App, area: Rect) {
 
     // Append live tool activity (not cached — changes independently of messages).
     let mut final_lines = visible_lines;
-    append_tool_activity_lines(&app.tool_activity, &mut final_lines);
+    append_tool_activity_lines(
+        &app.tool_activity,
+        &mut final_lines,
+        &app.channel_lead_names,
+    );
 
     let paragraph = Paragraph::new(final_lines);
 
@@ -265,8 +269,9 @@ fn count_tool_activity_lines(
 fn append_tool_activity_lines(
     tool_activity: &std::collections::HashMap<String, Vec<String>>,
     lines: &mut Vec<Line<'static>>,
+    channel_lead_names: &[String],
 ) {
-    use super::styles::get_sender_color;
+    use super::styles::get_sender_color_with_leads;
 
     // Only render if at least one agent has non-empty headers
     let has_activity = tool_activity.values().any(|h| !h.is_empty());
@@ -287,7 +292,7 @@ fn append_tool_activity_lines(
             continue;
         }
 
-        let color = get_sender_color(agent);
+        let color = get_sender_color_with_leads(agent, channel_lead_names);
 
         // Agent name header: "amsterdam working…"
         lines.push(Line::from(vec![
@@ -611,7 +616,7 @@ mod tests {
     fn test_append_tool_activity_lines_empty_map() {
         let activity: HashMap<String, Vec<String>> = HashMap::new();
         let mut lines: Vec<Line<'static>> = Vec::new();
-        append_tool_activity_lines(&activity, &mut lines);
+        append_tool_activity_lines(&activity, &mut lines, &[]);
         assert!(
             lines.is_empty(),
             "No lines should be emitted for empty activity"
@@ -622,7 +627,7 @@ mod tests {
     fn test_append_tool_activity_lines_empty_headers() {
         let activity = make_activity("amsterdam", vec![]);
         let mut lines: Vec<Line<'static>> = Vec::new();
-        append_tool_activity_lines(&activity, &mut lines);
+        append_tool_activity_lines(&activity, &mut lines, &[]);
         assert!(lines.is_empty(), "No lines for agent with empty headers");
     }
 
@@ -630,7 +635,7 @@ mod tests {
     fn test_append_tool_activity_lines_in_progress_prefix_color() {
         let activity = make_activity("amsterdam", vec!["› Read foo.rs"]);
         let mut lines: Vec<Line<'static>> = Vec::new();
-        append_tool_activity_lines(&activity, &mut lines);
+        append_tool_activity_lines(&activity, &mut lines, &[]);
 
         // Lines: blank separator, agent header, tool call line
         assert_eq!(lines.len(), 3);
@@ -654,7 +659,7 @@ mod tests {
     fn test_append_tool_activity_lines_success_prefix_color() {
         let activity = make_activity("amsterdam", vec!["✓ Read foo.rs"]);
         let mut lines: Vec<Line<'static>> = Vec::new();
-        append_tool_activity_lines(&activity, &mut lines);
+        append_tool_activity_lines(&activity, &mut lines, &[]);
 
         let call_line = &lines[2];
         assert_eq!(
@@ -673,7 +678,7 @@ mod tests {
     fn test_append_tool_activity_lines_error_prefix_color() {
         let activity = make_activity("amsterdam", vec!["✗ Run tests"]);
         let mut lines: Vec<Line<'static>> = Vec::new();
-        append_tool_activity_lines(&activity, &mut lines);
+        append_tool_activity_lines(&activity, &mut lines, &[]);
 
         let call_line = &lines[2];
         assert_eq!(
@@ -689,6 +694,28 @@ mod tests {
     }
 
     #[test]
+    fn test_append_tool_activity_lines_channel_lead_color() {
+        // A channel lead ("auth") posting tool activity must display with LightYellow,
+        // matching their message color in the chat — not the default Color::White for
+        // unknown senders.
+        let activity = make_activity("auth", vec!["› Read config.toml"]);
+        let channel_lead_names: Vec<String> = vec!["auth".to_string()];
+        let mut lines: Vec<Line<'static>> = Vec::new();
+        append_tool_activity_lines(&activity, &mut lines, &channel_lead_names);
+
+        // Lines: blank separator, agent header, tool call line
+        assert_eq!(lines.len(), 3);
+        let header_line = &lines[1];
+
+        // The agent name span (first span) should be LightYellow for channel leads
+        assert_eq!(
+            header_line.spans[0].style.fg,
+            Some(Color::LightYellow),
+            "Channel lead 'auth' in tool activity strip must be LightYellow, not White"
+        );
+    }
+
+    #[test]
     fn test_append_tool_activity_lines_shows_only_most_recent() {
         // 5 headers — should show only the last 1 (most recent)
         let activity = make_activity(
@@ -696,7 +723,7 @@ mod tests {
             vec!["✓ call1", "✓ call2", "✓ call3", "✓ call4", "› call5"],
         );
         let mut lines: Vec<Line<'static>> = Vec::new();
-        append_tool_activity_lines(&activity, &mut lines);
+        append_tool_activity_lines(&activity, &mut lines, &[]);
 
         // blank sep + agent header + 1 call line
         assert_eq!(lines.len(), 3, "Should emit blank + agent + 1 call line");

--- a/src/bin/midtown/cli/chat/ui/styles.rs
+++ b/src/bin/midtown/cli/chat/ui/styles.rs
@@ -48,15 +48,9 @@ pub fn is_dim_sender(sender: &str) -> bool {
 
 /// Get color for a sender name.
 ///
-/// For channel leads (e.g. a lead posting from topic channel "auth"), pass
-/// their names via [`get_sender_color_with_leads`] so they receive the same
-/// LightYellow treatment as the main lead.
-pub fn get_sender_color(name: &str) -> Color {
-    get_sender_color_with_leads(name, &[])
-}
-
-/// Like [`get_sender_color`], but also checks `channel_lead_names` so that
-/// channel-specific leads get LightYellow instead of the default Color::White.
+/// Pass `channel_lead_names` to give channel-specific leads (e.g. a lead
+/// posting from topic channel "auth") the same LightYellow treatment as the
+/// main lead. Pass an empty slice when no channel lead context is available.
 pub fn get_sender_color_with_leads(name: &str, channel_lead_names: &[String]) -> Color {
     match name.to_lowercase().as_str() {
         "lead" => Color::LightYellow,

--- a/src/daemon/rpc_kanban.rs
+++ b/src/daemon/rpc_kanban.rs
@@ -56,10 +56,17 @@ pub(crate) async fn handle_kanban_data(id: RequestId, state: &DaemonState) -> Re
         compute_coworker_state_hash(&coworker_records, &cache_channel_lead_names)
     };
 
-    // Combine repo hash and coworker state hash for the final cache key
+    // Combine repo hash, coworker state hash, and channel lead names for the final cache key.
+    // Channel lead names must be included because they appear in the cached `channel_leads`
+    // response field — if the set changes (lead added/removed), the cache must be invalidated.
+    // Sort the names before hashing for determinism (HashSet iteration order is not guaranteed).
+    let mut sorted_lead_names: Vec<&String> = cache_channel_lead_names.iter().collect();
+    sorted_lead_names.sort();
+
     let mut cache_key_hasher = DefaultHasher::new();
     repo_hash.hash(&mut cache_key_hasher);
     coworker_state_hash.hash(&mut cache_key_hasher);
+    sorted_lead_names.hash(&mut cache_key_hasher);
     let cache_key = cache_key_hasher.finish();
 
     // Check cache first

--- a/src/daemon/rpc_kanban_tests.rs
+++ b/src/daemon/rpc_kanban_tests.rs
@@ -464,6 +464,71 @@ fn test_cache_key_stable_when_idle_coworker_updates_progress() {
     );
 }
 
+/// Test that the full cache key (repo + coworker state + channel leads) changes
+/// when the set of channel leads changes.
+///
+/// This covers a bug where `channel_lead_names` appeared in the kanban response
+/// (`channel_leads` field) but was not included in the cache key — so when a
+/// channel lead was added or removed, the cached response served stale data.
+#[test]
+fn test_cache_key_changes_when_channel_lead_set_changes() {
+    use crate::coworker_state::WorkflowPhase;
+
+    // Helper: compute the same combined key that handle_kanban_data computes.
+    // repo_hash + coworker_state_hash + sorted channel_lead_names → final key.
+    fn combined_key(
+        repo_hash: u64,
+        records: &HashMap<String, crate::rules::CoworkerRecord>,
+        channel_leads: &std::collections::HashSet<String>,
+    ) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let coworker_hash = super::compute_coworker_state_hash(records, channel_leads);
+
+        let mut sorted_names: Vec<&String> = channel_leads.iter().collect();
+        sorted_names.sort();
+
+        let mut hasher = DefaultHasher::new();
+        repo_hash.hash(&mut hasher);
+        coworker_hash.hash(&mut hasher);
+        sorted_names.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    let repo_hash: u64 = 42;
+
+    let mut records = HashMap::new();
+    records.insert(
+        "madison".to_string(),
+        make_record(Some(WorkflowPhase::Developing), Some(1500), None),
+    );
+
+    // No channel leads
+    let no_leads: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // One channel lead added
+    let with_lead: std::collections::HashSet<String> =
+        ["auth"].iter().map(|s| s.to_string()).collect();
+    // A different channel lead
+    let with_other_lead: std::collections::HashSet<String> =
+        ["tui"].iter().map(|s| s.to_string()).collect();
+
+    let key_no_leads = combined_key(repo_hash, &records, &no_leads);
+    let key_with_lead = combined_key(repo_hash, &records, &with_lead);
+    let key_with_other_lead = combined_key(repo_hash, &records, &with_other_lead);
+
+    // After the fix: adding a channel lead must change the cache key.
+    assert_ne!(
+        key_no_leads, key_with_lead,
+        "Cache key must change when a channel lead is added"
+    );
+    // Adding a different channel lead must also produce a different key.
+    assert_ne!(
+        key_with_lead, key_with_other_lead,
+        "Cache key must differ for different channel lead sets"
+    );
+}
+
 #[test]
 fn test_cache_key_stable_when_channel_lead_phase_changes() {
     // Channel leads are excluded from the kanban coworker list (they're scoped


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

Fixes two bugs found in PR #1295 review (amsterdam):

- **Kanban cache staleness (!1587)**: The `channel_leads` field in the kanban RPC response was not included in the cache key. When a channel lead session was added or removed, cached responses served stale data. Fix: hash the sorted channel lead names into the combined cache key in `handle_kanban_data`.

- **Tool activity strip color inconsistency (!1588)**: `append_tool_activity_lines` called `get_sender_color` (no channel lead awareness), so channel leads displayed with `Color::White` in the activity strip instead of `LightYellow` like the chat pane. Fix: pass `channel_lead_names` to `append_tool_activity_lines` and use `get_sender_color_with_leads`. Remove now-unused `get_sender_color` wrapper.

## Test plan
- [x] `test_cache_key_changes_when_channel_lead_set_changes` — verifies cache key changes when channel lead set changes
- [x] `test_append_tool_activity_lines_channel_lead_color` — verifies channel leads get LightYellow in activity strip
- [x] `cargo clippy -- -D warnings` passes
- [x] All existing tests pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)