### PR TITLE
fix: Keep TUI open after click-to-attach on task owner

### DIFF
--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -1059,8 +1059,7 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                         && let Some(owner) = task_owner
                     {
                         // Task has an owner - attach to their session
-                        attach_coworker_split(owner);
-                        return EventResult::Exit;
+                        return EventResult::AttachCoworker(owner.clone());
                     }
 
                     // Click in board area (but not on a task with owner) - focus it


### PR DESCRIPTION
## Summary

- When clicking a task with an owner in the sidebar, the TUI was exiting after opening the attach split pane (`EventResult::Exit` on line 1063)
- The keyboard-triggered attach paths (Ctrl+L, `AttachCoworker` event) correctly keep the TUI running
- Changed the click handler to return `EventResult::AttachCoworker(owner.clone())` instead of calling `attach_coworker_split()` directly and exiting
- One-line fix: consistent behavior between click and keyboard attach

## Test plan
- [ ] Click on a task with an active owner in the sidebar — split opens, TUI stays running
- [ ] Ctrl+L attach still works as before
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)