### PR TITLE
feat: Split coworker state out of kanban.data into coworkers.status RPC [Midtown !1639]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -70,24 +70,30 @@ pub struct PendingImageInfo {
     pub media_type: String,
 }
 
-/// Data fetched from background thread for kanban refresh
+/// Data fetched from background thread for kanban refresh (PR/repo data only).
 struct KanbanData {
     prs: Vec<KanbanPr>,
     merged_prs: Vec<MergedPr>,
     /// Repo metadata from daemon RPC (label, full_name)
     repos: Vec<(String, String)>,
-    /// Coworker status data from daemon
+}
+
+/// Data fetched from background thread for coworker status refresh.
+///
+/// Polled via `coworkers.status` RPC at a faster interval than PR data.
+/// No GraphQL involved — always reflects current daemon state.
+struct CoworkerStatusData {
+    /// Active coworkers with their current status
     coworkers: Vec<CoworkerInfo>,
     /// Maximum number of coworkers from daemon config
     max_coworkers: usize,
     /// Whether the headless lead session is actively working
     lead_working: bool,
-    /// Recent tool call activity per agent: agent name → list of semantic headers.
-    /// Populated from kanban.data RPC `tool_activity` field (live, not cached).
+    /// Recent tool call activity per agent
     tool_activity: HashMap<String, Vec<String>>,
     /// Pending questions from coworkers waiting for user input
     pending_questions: Vec<PendingQuestion>,
-    /// Names of active channel leads (e.g. "auth", "tui"), for sender color assignment.
+    /// Names of active channel leads (e.g. "auth", "tui")
     channel_lead_names: Vec<String>,
 }
 
