### PR TITLE
test: regression test for thread reply accumulation bug #3 [Midtown !1662]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -3472,6 +3472,15 @@ pub(super) mod tests {
         }
     }
 
+    /// Like `test_app()` but with the given channel attached.
+    pub(crate) fn test_app_with_channel(channel: Channel) -> App {
+        App {
+            channel: Some(channel),
+            initial_load_done: true,
+            ..test_app()
+        }
+    }
+
     #[test]
     fn test_resize_sidebar_to_normal() {
         let mut app = test_app();
@@ -5035,77 +5044,6 @@ pub(super) mod tests {
         assert!(
             !app.channel_lead_thinking.contains_key("myproject"),
             "Thinking should be cleared when an InProgress tool entry exists"
-        );
-    }
-
-    /// Bug #3: Thread replies must not accumulate in `messages` or `thread_messages`
-    /// across multiple refresh cycles.
-    ///
-    /// Before the fix, thread replies stored with `thread_parent_id` were included
-    /// in `visible_messages()` without filtering. They appeared in the main channel
-    /// on every render — not just once at arrival, but on every subsequent refresh
-    /// cycle because the reply remained in `app.messages` and was rendered without
-    /// any filter. The fix adds a `thread_parent_id.is_none()` filter in
-    /// `draw_chat_messages()`, and the cursor-based reader ensures each reply is
-    /// only ingested once regardless of how many times `refresh()` is called.
-    #[test]
-    fn test_thread_replies_not_duplicated_across_refresh_cycles() {
-        use tempfile::TempDir;
-
-        let temp_dir = TempDir::new().unwrap();
-        let channel = Channel::new(temp_dir.path(), "test-channel").unwrap();
-
-        // Write a parent message and a thread reply to the channel file.
-        let parent = Message::text("alice", "parent message");
-        let parent_id = parent.id.clone();
-        let mut reply = Message::text("bob", "thread reply content");
-        reply.thread_parent_id = Some(parent_id.clone());
-        channel.send(&parent).unwrap();
-        channel.send(&reply).unwrap();
-
-        // Allow the write lock to be released before reading.
-        std::thread::sleep(Duration::from_millis(50));
-
-        // Create an App with the real channel. `test_app()` sets
-        // `initial_load_done: true` and `session_id: "test-session"`, so the
-        // first `refresh()` uses cursor-based reading starting at byte 0,
-        // which reads all pre-existing messages exactly once.
-        let mut app = App {
-            channel: Some(channel),
-            ..test_app()
-        };
-
-        // First refresh reads both parent and reply from the cursor.
-        app.refresh();
-        assert_eq!(
-            app.messages.len(),
-            2,
-            "Initial refresh must read parent + reply"
-        );
-
-        // Open the thread — open_thread() collects existing replies from messages.
-        app.open_thread(&parent_id);
-        assert_eq!(
-            app.thread_messages.len(),
-            1,
-            "Thread panel must show exactly 1 reply after open"
-        );
-
-        // Bug #3: subsequent refresh cycles must NOT re-add the reply.
-        // The cursor is now at EOF, so read_since_cursor returns nothing.
-        app.refresh();
-        app.refresh();
-        app.refresh();
-
-        assert_eq!(
-            app.messages.len(),
-            2,
-            "messages must not accumulate across refresh cycles (bug #3)"
-        );
-        assert_eq!(
-            app.thread_messages.len(),
-            1,
-            "thread_messages must not accumulate across refresh cycles (bug #3)"
         );
     }
 }

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -2762,3 +2762,7 @@ mod paste_tests;
 #[path = "thread_click_tests.rs"]
 #[cfg(test)]
 mod thread_click_tests;
+
+#[path = "thread_reply_tests.rs"]
+#[cfg(test)]
+mod thread_reply_tests;

