### PR TITLE
feat: Nudge channel leads when coworkers post insights [Midtown !1643]

### DIFF
--- a/agents/channel-lead.md
+++ b/agents/channel-lead.md
@@ -66,8 +66,19 @@ You receive nudges about activity in your channel:
 - New tasks assigned to #{channel_name}
 - PRs opened or merged for your channel's tasks
 - CI failures on your channel's PRs
+- Insights posted by coworkers in #{channel_name}
 
 Use this awareness to keep your domain context current and surface relevant information when the user asks.
+
+### Responding to Insights
+
+When a coworker posts an insight (💡) in #{channel_name}, you will receive a nudge with the insight content and a message ID. If you have additional context to add, reply **in the thread** using the `--thread` flag:
+
+```bash
+midtown channel post "Additional context: ..." --thread <message-id> --channel {channel_name}
+```
+
+Keep thread replies focused and additive — only reply if you have meaningful domain context to contribute. If the insight stands on its own, no reply is needed.
 
 ## Tools
 

--- a/src/daemon/rpc_insight.rs
+++ b/src/daemon/rpc_insight.rs
@@ -66,6 +66,37 @@ pub(super) async fn handle_insight_report(
         agent, channel_name
     );
 
+    // Nudge the channel lead for topic channels so they can reply in-thread with context.
+    // Main channel has no channel lead, so skip nudging there.
+    let default_channel = state.channel_router.default_channel_name();
+    if channel_name != default_channel {
+        let session_name = crate::launch::channel_lead_session_name(channel_name);
+        if state.session_manager.is_alive(&session_name).await {
+            let nudge_msg = format!(
+                "{agent} posted an insight in #{channel_name}:\n\n{insight}\n\nIf you have additional context, reply in the thread:\n  midtown channel post \"...\" --thread {msg_id} --channel {channel_name}",
+                agent = agent,
+                channel_name = channel_name,
+                insight = insight,
+                msg_id = msg.id,
+            );
+            if let Err(e) = state
+                .session_manager
+                .send_message(&session_name, &nudge_msg)
+                .await
+            {
+                warn!(
+                    "insight.report: failed to nudge channel lead '{}': {}",
+                    channel_name, e
+                );
+            } else {
+                info!(
+                    "insight.report: nudged channel lead '{}' about insight from {}",
+                    channel_name, agent
+                );
+            }
+        }
+    }
+
     // Determine working directory for the architect session.
     let cwd = if is_coworker_sender(agent) {
         let worktree = crate::paths::coworkers_dir_for_repo(&state.repo_name).join(agent);

--- a/src/daemon/rpc_insight_tests.rs
+++ b/src/daemon/rpc_insight_tests.rs
@@ -1,6 +1,11 @@
 //! Tests for insight RPC handlers.
 
+use std::process::Command;
+
+use super::super::DaemonState;
+use super::handle_insight_report;
 use super::hash_insight;
+use crate::rpc::RequestId;
 
 #[test]
 fn test_hash_insight_deterministic() {
@@ -26,4 +31,126 @@ fn test_hash_insight_normalizes_whitespace() {
     assert_eq!(hash1, hash2, "extra whitespace should be normalized");
     assert_eq!(hash1, hash3, "newlines should be normalized");
     assert_eq!(hash1, hash4, "case should be normalized");
+}
+
+fn make_test_state(
+    repo_name: &str,
+) -> (
+    DaemonState,
+    tempfile::TempDir,
+    crate::paths::TestMidtownBaseDirGuard,
+) {
+    let midtown_dir = tempfile::tempdir().expect("midtown temp dir");
+    let _guard = crate::paths::set_test_midtown_base_dir(midtown_dir.path().to_path_buf());
+
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    Command::new("git")
+        .args(["init"])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("git init");
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("git config");
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("git config");
+    Command::new("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("git commit");
+
+    let wm = crate::worktree::WorktreeManager::new(temp_dir.path().to_path_buf())
+        .expect("worktree manager");
+    let cm = crate::coworker::CoworkerManager::new(wm);
+
+    let base_dir = temp_dir.path().to_path_buf();
+    let channel_router = crate::ChannelRouter::new(&base_dir, "midtown");
+    let (shutdown_tx, _) = tokio::sync::broadcast::channel::<()>(1);
+    let state = DaemonState::new(
+        "/tmp/test.sock".into(),
+        cm,
+        repo_name.to_string(),
+        vec![base_dir],
+        channel_router,
+        None,
+        10,
+        None,
+        "main".to_string(),
+        shutdown_tx,
+    )
+    .expect("daemon state");
+    (state, temp_dir, _guard)
+}
+
+/// Posting an insight to the main channel should succeed without attempting to
+/// nudge a channel lead (there is none for the main channel).
+#[tokio::test]
+async fn test_insight_main_channel_posts_successfully() {
+    let (state, _temp_dir, _guard) = make_test_state("testrepo");
+
+    let response = handle_insight_report(
+        RequestId::Number(1),
+        "coworker1",
+        "An insight",
+        None,
+        &state,
+    )
+    .await;
+
+    let result = response.result.expect("should return success result");
+    assert_eq!(result["posted"], true);
+}
+
+/// Posting an insight to a topic channel should succeed even when no channel
+/// lead session is active — the nudge is skipped gracefully.
+#[tokio::test]
+async fn test_insight_topic_channel_skips_nudge_when_no_session() {
+    let (state, _temp_dir, _guard) = make_test_state("testrepo");
+
+    let response = handle_insight_report(
+        RequestId::Number(2),
+        "coworker1",
+        "Topic insight",
+        Some("my-topic"),
+        &state,
+    )
+    .await;
+
+    // Should succeed — nudge is silently skipped when channel lead isn't running.
+    let result = response.result.expect("should return success result");
+    assert_eq!(result["posted"], true);
+}
+
+/// Duplicate insights should be deduplicated and return posted=false.
+#[tokio::test]
+async fn test_insight_deduplication() {
+    let (state, _temp_dir, _guard) = make_test_state("testrepo");
+
+    let first = handle_insight_report(
+        RequestId::Number(1),
+        "coworker1",
+        "Unique insight text",
+        None,
+        &state,
+    )
+    .await;
+    assert_eq!(first.result.unwrap()["posted"], true);
+
+    let second = handle_insight_report(
+        RequestId::Number(2),
+        "coworker1",
+        "Unique insight text",
+        None,
+        &state,
+    )
+    .await;
+    let second_result = second.result.unwrap();
+    assert_eq!(second_result["posted"], false);
+    assert_eq!(second_result["reason"], "duplicate");
 }


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary

- After an insight (💡) is posted to a topic channel, the daemon nudges the channel lead session (if it's alive) with the insight text and message ID
- Channel leads can then reply in the thread with additional context using `--thread <message-id>`
- Updates `agents/channel-lead.md` with instructions for responding to insight nudges via threads
- Main channel insights are skipped (no channel lead for main)
- Nudge is silently skipped if the channel lead session isn't running

## Implementation

In `rpc_insight.rs::handle_insight_report`, after successfully posting the insight to the channel:
1. Checks if the channel is a topic channel (not the main channel)
2. Looks up the channel lead session name via `launch::channel_lead_session_name(channel_name)`
3. If the session is alive, sends a nudge with the insight content and message ID for threading

## Test plan

- [x] `test_insight_main_channel_posts_successfully` — main channel returns `posted: true`, no nudge attempted
- [x] `test_insight_topic_channel_skips_nudge_when_no_session` — topic channel succeeds gracefully when channel lead isn't running
- [x] `test_insight_deduplication` — duplicate insights are rejected
- [x] All 1697 lib tests pass
- [x] `cargo clippy -- -D warnings` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)