### PR TITLE
fix: Simplify channel sidebar headers and fix unread count tracking

### DIFF
--- a/src/bin/midtown/cli/chat/ui/board.rs
+++ b/src/bin/midtown/cli/chat/ui/board.rs
@@ -131,18 +131,6 @@ pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> (Vec<Hyperl
 
     let wrap_width = area.width.saturating_sub(2).max(20) as usize;
 
-    // Count active PRs per channel
-    let mut prs_by_channel: HashMap<String, Vec<&KanbanPr>> = HashMap::new();
-    for pr in &app.prs {
-        if let Some(task_id) = midtown::tasks::extract_task_id_from_pr_title(&pr.title) {
-            let task_id_str = task_id.to_string();
-            if let Some(task) = app.tasks.iter().find(|t| t.id == task_id_str) {
-                let channel_key = task.channel.as_deref().unwrap_or(main_channel).to_string();
-                prs_by_channel.entry(channel_key).or_default().push(pr);
-            }
-        }
-    }
-
     // Build task_line_map and channel_line_map before rendering (to avoid borrow conflicts)
     // task_line_map: maps line numbers to (task_id, owner) for click-to-attach
     // channel_line_map: maps line numbers to channel_name for click-to-select
@@ -203,7 +191,7 @@ pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> (Vec<Hyperl
 
     // Render each channel as a swimlane
     for (channel_name, tasks) in &channels_to_display {
-        render_channel_header(app, channel_name, tasks, &prs_by_channel, &mut lines);
+        render_channel_header(app, channel_name, &mut lines);
 
         let task_indentation = compute_task_indentation(tasks);
 
@@ -249,22 +237,12 @@ pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> (Vec<Hyperl
     (hyperlinks, tasks_area)
 }
 
-/// Render a channel header line with task count and unread count.
-fn render_channel_header(
-    app: &App,
-    channel_name: &str,
-    tasks: &[&KanbanTask],
-    _prs_by_channel: &HashMap<String, Vec<&KanbanPr>>,
-    lines: &mut Vec<Line<'static>>,
-) {
-    let task_count = tasks.len();
+/// Render a channel header line: `#channel-name` with optional `(X)` unread count.
+fn render_channel_header(app: &App, channel_name: &str, lines: &mut Vec<Line<'static>>) {
     let channel_header = if let Some(&unread_count) = app.channel_unread_counts.get(channel_name) {
-        format!(
-            "#{} ({}) — {} tasks",
-            channel_name, unread_count, task_count
-        )
+        format!("#{} ({})", channel_name, unread_count)
     } else {
-        format!("#{} — {} tasks", channel_name, task_count)
+        format!("#{}", channel_name)
     };
 
     let is_selected = app.board_selection.as_ref().is_some_and(|sel| match sel {

--- a/src/bin/midtown/cli/chat/ui/board_tests.rs
+++ b/src/bin/midtown/cli/chat/ui/board_tests.rs
@@ -51,6 +51,44 @@ fn test_task_line_map_registers_continuation_line_with_phase_label() {
     );
 }
 
+// --- render_channel_header tests ---
+
+#[test]
+fn test_channel_header_no_unread() {
+    let app = super::super::super::app::tests::test_app();
+    let mut lines = Vec::new();
+    render_channel_header(&app, "midtown", &mut lines);
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines[0].spans[0].content.as_ref(), "#midtown");
+}
+
+#[test]
+fn test_channel_header_with_unread() {
+    let mut app = super::super::super::app::tests::test_app();
+    app.channel_unread_counts.insert("auth".to_string(), 5);
+    let mut lines = Vec::new();
+    render_channel_header(&app, "auth", &mut lines);
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines[0].spans[0].content.as_ref(), "#auth (5)");
+}
+
+#[test]
+fn test_channel_header_no_task_count() {
+    // Task count should not appear in the header regardless of task presence
+    let app = super::super::super::app::tests::test_app();
+    let mut lines = Vec::new();
+    render_channel_header(&app, "tui", &mut lines);
+    let content = lines[0].spans[0].content.as_ref();
+    assert!(
+        !content.contains("tasks"),
+        "header should not mention tasks: {content}"
+    );
+    assert!(
+        !content.contains("—"),
+        "header should not contain separator: {content}"
+    );
+}
+
 // --- draw_ops_mini_channel tests ---
 
 #[test]

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -823,9 +823,15 @@ impl Channel {
     /// pick up new messages. For new sessions that should not replay
     /// historical messages, call this before the first `read_since_cursor`.
     pub fn set_cursor_to_end(&self, agent: &str, session_id: &str) -> Result<()> {
+        // Read the last message ID so that unread-count calculations
+        // (which key off last_message_id) correctly treat the channel as fully read.
+        let last_message_id = self
+            .read_last_n_messages(1)
+            .ok()
+            .and_then(|(msgs, _)| msgs.into_iter().next().map(|m| m.id));
         let mut cursor =
             Cursor::load_or_create(&self.base_dir, &self.channel_name, agent, session_id)?;
-        cursor.update(self.file_size(), None);
+        cursor.update(self.file_size(), last_message_id);
         cursor.save(&self.base_dir, &self.channel_name)?;
         Ok(())
     }

--- a/src/channel_tests.rs
+++ b/src/channel_tests.rs
@@ -190,6 +190,32 @@ fn test_cursor_reset() {
 }
 
 #[test]
+fn test_set_cursor_to_end_records_last_message_id() {
+    // Regression: set_cursor_to_end was passing None for last_message_id,
+    // causing refresh_unread_counts to treat the channel as fully unread.
+    let temp_dir = TempDir::new().unwrap();
+    let channel = Channel::new(temp_dir.path(), "midtown").unwrap();
+
+    let msg1 = Message::text("alice", "first");
+    let msg2 = Message::text("alice", "second");
+    let last_id = msg2.id.clone();
+    channel.send(&msg1).unwrap();
+    channel.send(&msg2).unwrap();
+
+    channel
+        .set_cursor_to_end("chat-tui", "test-session")
+        .unwrap();
+
+    let cursor =
+        Cursor::load_or_create(temp_dir.path(), "midtown", "chat-tui", "test-session").unwrap();
+    assert_eq!(
+        cursor.last_message_id,
+        Some(last_id),
+        "set_cursor_to_end must record the last message ID so unread counts reset to 0"
+    );
+}
+
+#[test]
 fn test_message_count() {
     let temp_dir = TempDir::new().unwrap();
     let channel = Channel::new(temp_dir.path(), "midtown").unwrap();


### PR DESCRIPTION
## Summary

- **Channel headers simplified**: sidebar now shows `#channel-name` and, only when there are unread messages, appends ` (X)` — removes the noisy `— X tasks` suffix entirely
- **Unread count bug fixed**: `set_cursor_to_end()` was passing `None` for `last_message_id`, causing `refresh_unread_counts()` to treat the channel as fully unread even after viewing it; now reads and stores the actual last message ID
- Removes unused `prs_by_channel` build (was passed to `render_channel_header` but never used)

## Test plan

- [ ] New unit tests for `render_channel_header`: no-unread format, with-unread format, no task count
- [ ] Regression test for `set_cursor_to_end` recording `last_message_id` (was failing before fix, passes after)
- [ ] All existing tests pass (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)