### PR TITLE
fix: Strip markdown fences from clusterer response before JSON parsing [Midtown !1657]

### DIFF
--- a/src/daemon/clusterer.rs
+++ b/src/daemon/clusterer.rs
@@ -77,6 +77,34 @@ pub struct CompletedTaskInfo {
 /// archive, and merge channels as part of its decision.
 pub type ClustererResponse = crate::clustering::ClusteringDiff;
 
+/// Strip markdown code fences from a model response.
+///
+/// Models sometimes wrap JSON output in triple-backtick fences, e.g.:
+/// ```json
+/// { ... }
+/// ```
+///
+/// This function returns the inner content when fences are present, or the
+/// original string otherwise.
+fn strip_markdown_fences(s: &str) -> &str {
+    let trimmed = s.trim();
+    // Match opening fence: ``` optionally followed by a language tag
+    let after_open = if let Some(rest) = trimmed.strip_prefix("```") {
+        // Skip optional language tag on the opening line
+        match rest.find('\n') {
+            Some(newline_pos) => &rest[newline_pos + 1..],
+            None => return s, // malformed — no newline after opening fence
+        }
+    } else {
+        return s;
+    };
+    // Strip the closing fence
+    match after_open.rfind("```") {
+        Some(close_pos) => after_open[..close_pos].trim(),
+        None => s, // no closing fence — return original
+    }
+}
+
 /// Clusterer role implementation.
 struct ClustererRole;
 
@@ -121,7 +149,8 @@ impl SpecializedRole for ClustererRole {
     }
 
     fn parse_response(&self, raw: &str) -> Result<Self::Response, String> {
-        serde_json::from_str(raw).map_err(|e| {
+        let stripped = strip_markdown_fences(raw);
+        serde_json::from_str(stripped).map_err(|e| {
             format!(
                 "Failed to parse clusterer response as JSON: {} (response: {})",
                 e, raw

--- a/src/daemon/clusterer_tests.rs
+++ b/src/daemon/clusterer_tests.rs
@@ -120,6 +120,34 @@ fn test_clusterer_role_basics() {
     assert!(err.is_err());
 }
 
+#[test]
+fn test_parse_response_strips_markdown_fences() {
+    let role = ClustererRole;
+
+    let fenced = "```json\n{\n    \"create_channels\": [],\n    \"archive_channels\": [],\n    \"merge_channels\": [],\n    \"assign_tasks\": [{\"task\": \"1234\", \"channel\": \"auth\"}]\n}\n```";
+    let response = role.parse_response(fenced);
+    assert!(
+        response.is_ok(),
+        "should strip markdown fences before parsing: {:?}",
+        response
+    );
+    assert_eq!(response.unwrap().assign_tasks[0].channel, "auth");
+}
+
+#[test]
+fn test_parse_response_strips_plain_backtick_fences() {
+    let role = ClustererRole;
+
+    let fenced = "```\n{\n    \"create_channels\": [],\n    \"archive_channels\": [],\n    \"merge_channels\": [],\n    \"assign_tasks\": [{\"task\": \"42\", \"channel\": \"midtown\"}]\n}\n```";
+    let response = role.parse_response(fenced);
+    assert!(
+        response.is_ok(),
+        "should strip plain backtick fences before parsing: {:?}",
+        response
+    );
+    assert_eq!(response.unwrap().assign_tasks[0].channel, "midtown");
+}
+
 // ============================================================================
 // Session failure tracking tests
 // ============================================================================


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Added `strip_markdown_fences()` helper that removes triple-backtick code fences (with optional language tag like `json`) from a string
- `ClustererRole::parse_response` now calls this helper before passing the content to `serde_json::from_str`
- Added two regression tests: one for ` ```json ` fences, one for plain ` ``` ` fences

## Root Cause
Haiku sometimes wraps its JSON output in markdown code fences:
```
```json
{ "create_channels": [], ... }
```
```
The raw response starts with a backtick, not `{`, so `serde_json` fails immediately with "expected value at line 1 column 1".

## Test Plan
- [x] `test_parse_response_strips_markdown_fences` — verifies ` ```json\n{...}\n``` ` is parsed correctly
- [x] `test_parse_response_strips_plain_backtick_fences` — verifies ` ```\n{...}\n``` ` is parsed correctly
- [x] All existing clusterer tests still pass (12/12)
- [x] `cargo clippy -- -D warnings` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)