### PR TITLE
feat: Resume channel lead sessions on user messages [Midtown !1607]

### DIFF
--- a/src/daemon/rpc_channel.rs
+++ b/src/daemon/rpc_channel.rs
@@ -250,18 +250,11 @@ pub(super) async fn handle_channel_post(
                 match state.spawn_coworker(&config).await {
                     Ok(()) => true,
                     Err(e) => {
-                        error!("Failed to resume channel lead '{}': {}", channel_name, e);
-                        // Clean up placeholder if spawn failed
-                        if is_fresh {
-                            let mut ps = state.persistent_state.lock().await;
-                            ps.channel_lead_sessions.remove(channel_name);
-                            if let Err(save_err) = ps.save_for_repo(&state.repo_name) {
-                                error!(
-                                    "Failed to save daemon state after failed channel lead spawn: {}",
-                                    save_err
-                                );
-                            }
-                        }
+                        error!("Failed to spawn channel lead '{}': {}", channel_name, e);
+                        // Keep the placeholder in channel_lead_sessions even on spawn failure.
+                        // An empty-string placeholder is harmless (startup recovery handles it
+                        // with SessionMode::Fresh), and preserving it means the channel is
+                        // registered for restart recovery even if this spawn attempt failed.
                         false
                     }
                 }

--- a/src/daemon/rpc_channel_tests.rs
+++ b/src/daemon/rpc_channel_tests.rs
@@ -584,14 +584,10 @@ async fn test_fresh_spawn_registers_channel_lead_sessions() {
     .await;
     assert!(response.error.is_none(), "channel.post should succeed");
 
-    // The placeholder should have been registered in channel_lead_sessions.
-    // If spawn succeeded, it stays; if spawn failed, it gets cleaned up.
-    // Either way, the registration happened before spawn — which is the key invariant.
-    // We verify the placeholder was inserted by checking that a save occurred
-    // (the state file should exist or be updated).
-    //
-    // In the test environment, spawn_coworker succeeds (process starts then dies),
-    // so the placeholder should remain.
+    // The placeholder is registered before spawn and kept regardless of whether
+    // spawn succeeds or fails. An empty-string placeholder is harmless — startup
+    // recovery handles it with SessionMode::Fresh. Keeping it ensures the channel
+    // is registered for restart recovery even if this spawn attempt failed.
     {
         let ps = state.persistent_state.lock().await;
         assert!(


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- **Topic channels**: When a user posts to a topic channel and the channel lead session isn't running, resume it (using the saved session ID if available, otherwise spawn fresh) before nudging it. Previously, user messages were silently dropped if no lead was active.
- **Main channel**: Always nudge the lead on user messages, even when the user @mentions specific coworkers. Coworker routing still fires alongside the lead nudge — both paths run.
- **Refactor**: Merged duplicate nudge sends in the topic channel path into a single `send_message` call, using a `session_ready` bool to unify the "already alive" and "just spawned" branches.

## Test plan
- [x] `test_user_message_with_coworker_mention_still_nudges_lead` — lead nudged even when @coworker mentioned
- [x] `test_user_message_to_topic_channel_inactive_lead_attempts_resume` — resume attempted gracefully, no main lead nudge
- [x] Existing tests pass: `test_user_message_queues_headed_lead_nudge`, `test_user_message_to_main_channel_nudges_lead`, `test_user_message_to_topic_channel_no_lead_no_main_nudge`
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)