### PR TITLE
fix: Remove premature truncation from TUI tool call display [Midtown !1661]

### DIFF
--- a/src/universal_events/claude.rs
+++ b/src/universal_events/claude.rs
@@ -15,9 +15,11 @@ mod tests;
 /// Inspects the tool name and input arguments to produce a concise,
 /// Pi-agent-style description of what the tool is doing.
 ///
-/// Headers are **not** truncated here — the TUI render layer (ratatui) clips
-/// lines at the actual terminal width, so pre-truncating with hardcoded limits
-/// would prevent the full text from reaching wide terminals.
+/// Headers are not aggressively truncated — the TUI render layer (ratatui)
+/// clips lines at the actual terminal width. However, headers are capped at
+/// [`MAX_SEMANTIC_HEADER_BYTES`] to bound RPC/WebSocket payload size, since
+/// these strings also flow through `collect_tool_activity()` and
+/// `BroadcastUniversalItems`.
 ///
 /// # Format table
 ///
@@ -38,7 +40,7 @@ mod tests;
 /// | `MultiEdit`  | `multi-edit <file_path>`       |
 /// | (default)    | lowercase tool name            |
 pub fn semantic_header(name: &str, input: &serde_json::Value) -> String {
-    match name {
+    let raw = match name {
         "Bash" => {
             let command = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
             format!("$ {command}")
@@ -92,6 +94,14 @@ pub fn semantic_header(name: &str, input: &serde_json::Value) -> String {
             format!("multi-edit {path}")
         }
         _ => name.to_lowercase(),
+    };
+
+    // Cap header size for RPC/WebSocket payloads (TUI uses ratatui clipping).
+    if raw.len() > MAX_SEMANTIC_HEADER_BYTES {
+        let boundary = raw.floor_char_boundary(MAX_SEMANTIC_HEADER_BYTES);
+        format!("{}\u{2026}", &raw[..boundary])
+    } else {
+        raw
     }
 }
 
@@ -249,6 +259,14 @@ pub fn extract_tool_events(
 
     items
 }
+
+/// Maximum bytes retained in a `semantic_header` string.
+///
+/// Matches the bounding strategy used by [`MAX_TOOL_RESULT_OUTPUT_BYTES`]:
+/// headers flow through RPC (`kanban.data`) and WebSocket broadcasts, so they
+/// need a size cap even though the TUI would clip them naturally. 256 bytes is
+/// generous enough for any practical terminal width.
+const MAX_SEMANTIC_HEADER_BYTES: usize = 256;
 
 /// Maximum bytes retained from a tool result's output string.
 ///

--- a/src/universal_events/claude_tests.rs
+++ b/src/universal_events/claude_tests.rs
@@ -141,6 +141,63 @@ fn test_semantic_header_read_uses_path_fallback() {
     assert_eq!(semantic_header("Read", &input), "read /some/path");
 }
 
+#[test]
+fn test_semantic_header_bash_extreme_length_is_bounded() {
+    // Very long commands must be capped for RPC/WebSocket payloads.
+    let long_cmd = "x".repeat(10_000);
+    let input = json!({"command": long_cmd});
+    let header = semantic_header("Bash", &input);
+    assert!(
+        header.len() <= MAX_SEMANTIC_HEADER_BYTES + "…".len(),
+        "header should be bounded to ~MAX_SEMANTIC_HEADER_BYTES, got {} bytes",
+        header.len()
+    );
+    assert!(
+        header.ends_with('…'),
+        "truncated header should end with ellipsis"
+    );
+}
+
+#[test]
+fn test_semantic_header_webfetch_fallback_extreme_length_is_bounded() {
+    // Malformed URLs where extract_url_host returns None should still be bounded.
+    let long_url = "not-a-url-".repeat(1000);
+    let input = json!({"url": long_url});
+    let header = semantic_header("WebFetch", &input);
+    assert!(
+        header.len() <= MAX_SEMANTIC_HEADER_BYTES + "…".len(),
+        "header should be bounded, got {} bytes",
+        header.len()
+    );
+}
+
+#[test]
+fn test_semantic_header_task_extreme_length_is_bounded() {
+    let long_desc = "y".repeat(10_000);
+    let input = json!({"description": long_desc});
+    let header = semantic_header("Task", &input);
+    assert!(
+        header.len() <= MAX_SEMANTIC_HEADER_BYTES + "…".len(),
+        "header should be bounded, got {} bytes",
+        header.len()
+    );
+}
+
+#[test]
+fn test_semantic_header_truncation_at_multibyte_boundary() {
+    // Build a Bash command where the 256-byte boundary falls inside a multi-byte char.
+    let prefix = "x".repeat(253); // "$ " prefix is 2 bytes → 255 bytes total before the arrow
+    let command = format!("{}→ more text", prefix); // → is 3 bytes at pos 255..258
+    let input = json!({"command": command});
+    let header = semantic_header("Bash", &input);
+    // Should not panic, and should be bounded.
+    assert!(
+        header.len() <= MAX_SEMANTIC_HEADER_BYTES + "…".len(),
+        "header should be bounded near MAX_SEMANTIC_HEADER_BYTES, got {} bytes",
+        header.len()
+    );
+}
+
 // ── extract_tool_events: tool call tests ─────────────────────────────
 
 #[test]


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary

- Tool call headers (Bash commands, Task descriptions) were truncated at hardcoded limits (60 and 40 chars) before reaching ratatui
- This caused them to appear cut off even on wide terminals where more text would fit
- Ratatui already clips lines at the actual terminal width naturally, making pre-truncation unnecessary
- Removes the hardcoded limits and the now-unused `truncate_chars` helper function

## Root Cause

`semantic_header()` in `src/universal_events/claude.rs` applied hardcoded character limits at event serialization time — before the TUI had any opportunity to use the terminal width. The `draw_lead_indicator` function already had a comment stating "Descriptions are not explicitly truncated — ratatui clips at the terminal edge naturally", but the upstream function was doing the truncation anyway.

## Test plan

- [x] Added `test_semantic_header_bash_no_premature_truncation`: verifies Bash commands >60 chars are preserved in full
- [x] Added `test_semantic_header_task_no_premature_truncation`: verifies Task descriptions >40 chars are preserved in full  
- [x] All existing semantic_header tests pass
- [x] clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)