@@ -275,7 +281,7 @@ pub struct App {
     pub lead_working: bool,
     /// Recent tool call activity per agent, keyed by lowercase agent name.
     /// Contains human-readable semantic headers (e.g., "$ git status", "read src/lib.rs").
-    /// Updated from kanban.data RPC (live, not cached). Cleared when agent posts a message.
+    /// Updated from coworkers.status RPC (live, not cached). Cleared when agent posts a message.
     pub tool_activity: HashMap<String, Vec<ToolActivityEntry>>,
     /// Maximum number of coworkers allowed
     pub max_coworkers: usize,
@@ -288,6 +294,10 @@ pub struct App {
     kanban_last_refresh: Instant,
     /// Receiver for async kanban data from background thread
     kanban_receiver: Option<Receiver<KanbanData>>,
+    /// Last time coworker status was refreshed
+    coworker_status_last_refresh: Instant,
+    /// Receiver for async coworker status from background thread
+    coworker_status_receiver: Option<Receiver<CoworkerStatusData>>,
     /// Repository status (commit, CI, release info) - primary repo
     pub repo_status: RepoStatus,
     /// Multi-repo statuses (label, full_name, status) for all project repos
@@ -355,7 +365,7 @@ pub struct App {
     spinner_frame: usize,
     /// Last time the spinner frame was advanced (for time-based animation)
     spinner_last_tick: Instant,
-    /// Names of active channel leads (e.g. "auth", "tui"), populated from kanban data.
+    /// Names of active channel leads (e.g. "auth", "tui"), populated from coworkers.status.
     /// Used to color their messages LightYellow like the main lead.
     pub channel_lead_names: Vec<String>,
     /// List of all available channels (including empty ones)
@@ -462,8 +472,11 @@ pub struct ChannelSwitcherItem {
     pub unread_count: usize,
 }
 
-/// Interval between kanban data refreshes (5 seconds)
+/// Interval between kanban data refreshes (5 seconds — PR data via GraphQL)
 const KANBAN_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Interval between coworker status refreshes (2 seconds — live in-memory state, no GraphQL)
+const COWORKER_STATUS_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Interval between repo status refreshes (60 seconds)
 const REPO_STATUS_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
@@ -520,6 +533,8 @@ impl App {
             repo_name,
             kanban_last_refresh: Instant::now() - KANBAN_REFRESH_INTERVAL, // Force initial refresh
             kanban_receiver: None,
+            coworker_status_last_refresh: Instant::now() - COWORKER_STATUS_REFRESH_INTERVAL, // Force initial refresh
+            coworker_status_receiver: None,
             repo_status: RepoStatus::default(),
             repo_statuses: Vec::new(),
             repo_status_last_refresh: Instant::now() - REPO_STATUS_REFRESH_INTERVAL, // Force initial refresh
@@ -642,15 +657,6 @@ impl App {
                 Ok(data) => {
                     self.prs = data.prs;
                     self.merged_prs = data.merged_prs;
-                    self.coworkers = data.coworkers;
-                    self.lead_working = data.lead_working;
-                    self.tool_activity = merge_tool_activity(
-                        std::mem::take(&mut self.tool_activity),
-                        data.tool_activity,
-                    );
-                    self.max_coworkers = data.max_coworkers;
-                    self.pending_questions = data.pending_questions;
-                    self.channel_lead_names = data.channel_lead_names;
                     // Update repo info from daemon if available
                     if !data.repos.is_empty() {
                         let new_repos: Vec<RepoInfo> = data
@@ -695,6 +701,38 @@ impl App {
         {
             self.refresh_kanban();
             self.kanban_last_refresh = Instant::now();
+        }
+
+        // Check for coworker status data from background thread (non-blocking)
+        if let Some(ref receiver) = self.coworker_status_receiver {
+            match receiver.try_recv() {
+                Ok(data) => {
+                    self.coworkers = data.coworkers;
+                    self.lead_working = data.lead_working;
+                    self.tool_activity = merge_tool_activity(
+                        std::mem::take(&mut self.tool_activity),
+                        data.tool_activity,
+                    );
+                    self.max_coworkers = data.max_coworkers;
+                    self.pending_questions = data.pending_questions;
+                    self.channel_lead_names = data.channel_lead_names;
+                    self.coworker_status_receiver = None;
+                }
+                Err(TryRecvError::Empty) => {
+                    // Still waiting for data, continue
+                }
+                Err(TryRecvError::Disconnected) => {
+                    self.coworker_status_receiver = None;
+                }
+            }
+        }
+
+        // Refresh coworker status frequently — cheap RPC call, no GraphQL
+        if self.coworker_status_last_refresh.elapsed() >= COWORKER_STATUS_REFRESH_INTERVAL
+            && self.coworker_status_receiver.is_none()
+        {
+            self.refresh_coworker_status();
+            self.coworker_status_last_refresh = Instant::now();
         }
 
         // Check for repo status data from background thread (non-blocking)
@@ -833,7 +871,9 @@ impl App {
         }
     }
 
-    /// Refresh kanban board data (tasks and PRs)
+    /// Refresh kanban board data (tasks and PRs via kanban.data RPC).
+    ///
+    /// Coworker status is refreshed separately by `refresh_coworker_status`.
     fn refresh_kanban(&mut self) {
         // Tasks are local file reads - fast, can stay synchronous
         self.tasks = fetch_tasks();
@@ -843,40 +883,35 @@ impl App {
         self.kanban_receiver = Some(rx);
 
         thread::spawn(move || {
-            let (
-                prs,
-                merged_prs,
-                repos,
-                coworkers,
-                max_coworkers,
-                lead_working,
-                tool_activity,
-                channel_lead_names,
-            ) = fetch_kanban_data_via_rpc().unwrap_or_else(|| {
-                (
-                    fetch_prs(),
-                    fetch_merged_prs(),
-                    Vec::new(),
-                    Vec::new(),
-                    10,
-                    false,
-                    HashMap::new(),
-                    Vec::new(),
-                )
-            });
-            let pending_questions = fetch_pending_questions_via_rpc();
+            let (prs, merged_prs, repos) = fetch_kanban_data_via_rpc()
+                .unwrap_or_else(|| (fetch_prs(), fetch_merged_prs(), Vec::new()));
             // Ignore send error if receiver dropped (app closed)
             let _ = tx.send(KanbanData {
                 prs,
                 merged_prs,
                 repos,
-                coworkers,
-                max_coworkers,
-                lead_working,
-                tool_activity,
-                pending_questions,
-                channel_lead_names,
             });
+        });
+    }
+
+    /// Refresh coworker status via the `coworkers.status` RPC.
+    ///
+    /// Runs in a background thread to avoid blocking the TUI. The result is
+    /// received in `refresh()` via `coworker_status_receiver`.
+    fn refresh_coworker_status(&mut self) {
+        let (tx, rx) = mpsc::channel();
+        self.coworker_status_receiver = Some(rx);
+
+        thread::spawn(move || {
+            let data = fetch_coworker_status_via_rpc().unwrap_or_else(|| CoworkerStatusData {
+                coworkers: Vec::new(),
+                max_coworkers: 10,
+                lead_working: false,
+                tool_activity: HashMap::new(),
+                pending_questions: Vec::new(),
+                channel_lead_names: Vec::new(),
+            });
+            let _ = tx.send(data);
         });
     }
 
@@ -2631,20 +2666,13 @@ fn fetch_merged_prs() -> Vec<MergedPr> {
     prs
 }
 
-/// Fetch kanban PR data from the daemon via RPC.
+type KanbanRpcResult = Option<(Vec<KanbanPr>, Vec<MergedPr>, Vec<(String, String)>)>;
+
+/// Fetch kanban PR data from the daemon via RPC (`kanban.data`).
 ///
-/// Returns None if the daemon is not available, allowing fallback to direct gh CLI.
-#[allow(clippy::type_complexity)]
-fn fetch_kanban_data_via_rpc() -> Option<(
-    Vec<KanbanPr>,
-    Vec<MergedPr>,
-    Vec<(String, String)>,
-    Vec<CoworkerInfo>,
-    usize,
-    bool,
-    HashMap<String, Vec<String>>,
-    Vec<String>,
-)> {
+/// Returns `None` if the daemon is not available, allowing fallback to direct gh CLI.
+/// Coworker data is fetched separately via `fetch_coworker_status_via_rpc`.
+fn fetch_kanban_data_via_rpc() -> KanbanRpcResult {
     use crate::client::DaemonClient;
 
     let client = DaemonClient::connect().ok()?;
@@ -2652,7 +2680,6 @@ fn fetch_kanban_data_via_rpc() -> Option<(
 
     let prs_json = data.get("prs").and_then(|v| v.as_array())?;
     let merged_json = data.get("merged_prs").and_then(|v| v.as_array())?;
-    let coworkers_json = data.get("coworkers").and_then(|v| v.as_array());
 
     // Extract repo metadata if present
     let repos: Vec<(String, String)> = data
@@ -2672,13 +2699,6 @@ fn fetch_kanban_data_via_rpc() -> Option<(
                 .collect()
         })
         .unwrap_or_default();
-
-    // Extract max_coworkers from daemon config
-    let max_coworkers = data
-        .get("max_coworkers")
-        .and_then(|v| v.as_u64())
-        .map(|n| n as usize)
-        .unwrap_or(10); // Default fallback
 
     let prs: Vec<KanbanPr> = prs_json
         .iter()
@@ -2786,7 +2806,27 @@ fn fetch_kanban_data_via_rpc() -> Option<(
         })
         .collect();
 
-    // Parse coworker data from the daemon response
+    Some((prs, merged_prs, repos))
+}
+
+/// Fetch live coworker status from the daemon via the `coworkers.status` RPC.
+///
+/// Also fetches pending questions via `coworker.questions`. Returns `None` if
+/// the daemon is unreachable so the caller can use a default empty value.
+fn fetch_coworker_status_via_rpc() -> Option<CoworkerStatusData> {
+    use crate::client::DaemonClient;
+
+    let client = DaemonClient::connect().ok()?;
+    let data = client.coworkers_status().ok()?;
+
+    let coworkers_json = data.get("coworkers").and_then(|v| v.as_array());
+
+    let max_coworkers = data
+        .get("max_coworkers")
+        .and_then(|v| v.as_u64())
+        .map(|n| n as usize)
+        .unwrap_or(10);
+
     let coworkers: Vec<CoworkerInfo> = coworkers_json
         .map(|arr| {
             arr.iter()
@@ -2811,7 +2851,6 @@ fn fetch_kanban_data_via_rpc() -> Option<(
                         .and_then(|v| v.as_str())
                         .unwrap_or("claude")
                         .to_string();
-                    // Profile is not currently in kanban response, use default
                     let profile = cw
                         .get("profile")
                         .and_then(|v| v.as_str())
@@ -2822,7 +2861,6 @@ fn fetch_kanban_data_via_rpc() -> Option<(
                         .get("time_estimate")
                         .and_then(|v| v.as_str())
                         .map(|s| s.to_string());
-
                     Some(CoworkerInfo {
                         name,
                         task_id,
@@ -2844,7 +2882,6 @@ fn fetch_kanban_data_via_rpc() -> Option<(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    // Parse tool_activity: { agent_name: [UniversalItem, ...] } → { agent_name: [semantic_header, ...] }
     let tool_activity: HashMap<String, Vec<String>> = data
         .get("tool_activity")
         .and_then(|v| v.as_object())
@@ -2861,8 +2898,7 @@ fn fetch_kanban_data_via_rpc() -> Option<(
         })
         .unwrap_or_default();
 
-    // Parse channel_leads: list of channel lead names (e.g. ["auth", "tui"])
-    let channel_leads: Vec<String> = data
+    let channel_lead_names: Vec<String> = data
         .get("channel_leads")
         .and_then(|v| v.as_array())
         .map(|arr| {
@@ -2872,16 +2908,16 @@ fn fetch_kanban_data_via_rpc() -> Option<(
         })
         .unwrap_or_default();
 
-    Some((
-        prs,
-        merged_prs,
-        repos,
+    let pending_questions = fetch_pending_questions_via_rpc();
+
+    Some(CoworkerStatusData {
         coworkers,
         max_coworkers,
         lead_working,
         tool_activity,
-        channel_leads,
-    ))
+        pending_questions,
+        channel_lead_names,
+    })
 }
 
 /// Fetch pending questions from coworkers via daemon RPC.
@@ -3281,6 +3317,8 @@ pub(super) mod tests {
             repo_name: "test".to_string(),
             kanban_last_refresh: Instant::now(),
             kanban_receiver: None,
+            coworker_status_last_refresh: Instant::now(),
+            coworker_status_receiver: None,
             repo_status: RepoStatus::default(),
             repo_statuses: Vec::new(),
             repo_status_last_refresh: Instant::now(),

--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -589,6 +589,14 @@ impl DaemonClient {
         self.send_raw("kanban.data", None)
     }
 
+    /// Fetch live coworker status from the daemon.
+    ///
+    /// This is a lightweight call — no GraphQL, no caching. Returns coworkers,
+    /// max_coworkers, lead_working, tool_activity, and channel_leads.
+    pub fn coworkers_status(&self) -> Result<Value, String> {
+        self.send_raw("coworkers.status", None)
+    }
+
     // Headless execution
 
     /// Execute a headless Claude Code session via the daemon.

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -193,9 +193,10 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
     let request_method = request.method.clone();
 
     // Methods with their own domain-specific caching should skip the RPC idempotency cache.
-    // kanban.data has a dedicated 30s TTL cache in DaemonState; the RPC cache (60s, keyed by
+    // kanban.data has a dedicated TTL cache in DaemonState; the RPC cache (60s, keyed by
     // request ID) would shadow it because the web server always sends id=1 for kanban requests.
-    let skip_rpc_cache = request_method == "kanban.data";
+    // coworkers.status is never cached (it returns live state).
+    let skip_rpc_cache = request_method == "kanban.data" || request_method == "coworkers.status";
 
     // Check cache for idempotent response (within 60 second TTL)
     if !skip_rpc_cache {
@@ -390,6 +391,8 @@ async fn dispatch_request(request: Request, state: &DaemonState) -> Response {
         "status" => super::rpc_status::handle_status(request.id, state).await,
 
         "kanban.data" => super::rpc_kanban::handle_kanban_data(request.id, state).await,
+
+        "coworkers.status" => super::rpc_kanban::handle_coworkers_status(request.id, state).await,
 
         // ---- Channel ----
         "channel.post" => {

--- a/src/daemon/rpc_kanban.rs
+++ b/src/daemon/rpc_kanban.rs
@@ -1,8 +1,8 @@
 //! Kanban board data handler and helpers.
 //!
 //! Extracted from `rpc.rs` to keep the main RPC module focused on dispatch.
-//! Contains the `kanban.data` RPC handler, the `KanbanCache`, and all
-//! GraphQL/PR-formatting logic for the web UI kanban board.
+//! Contains the `kanban.data` and `coworkers.status` RPC handlers, the `KanbanCache`,
+//! and all GraphQL/PR-formatting logic for the web UI kanban board.
 
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
@@ -13,7 +13,6 @@ use chrono::Utc;
 use tracing::{debug, error, warn};
 
 use crate::rpc::{RequestId, Response, RpcError};
-use crate::rules::CoworkerRecord;
 
 use super::DaemonState;
 use super::snapshot::ProcessHealth;
@@ -30,100 +29,39 @@ use super::snapshot::ProcessHealth;
 /// Runs blocking GraphQL operations in spawn_blocking to avoid blocking
 /// the async runtime and causing RPC timeouts.
 ///
-/// Uses a 30s TTL cache (via `DaemonState::kanban_cache`) to avoid expensive
-/// GraphQL queries on every call and reduce GitHub API usage.
+/// Uses a 60s TTL cache (via `DaemonState::kanban_cache`) to avoid expensive
+/// GraphQL queries on every call and reduce GitHub API usage. The cache key
+/// is based only on repo paths — coworker state is no longer included since
+/// coworker data is served by the separate `coworkers.status` RPC.
 pub(crate) async fn handle_kanban_data(id: RequestId, state: &DaemonState) -> Response {
     // Clone data needed for cache key computation
     let all_repo_paths = state.all_repo_paths.clone();
-
-    // Extract channel lead names early for cache key computation (best-effort)
-    let cache_channel_lead_names: std::collections::HashSet<String> = state
-        .persistent_state
-        .try_lock()
-        .map(|ps| ps.channel_lead_sessions.keys().cloned().collect())
-        .unwrap_or_default();
 
     // Compute a hash of all repo paths for cache keying
     let mut hasher = DefaultHasher::new();
     for path in &all_repo_paths {
         path.hash(&mut hasher);
     }
-    let repo_hash = hasher.finish();
-
-    // Compute a hash of coworker state for cache invalidation
-    let coworker_state_hash = {
-        let coworker_records = state.coworker_records.read().await;
-        compute_coworker_state_hash(&coworker_records, &cache_channel_lead_names)
-    };
-
-    // Combine repo hash, coworker state hash, and channel lead names for the final cache key.
-    // Channel lead names must be included because they appear in the cached `channel_leads`
-    // response field — if the set changes (lead added/removed), the cache must be invalidated.
-    // Sort the names before hashing for determinism (HashSet iteration order is not guaranteed).
-    let mut sorted_lead_names: Vec<&String> = cache_channel_lead_names.iter().collect();
-    sorted_lead_names.sort();
-
-    let mut cache_key_hasher = DefaultHasher::new();
-    repo_hash.hash(&mut cache_key_hasher);
-    coworker_state_hash.hash(&mut cache_key_hasher);
-    sorted_lead_names.hash(&mut cache_key_hasher);
-    let cache_key = cache_key_hasher.finish();
+    let cache_key = hasher.finish();
 
     // Check cache first
-    if let Some(mut cached) = state.kanban_cache.get(cache_key) {
+    if let Some(cached) = state.kanban_cache.get(cache_key) {
         debug!(
             "Returning cached kanban data (TTL: {}s)",
             KANBAN_CACHE_TTL.as_secs()
         );
-        // lead_working and tool_activity are never cached — inject live values.
-        let lead_working = is_lead_actively_working(state);
-        let tool_activity = collect_tool_activity(state);
-        if let Some(obj) = cached.as_object_mut() {
-            obj.insert("lead_working".to_string(), serde_json::json!(lead_working));
-            obj.insert("tool_activity".to_string(), tool_activity);
-        }
         return Response::success(id, cached);
     }
 
     // Cache miss - fetch fresh data
     debug!("Cache miss, fetching fresh kanban data");
 
-    // Get reviewer assignments, worktree registry, and channel lead names from persistent state
-    // (best-effort via try_lock)
-    let (reviewer_assignments, worktree_pr_map, channel_lead_names): (
-        HashMap<u64, crate::github_state::PrReviewerAssignment>,
-        HashMap<String, u64>,
-        std::collections::HashSet<String>,
-    ) = state
+    // Get reviewer assignments from persistent state (best-effort via try_lock)
+    let reviewer_assignments: HashMap<u64, crate::github_state::PrReviewerAssignment> = state
         .persistent_state
         .try_lock()
-        .map(|ps| {
-            let assignments = ps.github.active_assignments();
-            // Build coworker -> PR map from worktree registry (for reviewers)
-            let wt_map: HashMap<String, u64> = ps
-                .worktree_registry
-                .all_assignments()
-                .iter()
-                .filter_map(|(_, assignment)| {
-                    let coworker = assignment.current_coworker.as_ref()?;
-                    let pr_number = assignment.pr_number?;
-                    Some((coworker.clone(), pr_number))
-                })
-                .collect();
-            let cl_names: std::collections::HashSet<String> =
-                ps.channel_lead_sessions.keys().cloned().collect();
-            (assignments, wt_map, cl_names)
-        })
+        .map(|ps| ps.github.active_assignments())
         .unwrap_or_default();
-
-    // Build reviewer -> PR number map from reviewer_assignments
-    // We do this before spawn_blocking so we can use the reviewer_assignments data
-    // without needing a second try_lock() later (which could fail and cause reviewers
-    // to show their internal task IDs instead of the source task ID from PR titles).
-    let reviewer_pr_map: HashMap<String, u64> = reviewer_assignments
-        .iter()
-        .map(|(pr_number, assignment)| (assignment.reviewer.clone(), *pr_number))
-        .collect();
 
     let is_multi_repo = all_repo_paths.len() > 1;
 
@@ -176,135 +114,196 @@ pub(crate) async fn handle_kanban_data(id: RequestId, state: &DaemonState) -> Re
         }
     };
 
-    // Collect coworker data from daemon state
-    let coworkers_data = {
-        let active_coworkers = state.coworkers.list();
-        let coworker_records = state.coworker_records.read().await;
-        let prs_by_task_id = build_pr_task_map(&prs);
-
-        // Read tasks to get explicit PR associations (task !1151)
-        let all_tasks = crate::tasks::read_tasks();
-        let task_pr_map: HashMap<u32, u64> = all_tasks
-            .iter()
-            .filter_map(|task| {
-                let task_id: u32 = task.id.parse().ok()?;
-                let pr = task.pr?;
-                Some((task_id, pr))
-            })
-            .collect();
-
-        // Build reverse map: PR number -> source task ID (from PR titles)
-        let task_id_by_pr: HashMap<u64, u32> = prs
-            .iter()
-            .filter_map(|pr| {
-                let pr_number = pr.get("number")?.as_u64()?;
-                let title = pr.get("title")?.as_str()?;
-                let task_id = crate::tasks::extract_task_id_from_pr_title(title)?;
-                let task_id_u32 = u32::try_from(task_id).ok()?;
-                Some((pr_number, task_id_u32))
-            })
-            .collect();
-
-        // Clone health data to avoid holding the lock across await
-        let health_snapshot: HashMap<String, ProcessHealth> = {
-            let health_guard = state.headless_health.read().unwrap();
-            health_guard.clone()
-        };
-
-        active_coworkers
-            .iter()
-            .filter_map(|cw| {
-                // Skip channel lead sessions — they are scoped to a specific topic
-                // channel and must not appear in the general coworker status panel.
-                // The lead session itself also uses a reserved name and is excluded.
-                if is_channel_lead(&cw.name, &channel_lead_names)
-                    || cw.name.eq_ignore_ascii_case("lead")
-                {
-                    return None;
-                }
-
-                // Get coworker's workflow state from records
-                let record = coworker_records.get(&cw.name);
-                let workflow_phase = record.and_then(|r| r.workflow_phase);
-                let task_id = record.and_then(|r| r.task_id);
-
-                // Skip idle coworkers (phase = Idle or Completed)
-                if matches!(
-                    workflow_phase,
-                    Some(crate::coworker_state::WorkflowPhase::Idle)
-                        | Some(crate::coworker_state::WorkflowPhase::Completed)
-                ) {
-                    return None;
-                }
-
-                // Get health status
-                let health = health_snapshot.get(&cw.name);
-                let health_color = if let Some(h) = health {
-                    if !h.is_alive {
-                        "red" // dead
-                    } else if h.has_usage_limit || h.has_api_error {
-                        "yellow" // degraded
-                    } else {
-                        "green" // healthy
-                    }
-                } else {
-                    "green" // default healthy
-                };
-
-                // Find PR number for this coworker, trying sources in priority order:
-                // 1. Explicit task.pr field (task !1151) - most authoritative
-                // 2. GitHub reviewer assignment (for review tasks)
-                // 3. Worktree registry (for reviewers when reviewer_pr_map is empty)
-                // 4. PR title extraction (final fallback)
-                let pr_number = task_id
-                    .and_then(|tid| task_pr_map.get(&tid).copied())
-                    .or_else(|| reviewer_pr_map.get(&cw.name).copied())
-                    .or_else(|| worktree_pr_map.get(&cw.name).copied())
-                    .or_else(|| task_id.and_then(|tid| prs_by_task_id.get(&tid).copied()));
-
-                // For display: prefer source task ID (from PR title) over internal task ID
-                // This ensures reviewers show the meaningful task ID, not their ephemeral one
-                let display_task_id = pr_number
-                    .and_then(|pr| task_id_by_pr.get(&pr).copied())
-                    .or(task_id);
-
-                Some(serde_json::json!({
-                    "name": cw.name,
-                    "task_id": display_task_id,
-                    "phase": workflow_phase.map(|p| p.abbreviation()),
-                    "pr_number": pr_number,
-                    "health": health_color,
-                    "provider": cw.provider.as_str(),
-                    "profile": cw.profile,
-                    "progress": record.and_then(|r| r.progress),
-                    "time_estimate": record.and_then(|r| r.format_time_remaining()),
-                }))
-            })
-            .collect::<Vec<_>>()
-    };
-
-    // Build the cacheable response (WITHOUT lead_working or tool_activity — they're live state)
-    let channel_leads: Vec<&String> = channel_lead_names.iter().collect();
-    let mut response_data = serde_json::json!({
+    let response_data = serde_json::json!({
         "prs": prs,
         "merged_prs": merged_prs,
         "repos": repos,
-        "coworkers": coworkers_data,
-        "max_coworkers": state.max_coworkers,
-        "channel_leads": channel_leads,
     });
 
     state.kanban_cache.set(response_data.clone(), cache_key);
 
-    // Inject live state (not cached): lead_working and tool_activity.
+    Response::success(id, response_data)
+}
+
+/// Handle coworkers.status RPC method - returns live coworker state.
+///
+/// This is a lightweight endpoint with no GraphQL queries and no caching.
+/// It reads directly from in-memory daemon state so responses are always
+/// current (microsecond latency). The TUI polls this at 1–2s to keep the
+/// coworker status panel up-to-date without delay.
+///
+/// Returns: coworkers, max_coworkers, lead_working, tool_activity, channel_leads.
+pub(crate) async fn handle_coworkers_status(id: RequestId, state: &DaemonState) -> Response {
+    let (coworkers_data, channel_lead_names) = build_coworkers_data(state, &[]).await;
+
     let lead_working = is_lead_actively_working(state);
     let tool_activity = collect_tool_activity(state);
-    if let Some(obj) = response_data.as_object_mut() {
-        obj.insert("lead_working".to_string(), serde_json::json!(lead_working));
-        obj.insert("tool_activity".to_string(), tool_activity);
-    }
+    let channel_leads: Vec<&String> = channel_lead_names.iter().collect();
 
-    Response::success(id, response_data)
+    Response::success(
+        id,
+        serde_json::json!({
+            "coworkers": coworkers_data,
+            "max_coworkers": state.max_coworkers,
+            "lead_working": lead_working,
+            "tool_activity": tool_activity,
+            "channel_leads": channel_leads,
+        }),
+    )
+}
+
+/// Build the coworker data array from daemon state.
+///
+/// Accepts an optional slice of PR JSON objects. When non-empty, PR title
+/// parsing is used to map PR numbers to source task IDs (for reviewers).
+/// Pass an empty slice from `coworkers.status` (no GraphQL available);
+/// pass the fetched PRs from `kanban.data` for richer display.
+///
+/// Returns `(coworkers_data, channel_lead_names)`.
+async fn build_coworkers_data(
+    state: &DaemonState,
+    prs: &[serde_json::Value],
+) -> (Vec<serde_json::Value>, std::collections::HashSet<String>) {
+    // Get reviewer assignments, worktree registry, and channel lead names from persistent state
+    // (best-effort via try_lock)
+    let (reviewer_assignments, worktree_pr_map, channel_lead_names): (
+        HashMap<u64, crate::github_state::PrReviewerAssignment>,
+        HashMap<String, u64>,
+        std::collections::HashSet<String>,
+    ) = state
+        .persistent_state
+        .try_lock()
+        .map(|ps| {
+            let assignments = ps.github.active_assignments();
+            // Build coworker -> PR map from worktree registry (for reviewers)
+            let wt_map: HashMap<String, u64> = ps
+                .worktree_registry
+                .all_assignments()
+                .iter()
+                .filter_map(|(_, assignment)| {
+                    let coworker = assignment.current_coworker.as_ref()?;
+                    let pr_number = assignment.pr_number?;
+                    Some((coworker.clone(), pr_number))
+                })
+                .collect();
+            let cl_names: std::collections::HashSet<String> =
+                ps.channel_lead_sessions.keys().cloned().collect();
+            (assignments, wt_map, cl_names)
+        })
+        .unwrap_or_default();
+
+    // Build reviewer -> PR number map from reviewer_assignments
+    let reviewer_pr_map: HashMap<String, u64> = reviewer_assignments
+        .iter()
+        .map(|(pr_number, assignment)| (assignment.reviewer.clone(), *pr_number))
+        .collect();
+
+    let active_coworkers = state.coworkers.list();
+    let coworker_records = state.coworker_records.read().await;
+
+    let prs_by_task_id = build_pr_task_map(prs);
+
+    // Read tasks to get explicit PR associations (task !1151)
+    let all_tasks = crate::tasks::read_tasks();
+    let task_pr_map: HashMap<u32, u64> = all_tasks
+        .iter()
+        .filter_map(|task| {
+            let task_id: u32 = task.id.parse().ok()?;
+            let pr = task.pr?;
+            Some((task_id, pr))
+        })
+        .collect();
+
+    // Build reverse map: PR number -> source task ID (from PR titles)
+    let task_id_by_pr: HashMap<u64, u32> = prs
+        .iter()
+        .filter_map(|pr| {
+            let pr_number = pr.get("number")?.as_u64()?;
+            let title = pr.get("title")?.as_str()?;
+            let task_id = crate::tasks::extract_task_id_from_pr_title(title)?;
+            let task_id_u32 = u32::try_from(task_id).ok()?;
+            Some((pr_number, task_id_u32))
+        })
+        .collect();
+
+    // Clone health data to avoid holding the lock across await
+    let health_snapshot: HashMap<String, ProcessHealth> = {
+        let health_guard = state.headless_health.read().unwrap();
+        health_guard.clone()
+    };
+
+    let coworkers_data = active_coworkers
+        .iter()
+        .filter_map(|cw| {
+            // Skip channel lead sessions — they are scoped to a specific topic
+            // channel and must not appear in the general coworker status panel.
+            // The lead session itself also uses a reserved name and is excluded.
+            if is_channel_lead(&cw.name, &channel_lead_names)
+                || cw.name.eq_ignore_ascii_case("lead")
+            {
+                return None;
+            }
+
+            // Get coworker's workflow state from records
+            let record = coworker_records.get(&cw.name);
+            let workflow_phase = record.and_then(|r| r.workflow_phase);
+            let task_id = record.and_then(|r| r.task_id);
+
+            // Skip idle coworkers (phase = Idle or Completed)
+            if matches!(
+                workflow_phase,
+                Some(crate::coworker_state::WorkflowPhase::Idle)
+                    | Some(crate::coworker_state::WorkflowPhase::Completed)
+            ) {
+                return None;
+            }
+
+            // Get health status
+            let health = health_snapshot.get(&cw.name);
+            let health_color = if let Some(h) = health {
+                if !h.is_alive {
+                    "red" // dead
+                } else if h.has_usage_limit || h.has_api_error {
+                    "yellow" // degraded
+                } else {
+                    "green" // healthy
+                }
+            } else {
+                "green" // default healthy
+            };
+
+            // Find PR number for this coworker, trying sources in priority order:
+            // 1. Explicit task.pr field (task !1151) - most authoritative
+            // 2. GitHub reviewer assignment (for review tasks)
+            // 3. Worktree registry (for reviewers when reviewer_pr_map is empty)
+            // 4. PR title extraction (final fallback, only when PR data is available)
+            let pr_number = task_id
+                .and_then(|tid| task_pr_map.get(&tid).copied())
+                .or_else(|| reviewer_pr_map.get(&cw.name).copied())
+                .or_else(|| worktree_pr_map.get(&cw.name).copied())
+                .or_else(|| task_id.and_then(|tid| prs_by_task_id.get(&tid).copied()));
+
+            // For display: prefer source task ID (from PR title) over internal task ID
+            // This ensures reviewers show the meaningful task ID, not their ephemeral one
+            let display_task_id = pr_number
+                .and_then(|pr| task_id_by_pr.get(&pr).copied())
+                .or(task_id);
+
+            Some(serde_json::json!({
+                "name": cw.name,
+                "task_id": display_task_id,
+                "phase": workflow_phase.map(|p| p.abbreviation()),
+                "pr_number": pr_number,
+                "health": health_color,
+                "provider": cw.provider.as_str(),
+                "profile": cw.profile,
+                "progress": record.and_then(|r| r.progress),
+                "time_estimate": record.and_then(|r| r.format_time_remaining()),
+            }))
+        })
+        .collect::<Vec<_>>();
+
+    (coworkers_data, channel_lead_names)
 }
 
 // ============================================================================
@@ -384,68 +383,6 @@ fn serialize_tool_activity(
         .filter_map(|(agent, items)| serde_json::to_value(items).ok().map(|v| (agent.clone(), v)))
         .collect();
     serde_json::Value::Object(obj)
-}
-
-/// Compute a hash representing coworker state for cache invalidation.
-///
-/// The hash includes:
-/// - Coworker count
-/// - Each coworker's name, task_id, and workflow phase
-///
-/// When any of these change (coworker spawns/shuts down, task assigned, phase changes),
-/// the hash changes and the cache misses, ensuring fresh data is fetched.
-/// Progress is intentionally excluded — see `compute_coworker_state_hash` for details.
-fn compute_coworker_state_hash(
-    coworker_records: &HashMap<String, CoworkerRecord>,
-    channel_lead_names: &std::collections::HashSet<String>,
-) -> u64 {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
-    let mut hasher = DefaultHasher::new();
-
-    // Collect (name, task_id, phase) tuples and sort by name for deterministic hashing.
-    // Progress is intentionally excluded: it changes frequently (every `midtown state --progress N`
-    // call) and including it would cause a cache miss and a new GraphQL API call on every progress
-    // update. The cached response includes progress data that grows stale within the 30s TTL window,
-    // which is acceptable — kanban consumers don't need sub-second progress precision.
-    let mut state: Vec<(
-        &String,
-        Option<u32>,
-        Option<crate::coworker_state::WorkflowPhase>,
-    )> = coworker_records
-        .iter()
-        .filter_map(|(name, record)| {
-            // Skip channel leads and the lead session — they don't appear in the kanban
-            // response (mirroring the filter in handle_kanban_data's output section).
-            if is_channel_lead(name, channel_lead_names) || name.eq_ignore_ascii_case("lead") {
-                return None;
-            }
-
-            // Skip idle coworkers (they don't appear in the kanban response)
-            if matches!(
-                record.workflow_phase,
-                Some(crate::coworker_state::WorkflowPhase::Idle)
-                    | Some(crate::coworker_state::WorkflowPhase::Completed)
-            ) {
-                return None;
-            }
-
-            Some((name, record.task_id, record.workflow_phase))
-        })
-        .collect();
-
-    state.sort_by(|a, b| a.0.cmp(b.0));
-
-    for (name, task_id, phase) in state {
-        name.hash(&mut hasher);
-        task_id.hash(&mut hasher);
-        // WorkflowPhase derives Hash, so Option<WorkflowPhase> is also Hash. This correctly
-        // distinguishes Developing from PullRequest, etc., while excluding progress.
-        phase.hash(&mut hasher);
-    }
-
-    hasher.finish()
 }
 
 /// Build a map of task_id -> pr_number from PR data.

--- a/src/daemon/rpc_kanban_tests.rs
+++ b/src/daemon/rpc_kanban_tests.rs
@@ -42,137 +42,38 @@ fn test_is_channel_lead_empty_set() {
     assert!(!is_channel_lead("madison", &channel_leads));
 }
 
-#[test]
-fn test_current_cache_serves_stale_data_on_coworker_change() {
-    // This test documents the current bug: KANBAN_CACHE uses only repo_hash
-    // as the key, so when coworker state changes, stale data is served.
+// ============================================================================
+// Tests for KanbanCache — repo-path-keyed cache for PR GraphQL data
+//
+// The kanban cache now keys only on repo paths. Coworker state is no longer
+// part of the cache key — coworker data is served by `coworkers.status` at
+// a faster refresh rate. This keeps the expensive GraphQL cache stable.
+// ============================================================================
 
+#[test]
+fn test_kanban_cache_serves_pr_data_on_repo_hash() {
     let cache = KanbanCache::new();
     let repo_hash: u64 = 12345;
 
-    // Cache response with no coworkers
-    let response_no_coworkers = serde_json::json!({"coworkers": []});
-    cache.set(response_no_coworkers.clone(), repo_hash);
+    // Cache PR response
+    let response = serde_json::json!({"prs": [], "merged_prs": [], "repos": []});
+    cache.set(response.clone(), repo_hash);
 
-    // Verify cache hit
-    assert_eq!(cache.get(repo_hash), Some(response_no_coworkers.clone()));
-
-    // BUG: Even if coworker state changed in the real world (madison spawned
-    // and got task 1234), cache.get(repo_hash) still returns the old response
-    // because repo_hash hasn't changed.
-    //
-    // The test simulates this by checking with the same repo_hash.
-    // In the real system, the coworker state would have changed between
-    // these two calls, but the cache serves stale data.
-    assert_eq!(
-        cache.get(repo_hash),
-        Some(response_no_coworkers),
-        "BUG: Cache returns stale data when coworker state changes"
-    );
+    // Verify cache hit with the same repo hash
+    assert_eq!(cache.get(repo_hash), Some(response));
 }
 
 #[test]
-fn test_fixed_cache_invalidates_on_coworker_state_change() {
-    // This test verifies that with the fix, KANBAN_CACHE invalidates when
-    // coworker state changes.
-
+fn test_kanban_cache_misses_on_different_repo_hash() {
     let cache = KanbanCache::new();
+    let repo_hash_a: u64 = 12345;
+    let repo_hash_b: u64 = 99999;
 
-    // Scenario 1: Cache with no coworkers active
-    let repo_hash: u64 = 12345;
-    let coworker_state_1: u64 = 0; // No coworkers
-    let cache_key_1 = compute_cache_key(repo_hash, coworker_state_1);
+    let response = serde_json::json!({"prs": [], "merged_prs": []});
+    cache.set(response.clone(), repo_hash_a);
 
-    let response_1 = serde_json::json!({"coworkers": []});
-    cache.set(response_1.clone(), cache_key_1);
-
-    // Verify we get the cached value back
-    assert_eq!(cache.get(cache_key_1), Some(response_1.clone()));
-
-    // Scenario 2: Coworker spawns and gets assigned task
-    // The coworker state changes (now 1 active coworker with task assignment)
-    let coworker_state_2: u64 = compute_coworker_state_hash(&[("madison", Some(1234), None)]);
-    let cache_key_2 = compute_cache_key(repo_hash, coworker_state_2);
-
-    // With the fix, cache.get(cache_key_2) returns None because the cache key
-    // is different (includes coworker state).
-    assert_eq!(
-        cache.get(cache_key_2),
-        None,
-        "Cache should miss when coworker state changes"
-    );
-
-    // Store new response with updated coworker data
-    let response_2 = serde_json::json!({"coworkers": [{"name": "madison", "task_id": 1234}]});
-    cache.set(response_2.clone(), cache_key_2);
-
-    // Verify we get the new cached value with the new key
-    assert_eq!(cache.get(cache_key_2), Some(response_2.clone()));
-
-    // Note: The old cache entry is overwritten (cache stores only one entry).
-    // The old key now returns None.
-    assert_eq!(cache.get(cache_key_1), None);
-}
-
-/// Compute a cache key combining repo and coworker state.
-fn compute_cache_key(repo_hash: u64, coworker_state_hash: u64) -> u64 {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
-    let mut hasher = DefaultHasher::new();
-    repo_hash.hash(&mut hasher);
-    coworker_state_hash.hash(&mut hasher);
-    hasher.finish()
-}
-
-/// Compute a hash representing coworker state.
-///
-/// Input: list of (coworker_name, task_id, pr_number) tuples.
-/// Returns a hash that changes when task assignments or PR associations change.
-fn compute_coworker_state_hash(coworkers: &[(&str, Option<u32>, Option<u64>)]) -> u64 {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
-    let mut hasher = DefaultHasher::new();
-
-    // Sort by name for deterministic hashing
-    let mut sorted = coworkers.to_vec();
-    sorted.sort_by_key(|(name, _, _)| *name);
-
-    for (name, task_id, pr_number) in sorted {
-        name.hash(&mut hasher);
-        task_id.hash(&mut hasher);
-        pr_number.hash(&mut hasher);
-    }
-
-    hasher.finish()
-}
-
-#[test]
-fn test_coworker_state_hash_changes_on_assignment() {
-    // Empty state
-    let hash_0 = compute_coworker_state_hash(&[]);
-
-    // One coworker, no task
-    let hash_1 = compute_coworker_state_hash(&[("madison", None, None)]);
-
-    // Same coworker, with task
-    let hash_2 = compute_coworker_state_hash(&[("madison", Some(1234), None)]);
-
-    // Same coworker, with task and PR
-    let hash_3 = compute_coworker_state_hash(&[("madison", Some(1234), Some(42))]);
-
-    // Two coworkers
-    let hash_4 = compute_coworker_state_hash(&[
-        ("madison", Some(1234), Some(42)),
-        ("park", Some(1235), None),
-    ]);
-
-    // All hashes should be different
-    assert_ne!(hash_0, hash_1);
-    assert_ne!(hash_1, hash_2);
-    assert_ne!(hash_2, hash_3);
-    assert_ne!(hash_3, hash_4);
+    // Different repo hash → cache miss
+    assert_eq!(cache.get(repo_hash_b), None);
 }
 
 #[test]
@@ -308,271 +209,4 @@ fn test_serialize_tool_activity_with_tool_result() {
     let content = &item["content"][0]["ToolResult"];
     assert_eq!(content["call_id"], "call_002");
     assert!(!content["is_error"].as_bool().unwrap());
-}
-
-// ============================================================================
-// Tests for compute_coworker_state_hash — cache key stability fix
-// ============================================================================
-
-/// Build a CoworkerRecord with the given phase, task_id, and progress.
-fn make_record(
-    phase: Option<crate::coworker_state::WorkflowPhase>,
-    task_id: Option<u32>,
-    progress: Option<u8>,
-) -> crate::rules::CoworkerRecord {
-    crate::rules::CoworkerRecord {
-        workflow_phase: phase,
-        task_id,
-        progress,
-        ..Default::default()
-    }
-}
-
-#[test]
-fn test_cache_key_stable_on_progress_update() {
-    // Progress updates should NOT change the cache key — they were the root cause
-    // of excessive GraphQL API calls (every `midtown state --progress N` caused
-    // a cache miss and a new API call).
-
-    use crate::coworker_state::WorkflowPhase;
-
-    let mut records_before = HashMap::new();
-    records_before.insert(
-        "madison".to_string(),
-        make_record(Some(WorkflowPhase::Developing), Some(1234), Some(20)),
-    );
-
-    let mut records_after = HashMap::new();
-    records_after.insert(
-        "madison".to_string(),
-        make_record(Some(WorkflowPhase::Developing), Some(1234), Some(60)),
-    );
-
-    let empty_cl: std::collections::HashSet<String> = std::collections::HashSet::new();
-    // Use the real function from the parent module (not the local test helper below)
-    let hash_before = super::compute_coworker_state_hash(&records_before, &empty_cl);
-    let hash_after = super::compute_coworker_state_hash(&records_after, &empty_cl);
-
-    assert_eq!(
-        hash_before, hash_after,
-        "Progress update (20→60) must NOT change the cache key"
-    );
-}
-
-#[test]
-fn test_cache_key_changes_on_phase_transition() {
-    use crate::coworker_state::WorkflowPhase;
-
-    let mut records_dev = HashMap::new();
-    records_dev.insert(
-        "york".to_string(),
-        make_record(Some(WorkflowPhase::Developing), Some(1500), Some(80)),
-    );
-
-    let mut records_pr = HashMap::new();
-    records_pr.insert(
-        "york".to_string(),
-        make_record(Some(WorkflowPhase::PullRequest), Some(1500), Some(90)),
-    );
-
-    let empty_cl: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let hash_dev = super::compute_coworker_state_hash(&records_dev, &empty_cl);
-    let hash_pr = super::compute_coworker_state_hash(&records_pr, &empty_cl);
-
-    assert_ne!(
-        hash_dev, hash_pr,
-        "Phase transition (Developing→PullRequest) must change the cache key"
-    );
-}
-
-#[test]
-fn test_cache_key_changes_on_task_assignment() {
-    use crate::coworker_state::WorkflowPhase;
-
-    let mut records_no_task = HashMap::new();
-    records_no_task.insert(
-        "lexington".to_string(),
-        make_record(Some(WorkflowPhase::Claiming), None, None),
-    );
-
-    let mut records_with_task = HashMap::new();
-    records_with_task.insert(
-        "lexington".to_string(),
-        make_record(Some(WorkflowPhase::Developing), Some(999), None),
-    );
-
-    let empty_cl: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let hash_no_task = super::compute_coworker_state_hash(&records_no_task, &empty_cl);
-    let hash_with_task = super::compute_coworker_state_hash(&records_with_task, &empty_cl);
-
-    assert_ne!(
-        hash_no_task, hash_with_task,
-        "Task assignment must change the cache key"
-    );
-}
-
-#[test]
-fn test_cache_key_changes_on_coworker_spawn() {
-    use crate::coworker_state::WorkflowPhase;
-
-    // No coworkers
-    let records_empty: HashMap<String, crate::rules::CoworkerRecord> = HashMap::new();
-
-    // One coworker spawned
-    let mut records_one = HashMap::new();
-    records_one.insert(
-        "amsterdam".to_string(),
-        make_record(Some(WorkflowPhase::Developing), Some(1200), None),
-    );
-
-    let empty_cl: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let hash_empty = super::compute_coworker_state_hash(&records_empty, &empty_cl);
-    let hash_one = super::compute_coworker_state_hash(&records_one, &empty_cl);
-
-    assert_ne!(
-        hash_empty, hash_one,
-        "Coworker spawn must change the cache key"
-    );
-}
-
-#[test]
-fn test_cache_key_stable_when_idle_coworker_updates_progress() {
-    // Idle coworkers are excluded from the hash entirely, so their progress
-    // updates definitely should not affect the cache key.
-    use crate::coworker_state::WorkflowPhase;
-
-    let mut records_idle_no_progress = HashMap::new();
-    records_idle_no_progress.insert(
-        "riverside".to_string(),
-        make_record(Some(WorkflowPhase::Idle), Some(1400), None),
-    );
-
-    let mut records_idle_with_progress = HashMap::new();
-    records_idle_with_progress.insert(
-        "riverside".to_string(),
-        make_record(Some(WorkflowPhase::Idle), Some(1400), Some(100)),
-    );
-
-    let empty_cl: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let hash_no_progress = super::compute_coworker_state_hash(&records_idle_no_progress, &empty_cl);
-    let hash_with_progress =
-        super::compute_coworker_state_hash(&records_idle_with_progress, &empty_cl);
-
-    assert_eq!(
-        hash_no_progress, hash_with_progress,
-        "Idle coworker progress must not affect the cache key (idle coworkers are excluded)"
-    );
-}
-
-/// Test that the full cache key (repo + coworker state + channel leads) changes
-/// when the set of channel leads changes.
-///
-/// This covers a bug where `channel_lead_names` appeared in the kanban response
-/// (`channel_leads` field) but was not included in the cache key — so when a
-/// channel lead was added or removed, the cached response served stale data.
-#[test]
-fn test_cache_key_changes_when_channel_lead_set_changes() {
-    use crate::coworker_state::WorkflowPhase;
-
-    // Helper: compute the same combined key that handle_kanban_data computes.
-    // repo_hash + coworker_state_hash + sorted channel_lead_names → final key.
-    fn combined_key(
-        repo_hash: u64,
-        records: &HashMap<String, crate::rules::CoworkerRecord>,
-        channel_leads: &std::collections::HashSet<String>,
-    ) -> u64 {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-
-        let coworker_hash = super::compute_coworker_state_hash(records, channel_leads);
-
-        let mut sorted_names: Vec<&String> = channel_leads.iter().collect();
-        sorted_names.sort();
-
-        let mut hasher = DefaultHasher::new();
-        repo_hash.hash(&mut hasher);
-        coworker_hash.hash(&mut hasher);
-        sorted_names.hash(&mut hasher);
-        hasher.finish()
-    }
-
-    let repo_hash: u64 = 42;
-
-    let mut records = HashMap::new();
-    records.insert(
-        "madison".to_string(),
-        make_record(Some(WorkflowPhase::Developing), Some(1500), None),
-    );
-
-    // No channel leads
-    let no_leads: std::collections::HashSet<String> = std::collections::HashSet::new();
-    // One channel lead added
-    let with_lead: std::collections::HashSet<String> =
-        ["auth"].iter().map(|s| s.to_string()).collect();
-    // A different channel lead
-    let with_other_lead: std::collections::HashSet<String> =
-        ["tui"].iter().map(|s| s.to_string()).collect();
-
-    let key_no_leads = combined_key(repo_hash, &records, &no_leads);
-    let key_with_lead = combined_key(repo_hash, &records, &with_lead);
-    let key_with_other_lead = combined_key(repo_hash, &records, &with_other_lead);
-
-    // After the fix: adding a channel lead must change the cache key.
-    assert_ne!(
-        key_no_leads, key_with_lead,
-        "Cache key must change when a channel lead is added"
-    );
-    // Adding a different channel lead must also produce a different key.
-    assert_ne!(
-        key_with_lead, key_with_other_lead,
-        "Cache key must differ for different channel lead sets"
-    );
-}
-
-#[test]
-fn test_cache_key_stable_when_channel_lead_phase_changes() {
-    // Channel leads are excluded from the kanban coworker list (they're scoped
-    // to a specific topic channel). The hash function must mirror this exclusion:
-    // a channel lead's phase or task change must NOT change the cache key.
-    use crate::coworker_state::WorkflowPhase;
-
-    // Channel leads use bare channel names (e.g. "auth", not "ch-auth")
-    let channel_leads: std::collections::HashSet<String> =
-        ["auth"].iter().map(|s| s.to_string()).collect();
-
-    // Baseline: one regular coworker active
-    let mut base_records = HashMap::new();
-    base_records.insert(
-        "madison".to_string(),
-        make_record(Some(WorkflowPhase::Developing), Some(1500), None),
-    );
-
-    // Same regular coworker + a channel lead in Developing phase
-    let mut records_with_cl_dev = base_records.clone();
-    records_with_cl_dev.insert(
-        "auth".to_string(),
-        make_record(Some(WorkflowPhase::Developing), Some(777), None),
-    );
-
-    // Same regular coworker + the same channel lead, now in PullRequest phase
-    let mut records_with_cl_pr = base_records.clone();
-    records_with_cl_pr.insert(
-        "auth".to_string(),
-        make_record(Some(WorkflowPhase::PullRequest), Some(777), None),
-    );
-
-    let hash_base = super::compute_coworker_state_hash(&base_records, &channel_leads);
-    let hash_with_cl_dev = super::compute_coworker_state_hash(&records_with_cl_dev, &channel_leads);
-    let hash_with_cl_pr = super::compute_coworker_state_hash(&records_with_cl_pr, &channel_leads);
-
-    // Channel leads must be invisible to the hash — adding one or changing its
-    // phase/task must not change the cache key.
-    assert_eq!(
-        hash_base, hash_with_cl_dev,
-        "Adding a channel lead must NOT change the cache key"
-    );
-    assert_eq!(
-        hash_with_cl_dev, hash_with_cl_pr,
-        "Channel lead phase change (Developing→PullRequest) must NOT change the cache key"
-    );
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -614,30 +614,18 @@ pub struct RepoStatus {
     pub release_time: Option<String>,
 }
 
-/// Fetch kanban data (PRs + merged PRs + coworkers) from the daemon via RPC.
-///
-/// Connects to the daemon's Unix socket and calls `kanban.data`, which uses
-/// a single batched GraphQL query internally. Returns `None` if the daemon
-/// is unreachable or the response is unexpected.
-fn fetch_kanban_via_rpc(
-    repo: &str,
-) -> Option<(
-    Vec<serde_json::Value>,
-    Vec<serde_json::Value>,
-    Vec<serde_json::Value>,
-)> {
+/// Send a single JSON-RPC request over a Unix socket and return the result value.
+fn rpc_call(socket: &std::path::Path, method: &str, id: u64) -> Option<serde_json::Value> {
     use std::io::{BufRead, BufReader, Write};
     use std::os::unix::net::UnixStream;
 
-    let socket = crate::paths::daemon_socket_for_repo(repo);
-    let mut stream = UnixStream::connect(&socket).ok()?;
-    // Set a timeout so we don't block forever if daemon is busy
+    let mut stream = UnixStream::connect(socket).ok()?;
     stream.set_read_timeout(Some(Duration::from_secs(5))).ok()?;
 
     let request = serde_json::json!({
         "jsonrpc": "2.0",
-        "method": "kanban.data",
-        "id": 1
+        "method": method,
+        "id": id
     });
     writeln!(stream, "{}", request).ok()?;
     stream.flush().ok()?;
@@ -647,15 +635,31 @@ fn fetch_kanban_via_rpc(
     reader.read_line(&mut line).ok()?;
 
     let resp: serde_json::Value = serde_json::from_str(&line).ok()?;
-    let result = resp.get("result")?;
+    resp.get("result").cloned()
+}
 
-    let prs = result.get("prs")?.as_array()?.clone();
-    let merged = result.get("merged_prs")?.as_array()?.clone();
-    let coworkers = result
-        .get("coworkers")
-        .and_then(|v| v.as_array())
-        .cloned()
+/// Fetch kanban data (PRs + merged PRs) from the daemon via the `kanban.data` RPC.
+///
+/// Returns `None` if the daemon is unreachable or the response is unexpected.
+fn fetch_kanban_via_rpc(
+    repo: &str,
+) -> Option<(
+    Vec<serde_json::Value>,
+    Vec<serde_json::Value>,
+    Vec<serde_json::Value>,
+)> {
+    let socket = crate::paths::daemon_socket_for_repo(repo);
+
+    // Fetch PR data from kanban.data (cached, may involve GraphQL)
+    let kanban_result = rpc_call(&socket, "kanban.data", 1)?;
+    let prs = kanban_result.get("prs")?.as_array()?.clone();
+    let merged = kanban_result.get("merged_prs")?.as_array()?.clone();
+
+    // Fetch live coworker data from coworkers.status (no GraphQL, no caching)
+    let coworkers = rpc_call(&socket, "coworkers.status", 2)
+        .and_then(|r| r.get("coworkers").and_then(|v| v.as_array()).cloned())
         .unwrap_or_default();
+
     Some((prs, merged, coworkers))
 }
 


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

- Adds a new `coworkers.status` RPC endpoint that returns live coworker state (phase, progress, health, tool activity, channel leads) with no caching
- Removes coworker data fields from `kanban.data` response, which now serves PR/repo data only with a simplified cache key (repo paths hash only)
- TUI polls `coworkers.status` at 2s and `kanban.data` at 5s independently, fixing the 60s coworker status delay
- Web server calls both endpoints separately and merges the results

### Problem

Coworker status was gated behind the 60s PR data GraphQL cache. The expensive GitHub API call was the bottleneck — coworker state (which is purely in-memory) couldn't update faster than the cache TTL.

### Solution

Split into two endpoints with different refresh semantics:

| Endpoint | Refresh | Cache | Data |
|---|---|---|---|
| `kanban.data` | 5s (TUI), on-demand (web) | 60s TTL, repo-path keyed | PRs, merged PRs, repos |
| `coworkers.status` | **2s** (TUI), on-demand (web) | **None** | Coworkers, lead status, tool activity |

### Key changes

- `rpc_kanban.rs`: Extracted `build_coworkers_data()` shared helper; added `handle_coworkers_status()`; simplified `handle_kanban_data()` cache key to repo-path hash only
- `rpc.rs`: Registered `coworkers.status` in the dispatch table with cache-skip
- `client/mod.rs`: Added `DaemonClient::coworkers_status()` method
- `web.rs`: Added `rpc_call()` helper; updated `fetch_kanban_via_rpc()` to call both endpoints
- `app.rs`: Added `CoworkerStatusData` struct; added separate 2s coworker status polling thread; `KanbanData` now PR-data only

## Test plan

- [x] Unit tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] `rpc_kanban_tests.rs` updated to reflect new repo-hash-only cache key design

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)