### PR TITLE
fix: Use char-boundary-safe truncation in board channel messages [Midtown !1613]

### DIFF
--- a/src/bin/midtown/cli/chat/ui/board.rs
+++ b/src/bin/midtown/cli/chat/ui/board.rs
@@ -520,7 +520,11 @@ fn draw_ops_mini_channel(f: &mut Frame, ops_messages: &[&midtown::Message], area
             let name = msg.from.clone();
             let remaining = content_width.saturating_sub(prefix.len() + name.len() + 1);
             let body = if remaining > 0 && content.len() > remaining {
-                format!("{}..", &content[..remaining.saturating_sub(2)])
+                let mut end = remaining.saturating_sub(2);
+                while end > 0 && !content.is_char_boundary(end) {
+                    end -= 1;
+                }
+                format!("{}..", &content[..end])
             } else {
                 content.clone()
             };
@@ -551,7 +555,11 @@ fn draw_ops_mini_channel(f: &mut Frame, ops_messages: &[&midtown::Message], area
                 content_width.saturating_sub(time_str.len() + 1 + sender.len() + 2)
             };
             let body = if remaining > 0 && msg.content.len() > remaining {
-                format!("{}..", &msg.content[..remaining.saturating_sub(2)])
+                let mut end = remaining.saturating_sub(2);
+                while end > 0 && !msg.content.is_char_boundary(end) {
+                    end -= 1;
+                }
+                format!("{}..", &msg.content[..end])
             } else {
                 msg.content.clone()
             };


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Fixes TUI panic when channel messages containing multi-byte UTF-8 characters (e.g., em-dash `—`) are truncated to fit display width
- The panic occurred at `board.rs:530` when `&content[..n]` sliced at a byte offset inside a multi-byte character
- Fix walks backwards from the target offset to find a valid char boundary before slicing

## Root Cause
Rust's `str` indexing panics if the index doesn't fall on a character boundary. The em-dash `—` (U+2014) is 3 bytes in UTF-8, so a truncation offset could land at byte 1 or 2 of the character, causing a panic.

## Changes
- `src/bin/midtown/cli/chat/ui/board.rs`: Two instances of direct byte-slice truncation replaced with backward-walking char-boundary search

## Test plan
- [x] Compiles cleanly (`cargo build`)
- [ ] Manual: Open TUI with a channel message containing `—` long enough to be truncated

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)