### PR TITLE
feat: Hide internal/plumbing commands from midtown --help [Midtown !1610]

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,8 @@ The lead is just a claude code session, but it's been booted with some a [specia
 | `midtown start` | Start the daemon and Zellij session |
 | `midtown stop` | Stop everything |
 | `midtown restart` | Restart the daemon |
-| `midtown attach` | Attach to the Zellij session |
 | `midtown status` | Show system status |
-| `midtown chat` | Open the IRC-style chat TUI |
-| `midtown log [-f]` | View daemon logs |
+| `midtown view` | Launch chat UI (use `--attach` to open Lead in a split) |
 | `midtown channel post <msg>` | Post to the team channel |
 | `midtown channel read` | Read recent messages |
 | `midtown coworker call-in` | Spawn a new coworker |
@@ -112,10 +110,12 @@ The lead is just a claude code session, but it's been booted with some a [specia
 | `midtown task list` | List tasks |
 | `midtown task view <id>` | View task details |
 | `midtown pr list` | List pull requests |
+| `midtown config get/set/list` | Manage [configuration](docs/configuration.md) |
 | `midtown auth` | Manage [auth profiles](docs/authentication.md) (multiple accounts supported) |
-| `midtown headless "<prompt>"` | Run a headless Claude session |
 
 See the [full CLI reference](docs/cli.md) for all flags and options.
+
+> **Note:** `midtown view` also accepts `midtown chat` and `midtown attach` as aliases.
 
 ## Documentation
 
@@ -127,7 +127,11 @@ See the [full CLI reference](docs/cli.md) for all flags and options.
 | [Architecture](docs/architecture.md) | Daemon, coworkers, channel sync, GitHub integration, web UI |
 | [Docker](docs/docker.md) | Docker images, running in containers |
 
-### Headless Execution
+### Hidden/Advanced Commands
+
+These commands are not shown in `midtown --help` but remain fully functional. They are used internally by the daemon, coworker hooks, and agent prompts.
+
+#### Headless Execution
 
 Run Claude Code sessions non-interactively with JSON streaming output:
 
@@ -145,16 +149,15 @@ midtown headless "Fix the bug" --allow-tools --max-budget-usd 0.50
 | `--max-budget-usd <float>` | Maximum budget in USD |
 | `--allow-tools` | Allow tool use (default: no tools) |
 
-### Lead Commands
+#### Lead Commands
 
 | Command | Description |
 |---------|-------------|
-| `midtown lead register-session` | Register Lead's Claude session for task sharing |
 | `midtown lead remind all-work-merged <message>` | Set a reminder for when all work is merged |
 | `midtown lead remind list` | List active reminders |
 | `midtown lead remind cancel <id>` | Cancel a reminder |
 
-### Webserver
+#### Webserver
 
 The multi-project webserver serves the web UI and proxies to per-project daemons.
 
@@ -164,7 +167,15 @@ The multi-project webserver serves the web UI and proxies to per-project daemons
 | `midtown webserver stop` | Stop the webserver |
 | `midtown webserver restart` | Restart the webserver |
 
-### E2E Testing
+#### Logs
+
+| Command | Description |
+|---------|-------------|
+| `midtown log` | View daemon logs (follows by default) |
+| `midtown log --hooks` | View hooks log |
+| `midtown log --path` | Print log file path |
+
+#### E2E Testing
 
 | Command | Description |
 |---------|-------------|

--- a/src/bin/midtown/main.rs
+++ b/src/bin/midtown/main.rs
@@ -120,6 +120,7 @@ enum Commands {
         command: ConfigCommand,
     },
     /// Project management commands
+    #[command(hide = true)]
     Project {
         #[command(subcommand)]
         command: ProjectCommand,
@@ -148,6 +149,7 @@ enum Commands {
     /// Show system status
     Status,
     /// Headed wrapper intercom (register/poll/ack + PTY-backed run-agent)
+    #[command(hide = true)]
     HeadedWrapper {
         #[command(subcommand)]
         command: HeadedWrapperCommand,
@@ -158,13 +160,16 @@ enum Commands {
         command: PrCommand,
     },
     /// Lead-specific commands
+    #[command(hide = true)]
     Lead {
         #[command(subcommand)]
         command: LeadCommand,
     },
     /// Open IRC-style chat TUI
+    #[command(hide = true)]
     Chat,
     /// E2E testing commands (auth setup, run containerized tests)
+    #[command(hide = true)]
     E2e {
         #[command(subcommand)]
         command: E2eCommand,
@@ -179,6 +184,7 @@ enum Commands {
         command: Option<AuthCommand>,
     },
     /// Report coworker workflow state (called by coworkers to update status)
+    #[command(hide = true)]
     State {
         /// Workflow phase
         #[arg(value_enum)]
@@ -193,16 +199,19 @@ enum Commands {
         progress: Option<u8>,
     },
     /// Hook handlers (insight, idle, task, ask) - called by Claude Code hooks
+    #[command(hide = true)]
     Hook {
         #[command(subcommand)]
         command: HookCommand,
     },
     /// Diagram utilities (validation, rendering)
+    #[command(hide = true)]
     Diagram {
         #[command(subcommand)]
         command: DiagramCommand,
     },
     /// View daemon or hook logs
+    #[command(hide = true)]
     Log {
         /// Show hooks log instead of daemon log
         #[arg(long)]
@@ -221,17 +230,20 @@ enum Commands {
         lines: u32,
     },
     /// Standalone multi-project webserver
+    #[command(hide = true)]
     Webserver {
         #[command(subcommand)]
         command: WebserverCommand,
     },
     /// Run Claude Code using the current midtown auth profile
+    #[command(hide = true)]
     Claude {
         /// Additional arguments to pass to the claude CLI
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
     /// Run a headless Claude Code session via the daemon (JSON streaming)
+    #[command(hide = true)]
     Headless {
         /// Prompt to send to Claude
         prompt: String,
@@ -283,6 +295,7 @@ enum WebserverCommand {
 #[derive(Subcommand, Clone)]
 enum LeadCommand {
     /// Register this session for task sharing with coworkers
+    #[command(hide = true)]
     RegisterSession,
     /// Manage reminders (condition-based notifications)
     Remind {


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

- Added `#[command(hide = true)]` to 12 internal/plumbing command variants: `state`, `hook`, `headed-wrapper`, `diagram`, `webserver`, `headless`, `claude`, `chat`, `project`, `lead`, `log`, `e2e`
- Hidden `lead register-session` subcommand (keeping `lead remind` visible)
- Updated README CLI Overview to show only the 12 user-facing commands, added a "Hidden/Advanced Commands" section

All hidden commands remain fully functional — `#[command(hide = true)]` only affects help output. Zero breaking changes.

## Verification

- `midtown --help` now shows 12 commands (start, stop, restart, view, config, channel, coworker, session, task, status, pr, auth)
- `midtown hook idle`, `midtown state idle`, `midtown chat` all still work
- `cargo clippy -- -D warnings` passes
- `cargo test` passes

## Test plan

- [x] Build succeeds
- [x] `midtown --help` shows exactly 12 commands
- [x] Hidden commands remain accessible (hook, state, chat, log, etc.)
- [x] clippy passes with -D warnings
- [x] All tests pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)