### PR TITLE
fix: update E2E test to match @{project_name} nudge format

### DIFF
--- a/tests/daemon_e2e.rs
+++ b/tests/daemon_e2e.rs
@@ -361,6 +361,7 @@ fn test_headed_intercom_register_poll_ack() {
     );
 
     let unique_tag = format!("headed-intercom-{}", std::process::id());
+    let repo_name = fixture.repo_name.clone();
     let post = fixture.rpc_call(
         "channel.post",
         Some(serde_json::json!({
@@ -387,9 +388,9 @@ fn test_headed_intercom_register_poll_ack() {
         .expect("headed.poll messages should be an array");
     assert!(
         messages.iter().any(|m| {
-            m["text"]
-                .as_str()
-                .is_some_and(|s| s.contains("park mentioned @lead") && s.contains(&unique_tag))
+            m["text"].as_str().is_some_and(|s| {
+                s.contains(&format!("park mentioned @{}", repo_name)) && s.contains(&unique_tag)
+            })
         }),
         "Expected intercom nudge in headed.poll response, got: {:?}",
         messages


### PR DESCRIPTION
## Summary

- Fixes CI failure on PR #1368 (`test_headed_intercom_register_poll_ack`)
- The `585bef7` review-feedback commit changed the nudge format from `"park mentioned @lead: {}"` to `"park mentioned @{repo_name}: {}"` (consistent with the `@{project_name}` rename)
- The unit test in `rpc_channel_tests.rs` was correctly updated, but `test_headed_intercom_register_poll_ack` in `daemon_e2e.rs` still checked for the hardcoded `"park mentioned @lead"` string
- Fix: use `fixture.repo_name` to build the expected prefix dynamically

## Test plan
- [ ] CI passes on PR #1368 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)