### PR TITLE
fix: Ensure all tests clean up ~/.midtown/projects/ directories [Midtown !1604]

### DIFF
--- a/src/daemon/dispatch_session_tests.rs
+++ b/src/daemon/dispatch_session_tests.rs
@@ -173,7 +173,7 @@ fn test_orphan_recovery_skips_tasks_with_session_records() {
         ..snapshot::minimal_snapshot_for_test()
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
     let effects = check_and_recover_orphans_with_task_lookup(&snap, &state, |task_id| {
         if task_id == "42" {
             Some(in_progress_task_for_lookup(
@@ -223,7 +223,7 @@ fn test_orphan_recovery_falls_back_to_fresh_spawn_without_session() {
         ..snapshot::minimal_snapshot_for_test()
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
     let effects = check_and_recover_orphans_with_task_lookup(&snap, &state, |task_id| {
         if task_id == "42" {
             Some(in_progress_task_for_lookup(
@@ -293,7 +293,7 @@ fn test_no_dual_spawn_for_stopped_session_task() {
         ..snapshot::minimal_snapshot_for_test()
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // Run dispatch_via_sessions first (as events.rs does)
     let session_effects = dispatch_via_sessions(&snap);
@@ -339,9 +339,16 @@ fn test_no_dual_spawn_for_stopped_session_task() {
 
 /// Helper to create minimal DaemonState for testing (duplicated from dispatch_tests.rs
 /// because test module boundaries prevent sharing private helpers).
-fn make_test_state() -> DaemonState {
+fn make_test_state() -> (
+    DaemonState,
+    tempfile::TempDir,
+    crate::paths::TestMidtownBaseDirGuard,
+) {
     use std::process::Command;
     use tempfile::TempDir;
+
+    let midtown_dir = TempDir::new().expect("midtown temp dir");
+    let _guard = crate::paths::set_test_midtown_base_dir(midtown_dir.path().to_path_buf());
 
     let temp_dir = TempDir::new().expect("temp dir");
     Command::new("git")
@@ -369,14 +376,12 @@ fn make_test_state() -> DaemonState {
         .expect("worktree manager");
     let cm = crate::coworker::CoworkerManager::new(wm);
 
-    // Leak temp_dir so it survives the test
     let base_dir = temp_dir.path().to_path_buf();
-    std::mem::forget(temp_dir);
 
     let channel_router = crate::ChannelRouter::new(&base_dir, "midtown");
 
     let (shutdown_tx, _) = tokio::sync::broadcast::channel::<()>(1);
-    DaemonState::new(
+    let state = DaemonState::new(
         "/tmp/test.sock".into(),
         cm,
         "test-repo".to_string(),
@@ -388,5 +393,6 @@ fn make_test_state() -> DaemonState {
         "main".to_string(),
         shutdown_tx,
     )
-    .expect("daemon state")
+    .expect("daemon state");
+    (state, temp_dir, _guard)
 }

--- a/src/daemon/dispatch_tests.rs
+++ b/src/daemon/dispatch_tests.rs
@@ -1228,7 +1228,7 @@ fn test_spawn_for_pending_tasks_generates_registry_effects_new_task() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     let effects = spawn_for_pending_tasks(&snap, &state);
 
@@ -1388,7 +1388,7 @@ fn test_spawn_for_pending_tasks_reuses_worktree_for_owned_task() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     let effects = spawn_for_pending_tasks(&snap, &state);
 
@@ -1523,7 +1523,7 @@ fn test_spawn_for_pending_tasks_skips_when_owner_has_pending_task() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
     let effects = spawn_for_pending_tasks(&snap, &state);
 
     // Count how many SpawnCoworkerWithCallbacks effects are generated for broadway
@@ -1628,7 +1628,7 @@ fn test_spawn_owner_includes_record_task_assignment_for_cross_tick_dedup() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
     let effects = spawn_for_pending_tasks(&snap, &state);
 
     // Find the SpawnCoworkerWithCallbacks effect
@@ -1737,7 +1737,7 @@ fn test_cross_tick_dedup_skips_in_flight_owned_task() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // Simulate tick 1: generates spawn effects
     let effects_tick1 = spawn_for_pending_tasks(&snap, &state);
@@ -1875,7 +1875,7 @@ fn test_cross_case_dedup_prevents_same_coworker_from_case1_and_case2() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
     let effects = spawn_for_pending_tasks(&snap, &state);
 
     // Count total effects targeting broadway
@@ -1988,7 +1988,7 @@ fn test_spawn_for_pending_tasks_skips_via_snapshot_assignment_check() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
     let effects = spawn_for_pending_tasks(&snap, &state);
 
     // Should generate NO effects because broadway is already assigned to task !42
@@ -2086,7 +2086,7 @@ fn test_orphan_recovery_reuses_existing_task_worktree() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
     let effects = check_and_recover_orphans_with_task_lookup(&snap, &state, |task_id| {
         if task_id == "42" {
             Some(in_progress_task_for_lookup(
@@ -2242,7 +2242,7 @@ fn test_orphan_recovery_creates_new_worktree_when_none_exists() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
     let effects = check_and_recover_orphans_with_task_lookup(&snap, &state, |task_id| {
         if task_id == "42" {
             Some(in_progress_task_for_lookup(
@@ -2421,7 +2421,7 @@ fn test_spawn_for_pending_unowned_reuses_existing_worktree() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
     let effects = spawn_for_pending_tasks(&snap, &state);
 
     // Pre-spawn EnsureWorktree is top-level, then AssignAndSpawn
@@ -2938,7 +2938,7 @@ fn test_grouped_task_skips_if_already_assigned() {
         "task !1107 should be pending without owner"
     );
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // Tick 1: Task !1107 groups to york (PR #912), generates nudge
     let effects_tick1 = spawn_for_pending_tasks(&snap, &state);
@@ -3002,7 +3002,7 @@ fn test_spawn_coworker_with_callbacks_records_task_assignment() {
     snap.busy_coworkers.clear();
     snap.in_progress_tasks.clear();
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // Tick 1: generates SpawnCoworkerWithCallbacks with RecordTaskAssignment
     let effects = spawn_for_pending_tasks(&snap, &state);
@@ -3058,7 +3058,7 @@ fn test_case1_nudge_records_assignment_and_prevents_loop() {
     snap.busy_coworkers.clear();
     snap.in_progress_tasks.clear();
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // Tick 1: NudgeOwner fires with RecordTaskAssignment in on_success
     let effects_tick1 = spawn_for_pending_tasks(&snap, &state);
@@ -3214,7 +3214,7 @@ fn test_spawn_for_pending_tasks_when_all_coworkers_are_gone() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // The bug: when state.coworkers.list() is empty, spawn_for_pending_tasks
     // should still work — it should spawn fresh coworkers for pending tasks.
@@ -3247,9 +3247,16 @@ fn test_spawn_for_pending_tasks_when_all_coworkers_are_gone() {
 }
 
 /// Helper to create minimal DaemonState for testing
-fn make_test_state() -> DaemonState {
+fn make_test_state() -> (
+    DaemonState,
+    tempfile::TempDir,
+    crate::paths::TestMidtownBaseDirGuard,
+) {
     use std::process::Command;
     use tempfile::TempDir;
+
+    let midtown_dir = TempDir::new().expect("midtown temp dir");
+    let _guard = crate::paths::set_test_midtown_base_dir(midtown_dir.path().to_path_buf());
 
     let temp_dir = TempDir::new().expect("temp dir");
     Command::new("git")
@@ -3277,14 +3284,12 @@ fn make_test_state() -> DaemonState {
         .expect("worktree manager");
     let cm = crate::coworker::CoworkerManager::new(wm);
 
-    // Leak temp_dir so it survives the test
     let base_dir = temp_dir.path().to_path_buf();
-    std::mem::forget(temp_dir);
 
     let channel_router = crate::ChannelRouter::new(&base_dir, "midtown");
 
     let (shutdown_tx, _) = tokio::sync::broadcast::channel::<()>(1);
-    DaemonState::new(
+    let state = DaemonState::new(
         "/tmp/test.sock".into(),
         cm,
         "test-repo".to_string(),
@@ -3296,7 +3301,8 @@ fn make_test_state() -> DaemonState {
         "main".to_string(),
         shutdown_tx,
     )
-    .expect("daemon state")
+    .expect("daemon state");
+    (state, temp_dir, _guard)
 }
 
 // ======================================================================
@@ -3880,7 +3886,7 @@ fn test_spawn_extracts_model_alias_from_provider_model_format() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
     let effects = spawn_for_pending_tasks(&snap, &state);
 
     // Find the AssignAndSpawn effect and check its LaunchConfig
@@ -3995,7 +4001,7 @@ fn test_orphan_recovery_marks_task_in_flight() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
     let effects = check_and_recover_orphans_with_task_lookup(&snap, &state, |task_id| {
         if task_id == "1264" {
             Some(in_progress_task_for_lookup(
@@ -4099,7 +4105,7 @@ fn test_dual_dispatch_orphan_recovery_and_pending_same_tick() {
         ..snapshot::minimal_snapshot_for_test()
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // Simulate what events.rs does: collect orphan effects, then collect pending task effects
     let orphan_effects = check_and_recover_orphans_with_task_lookup(&snap, &state, |task_id| {
@@ -4283,7 +4289,7 @@ fn test_stale_task_cleanup_false_positive_task_about_merged_pr() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
     let effects = spawn_for_pending_tasks(&snap, &state);
 
     // Should NOT auto-complete the task. The task is about a bug that occurred during
@@ -4392,7 +4398,7 @@ fn test_stale_task_cleanup_correct_behavior_with_explicit_pr_field() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
     let effects = spawn_for_pending_tasks(&snap, &state);
 
     // SHOULD auto-complete the task because task.pr == 123 and PR #123 is merged
@@ -4964,7 +4970,7 @@ fn test_session_dispatch_excludes_task_from_pending_dispatch() {
         ..make_session_dispatch_snapshot(vec![], HashMap::new(), HashMap::new())
     };
 
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // Step 1: Session dispatch recovers the task
     let session_effects = dispatch_via_sessions(&snap);

--- a/src/daemon/effects_tests.rs
+++ b/src/daemon/effects_tests.rs
@@ -777,8 +777,9 @@ async fn test_cleanup_merged_worktree_saves_when_only_pr_session_removed() {
     use std::collections::HashMap;
     use tempfile::tempdir;
 
-    // Create temp dir for persistent state
-    let temp_dir = tempdir().unwrap();
+    // Create temp dir for persistent state, redirect ~/.midtown to it
+    let midtown_dir = tempdir().unwrap();
+    let _midtown_guard = crate::paths::set_test_midtown_base_dir(midtown_dir.path().to_path_buf());
     let repo_name = "test-repo";
 
     // Initial state: pr_author_sessions has a stale entry for PR #2001,
@@ -797,10 +798,7 @@ async fn test_cleanup_merged_worktree_saves_when_only_pr_session_removed() {
     );
     persistent_state.github.pr_author_sessions = pr_sessions;
 
-    // Save initial state to disk
-    unsafe {
-        std::env::set_var("MIDTOWN_PROJECTS_ROOT", temp_dir.path());
-    }
+    // Save initial state to disk (writes to midtown_dir, not ~/.midtown)
     persistent_state.save_for_repo(repo_name).unwrap();
 
     // Verify stale entry exists on disk

--- a/src/daemon/mod_tests.rs
+++ b/src/daemon/mod_tests.rs
@@ -1644,9 +1644,16 @@ fn test_limit_checks_exclude_stopped_coworkers() {
 // ============================================================================
 
 /// Construct a minimal DaemonState for cleanup tests.
-fn make_cleanup_test_state() -> DaemonState {
+fn make_cleanup_test_state() -> (
+    DaemonState,
+    tempfile::TempDir,
+    crate::paths::TestMidtownBaseDirGuard,
+) {
     use std::process::Command;
     use tempfile::TempDir;
+
+    let midtown_dir = TempDir::new().expect("midtown temp dir");
+    let _guard = crate::paths::set_test_midtown_base_dir(midtown_dir.path().to_path_buf());
 
     let temp_dir = TempDir::new().expect("temp dir");
     Command::new("git")
@@ -1675,24 +1682,13 @@ fn make_cleanup_test_state() -> DaemonState {
     let cm = crate::coworker::CoworkerManager::new(wm);
 
     let base_dir = temp_dir.path().to_path_buf();
-    std::mem::forget(temp_dir);
-
-    // Use a unique repo name per test invocation to prevent persistent state
-    // pollution between tests (DaemonState loads from ~/.midtown/projects/<repo>/).
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let unique_repo = format!(
-        "test-repo-{}-{}",
-        std::process::id(),
-        COUNTER.fetch_add(1, Ordering::Relaxed)
-    );
 
     let channel_router = crate::ChannelRouter::new(&base_dir, "midtown");
     let (shutdown_tx, _) = tokio::sync::broadcast::channel::<()>(1);
-    DaemonState::new(
+    let state = DaemonState::new(
         "/tmp/test-cleanup.sock".into(),
         cm,
-        unique_repo,
+        "test-repo".to_string(),
         vec![base_dir.clone()],
         channel_router,
         None,
@@ -1701,7 +1697,8 @@ fn make_cleanup_test_state() -> DaemonState {
         "main".to_string(),
         shutdown_tx,
     )
-    .expect("daemon state")
+    .expect("daemon state");
+    (state, temp_dir, _guard)
 }
 
 fn make_tool_item(id: &str) -> crate::universal_events::UniversalItem {
@@ -1716,7 +1713,7 @@ fn make_tool_item(id: &str) -> crate::universal_events::UniversalItem {
 
 #[tokio::test]
 async fn test_cleanup_coworker_state_clears_all_transient_state() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
     let name = "madison";
 
     // Populate all transient state for this coworker
@@ -1776,7 +1773,7 @@ async fn test_cleanup_coworker_state_clears_all_transient_state() {
 
 #[tokio::test]
 async fn test_cleanup_coworker_state_preserves_other_coworkers() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
 
     // Populate state for two coworkers
     {
@@ -1831,7 +1828,7 @@ async fn test_cleanup_coworker_state_preserves_other_coworkers() {
 
 #[tokio::test]
 async fn test_cleanup_coworker_state_records_stop_time() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
     let name = "madison";
 
     // No stop time initially
@@ -1854,7 +1851,7 @@ async fn test_cleanup_coworker_state_records_stop_time() {
 
 #[test]
 fn test_daemon_state_initializes_name_pool_with_all_coworker_names() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
     let pool = state.name_pool.lock().unwrap();
     let total = crate::coworker::AVENUE_NAMES.len() + crate::coworker::OVERFLOW_NAMES.len();
     assert_eq!(
@@ -1867,25 +1864,25 @@ fn test_daemon_state_initializes_name_pool_with_all_coworker_names() {
 
 #[test]
 fn test_session_for_name_returns_none_when_empty() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
     assert_eq!(state.session_for_name("park"), None);
 }
 
 #[test]
 fn test_name_for_session_returns_none_when_empty() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
     assert_eq!(state.name_for_session("sid-123"), None);
 }
 
 #[test]
 fn test_session_for_task_returns_none_when_empty() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
     assert_eq!(state.session_for_task("42"), None);
 }
 
 #[test]
 fn test_session_for_name_after_manual_population() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
     state
         .name_to_session
         .lock()
@@ -1901,7 +1898,7 @@ fn test_session_for_name_after_manual_population() {
 
 #[test]
 fn test_name_for_session_after_manual_population() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
     state
         .session_to_name
         .lock()
@@ -1917,7 +1914,7 @@ fn test_name_for_session_after_manual_population() {
 
 #[test]
 fn test_session_for_task_after_manual_population() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
     state
         .task_to_session
         .lock()
@@ -1930,7 +1927,7 @@ fn test_session_for_task_after_manual_population() {
 
 #[test]
 fn test_reverse_maps_bidirectional_consistency() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
 
     // Populate both directions
     {
@@ -1957,7 +1954,7 @@ fn test_reverse_maps_bidirectional_consistency() {
 
 #[tokio::test]
 async fn test_cleanup_releases_name_from_pool() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
 
     // Allocate a name from the pool
     let name = {
@@ -2013,7 +2010,7 @@ async fn test_cleanup_releases_name_from_pool() {
 
 #[tokio::test]
 async fn test_cleanup_preserves_other_sessions_reverse_maps() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
 
     // Allocate two names
     {
@@ -2073,7 +2070,7 @@ async fn test_cleanup_preserves_other_sessions_reverse_maps() {
 
 #[test]
 fn test_name_pool_allocate_and_release_round_trip() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
 
     // Allocate a name
     let name = {
@@ -2098,7 +2095,7 @@ fn test_name_pool_allocate_and_release_round_trip() {
 
 #[tokio::test]
 async fn test_cleanup_with_no_session_id_is_noop_for_reverse_maps() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
 
     // Allocate a name but don't populate reverse maps
     {
@@ -2121,7 +2118,7 @@ async fn test_cleanup_with_no_session_id_is_noop_for_reverse_maps() {
 
 #[tokio::test]
 async fn test_task_to_session_cleanup_removes_all_tasks_for_session() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
 
     // Allocate madison and populate reverse maps
     {
@@ -2170,7 +2167,7 @@ async fn test_task_to_session_cleanup_removes_all_tasks_for_session() {
 /// available for reuse.
 #[tokio::test]
 async fn test_repeated_shutdown_spawn_cycles_do_not_exhaust_name_pool() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
 
     for cycle in 0..3 {
         let session_id = format!("sid-madison-{cycle}");
@@ -2249,7 +2246,7 @@ async fn test_repeated_shutdown_spawn_cycles_do_not_exhaust_name_pool() {
 /// the preferred_name for future resume.
 #[tokio::test]
 async fn test_cleanup_marks_session_record_stopped_in_persistent_state() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
     let session_id = "sid-madison-001";
 
     // 1. Set up a running session: allocate name, populate reverse maps,
@@ -2334,7 +2331,7 @@ async fn test_cleanup_marks_session_record_stopped_in_persistent_state() {
 /// SessionRecords in persistent state.
 #[tokio::test]
 async fn test_cleanup_preserves_other_session_records_in_persistent_state() {
-    let state = make_cleanup_test_state();
+    let (state, _tmp, _guard) = make_cleanup_test_state();
 
     // Set up two sessions
     {

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -8,8 +8,17 @@ use std::sync::Mutex;
 static PATH_LOCK: Mutex<()> = Mutex::new(());
 
 /// Helper to create minimal DaemonState for testing
-fn make_test_state(repo_name: &str) -> DaemonState {
+fn make_test_state(
+    repo_name: &str,
+) -> (
+    DaemonState,
+    tempfile::TempDir,
+    crate::paths::TestMidtownBaseDirGuard,
+) {
     use std::process::Command;
+
+    let midtown_dir = tempfile::tempdir().expect("midtown temp dir");
+    let _guard = crate::paths::set_test_midtown_base_dir(midtown_dir.path().to_path_buf());
 
     let temp_dir = tempfile::tempdir().expect("temp dir");
     Command::new("git")
@@ -37,14 +46,12 @@ fn make_test_state(repo_name: &str) -> DaemonState {
         .expect("worktree manager");
     let cm = crate::coworker::CoworkerManager::new(wm);
 
-    // Leak temp_dir so it survives the test
     let base_dir = temp_dir.path().to_path_buf();
-    std::mem::forget(temp_dir);
 
     let channel_router = crate::ChannelRouter::new(&base_dir, "midtown");
 
     let (shutdown_tx, _) = tokio::sync::broadcast::channel::<()>(1);
-    DaemonState::new(
+    let state = DaemonState::new(
         "/tmp/test.sock".into(),
         cm,
         repo_name.to_string(),
@@ -56,13 +63,24 @@ fn make_test_state(repo_name: &str) -> DaemonState {
         "main".to_string(),
         shutdown_tx,
     )
-    .expect("daemon state")
+    .expect("daemon state");
+    (state, temp_dir, _guard)
 }
 
 /// Helper to create minimal DaemonState for testing with a specific repo owner.
 /// Adds a fake origin remote so DaemonState::new detects the owner from git URL.
-fn make_test_state_with_owner(repo_name: &str, owner: &str) -> DaemonState {
+fn make_test_state_with_owner(
+    repo_name: &str,
+    owner: &str,
+) -> (
+    DaemonState,
+    tempfile::TempDir,
+    crate::paths::TestMidtownBaseDirGuard,
+) {
     use std::process::Command;
+
+    let midtown_dir = tempfile::tempdir().expect("midtown temp dir");
+    let _guard = crate::paths::set_test_midtown_base_dir(midtown_dir.path().to_path_buf());
 
     let temp_dir = tempfile::tempdir().expect("temp dir");
     Command::new("git")
@@ -101,14 +119,12 @@ fn make_test_state_with_owner(repo_name: &str, owner: &str) -> DaemonState {
         .expect("worktree manager");
     let cm = crate::coworker::CoworkerManager::new(wm);
 
-    // Leak temp_dir so it survives the test
     let base_dir = temp_dir.path().to_path_buf();
-    std::mem::forget(temp_dir);
 
     let channel_router = crate::ChannelRouter::new(&base_dir, "midtown");
 
     let (shutdown_tx, _) = tokio::sync::broadcast::channel::<()>(1);
-    DaemonState::new(
+    let state = DaemonState::new(
         "/tmp/test.sock".into(),
         cm,
         repo_name.to_string(),
@@ -120,7 +136,8 @@ fn make_test_state_with_owner(repo_name: &str, owner: &str) -> DaemonState {
         "main".to_string(),
         shutdown_tx,
     )
-    .expect("daemon state")
+    .expect("daemon state");
+    (state, temp_dir, _guard)
 }
 
 /// Bug: collect_green_with_feedback_effects was using head_ref.split('/').next()
@@ -294,7 +311,7 @@ async fn test_orphaned_pr_with_merge_conflict_is_ignored() {
     // snap.worktree_branch_owners is empty - this simulates york being on break
 
     // Create minimal daemon state
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
 
     // Call poll_prs_for_issues (keep PATH_LOCK held to prevent test interference)
     let result = poll_prs_for_issues(&snap, &state).await;
@@ -373,7 +390,7 @@ async fn test_lead_pr_without_task_id_should_not_be_orphaned() {
         "createdAt": "2024-01-01T00:00:00Z",  // Old enough to pass review delay
     });
 
-    let state = make_test_state("midtown");
+    let (state, _tmp, _guard) = make_test_state("midtown");
     let registry = WorktreeRegistry::new();
 
     // Important: The lead's worktree exists, but NOT indexed by this branch name
@@ -464,7 +481,7 @@ async fn test_ci_wait_deduplication_uses_time_aware_hash() {
     snap.worktree_branch_owners
         .insert("york/test-branch".to_string(), "york".to_string());
 
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
 
     // First poll should post "Waiting for CI" message (keep PATH_LOCK held to prevent test interference)
     let effects1 = poll_prs_for_issues(&snap, &state).await.unwrap();
@@ -631,7 +648,7 @@ async fn test_orphaned_pr_with_task_branch_and_merge_conflict_is_ignored() {
     // snap.worktree_branch_owners is empty - this ensures owner_opt = None
 
     // Create minimal daemon state
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
 
     // Call poll_prs_for_issues (keep PATH_LOCK held to prevent test interference)
     let result = poll_prs_for_issues(&snap, &state).await;
@@ -712,7 +729,7 @@ async fn test_reviewer_spawns_when_worktree_exists_but_no_current_coworker() {
     // branch_owners_map is empty (mirrors snapshot after restart)
     let branch_owners: std::collections::HashMap<String, String> = std::collections::HashMap::new();
 
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
     let active_names = std::collections::HashSet::new();
 
     let effects = collect_reviewer_effects_with_source(
@@ -773,7 +790,7 @@ async fn test_completed_worktree_with_open_pr_gets_reviewer() {
         .unwrap();
 
     let branch_owners: std::collections::HashMap<String, String> = std::collections::HashMap::new();
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
     let active_names = std::collections::HashSet::new();
 
     let effects = collect_reviewer_effects_with_source(
@@ -847,7 +864,7 @@ async fn test_completed_worktree_with_snapshot_data() {
     let branch_owners: std::collections::HashMap<String, String> = std::collections::HashMap::new();
 
     // Create minimal test state
-    let state = make_test_state("midtown");
+    let (state, _tmp, _guard) = make_test_state("midtown");
     let active_names = std::collections::HashSet::new();
 
     // Call the function under test with snapshot's worktree registry and synthetic PR
@@ -925,7 +942,7 @@ async fn test_lead_pr_with_non_standard_branch_gets_reviewer() {
     // Create test state with repo_owner set to match the PR author.
     // The repo_owner is extracted from git remote URL at daemon startup;
     // in tests we configure it via a fake origin remote.
-    let state = make_test_state_with_owner("midtown", "btucker");
+    let (state, _tmp, _guard) = make_test_state_with_owner("midtown", "btucker");
     let active_names = std::collections::HashSet::new();
 
     // Call the function under test
@@ -1137,7 +1154,7 @@ fn extract_record_task_assignments(effects: &[Effect]) -> Vec<(&str, &str)> {
 /// RecordTaskAssignment when pr_task_associations has an entry for the PR.
 #[test]
 fn pr_action_spawn_owner_includes_record_task_assignment() {
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
     let ctx = make_pr_context_with_task(42, "100");
 
     let effects = pr_action_to_effects(
@@ -1165,7 +1182,7 @@ fn pr_action_spawn_owner_includes_record_task_assignment() {
 /// include RecordTaskAssignment when no task association exists.
 #[test]
 fn pr_action_spawn_owner_no_record_without_task_association() {
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
     let ctx = make_pr_context_empty();
 
     let effects = pr_action_to_effects(
@@ -1191,7 +1208,7 @@ fn pr_action_spawn_owner_no_record_without_task_association() {
 /// RecordTaskAssignment when pr_task_associations has an entry for the PR.
 #[test]
 fn comment_action_spawn_owner_includes_record_task_assignment() {
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
     let ctx = make_pr_context_with_task(55, "200");
 
     let effects = comment_action_to_effects(
@@ -1218,7 +1235,7 @@ fn comment_action_spawn_owner_includes_record_task_assignment() {
 /// include RecordTaskAssignment when no task association exists.
 #[test]
 fn comment_action_spawn_owner_no_record_without_task_association() {
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
     let ctx = make_pr_context_empty();
 
     let effects = comment_action_to_effects(
@@ -1243,7 +1260,7 @@ fn comment_action_spawn_owner_no_record_without_task_association() {
 /// RecordTaskAssignment when pr_task_associations has an entry for the PR.
 #[test]
 fn handoff_effects_include_record_task_assignment() {
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
     let ctx = make_pr_context_with_task(77, "300");
 
     let effects = handoff_to_coworker_effects(
@@ -1273,7 +1290,7 @@ fn handoff_effects_include_record_task_assignment() {
 /// RecordTaskAssignment when no task association exists.
 #[test]
 fn handoff_effects_no_record_without_task_association() {
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
     let ctx = make_pr_context_empty();
 
     let effects = handoff_to_coworker_effects(
@@ -1301,7 +1318,7 @@ fn handoff_effects_no_record_without_task_association() {
 /// includes RecordTaskAssignment when pr_task_associations has an entry for the PR.
 #[test]
 fn review_complete_spawn_owner_includes_record_task_assignment() {
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
     let ctx = make_pr_context_with_task(88, "400");
 
     let effects = review_complete_action_to_effects(
@@ -1328,7 +1345,7 @@ fn review_complete_spawn_owner_includes_record_task_assignment() {
 /// does NOT include RecordTaskAssignment when no task association exists.
 #[test]
 fn review_complete_spawn_owner_no_record_without_task_association() {
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
     let ctx = make_pr_context_empty();
 
     let effects = review_complete_action_to_effects(
@@ -1393,7 +1410,7 @@ fn test_reconcile_orphaned_prs_ignores_prs_with_active_tasks() {
 /// allowing cross-tick duplicate spawns for the same task.
 #[test]
 fn pr_action_to_effects_includes_record_task_assignment() {
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
 
     // Build PrContext with a PR→task association
     let mut pr_task_associations = HashMap::new();
@@ -1448,7 +1465,7 @@ fn pr_action_to_effects_includes_record_task_assignment() {
 /// Bug !1377: comment_action_to_effects was missing RecordTaskAssignment in on_success.
 #[test]
 fn comment_action_to_effects_includes_record_task_assignment() {
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
 
     let mut pr_task_associations = HashMap::new();
     pr_task_associations.insert(456, "99".to_string());
@@ -1498,7 +1515,7 @@ fn comment_action_to_effects_includes_record_task_assignment() {
 /// Bug !1377: handoff_to_coworker_effects was missing RecordTaskAssignment in on_success.
 #[test]
 fn handoff_to_coworker_effects_includes_record_task_assignment() {
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
 
     let mut pr_task_associations = HashMap::new();
     pr_task_associations.insert(789, "17".to_string());
@@ -1551,7 +1568,7 @@ fn handoff_to_coworker_effects_includes_record_task_assignment() {
 /// Bug !1377: review_complete_action_to_effects was missing RecordTaskAssignment in on_success.
 #[test]
 fn review_complete_action_to_effects_includes_record_task_assignment() {
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
 
     let mut pr_task_associations = HashMap::new();
     pr_task_associations.insert(321, "55".to_string());
@@ -1662,7 +1679,7 @@ async fn test_active_coworker_pr_without_worktree_is_not_orphaned() {
         "reviewDecision": "",
     });
 
-    let state = make_test_state("midtown");
+    let (state, _tmp, _guard) = make_test_state("midtown");
 
     // Empty branch_owners_map — the bug manifests because coworker_from_branch_with_map
     // still identifies "park" as the owner via the branch prefix
@@ -1719,7 +1736,7 @@ async fn test_headless_only_coworker_pr_is_not_orphaned() {
         "reviewDecision": "",
     });
 
-    let state = make_test_state("midtown");
+    let (state, _tmp, _guard) = make_test_state("midtown");
 
     // active_names includes "york" (as it would from WorldSnapshot which includes
     // headless sessions), but we do NOT insert york into state.coworkers — simulating
@@ -1951,7 +1968,7 @@ async fn test_poll_prs_session_based_owner_resolution() {
     }];
     snap.running_coworkers = snap.active_coworkers.clone();
 
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
 
     let result = poll_prs_for_issues(&snap, &state).await;
 
@@ -1998,7 +2015,7 @@ fn test_pr_context_name_session_map_provides_session_id_for_nudge() {
         message: "PR #42 has a merge conflict".to_string(),
     };
 
-    let state = make_test_state("test-repo");
+    let (state, _tmp, _guard) = make_test_state("test-repo");
     let effects = pr_action_to_effects(
         action,
         42,

--- a/src/daemon/rpc_channel_tests.rs
+++ b/src/daemon/rpc_channel_tests.rs
@@ -3,7 +3,16 @@
 use super::*;
 use std::process::Command;
 
-fn make_test_state(repo_name: &str) -> DaemonState {
+fn make_test_state(
+    repo_name: &str,
+) -> (
+    DaemonState,
+    tempfile::TempDir,
+    crate::paths::TestMidtownBaseDirGuard,
+) {
+    let midtown_dir = tempfile::tempdir().expect("midtown temp dir");
+    let _guard = crate::paths::set_test_midtown_base_dir(midtown_dir.path().to_path_buf());
+
     let temp_dir = tempfile::tempdir().expect("temp dir");
     Command::new("git")
         .args(["init"])
@@ -30,13 +39,11 @@ fn make_test_state(repo_name: &str) -> DaemonState {
         .expect("worktree manager");
     let cm = crate::coworker::CoworkerManager::new(wm);
 
-    // Leak temp_dir so it survives the test
     let base_dir = temp_dir.path().to_path_buf();
-    std::mem::forget(temp_dir);
 
     let channel_router = crate::ChannelRouter::new(&base_dir, "midtown");
     let (shutdown_tx, _) = tokio::sync::broadcast::channel::<()>(1);
-    DaemonState::new(
+    let state = DaemonState::new(
         "/tmp/test.sock".into(),
         cm,
         repo_name.to_string(),
@@ -48,7 +55,8 @@ fn make_test_state(repo_name: &str) -> DaemonState {
         "main".to_string(),
         shutdown_tx,
     )
-    .expect("daemon state")
+    .expect("daemon state");
+    (state, temp_dir, _guard)
 }
 
 #[test]
@@ -110,7 +118,7 @@ fn test_extract_review_note_pr_various_numbers() {
 
 #[tokio::test]
 async fn test_user_message_queues_headed_lead_nudge() {
-    let state = make_test_state("midtown-test-rpc-channel-queue-user");
+    let (state, _tmp, _guard) = make_test_state("midtown-test-rpc-channel-queue-user");
     let adapter_id = "test-adapter-user";
     state
         .headed_register("lead", adapter_id, crate::auth::AuthProvider::Claude)
@@ -140,7 +148,7 @@ async fn test_user_message_queues_headed_lead_nudge() {
 
 #[tokio::test]
 async fn test_coworker_at_lead_queues_headed_lead_nudge() {
-    let state = make_test_state("midtown-test-rpc-channel-queue-coworker");
+    let (state, _tmp, _guard) = make_test_state("midtown-test-rpc-channel-queue-coworker");
     let adapter_id = "test-adapter-coworker";
     state
         .headed_register("lead", adapter_id, crate::auth::AuthProvider::Claude)
@@ -212,7 +220,7 @@ fn test_parse_duration_invalid() {
 /// succeeds without error and does NOT nudge the main lead.
 #[tokio::test]
 async fn test_user_message_to_topic_channel_no_lead_no_main_nudge() {
-    let state = make_test_state("midtown-test-topic-no-lead");
+    let (state, _tmp, _guard) = make_test_state("midtown-test-topic-no-lead");
     let adapter_id = "test-adapter-topic-no-lead";
     state
         .headed_register("lead", adapter_id, crate::auth::AuthProvider::Claude)
@@ -245,7 +253,7 @@ async fn test_user_message_to_topic_channel_no_lead_no_main_nudge() {
 /// Verify that a user message to the main channel still nudges the main lead.
 #[tokio::test]
 async fn test_user_message_to_main_channel_nudges_lead() {
-    let state = make_test_state("midtown-test-main-channel-nudge");
+    let (state, _tmp, _guard) = make_test_state("midtown-test-main-channel-nudge");
     let adapter_id = "test-adapter-main-nudge";
     state
         .headed_register("lead", adapter_id, crate::auth::AuthProvider::Claude)
@@ -276,7 +284,7 @@ async fn test_user_message_to_main_channel_nudges_lead() {
 /// got main channel messages instead of their topic channel messages.
 #[tokio::test]
 async fn test_channel_read_with_channel_parameter() {
-    let state = make_test_state("midtown-test-channel-read-channel");
+    let (state, _tmp, _guard) = make_test_state("midtown-test-channel-read-channel");
 
     // Post a message to the topic channel
     let _r = handle_channel_post(
@@ -313,7 +321,7 @@ async fn test_channel_read_with_channel_parameter() {
 /// message being stored with thread_parent_id set in the channel log.
 #[tokio::test]
 async fn test_channel_post_with_thread_parent_id() {
-    let state = make_test_state("midtown-test-thread-parent-id");
+    let (state, _tmp, _guard) = make_test_state("midtown-test-thread-parent-id");
     let parent_id = "parent-msg-uuid-123";
 
     // Post a thread reply
@@ -342,7 +350,7 @@ async fn test_channel_post_with_thread_parent_id() {
 /// Verify that posting without thread_parent_id still works (None case).
 #[tokio::test]
 async fn test_channel_post_without_thread_parent_id() {
-    let state = make_test_state("midtown-test-no-thread-parent-id");
+    let (state, _tmp, _guard) = make_test_state("midtown-test-no-thread-parent-id");
 
     let response = handle_channel_post(
         1_i64.into(),
@@ -368,7 +376,7 @@ async fn test_channel_post_without_thread_parent_id() {
 /// when a message has one set.
 #[tokio::test]
 async fn test_channel_read_includes_thread_parent_id() {
-    let state = make_test_state("midtown-test-channel-read-thread-parent-id");
+    let (state, _tmp, _guard) = make_test_state("midtown-test-channel-read-thread-parent-id");
     let parent_id = "parent-uuid-abc";
 
     // Post a top-level message
@@ -416,7 +424,7 @@ async fn test_channel_read_includes_thread_parent_id() {
 
 #[tokio::test]
 async fn test_channel_read_with_last_parameter() {
-    let state = make_test_state("midtown-test-channel-read-last");
+    let (state, _tmp, _guard) = make_test_state("midtown-test-channel-read-last");
 
     // Post 10 messages to the channel
     for i in 1..=10 {

--- a/src/daemon/rpc_coworker_tests.rs
+++ b/src/daemon/rpc_coworker_tests.rs
@@ -13,9 +13,16 @@ use super::*;
 // Test helper
 // ============================================================================
 
-fn make_test_state() -> DaemonState {
+fn make_test_state() -> (
+    DaemonState,
+    tempfile::TempDir,
+    crate::paths::TestMidtownBaseDirGuard,
+) {
     use std::process::Command;
     use tempfile::TempDir;
+
+    let midtown_dir = TempDir::new().expect("midtown temp dir");
+    let _guard = crate::paths::set_test_midtown_base_dir(midtown_dir.path().to_path_buf());
 
     let temp_dir = TempDir::new().expect("temp dir");
     Command::new("git")
@@ -44,11 +51,10 @@ fn make_test_state() -> DaemonState {
     let cm = crate::coworker::CoworkerManager::new(wm);
 
     let base_dir = temp_dir.path().to_path_buf();
-    std::mem::forget(temp_dir);
 
     let channel_router = crate::ChannelRouter::new(&base_dir, "midtown");
     let (shutdown_tx, _) = tokio::sync::broadcast::channel::<()>(1);
-    DaemonState::new(
+    let state = DaemonState::new(
         "/tmp/test-rpc-coworker.sock".into(),
         cm,
         "test-repo".to_string(),
@@ -60,7 +66,8 @@ fn make_test_state() -> DaemonState {
         "main".to_string(),
         shutdown_tx,
     )
-    .expect("daemon state")
+    .expect("daemon state");
+    (state, temp_dir, _guard)
 }
 
 // ============================================================================
@@ -69,7 +76,7 @@ fn make_test_state() -> DaemonState {
 
 #[tokio::test]
 async fn test_coworker_asking_stores_pending_question() {
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // Initially no pending questions
     {
@@ -103,7 +110,7 @@ async fn test_coworker_asking_stores_pending_question() {
 
 #[tokio::test]
 async fn test_coworker_asking_multiple_questions_accumulate() {
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     handle_coworker_asking(RequestId::Number(1), "park", "First question?", &state).await;
 
@@ -128,7 +135,7 @@ async fn test_coworker_asking_multiple_questions_accumulate() {
 
 #[tokio::test]
 async fn test_coworker_asking_twice_replaces_previous_question() {
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     handle_coworker_asking(RequestId::Number(1), "madison", "First question?", &state).await;
     handle_coworker_asking(RequestId::Number(2), "madison", "Updated question?", &state).await;
@@ -148,7 +155,7 @@ async fn test_coworker_asking_twice_replaces_previous_question() {
 
 #[tokio::test]
 async fn test_cleanup_coworker_state_clears_pending_questions() {
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // Store pending questions for two coworkers
     handle_coworker_asking(
@@ -184,7 +191,7 @@ async fn test_cleanup_coworker_state_clears_pending_questions() {
 
 #[tokio::test]
 async fn test_coworker_nudge_clears_pending_question() {
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // Store a pending question for "madison"
     handle_coworker_asking(
@@ -224,7 +231,7 @@ async fn test_coworker_nudge_clears_pending_question() {
 
 #[tokio::test]
 async fn test_coworker_nudge_only_clears_target_coworkers_questions() {
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // Two coworkers each have a pending question
     handle_coworker_asking(
@@ -270,7 +277,7 @@ async fn test_coworker_nudge_only_clears_target_coworkers_questions() {
 
 #[tokio::test]
 async fn test_coworker_questions_returns_empty_when_no_questions() {
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     let response: crate::rpc::Response =
         handle_coworker_questions(RequestId::Number(1), &state).await;
@@ -286,7 +293,7 @@ async fn test_coworker_questions_returns_empty_when_no_questions() {
 
 #[tokio::test]
 async fn test_coworker_questions_returns_pending_questions() {
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // Store a pending question
     handle_coworker_asking(RequestId::Number(1), "york", "Can you help me?", &state).await;

--- a/src/daemon/rpc_session_tests.rs
+++ b/src/daemon/rpc_session_tests.rs
@@ -120,9 +120,16 @@ fn test_parse_attach_target_for_clear_name() {
 // resolve_attach_target verb parameter tests
 // ============================================================================
 
-fn make_test_state() -> DaemonState {
+fn make_test_state() -> (
+    DaemonState,
+    tempfile::TempDir,
+    crate::paths::TestMidtownBaseDirGuard,
+) {
     use std::process::Command;
     use tempfile::TempDir;
+
+    let midtown_dir = TempDir::new().expect("midtown temp dir");
+    let _guard = crate::paths::set_test_midtown_base_dir(midtown_dir.path().to_path_buf());
 
     let temp_dir = TempDir::new().expect("temp dir");
     Command::new("git")
@@ -151,11 +158,10 @@ fn make_test_state() -> DaemonState {
     let cm = crate::coworker::CoworkerManager::new(wm);
 
     let base_dir = temp_dir.path().to_path_buf();
-    std::mem::forget(temp_dir);
 
     let channel_router = crate::ChannelRouter::new(&base_dir, "midtown");
     let (shutdown_tx, _) = tokio::sync::broadcast::channel::<()>(1);
-    DaemonState::new(
+    let state = DaemonState::new(
         "/tmp/test-rpc-session.sock".into(),
         cm,
         "test-repo".to_string(),
@@ -167,12 +173,13 @@ fn make_test_state() -> DaemonState {
         "main".to_string(),
         shutdown_tx,
     )
-    .expect("daemon state")
+    .expect("daemon state");
+    (state, temp_dir, _guard)
 }
 
 #[tokio::test]
 async fn test_resolve_attach_target_multi_match_error_uses_verb() {
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // Create two coworkers assigned to the same task so task lookup returns multiple
     state.record_task_assignment("park", "42");
@@ -245,7 +252,7 @@ async fn insert_test_session_with_metadata(
 
 #[tokio::test]
 async fn test_session_clear_rejects_unknown_coworker() {
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     let resp = handle_session_clear(RequestId::Number(1), "name/nonexistent", &state).await;
 
@@ -258,7 +265,7 @@ async fn test_session_clear_rejects_unknown_coworker() {
 
 #[tokio::test]
 async fn test_session_clear_rejects_no_persisted_session() {
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // Register a coworker in the manager but don't add a persisted session
     state
@@ -285,7 +292,7 @@ async fn test_session_clear_rejects_no_persisted_session() {
 
 #[tokio::test]
 async fn test_session_clear_rejects_attached_session() {
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // Register coworker and add persisted session
     state
@@ -324,7 +331,7 @@ async fn test_session_clear_rejects_attached_session() {
 
 #[tokio::test]
 async fn test_session_clear_cleans_up_transient_state() {
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
     let name = "broadway";
 
     // Register coworker and add persisted session
@@ -381,7 +388,7 @@ async fn test_session_clear_cleans_up_transient_state() {
 
 #[tokio::test]
 async fn test_session_clear_uses_lead_config_for_lead_target() {
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     // Register lead and add persisted session
     state
@@ -416,7 +423,7 @@ async fn test_session_clear_uses_lead_config_for_lead_target() {
 /// and should handle reviewer-specific metadata (coworker_type, pr_number, channel).
 #[tokio::test]
 async fn test_session_clear_handles_reviewer_metadata() {
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     state
         .coworkers
@@ -455,7 +462,7 @@ async fn test_session_clear_handles_reviewer_metadata() {
 /// Regression test: session clear for a channel-lead coworker should not panic.
 #[tokio::test]
 async fn test_session_clear_handles_channel_lead_metadata() {
-    let state = make_test_state();
+    let (state, _tmp, _guard) = make_test_state();
 
     state
         .coworkers


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary

- All `make_test_state()` / `make_cleanup_test_state()` helpers in daemon test files now call `set_test_midtown_base_dir()` to redirect all `~/.midtown/projects/` writes to a temp directory isolated per test
- Each helper returns `(DaemonState, TempDir, TestMidtownBaseDirGuard)` — callers bind all three, ensuring both the git repo temp dir and the midtown base dir override stay alive until end of scope
- Removed `std::mem::forget(temp_dir)` leak pattern from all helpers since the `TempDir` is now returned to the caller
- Fixed `effects_tests.rs` which was setting `MIDTOWN_PROJECTS_ROOT` env var (never read anywhere) as a broken isolation attempt — replaced with `set_test_midtown_base_dir()`
- Removed the now-unnecessary unique-per-PID repo name strategy from `mod_tests.rs` — temp dir isolation makes it redundant
- Cleaned up 110+ stale test directories from `~/.midtown/projects/` that were left behind by previous test runs

## Files changed

- `src/daemon/rpc_coworker_tests.rs`
- `src/daemon/rpc_session_tests.rs`
- `src/daemon/rpc_channel_tests.rs`
- `src/daemon/dispatch_tests.rs`
- `src/daemon/dispatch_session_tests.rs`
- `src/daemon/pr_tests.rs`
- `src/daemon/mod_tests.rs`
- `src/daemon/effects_tests.rs`

## Test plan

- [x] `cargo test` — 1627+ tests pass, 0 failures
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Verified `~/.midtown/projects/` contains only real project dirs after test run

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)