### PR TITLE
fix: Register continuation line with phase label in task_line_map for wrapped titles [Midtown !1616]

### DIFF
--- a/src/bin/midtown/cli/chat/ui/board.rs
+++ b/src/bin/midtown/cli/chat/ui/board.rs
@@ -201,10 +201,18 @@ pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> (Vec<Hyperl
                     None
                 }
             });
-            if !title_wraps && task_phase_label(task, task_pr, coworker_phase).is_some() {
-                // Register the label line for click-to-attach as well
-                task_line_map.insert(current_line, (task.id.clone(), task.owner.clone()));
-                current_line += 1;
+            if task_phase_label(task, task_pr, coworker_phase).is_some() {
+                if title_wraps {
+                    // The phase label is merged into the first continuation line (wrapped_lines[1]).
+                    // That line's position is current_line - wrapped_lines.len() + 1.
+                    // Register it so click-to-attach works on the continuation line too.
+                    let continuation_line = current_line - wrapped_lines.len() as u16 + 1;
+                    task_line_map.insert(continuation_line, (task.id.clone(), task.owner.clone()));
+                } else {
+                    // Label is a separate line below the title; register it.
+                    task_line_map.insert(current_line, (task.id.clone(), task.owner.clone()));
+                    current_line += 1;
+                }
             }
         }
     }

--- a/src/bin/midtown/cli/chat/ui/board_tests.rs
+++ b/src/bin/midtown/cli/chat/ui/board_tests.rs
@@ -1,4 +1,55 @@
+use super::super::super::app::tests::test_app;
 use super::*;
+
+// --- Bug !1616: click-map regression for phase label on wrapped task titles ---
+
+/// When a task title wraps, the first continuation line (line index 1) has the phase label
+/// merged into it. That line must be registered in task_line_map so clicking it triggers
+/// click-to-attach.
+#[test]
+fn test_task_line_map_registers_continuation_line_with_phase_label() {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    let mut app = test_app();
+    // Use a subject long enough to wrap at narrow render width (width=30 forces wrap)
+    app.tasks = vec![KanbanTask {
+        id: "100".to_string(),
+        subject: "A very long task title that will definitely wrap when rendered at a narrow width in the sidebar".to_string(),
+        owner: Some("york".to_string()),
+        status: TaskStatus::InProgress,
+        modified_at: None,
+        channel: None,
+        blocked_by: vec![],
+    }];
+
+    let backend = TestBackend::new(30, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    terminal
+        .draw(|f| {
+            let area = f.area();
+            draw_board_panel(f, &mut app, area);
+        })
+        .unwrap();
+
+    // The channel header is line 0, the task title first line is line 1.
+    // The continuation line (with phase label merged) is line 2.
+    // All lines that belong to this task must be in task_line_map.
+    let task_lines: Vec<u16> = app
+        .task_line_map
+        .iter()
+        .filter(|(_, (id, _))| id == "100")
+        .map(|(line, _)| *line)
+        .collect();
+
+    // Must have at least 2 registered lines for this task (title line + continuation line)
+    assert!(
+        task_lines.len() >= 2,
+        "wrapped task title: continuation line with phase label must be registered in task_line_map, got lines: {:?}",
+        task_lines
+    );
+}
 
 // --- draw_ops_mini_channel tests ---
 


### PR DESCRIPTION
## Summary

- When a task title wraps, the phase label is merged into the first continuation line (`wrapped_lines[1]`) by PR #1324
- That continuation line was never registered in `task_line_map`, so clicking it (to attach to the task) did nothing
- Fix: when `title_wraps && phase_label.is_some()`, compute the continuation line's position and insert it into `task_line_map`

## Test plan

- [x] Added `test_task_line_map_registers_continuation_line_with_phase_label` in `board_tests.rs` — confirmed it failed before the fix, passes after
- [x] All 54 board tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)