### PR TITLE
fix: Disable insight capture hook for lead sessions [Midtown !1606]

### DIFF
--- a/agents/lead-settings.json
+++ b/agents/lead-settings.json
@@ -6,12 +6,6 @@
         "type": "command",
         "command": "{bin} hook lead-stop"
       }]
-    }],
-    "PostToolUse": [{
-      "hooks": [{
-        "type": "command",
-        "command": "{bin} hook insight"
-      }]
     }]
   }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -250,16 +250,11 @@ mod tests {
                 .ends_with("hook lead-stop")
         );
 
-        let post_tool_hooks = &settings["hooks"]["PostToolUse"];
-        assert!(post_tool_hooks.is_array());
-        // Lead has only the catch-all insight hook (task hooks removed —
-        // Lead now uses `midtown task` CLI instead of TaskCreate/TaskUpdate tools)
+        // Lead has no PostToolUse hooks — insight capture is disabled for the lead
+        // since lead text is auto-posted to the channel (no duplicate messages needed)
         assert!(
-            post_tool_hooks[0]["hooks"][0]["command"]
-                .as_str()
-                .unwrap()
-                .ends_with("hook insight"),
-            "PostToolUse hook should be the catch-all insight hook"
+            settings["hooks"]["PostToolUse"].is_null(),
+            "Lead should have no PostToolUse hooks (insight capture disabled)"
         );
 
         // Verify {bin} placeholders were replaced


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

- Removes the `PostToolUse` insight hook from `lead-settings.json`
- Lead text is auto-posted to the channel, so the insight hook caused duplicate insight blocks to appear in channel messages
- The `explanatory-output-style` plugin remains enabled for the lead — insights still appear in the lead's conversation, just not captured/re-posted as channel messages
- Updates `test_lead_settings_json_is_valid` to assert no PostToolUse hooks exist for the lead

## Test plan

- [x] `cargo test test_lead_settings_json_is_valid` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] Coworker settings unchanged — insight capture still enabled for coworkers

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)