### PR TITLE
feat: Click any message line to open thread panel [Midtown !1670]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -416,6 +416,11 @@ pub struct App {
     /// Used for click-to-open on "↳ N replies" indicator lines.
     /// Line numbers are relative to the chat content area (inside borders).
     pub thread_reply_line_map: HashMap<u16, String>,
+    /// Mapping of chat message area line numbers to message IDs.
+    /// Maps every visible line of a top-level message to that message's ID.
+    /// Line numbers are relative to the chat content area (inside borders).
+    /// Updated on every full render pass (cache misses only).
+    pub message_line_map: HashMap<u16, String>,
     /// Sidebar width as a percentage of the total horizontal area (20–60).
     /// The rendered width is further capped at `MAX_SIDEBAR_WIDTH` columns.
     pub sidebar_width_pct: u16,
@@ -608,6 +613,7 @@ impl App {
             task_line_map: HashMap::new(),
             channel_line_map: HashMap::new(),
             thread_reply_line_map: HashMap::new(),
+            message_line_map: HashMap::new(),
             sidebar_width_pct: 40,
             divider_x: None,
             dragging_divider: false,
@@ -3505,6 +3511,7 @@ pub(super) mod tests {
             task_line_map: HashMap::new(),
             channel_line_map: HashMap::new(),
             thread_reply_line_map: HashMap::new(),
+            message_line_map: HashMap::new(),
             sidebar_width_pct: 40,
             divider_x: None,
             dragging_divider: false,

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -1017,13 +1017,19 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                     && y >= chat_rect.y
                     && y < chat_rect.y + chat_rect.height
                 {
-                    // Check if click is on a reply indicator line (inside chat content area)
+                    // Check if click landed on any message or reply-indicator line.
+                    // message_line_map covers every visible line of each top-level message body.
+                    // thread_reply_line_map covers "↳ N replies" indicator lines below messages.
                     if x > chat_rect.x
                         && x < chat_rect.x + chat_rect.width.saturating_sub(1)
                         && y > chat_rect.y
                         && y < chat_rect.y + chat_rect.height.saturating_sub(1)
                     {
                         let content_y = y.saturating_sub(chat_rect.y + 1);
+                        if let Some(msg_id) = app.message_line_map.get(&content_y).cloned() {
+                            app.open_thread(&msg_id);
+                            return EventResult::Continue;
+                        }
                         if let Some(parent_id) = app.thread_reply_line_map.get(&content_y).cloned()
                         {
                             app.open_thread(&parent_id);

--- a/src/bin/midtown/cli/chat/thread_click_tests.rs
+++ b/src/bin/midtown/cli/chat/thread_click_tests.rs
@@ -69,6 +69,69 @@ fn test_click_reply_indicator_opens_thread() {
     assert_eq!(app.thread_messages.len(), 1);
 }
 
+/// Clicking the body of any message (even one with no replies yet) opens the thread panel.
+///
+/// Before this feature, clicks only triggered on "↳ N replies" indicator lines.
+/// Now any click on a message's body lines opens that message's thread.
+#[test]
+fn test_click_message_body_opens_thread() {
+    let backend = TestBackend::new(120, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let mut app = test_app();
+
+    // A message with NO replies — thread_reply_line_map will be empty for this message,
+    // so the test verifies the new message_line_map path, not the old reply-indicator path.
+    let parent = midtown::Message::text("park", "Top-level message with no replies yet");
+    let parent_id = parent.id.clone();
+
+    app.messages = VecDeque::from(vec![parent]);
+    app.selected_channel = "midtown".to_string();
+
+    // Render once so message_line_map is populated.
+    terminal
+        .draw(|f| {
+            ui::draw(f, &mut app);
+        })
+        .unwrap();
+
+    assert!(
+        !app.message_line_map.is_empty(),
+        "message_line_map should be populated after render"
+    );
+    assert!(
+        app.thread_reply_line_map.is_empty(),
+        "thread_reply_line_map must be empty (message has no replies)"
+    );
+
+    let (line, mapped_id) = app
+        .message_line_map
+        .iter()
+        .next()
+        .map(|(line, id)| (*line, id.clone()))
+        .expect("expected at least one clickable message line");
+    assert_eq!(
+        mapped_id, parent_id,
+        "message_line_map must map to the parent message ID"
+    );
+
+    let chat_area = app
+        .chat_messages_area
+        .expect("chat_messages_area should be populated after render");
+
+    let click_x = chat_area.x + 8;
+    let click_y = chat_area.y + 1 + line;
+    let result = handle_event(&mut app, mouse_click(click_x, click_y));
+    assert!(matches!(result, EventResult::Continue));
+
+    assert_eq!(
+        app.thread_parent_id,
+        Some(parent_id),
+        "clicking a message body line must open that message's thread"
+    );
+    assert_eq!(app.focused_pane, app::FocusedPane::Thread);
+}
+
 /// Bug #1: Thread reply messages must not appear in the main channel chat area.
 ///
 /// When a message has `thread_parent_id` set, it is a reply in a thread and

--- a/src/bin/midtown/cli/chat/ui/chat.rs
+++ b/src/bin/midtown/cli/chat/ui/chat.rs
@@ -312,6 +312,9 @@ fn draw_chat_messages(f: &mut Frame, app: &mut App, area: Rect) {
 
     let mut lines: Vec<Line> = Vec::new();
     let mut reply_line_map: HashMap<usize, String> = HashMap::new();
+    // Tracks (start_line, end_line_exclusive, message_id) for each rendered message.
+    // Used to build message_line_map after scroll truncation.
+    let mut message_ranges: Vec<(usize, usize, String)> = Vec::new();
     let prev_sender: Option<&str> = None;
 
     let mut mermaid_to_render: Vec<String> = Vec::new();
@@ -328,6 +331,8 @@ fn draw_chat_messages(f: &mut Frame, app: &mut App, area: Rect) {
         } else {
             prev_sender
         };
+
+        let msg_start_line = lines.len();
 
         if !has_special {
             let msg_lines = render_message(
@@ -354,6 +359,8 @@ fn draw_chat_messages(f: &mut Frame, app: &mut App, area: Rect) {
                 &mut mermaid_to_render,
             );
         }
+
+        message_ranges.push((msg_start_line, lines.len(), msg.id.clone()));
 
         // Add reply indicator if this message has thread replies
         if let Some((count, last_from)) = thread_reply_counts.get(&msg.id) {
@@ -395,6 +402,21 @@ fn draw_chat_messages(f: &mut Frame, app: &mut App, area: Rect) {
             } else {
                 None
             }
+        })
+        .collect();
+
+    // Rebuild click map covering every visible line of each top-level message.
+    // This allows clicking anywhere on a message (not just reply indicators) to open its thread.
+    app.message_line_map = message_ranges
+        .into_iter()
+        .flat_map(|(start, end, id)| {
+            (start..end).filter_map(move |line_idx| {
+                if line_idx >= visible_start && line_idx < visible_start + visible_len {
+                    Some(((line_idx - visible_start) as u16, id.clone()))
+                } else {
+                    None
+                }
+            })
         })
         .collect();
 


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Adds `message_line_map: HashMap<u16, String>` to `App` struct, mapping every visible message body line to its message ID
- Built during `draw_chat_messages()` alongside the existing `thread_reply_line_map`, using the same render-time line map pattern
- Click handler now checks `message_line_map` first, with `thread_reply_line_map` as fallback for "↳ N replies" indicator lines
- Clicking any line of a message (body text, timestamp, sender name) opens the thread panel for that message

Previously, only the "↳ N replies" indicator line below a message was clickable. This was non-obvious UX — users now discover threads by clicking directly on message content.

## Test plan
- [x] New test `test_click_message_body_opens_thread`: verifies a message with no replies can be opened into a thread by clicking any body line (exercises `message_line_map` path exclusively)
- [x] Existing test `test_click_reply_indicator_opens_thread` still passes (reply indicator path still works)
- [x] All 5 thread click tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)