### PR TITLE
fix: Channel::archive() clear error when archived dir already exists [Midtown !1671]

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -585,6 +585,18 @@ impl Channel {
             .base_dir
             .join("channels")
             .join(format!("{}.archived", &self.channel_name));
+
+        if archived_dir.exists() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                format!(
+                    "An archived version of channel '{}' already exists",
+                    self.channel_name
+                ),
+            )
+            .into());
+        }
+
         fs::rename(&channel_dir, &archived_dir)?;
         Ok(())
     }

--- a/src/channel_tests.rs
+++ b/src/channel_tests.rs
@@ -879,6 +879,32 @@ fn test_both_active_and_archived_files_treats_channel_as_active() {
 }
 
 #[test]
+fn test_archive_fails_with_clear_error_when_archived_dir_already_exists() {
+    let temp_dir = TempDir::new().unwrap();
+
+    // Create a channel and archive it once successfully
+    let channel = Channel::new(temp_dir.path(), "test-channel").unwrap();
+    channel.archive().unwrap();
+
+    // Re-create the active channel directory so archive() has something to rename
+    Channel::new(temp_dir.path(), "test-channel").unwrap();
+
+    // Archiving again should fail with a clear AlreadyExists error, not an
+    // opaque OS-level "Directory not empty" error
+    let result = channel.archive();
+    assert!(
+        result.is_err(),
+        "archive() should fail when .archived dir exists"
+    );
+    let err = result.unwrap_err();
+    let err_str = err.to_string();
+    assert!(
+        err_str.contains("already exists"),
+        "Error should mention 'already exists', got: {err_str}"
+    );
+}
+
+#[test]
 fn test_midtown_channel_not_duplicated_with_legacy_and_channels_dir() {
     let temp_dir = TempDir::new().unwrap();
 


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- `Channel::archive()` previously failed with the cryptic OS error `"Directory not empty"` when a `<name>.archived/` directory already existed from a prior archive operation
- Added a pre-check that returns a clear `AlreadyExists` error: `"An archived version of channel '<name>' already exists"`
- Added a regression test in `src/channel_tests.rs`

## Root cause
On macOS, `rename(2)` on directories fails with `ENOTEMPTY` when the destination is a non-empty directory. `Channel::archive()` called `fs::rename` directly without checking whether the destination already existed.

## Test plan
- [x] New test `test_archive_fails_with_clear_error_when_archived_dir_already_exists` fails before the fix, passes after
- [x] All 27 archive-related tests pass (`cargo test archive`)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)