--- a/src/bin/midtown/cli/chat/thread_reply_tests.rs
+++ b/src/bin/midtown/cli/chat/thread_reply_tests.rs
@@ -1,0 +1,83 @@
+use midtown::{Channel, Message};
+use tempfile::TempDir;
+
+use super::app::tests::test_app_with_channel;
+
+/// Bug #3: Thread replies must not accumulate in `messages` or `thread_messages`
+/// across multiple refresh cycles.
+///
+/// Before the fix, thread replies stored with `thread_parent_id` were included
+/// in the main channel view. The fix adds a `thread_parent_id.is_none()` filter
+/// in `draw_chat_messages()`. The cursor-based reader ensures each reply is
+/// only ingested once regardless of how many times `refresh()` is called.
+#[test]
+fn test_thread_replies_not_duplicated_across_refresh_cycles() {
+    let temp_dir = TempDir::new().unwrap();
+    let channel = Channel::new(temp_dir.path(), "test-channel").unwrap();
+
+    // Write a parent message and a first thread reply to the channel file.
+    let parent = Message::text("alice", "parent message");
+    let parent_id = parent.id.clone();
+    let mut reply1 = Message::text("bob", "first thread reply");
+    reply1.thread_parent_id = Some(parent_id.clone());
+    channel.send(&parent).unwrap();
+    channel.send(&reply1).unwrap();
+
+    // Create an App with the real channel. `test_app_with_channel()` sets
+    // `initial_load_done: true` and `session_id: "test-session"`, so the
+    // first `refresh()` uses cursor-based reading starting at byte 0,
+    // which reads all pre-existing messages exactly once.
+    let mut app = test_app_with_channel(channel.clone());
+
+    // First refresh reads both parent and reply from the cursor.
+    app.refresh();
+    assert_eq!(
+        app.messages.len(),
+        2,
+        "Initial refresh must read parent + reply1"
+    );
+
+    // Open the thread — open_thread() collects existing replies from messages.
+    app.open_thread(&parent_id);
+    assert_eq!(
+        app.thread_messages.len(),
+        1,
+        "Thread panel must show exactly 1 reply after open"
+    );
+
+    // Write a second thread reply AFTER the cursor is positioned at EOF.
+    // This exercises the live-message routing path in refresh().
+    let mut reply2 = Message::text("carol", "second thread reply");
+    reply2.thread_parent_id = Some(parent_id.clone());
+    channel.send(&reply2).unwrap();
+
+    // refresh() must route reply2 to thread_messages (thread is open) and
+    // also append it to messages — each exactly once.
+    app.refresh();
+    assert_eq!(
+        app.messages.len(),
+        3,
+        "After reply2 arrives: messages must contain parent + reply1 + reply2"
+    );
+    assert_eq!(
+        app.thread_messages.len(),
+        2,
+        "After reply2 arrives: thread_messages must contain reply1 + reply2"
+    );
+
+    // Bug #3: subsequent refresh cycles with no new messages must NOT
+    // re-add anything — the cursor is now at EOF.
+    app.refresh();
+    app.refresh();
+
+    assert_eq!(
+        app.messages.len(),
+        3,
+        "messages must not accumulate across refresh cycles (bug #3)"
+    );
+    assert_eq!(
+        app.thread_messages.len(),
+        2,
+        "thread_messages must not accumulate across refresh cycles (bug #3)"
+    );
+}


### PR DESCRIPTION
<!-- midtown: york -->

## Summary

- Adds `test_thread_replies_not_duplicated_across_refresh_cycles` to `cli::chat::app::tests`
- Verifies that calling `refresh()` multiple times does not accumulate thread replies in `app.messages` or `app.thread_messages`

## Background

Task !1662 covered three TUI thread panel bugs. Bugs 1 and 2 were fixed by coworker columbus in PR #1360. Bug 3 ("thread message repeatedly re-posted to main channel") shares the same root cause as bug 1 and was resolved by the same fix already merged on main.

The fix is: the cursor-based channel reader (`read_since_cursor`) ensures each message is only ingested once per session, and `draw_chat_messages()` filters out messages with `thread_parent_id` set so they never appear in the main channel view.

This PR adds a regression test that explicitly documents and protects that invariant at the data layer, without relying on UI rendering.

## Test plan

- [x] `cargo test -p midtown --bin midtown thread` — all 28 thread tests pass, including the new regression test
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)