### PR TITLE
fix: Wire check_and_restart_dead_reviewers into MultiTickHarness and mod.rs [Midtown !1656]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -76,9 +76,10 @@ pub use dispatch::{
 pub use events::DaemonEvent;
 #[doc(hidden)]
 pub use health::{
-    check_and_restart_stuck_reviewers, check_and_restart_tool_name_conflicts,
-    check_and_shutdown_idle_coworkers, check_for_usage_limits, detect_stale_attached_sessions,
-    ensure_channel_leads_alive, ensure_lead_alive, maybe_nudge_usage_limit_expiry,
+    check_and_restart_dead_reviewers, check_and_restart_stuck_reviewers,
+    check_and_restart_tool_name_conflicts, check_and_shutdown_idle_coworkers,
+    check_for_usage_limits, detect_stale_attached_sessions, ensure_channel_leads_alive,
+    ensure_lead_alive, maybe_nudge_usage_limit_expiry,
 };
 #[doc(hidden)]
 pub use pr::{collect_merged_pr_cleanup_effects, reconcile_orphaned_prs};

--- a/tests/multi_tick_harness.rs
+++ b/tests/multi_tick_harness.rs
@@ -53,8 +53,9 @@ use midtown::tasks::{Task, TaskStatus};
 ///
 /// ### SessionMonitorTick
 /// - Called: `check_and_shutdown_idle_coworkers`, `check_and_restart_stuck_reviewers`,
-///   `check_for_usage_limits`, `maybe_nudge_usage_limit_expiry`,
-///   `check_and_restart_tool_name_conflicts`, `ensure_channel_leads_alive`
+///   `check_and_restart_dead_reviewers`, `check_for_usage_limits`,
+///   `maybe_nudge_usage_limit_expiry`, `check_and_restart_tool_name_conflicts`,
+///   `ensure_channel_leads_alive`
 /// - Skipped (needs DaemonState): `check_and_handle_auth_errors`,
 ///   `check_and_restart_stuck_coworkers`, `check_and_nudge_api_errors`
 ///
@@ -277,6 +278,9 @@ impl MultiTickHarness {
                     &self.snapshot,
                 ));
                 effects.extend(midtown::daemon::check_and_restart_stuck_reviewers(
+                    &self.snapshot,
+                ));
+                effects.extend(midtown::daemon::check_and_restart_dead_reviewers(
                     &self.snapshot,
                 ));
                 effects.extend(midtown::daemon::check_for_usage_limits(&self.snapshot));


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

Follow-up to PR #1353 addressing two findings from Vernon's review that were merged unresolved:

- **`src/daemon/mod.rs`**: Add `check_and_restart_dead_reviewers` to the `pub use health::{...}` block so snapshot E2E tests can call it directly
- **`tests/multi_tick_harness.rs`**: Wire the function into the `SessionMonitorTick` handler after `check_and_restart_stuck_reviewers`, matching the call order in `events.rs`. Also update the doc comment.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (48 test suites, 0 failures)
- [x] Pre-commit hooks (clippy + fmt) pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)