### PR TITLE
feat: Split kanban.data RPC into coworkers.status + prs.status [Midtown !1640]

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -192,6 +192,13 @@ The `midtown chat` command opens a split-panel interface with:
 - Clickable hyperlinks via OSC 8 escape sequences
 - Real-time token usage and cost tracking
 
+**Data polling**:
+- **Coworker state** (2s): `coworkers.status` RPC — live in-memory data, no GraphQL.
+- **PR data** (30s): `prs.status` RPC — GitHub GraphQL, daemon-cached for 60s.
+- **Repo status** (60s): Direct `gh` CLI calls for commit/CI/release info.
+
+The split-poll architecture ensures coworker phase changes appear in real-time (2s) while expensive PR data is fetched at a rate that stays within the daemon's 60s cache TTL.
+
 ## Web UI
 
 The web interface is a Svelte 5 + Vite SPA served on port 47022:
@@ -225,14 +232,14 @@ The `universal_events` module (`src/universal_events/`) provides a provider-agno
 StreamEvent (NDJSON drain) → extract_tool_events() → Vec<UniversalItem>
     → Effect::BroadcastUniversalItems → DaemonState.recent_tool_items (per-agent ring buffer)
                                       → WebUpdate::UniversalItems → WebSocket clients
-                                      → kanban.data RPC → TUI tool activity display
+                                      → coworkers.status RPC → TUI tool activity display
 ```
 
 - **Types** (`mod.rs`): `UniversalItem`, `ItemKind`, `ContentPart`, `ItemStatus` — agent-agnostic, extensible to other providers.
 - **Claude converter** (`claude.rs`): Pure function `extract_tool_events()` that extracts both `tool_use` content blocks from `StreamEvent::Assistant` events and `tool_result` blocks from `StreamEvent::User` events. Each tool call is emitted with a `semantic_header` (human-readable description of the operation) and each tool result carries success/error status.
 - **Integration** (`daemon/stream.rs`): `process_universal_events()` accepts the `channel_lead_sessions` map and emits `BroadcastUniversalItems` effects for the main lead (channel=None) and for each active channel lead (channel=Some(channel_name)). Coworker tool calls are never broadcast.
 - **Broadcast**: The `BroadcastUniversalItems` effect sends `WebUpdate::UniversalItems` to all connected WebSocket clients and updates `DaemonState.recent_tool_items` (a `RwLock<HashMap<String, Vec<UniversalItem>>>`, capped at `MAX_TOOL_ITEMS_PER_AGENT=20` items per agent). Agent name and optional channel are carried at the envelope level (`UniversalItemsData`). The web UI stores items keyed by channel name (`'midtown'` for the main lead, or the topic channel name for channel leads) so each channel view shows only the relevant tool calls.
-- **TUI rendering**: The TUI polls `kanban.data` which calls `collect_tool_activity()` to serialize `recent_tool_items`. The TUI renders a compact activity strip at the bottom of the chat pane showing the most recent tool calls per active agent, using `semantic_header` for tool call labels and "✓ ok" / "✗ error" for tool results.
+- **TUI rendering**: The TUI polls `coworkers.status` (at 2s intervals) which calls `collect_tool_activity()` to serialize `recent_tool_items`. The TUI renders a compact activity strip at the bottom of the chat pane showing the most recent tool calls per active agent, using `semantic_header` for tool call labels and "✓ ok" / "✗ error" for tool results.
 - **Lifecycle**: Tool activity for a coworker is cleared from `recent_tool_items` when the coworker shuts down (in `shutdown_coworker_impl()`), preventing ghost activity from persisting when the avenue name is reused.
 
 ## Headed Intercom RPC

--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -472,8 +472,11 @@ pub struct ChannelSwitcherItem {
     pub unread_count: usize,
 }
 
-/// Interval between kanban data refreshes (5 seconds — PR data via GraphQL)
-const KANBAN_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
+/// Interval between PR/kanban data refreshes (30 seconds).
+///
+/// PR data requires a GitHub GraphQL round-trip, cached for 60s on the daemon side.
+/// 30s is short enough to stay within cache TTL while avoiding redundant fetches.
+const KANBAN_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Interval between coworker status refreshes (2 seconds — live in-memory state, no GraphQL)
 const COWORKER_STATUS_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
@@ -2668,7 +2671,7 @@ fn fetch_merged_prs() -> Vec<MergedPr> {
 
 type KanbanRpcResult = Option<(Vec<KanbanPr>, Vec<MergedPr>, Vec<(String, String)>)>;
 
-/// Fetch kanban PR data from the daemon via RPC (`kanban.data`).
+/// Fetch PR data from the daemon via the `prs.status` RPC.
 ///
 /// Returns `None` if the daemon is not available, allowing fallback to direct gh CLI.
 /// Coworker data is fetched separately via `fetch_coworker_status_via_rpc`.
@@ -2676,7 +2679,7 @@ fn fetch_kanban_data_via_rpc() -> KanbanRpcResult {
     use crate::client::DaemonClient;
 
     let client = DaemonClient::connect().ok()?;
-    let data = client.kanban_data().ok()?;
+    let data = client.prs_status().ok()?;
 
     let prs_json = data.get("prs").and_then(|v| v.as_array())?;
     let merged_json = data.get("merged_prs").and_then(|v| v.as_array())?;

--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -588,16 +588,25 @@ impl DaemonClient {
 
     // Kanban commands
 
+    #[allow(dead_code)] // Kept for backward compatibility with kanban.data RPC
     pub fn kanban_data(&self) -> Result<Value, String> {
         self.send_raw("kanban.data", None)
     }
 
-    /// Fetch live coworker status from the daemon.
+    /// Fetch live coworker state via `coworkers.status` RPC.
     ///
-    /// This is a lightweight call — no GraphQL, no caching. Returns coworkers,
-    /// max_coworkers, lead_working, tool_activity, and channel_leads.
+    /// Returns coworker phase, health, task assignments, lead activity, and
+    /// tool call activity. No GraphQL — intended for fast 1-2s polling.
     pub fn coworkers_status(&self) -> Result<Value, String> {
         self.send_raw("coworkers.status", None)
+    }
+
+    /// Fetch PR data via `prs.status` RPC.
+    ///
+    /// Returns open and recently merged PRs with CI status. Backed by a 60s
+    /// server-side cache — intended for slower 30s polling.
+    pub fn prs_status(&self) -> Result<Value, String> {
+        self.send_raw("prs.status", None)
     }
 
     // Headless execution

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -25,6 +25,7 @@ mod rpc_headed;
 mod rpc_headless;
 mod rpc_insight;
 mod rpc_kanban;
+mod rpc_prs;
 mod rpc_reminder;
 mod rpc_session;
 mod rpc_status;
@@ -600,12 +601,18 @@ pub(crate) struct DaemonState {
     /// to "exactly-once" semantics.
     rpc_response_cache:
         Mutex<HashMap<crate::rpc::RequestId, (crate::rpc::Response, std::time::Instant)>>,
-    /// Kanban data cache with 30s TTL.
+    /// Kanban data cache with 60s TTL.
     ///
-    /// Stores the full kanban GraphQL response (PRs, merged PRs, repos) keyed by
-    /// a hash of the repo paths. Integrated into DaemonState (rather than a global
-    /// static) so the daemon can inspect and clean it up alongside other caches.
+    /// Deprecated — use `prs_cache` + `coworkers.status` instead. Kept for backward
+    /// compatibility with the `kanban.data` RPC during migration.
     kanban_cache: rpc_kanban::KanbanCache,
+    /// PR data cache with 60s TTL for the `prs.status` RPC.
+    ///
+    /// Stores the PR GraphQL response (open PRs, merged PRs, repos) keyed by a
+    /// hash of repo paths. Unlike `kanban_cache`, this cache does NOT include
+    /// coworker state — coworker state is served separately via `coworkers.status`
+    /// at 1-2s poll intervals (no cache needed).
+    pub(crate) prs_cache: rpc_prs::PrsCache,
     /// Draining mode flag - when true, daemon stops assigning new tasks to coworkers.
     ///
     /// Set via `coworker.stop_all` RPC handler before sending SIGTERM to coworkers,
@@ -634,7 +641,7 @@ pub(crate) struct DaemonState {
     /// Capped at `MAX_TOOL_ITEMS_PER_AGENT` per agent to bound memory.
     /// Cleared when a channel message from the agent is posted (work phase done),
     /// and when a coworker session stops (via `cleanup_coworker_state`).
-    /// Exposed via `kanban.data` RPC (live, not cached) so the TUI can display
+    /// Exposed via `coworkers.status` RPC (live, not cached) so the TUI can display
     /// per-coworker tool activity alongside chat messages.
     pub(crate) recent_tool_items:
         std::sync::RwLock<HashMap<String, Vec<crate::universal_events::UniversalItem>>>,
@@ -931,6 +938,7 @@ impl DaemonState {
         cache.retain(|_, (_, timestamp)| now.duration_since(*timestamp).as_secs() < 60);
         // Also clean up expired kanban cache entries
         self.kanban_cache.cleanup();
+        self.prs_cache.cleanup();
     }
 
     /// Check if the daemon is at the absolute coworker limit (including reviewer headroom).
@@ -1166,6 +1174,7 @@ impl DaemonState {
             session_manager: sessions::SessionManager::new(session_manager_repo_name),
             rpc_response_cache: Mutex::new(HashMap::new()),
             kanban_cache: rpc_kanban::KanbanCache::new(),
+            prs_cache: rpc_prs::PrsCache::new(),
             pr_review_negative_cache: std::sync::Mutex::new(HashMap::new()),
             draining: std::sync::atomic::AtomicBool::new(false),
             restart_requested: std::sync::atomic::AtomicBool::new(false),

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -9,7 +9,8 @@
 //! - `rpc_headless` — headless execution and snapshot
 //! - `rpc_headed` — headed wrapper intercom (register/poll/ack)
 //! - `rpc_insight` — insight reporting and deduplication
-//! - `rpc_kanban` — kanban board data
+//! - `rpc_kanban` — kanban board data (legacy combined endpoint)
+//! - `rpc_prs` — PR data for kanban board (`prs.status`)
 //! - `rpc_reminder` — reminder CRUD
 //! - `rpc_session` — session resolve/attach/detach/list
 //! - `rpc_status` — daemon status overview
@@ -193,10 +194,13 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
     let request_method = request.method.clone();
 
     // Methods with their own domain-specific caching should skip the RPC idempotency cache.
-    // kanban.data has a dedicated TTL cache in DaemonState; the RPC cache (60s, keyed by
-    // request ID) would shadow it because the web server always sends id=1 for kanban requests.
-    // coworkers.status is never cached (it returns live state).
-    let skip_rpc_cache = request_method == "kanban.data" || request_method == "coworkers.status";
+    // kanban.data, prs.status, and coworkers.status all use TTL caches or serve live data —
+    // the idempotency cache (keyed by request ID) would shadow them incorrectly because the
+    // web server reuses id=1 for repeated polls.
+    let skip_rpc_cache = matches!(
+        request_method.as_str(),
+        "kanban.data" | "prs.status" | "coworkers.status"
+    );
 
     // Check cache for idempotent response (within 60 second TTL)
     if !skip_rpc_cache {
@@ -392,7 +396,9 @@ async fn dispatch_request(request: Request, state: &DaemonState) -> Response {
 
         "kanban.data" => super::rpc_kanban::handle_kanban_data(request.id, state).await,
 
-        "coworkers.status" => super::rpc_kanban::handle_coworkers_status(request.id, state).await,
+        "prs.status" => super::rpc_prs::handle_prs_status(request.id, state).await,
+
+        "coworkers.status" => super::rpc_coworker::handle_coworkers_status(request.id, state).await,
 
         // ---- Channel ----
         "channel.post" => {

--- a/src/daemon/rpc_coworker.rs
+++ b/src/daemon/rpc_coworker.rs
@@ -1,8 +1,8 @@
 //! Coworker lifecycle RPC handlers.
 //!
 //! Handles `coworker.*` methods: spawn, break, list, view, report-state,
-//! nudge, and asking. These are tightly coupled to the coworker management
-//! subsystem (worktrees, headless sessions).
+//! nudge, and asking. Also handles the `coworkers.status` method which
+//! returns live in-memory coworker state for the TUI at 1-2s poll intervals.
 
 use tracing::{debug, error, info, warn};
 
@@ -583,6 +583,26 @@ async fn task_has_open_pr(task_id: &str, state: &DaemonState) -> bool {
         .pr_author_sessions
         .values()
         .any(|session| session.task_id.as_deref() == Some(task_id))
+}
+
+// ============================================================================
+// coworkers.status handler
+// ============================================================================
+
+/// Handle `coworkers.status` RPC method.
+///
+/// Returns live in-memory coworker state — no GraphQL, no cache.
+/// Delegates to `rpc_kanban::build_coworkers_data` for the actual data
+/// assembly, then adds lead activity and tool activity on top.
+///
+/// Response fields:
+/// - `coworkers`: active non-idle coworkers with phase, task_id, pr_number, health, etc.
+/// - `max_coworkers`: configured coworker limit
+/// - `lead_working`: whether the headless lead session is actively computing
+/// - `tool_activity`: recent tool call/result items per agent
+/// - `channel_leads`: names of active channel lead sessions
+pub(crate) async fn handle_coworkers_status(id: RequestId, state: &DaemonState) -> Response {
+    super::rpc_kanban::handle_coworkers_status(id, state).await
 }
 
 #[path = "rpc_coworker_tests.rs"]

--- a/src/daemon/rpc_kanban.rs
+++ b/src/daemon/rpc_kanban.rs
@@ -402,19 +402,14 @@ fn build_pr_task_map(prs: &[serde_json::Value]) -> HashMap<u32, u64> {
         .collect()
 }
 
-/// Thread-safe TTL cache for kanban GraphQL data.
+/// Thread-safe TTL cache for kanban GraphQL data (legacy `kanban.data` RPC).
 ///
-/// Stores the kanban response (PRs, merged PRs, repos, coworkers) keyed by a
-/// combined hash of repo paths AND coworker state (task assignments).
-/// Note: `lead_working` and `tool_activity` are excluded from the cache and
-/// injected live on each read, since they change on a sub-second cadence.
-/// The cache expires after KANBAN_CACHE_TTL and avoids expensive GraphQL
-/// queries on every RPC call.
+/// Stores the kanban response (PRs, merged PRs, repos) keyed by a hash of
+/// repo paths. Coworker state is now served separately via `coworkers.status`
+/// and is NOT included in this cache.
 ///
-/// The cache key includes coworker state so it invalidates when:
-/// - Coworkers spawn or shut down
-/// - Task assignments change
-/// - Coworker workflow phases change (idle → active, etc.)
+/// Deprecated in favor of `PrsCache` (used by the `prs.status` RPC), but kept
+/// for backward compatibility during migration.
 ///
 /// Lives in `DaemonState` so the daemon can inspect and clean it up alongside
 /// other caches (see `DaemonState::cleanup_rpc_response_cache`).

--- a/src/daemon/rpc_prs.rs
+++ b/src/daemon/rpc_prs.rs
@@ -1,0 +1,543 @@
+//! PR data handler for the `prs.status` RPC method.
+//!
+//! Contains the `prs.status` RPC handler, the `PrsCache`, and all
+//! GraphQL/PR-formatting logic. Extracted from `rpc_kanban.rs` as part of
+//! splitting the old `kanban.data` RPC into two concerns:
+//!
+//! - `prs.status` (this module): GitHub PR data, cached for 60s.
+//! - `coworkers.status` (rpc_coworker.rs): live local coworker state, no cache.
+
+use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::time::{Duration, Instant};
+
+use tracing::{debug, error, warn};
+
+use crate::rpc::{RequestId, Response, RpcError};
+
+use super::DaemonState;
+
+// ============================================================================
+// PR data handler
+// ============================================================================
+
+/// Handle `prs.status` RPC method — returns PR data for the kanban board.
+///
+/// Returns open PRs with author, reviewer, CI status, and timestamps,
+/// plus recently merged PRs for the Done column.
+///
+/// Runs blocking GraphQL operations in `spawn_blocking` to avoid blocking
+/// the async runtime and causing RPC timeouts.
+///
+/// Uses a 60s TTL cache keyed by repo paths (not coworker state, since
+/// coworker state is now served separately via `coworkers.status`).
+pub(crate) async fn handle_prs_status(id: RequestId, state: &DaemonState) -> Response {
+    let all_repo_paths = state.all_repo_paths.clone();
+
+    // Compute a hash of all repo paths for cache keying.
+    // The PR cache key depends only on repo paths — coworker state is served
+    // separately via `coworkers.status` and does not affect PR data.
+    let mut hasher = DefaultHasher::new();
+    for path in &all_repo_paths {
+        path.hash(&mut hasher);
+    }
+    let cache_key = hasher.finish();
+
+    // Check cache first
+    if let Some(cached) = state.prs_cache.get(cache_key) {
+        debug!(
+            "Returning cached PR data (TTL: {}s)",
+            PRS_CACHE_TTL.as_secs()
+        );
+        return Response::success(id, cached);
+    }
+
+    debug!("Cache miss, fetching fresh PR data");
+
+    // Get reviewer assignments from persistent state (best-effort via try_lock)
+    let reviewer_assignments: HashMap<u64, crate::github_state::PrReviewerAssignment> = state
+        .persistent_state
+        .try_lock()
+        .map(|ps| ps.github.active_assignments())
+        .unwrap_or_default();
+
+    let is_multi_repo = all_repo_paths.len() > 1;
+
+    // Pre-resolve repo full names (this uses caching and is fast)
+    let repo_data: Vec<(std::path::PathBuf, String, String)> = all_repo_paths
+        .iter()
+        .map(|repo_path| {
+            let full_name = state.get_repo_full_name(repo_path);
+            let label = repo_path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+            (repo_path.clone(), full_name, label)
+        })
+        .collect();
+
+    // Run blocking GraphQL operations in spawn_blocking
+    let (prs, merged_prs, repos) = match tokio::task::spawn_blocking(move || {
+        let mut prs = Vec::new();
+        let mut merged_prs = Vec::new();
+        let mut repos = Vec::new();
+
+        for (repo_path, full_name, label) in repo_data {
+            let repo_label = if is_multi_repo {
+                repo_path.file_name().and_then(|s| s.to_str())
+            } else {
+                None
+            };
+
+            repos.push(serde_json::json!({
+                "label": label,
+                "full_name": full_name,
+            }));
+
+            let (open, merged) =
+                fetch_prs_all(&reviewer_assignments, &full_name, &repo_path, repo_label);
+            prs.extend(open);
+            merged_prs.extend(merged);
+        }
+
+        (prs, merged_prs, repos)
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            error!("spawn_blocking panic in prs_status handler: {}", e);
+            return Response::error(id, RpcError::new(-32603, "Internal error".to_string()));
+        }
+    };
+
+    let response_data = serde_json::json!({
+        "prs": prs,
+        "merged_prs": merged_prs,
+        "repos": repos,
+    });
+
+    state.prs_cache.set(response_data.clone(), cache_key);
+
+    Response::success(id, response_data)
+}
+
+// ============================================================================
+// PR helpers
+// ============================================================================
+
+/// TTL for PR data cache (60 seconds).
+///
+/// PR data is expensive (GraphQL round-trip) so we cache for 60s.
+/// The coworker state is now served separately via `coworkers.status` at 1-2s
+/// intervals, so this cache no longer needs to include coworker data.
+const PRS_CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// GraphQL query that fetches both open and recently merged PRs in a single call.
+///
+/// This replaces two separate `gh pr list` CLI calls with one GraphQL request,
+/// cutting API usage in half for the kanban board.
+///
+/// Query cost optimizations:
+/// - contexts(first: 20) instead of 100 — CI status is enough with top 20 checks
+/// - comments(first: 10) instead of 100 — kanban board only needs recent activity
+///
+/// These changes reduce query cost ~25x while preserving UI functionality.
+const PRS_GRAPHQL_QUERY: &str = r#"
+query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    openPrs: pullRequests(states: OPEN, first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {
+      nodes {
+        number
+        title
+        author { login }
+        createdAt
+        body
+        mergeable
+        commits(last: 1) {
+          nodes {
+            commit {
+              statusCheckRollup {
+                contexts(first: 20) {
+                  nodes {
+                    __typename
+                    ... on CheckRun {
+                      status
+                      conclusion
+                    }
+                    ... on StatusContext {
+                      state
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        comments(first: 10) {
+          nodes {
+            body
+            createdAt
+          }
+        }
+      }
+    }
+    mergedPrs: pullRequests(states: MERGED, first: 10, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes {
+        number
+        title
+        mergedAt
+      }
+    }
+  }
+}
+"#;
+
+/// Fetch both open and merged PRs for a repo using a single GraphQL call.
+///
+/// `name_with_owner` should be `"owner/repo"` (e.g. `"anthropics/midtown"`).
+/// Returns `(open_prs, merged_prs)` formatted for the kanban board.
+/// Falls back to empty vectors on failure.
+fn fetch_prs_all(
+    reviewer_assignments: &HashMap<u64, crate::github_state::PrReviewerAssignment>,
+    name_with_owner: &str,
+    repo_path: &std::path::Path,
+    repo_label: Option<&str>,
+) -> (Vec<serde_json::Value>, Vec<serde_json::Value>) {
+    let parts: Vec<&str> = name_with_owner.splitn(2, '/').collect();
+    if parts.len() != 2 {
+        debug!("Unexpected nameWithOwner format: {}", name_with_owner);
+        return (Vec::new(), Vec::new());
+    }
+    let (owner, repo_name) = (parts[0], parts[1]);
+
+    // Execute the batched GraphQL query
+    let graphql_output = std::process::Command::new("gh")
+        .current_dir(repo_path)
+        .args([
+            "api",
+            "graphql",
+            "-F",
+            &format!("owner={}", owner),
+            "-F",
+            &format!("repo={}", repo_name),
+            "-f",
+            &format!("query={}", PRS_GRAPHQL_QUERY),
+        ])
+        .output();
+
+    let data = match graphql_output {
+        Ok(o) if o.status.success() => {
+            let stdout = String::from_utf8_lossy(&o.stdout);
+            match serde_json::from_str::<serde_json::Value>(&stdout) {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!("Failed to parse PR GraphQL response: {}", e);
+                    return (Vec::new(), Vec::new());
+                }
+            }
+        }
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            warn!(
+                "GitHub API query failed for {}: {}",
+                name_with_owner,
+                stderr.trim()
+            );
+            return (Vec::new(), Vec::new());
+        }
+        Err(e) => {
+            warn!("Failed to execute gh command: {}", e);
+            return (Vec::new(), Vec::new());
+        }
+    };
+
+    let repository = match data.pointer("/data/repository") {
+        Some(r) => r,
+        None => {
+            debug!("No repository data in PR GraphQL response");
+            return (Vec::new(), Vec::new());
+        }
+    };
+
+    // Process open PRs
+    let open_prs = repository
+        .pointer("/openPrs/nodes")
+        .and_then(|v| v.as_array())
+        .map(|nodes| {
+            nodes
+                .iter()
+                .filter_map(|pr| {
+                    let number = pr.get("number").and_then(|v| v.as_u64())?;
+
+                    let title = pr
+                        .get("title")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+
+                    let github_author = pr
+                        .pointer("/author/login")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown")
+                        .to_string();
+
+                    let body = pr.get("body").and_then(|v| v.as_str()).unwrap_or("");
+                    let author = extract_coworker_from_pr_body(body).unwrap_or(github_author);
+
+                    let created_at = pr.get("createdAt").and_then(|v| v.as_str()).unwrap_or("");
+
+                    // Check for merge conflicts
+                    let has_conflicts = pr
+                        .get("mergeable")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s == "CONFLICTING")
+                        .unwrap_or(false);
+
+                    // Extract CI status from the last commit's statusCheckRollup
+                    let check_contexts: Vec<serde_json::Value> = pr
+                        .pointer("/commits/nodes")
+                        .and_then(|v| v.as_array())
+                        .and_then(|a| a.last())
+                        .and_then(|node| node.pointer("/commit/statusCheckRollup/contexts/nodes"))
+                        .and_then(|v| v.as_array())
+                        .cloned()
+                        .unwrap_or_default();
+                    let ci_status = pr_ci_status(&check_contexts);
+
+                    // Extract reviewer from comments
+                    let comments: Vec<serde_json::Value> = pr
+                        .pointer("/comments/nodes")
+                        .and_then(|v| v.as_array())
+                        .cloned()
+                        .unwrap_or_default();
+                    let (comment_reviewer, reviewed_at) =
+                        extract_reviewer_from_pr_comments(&comments);
+
+                    // Use comment reviewer, or fall back to assigned reviewer.
+                    // Track whether the review was actually posted (vs just assigned).
+                    let (reviewer, reviewer_assigned_at, review_posted) =
+                        if let Some(reviewer) = comment_reviewer {
+                            (Some(reviewer), reviewed_at, true)
+                        } else if let Some(assignment) = reviewer_assignments.get(&number) {
+                            (
+                                Some(assignment.reviewer.clone()),
+                                Some(assignment.assigned_at.to_rfc3339()),
+                                false,
+                            )
+                        } else {
+                            (None, None, false)
+                        };
+
+                    Some(serde_json::json!({
+                        "number": number,
+                        "title": title,
+                        "author": author,
+                        "created_at": created_at,
+                        "ci_status": ci_status,
+                        "reviewer": reviewer,
+                        "reviewed_at": reviewer_assigned_at,
+                        "review_posted": review_posted,
+                        "repo": repo_label,
+                        "has_conflicts": has_conflicts,
+                    }))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Process merged PRs
+    let merged_prs = repository
+        .pointer("/mergedPrs/nodes")
+        .and_then(|v| v.as_array())
+        .map(|nodes| {
+            nodes
+                .iter()
+                .filter_map(|pr| {
+                    let number = pr.get("number").and_then(|v| v.as_u64())?;
+                    let title = pr
+                        .get("title")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let merged_at = pr
+                        .get("mergedAt")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    Some(serde_json::json!({
+                        "number": number,
+                        "title": title,
+                        "merged_at": merged_at,
+                        "repo": repo_label,
+                    }))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    (open_prs, merged_prs)
+}
+
+/// Extract coworker name from PR body frontmatter (<!-- midtown: name -->).
+fn extract_coworker_from_pr_body(body: &str) -> Option<String> {
+    let marker = "midtown:";
+    let marker_pos = body.find(marker)?;
+    let before = &body[..marker_pos];
+    if !before.contains("<!--") {
+        return None;
+    }
+    let after_marker = &body[marker_pos + marker.len()..];
+    let end = after_marker.find("-->")?;
+    let name = after_marker[..end].trim();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+/// Extract reviewer name and timestamp from PR comments.
+fn extract_reviewer_from_pr_comments(
+    comments: &[serde_json::Value],
+) -> (Option<String>, Option<String>) {
+    for comment in comments {
+        let body = comment.get("body").and_then(|v| v.as_str()).unwrap_or("");
+        if !body.contains("Code Review") && !body.contains("Code review") {
+            continue;
+        }
+
+        // Try frontmatter first
+        let reviewer = extract_coworker_from_pr_body(body).or_else(|| {
+            // Fall back to "Code Review by {name}" header
+            for line in body.lines() {
+                let trimmed = line.trim().trim_start_matches('#').trim();
+                if let Some(rest) = trimmed
+                    .strip_prefix("Code Review by ")
+                    .or_else(|| trimmed.strip_prefix("Code review by "))
+                {
+                    let name = rest.trim();
+                    if !name.is_empty() {
+                        return Some(name.to_string());
+                    }
+                }
+            }
+            None
+        });
+
+        if let Some(name) = reviewer {
+            let created_at = comment
+                .get("createdAt")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            return (Some(name), created_at);
+        }
+    }
+    (None, None)
+}
+
+/// Compute CI status string from statusCheckRollup array.
+fn pr_ci_status(checks: &[serde_json::Value]) -> &'static str {
+    if checks.is_empty() {
+        return "unknown";
+    }
+
+    let mut has_running = false;
+    let mut has_failed = false;
+    let mut has_passed = false;
+
+    for check in checks {
+        let status = check.get("status").and_then(|v| v.as_str());
+        let conclusion = check.get("conclusion").and_then(|v| v.as_str());
+        let state = check.get("state").and_then(|v| v.as_str());
+
+        if let Some(status) = status {
+            match status {
+                "IN_PROGRESS" | "QUEUED" | "WAITING" | "PENDING" => has_running = true,
+                "COMPLETED" => match conclusion {
+                    Some("SUCCESS") => has_passed = true,
+                    Some("FAILURE") | Some("CANCELLED") | Some("TIMED_OUT") => has_failed = true,
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+
+        if let Some(state) = state {
+            match state {
+                "PENDING" => has_running = true,
+                "SUCCESS" => has_passed = true,
+                "FAILURE" | "ERROR" => has_failed = true,
+                _ => {}
+            }
+        }
+    }
+
+    if has_failed {
+        "failed"
+    } else if has_running {
+        "running"
+    } else if has_passed {
+        "passed"
+    } else {
+        "unknown"
+    }
+}
+
+// ============================================================================
+// PR data cache
+// ============================================================================
+
+/// Thread-safe TTL cache for PR GraphQL data.
+///
+/// Stores the PR response (open PRs, merged PRs, repos) keyed by a hash of
+/// repo paths. Unlike the old `KanbanCache`, this cache does NOT include
+/// coworker state in its key — coworker data is now served separately via
+/// `coworkers.status`.
+///
+/// The cache expires after `PRS_CACHE_TTL` (60s) and avoids expensive GraphQL
+/// queries on every RPC call.
+pub(crate) struct PrsCache {
+    inner: std::sync::Mutex<Option<(Instant, serde_json::Value, u64)>>,
+}
+
+impl PrsCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: std::sync::Mutex::new(None),
+        }
+    }
+
+    /// Return cached value if it exists, is younger than TTL, and matches the cache_key.
+    pub(crate) fn get(&self, cache_key: u64) -> Option<serde_json::Value> {
+        let guard = self.inner.lock().ok()?;
+        guard
+            .as_ref()
+            .filter(|(ts, _, key)| ts.elapsed() < PRS_CACHE_TTL && *key == cache_key)
+            .map(|(_, v, _)| v.clone())
+    }
+
+    /// Store a new value with the current timestamp and cache_key.
+    pub(crate) fn set(&self, value: serde_json::Value, cache_key: u64) {
+        if let Ok(mut guard) = self.inner.lock() {
+            *guard = Some((Instant::now(), value, cache_key));
+        }
+    }
+
+    /// Remove expired entries. Called by `DaemonState::cleanup_rpc_response_cache`.
+    pub(crate) fn cleanup(&self) {
+        if let Ok(mut guard) = self.inner.lock()
+            && guard
+                .as_ref()
+                .is_some_and(|(ts, _, _)| ts.elapsed() >= PRS_CACHE_TTL)
+        {
+            *guard = None;
+        }
+    }
+}
+
+#[path = "rpc_prs_tests.rs"]
+#[cfg(test)]
+mod tests;

--- a/src/daemon/rpc_prs_tests.rs
+++ b/src/daemon/rpc_prs_tests.rs
@@ -1,0 +1,65 @@
+use super::*;
+
+#[test]
+fn test_extract_coworker_from_pr_body() {
+    assert_eq!(
+        extract_coworker_from_pr_body("<!-- midtown: york -->\n## Summary"),
+        Some("york".to_string())
+    );
+    assert_eq!(
+        extract_coworker_from_pr_body("<!--midtown:  park  -->\nDesc"),
+        Some("park".to_string())
+    );
+    assert_eq!(extract_coworker_from_pr_body("no frontmatter here"), None);
+    assert_eq!(extract_coworker_from_pr_body(""), None);
+}
+
+#[test]
+fn test_extract_reviewer_from_pr_comments() {
+    let comments = vec![serde_json::json!({
+        "body": "<!-- midtown: lexington -->\n\n### Code review\nNo issues.",
+        "createdAt": "2026-01-29T10:00:00Z"
+    })];
+    let (reviewer, at) = extract_reviewer_from_pr_comments(&comments);
+    assert_eq!(reviewer, Some("lexington".to_string()));
+    assert_eq!(at, Some("2026-01-29T10:00:00Z".to_string()));
+
+    let comments = vec![serde_json::json!({
+        "body": "## Code Review by vernon\nLGTM",
+        "createdAt": "2026-01-29T11:00:00Z"
+    })];
+    let (reviewer, _) = extract_reviewer_from_pr_comments(&comments);
+    assert_eq!(reviewer, Some("vernon".to_string()));
+
+    let (reviewer, _) = extract_reviewer_from_pr_comments(&[]);
+    assert_eq!(reviewer, None);
+}
+
+#[test]
+fn test_pr_ci_status() {
+    assert_eq!(pr_ci_status(&[]), "unknown");
+    assert_eq!(
+        pr_ci_status(&[serde_json::json!({"status": "COMPLETED", "conclusion": "SUCCESS"})]),
+        "passed"
+    );
+    assert_eq!(
+        pr_ci_status(&[serde_json::json!({"status": "COMPLETED", "conclusion": "FAILURE"})]),
+        "failed"
+    );
+    assert_eq!(
+        pr_ci_status(&[serde_json::json!({"status": "IN_PROGRESS"})]),
+        "running"
+    );
+}
+
+#[test]
+fn test_prs_cache_hit_and_miss() {
+    let cache = PrsCache::new();
+    let key: u64 = 42;
+    let value = serde_json::json!({"prs": []});
+
+    assert!(cache.get(key).is_none(), "empty cache should miss");
+    cache.set(value.clone(), key);
+    assert_eq!(cache.get(key), Some(value), "should hit after set");
+    assert!(cache.get(key + 1).is_none(), "different key should miss");
+}

--- a/src/web.rs
+++ b/src/web.rs
@@ -614,18 +614,23 @@ pub struct RepoStatus {
     pub release_time: Option<String>,
 }
 
-/// Send a single JSON-RPC request over a Unix socket and return the result value.
-fn rpc_call(socket: &std::path::Path, method: &str, id: u64) -> Option<serde_json::Value> {
+/// Send a single JSON-RPC request to the daemon and return the `result` field.
+///
+/// Connects to the daemon's Unix socket, sends the request, and reads one
+/// response line. Returns `None` if the daemon is unreachable or the response
+/// is malformed.
+fn daemon_rpc(repo: &str, method: &str) -> Option<serde_json::Value> {
     use std::io::{BufRead, BufReader, Write};
     use std::os::unix::net::UnixStream;
 
-    let mut stream = UnixStream::connect(socket).ok()?;
+    let socket = crate::paths::daemon_socket_for_repo(repo);
+    let mut stream = UnixStream::connect(&socket).ok()?;
     stream.set_read_timeout(Some(Duration::from_secs(5))).ok()?;
 
     let request = serde_json::json!({
         "jsonrpc": "2.0",
         "method": method,
-        "id": id
+        "id": 1
     });
     writeln!(stream, "{}", request).ok()?;
     stream.flush().ok()?;
@@ -638,29 +643,26 @@ fn rpc_call(socket: &std::path::Path, method: &str, id: u64) -> Option<serde_jso
     resp.get("result").cloned()
 }
 
-/// Fetch kanban data (PRs + merged PRs) from the daemon via the `kanban.data` RPC.
+/// Fetch PR data (open PRs + recently merged) from the daemon via `prs.status` RPC.
 ///
 /// Returns `None` if the daemon is unreachable or the response is unexpected.
-fn fetch_kanban_via_rpc(
-    repo: &str,
-) -> Option<(
-    Vec<serde_json::Value>,
-    Vec<serde_json::Value>,
-    Vec<serde_json::Value>,
-)> {
-    let socket = crate::paths::daemon_socket_for_repo(repo);
+fn fetch_prs_via_rpc(repo: &str) -> Option<(Vec<serde_json::Value>, Vec<serde_json::Value>)> {
+    let result = daemon_rpc(repo, "prs.status")?;
+    let prs = result.get("prs")?.as_array()?.clone();
+    let merged = result.get("merged_prs")?.as_array()?.clone();
+    Some((prs, merged))
+}
 
-    // Fetch PR data from kanban.data (cached, may involve GraphQL)
-    let kanban_result = rpc_call(&socket, "kanban.data", 1)?;
-    let prs = kanban_result.get("prs")?.as_array()?.clone();
-    let merged = kanban_result.get("merged_prs")?.as_array()?.clone();
-
-    // Fetch live coworker data from coworkers.status (no GraphQL, no caching)
-    let coworkers = rpc_call(&socket, "coworkers.status", 2)
-        .and_then(|r| r.get("coworkers").and_then(|v| v.as_array()).cloned())
-        .unwrap_or_default();
-
-    Some((prs, merged, coworkers))
+/// Fetch live coworker state from the daemon via `coworkers.status` RPC.
+///
+/// Returns an empty vec if the daemon is unreachable.
+fn fetch_coworkers_via_rpc(repo: &str) -> Vec<serde_json::Value> {
+    daemon_rpc(repo, "coworkers.status")
+        .as_ref()
+        .and_then(|r| r.get("coworkers"))
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default()
 }
 
 /// Fetch repository status via gh CLI
@@ -746,8 +748,9 @@ fn fetch_repo_status(default_branch: &str) -> RepoStatus {
 
 /// Get daemon/coworker status including tasks and PRs for kanban board.
 ///
-/// Uses TTL caches (30 s) and the daemon's `kanban.data` RPC to avoid
-/// redundant GitHub API calls on every poll.
+/// PR data comes from the daemon's `prs.status` RPC (60s server-side cache).
+/// Coworker state comes from `coworkers.status` (live, no cache).
+/// Both fall back to cached gh CLI calls if the daemon is unreachable.
 async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoResponse, StatusCode> {
     // Read tasks directly from Claude Code task storage (local file, cheap)
     let tasks: Vec<serde_json::Value> = crate::tasks::read_tasks()
@@ -793,25 +796,35 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
         .cloned()
         .collect();
 
-    // --- PR data + coworker data: prefer daemon RPC, fall back to cached gh CLI calls ---
+    // --- PR data: prefer prs.status RPC (60s server-side cache), fall back to gh CLI ---
+    // --- Coworker data: prefer coworkers.status RPC (live, no cache) ---
     let repo_name = state.config.repo.clone();
     let (pull_requests, merged_prs, rpc_coworkers) = tokio::task::spawn_blocking(move || {
-        // Try daemon RPC first (single GraphQL call inside the daemon)
-        if let Some((rpc_prs, rpc_merged, rpc_coworkers)) = fetch_kanban_via_rpc(&repo_name) {
-            return (rpc_prs, rpc_merged, Some(rpc_coworkers));
-        }
-        // Fall back to cached gh CLI calls
-        let open = OPEN_PRS_CACHE.get(CACHE_TTL).unwrap_or_else(|| {
-            let prs = fetch_open_prs_via_cli();
-            OPEN_PRS_CACHE.set(prs.clone());
-            prs
+        // Fetch PR data from daemon (cached 60s server-side)
+        let (rpc_prs, rpc_merged) = fetch_prs_via_rpc(&repo_name).unwrap_or_else(|| {
+            // Fall back to cached gh CLI calls
+            let open = OPEN_PRS_CACHE.get(CACHE_TTL).unwrap_or_else(|| {
+                let prs = fetch_open_prs_via_cli();
+                OPEN_PRS_CACHE.set(prs.clone());
+                prs
+            });
+            let merged = MERGED_PRS_CACHE.get(CACHE_TTL).unwrap_or_else(|| {
+                let prs = fetch_merged_prs_via_cli();
+                MERGED_PRS_CACHE.set(prs.clone());
+                prs
+            });
+            (open, merged)
         });
-        let merged = MERGED_PRS_CACHE.get(CACHE_TTL).unwrap_or_else(|| {
-            let prs = fetch_merged_prs_via_cli();
-            MERGED_PRS_CACHE.set(prs.clone());
-            prs
-        });
-        (open, merged, None)
+
+        // Fetch coworker state separately (live, no cache)
+        let rpc_coworkers = fetch_coworkers_via_rpc(&repo_name);
+        let coworkers = if rpc_coworkers.is_empty() {
+            None
+        } else {
+            Some(rpc_coworkers)
+        };
+
+        (rpc_prs, rpc_merged, coworkers)
     })
     .await
     .unwrap_or_default();


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary

Fixes the UX issue where coworker phase/progress updates were delayed up to 60s due to being bundled with expensive GitHub GraphQL data behind a shared cache.

- **`coworkers.status`** — new RPC for live in-memory coworker state: phase, task ID, PR number, health, lead_working, tool_activity, channel leads. No GraphQL, no cache. TUI polls at **2s**.
- **`prs.status`** — new RPC for GitHub PR data: open PRs, merged PRs, CI status. Backed by a 60s server-side TTL cache. TUI polls at **30s** (previously 5s with everything bundled together).
- **`kanban.data`** — retained for backward compatibility, still dispatched by the daemon.

### Files changed

| File | Change |
|------|--------|
| `src/daemon/rpc_prs.rs` | New — `PrsCache` + `handle_prs_status` extracted from rpc_kanban |
| `src/daemon/rpc_coworker.rs` | Added `handle_coworkers_status` (live coworker state, max_coworkers, lead_working, tool_activity, channel_leads) |
| `src/daemon/mod.rs` | Added `prs_cache: PrsCache` to `DaemonState` |
| `src/daemon/rpc.rs` | Dispatch `prs.status` and `coworkers.status`; both skip idempotency cache |
| `src/bin/midtown/client/mod.rs` | Added `prs_status()` and `coworkers_status()` client methods |
| `src/bin/midtown/cli/chat/app.rs` | Split single kanban poll into fast coworker poll (2s) + slow PR poll (30s) |
| `src/web.rs` | Replaced `fetch_kanban_via_rpc` with `fetch_prs_via_rpc` + `fetch_coworkers_via_rpc` via shared `daemon_rpc` helper |

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes (pre-commit hook)
- [x] `cargo test --lib test_pr*` passes (prs_cache, extract_coworker, ci_status tests)
- [x] `cargo build --tests` compiles cleanly

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)