### PR TITLE
fix: Apply theme background to board sidebar panels

### DIFF
--- a/src/bin/midtown/cli/chat/ui/board.rs
+++ b/src/bin/midtown/cli/chat/ui/board.rs
@@ -220,7 +220,8 @@ pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> (Vec<Hyperl
     let block = Block::default()
         .borders(Borders::ALL)
         .title("Board")
-        .border_style(Style::default().fg(border_color));
+        .border_style(Style::default().fg(border_color))
+        .style(Style::default().bg(palette.bg));
 
     let paragraph = Paragraph::new(lines).block(block);
     f.render_widget(paragraph, tasks_area);
@@ -475,7 +476,8 @@ fn draw_ops_mini_channel(
     // Render the bordered container
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(palette.muted));
+        .border_style(Style::default().fg(palette.muted))
+        .style(Style::default().bg(palette.bg));
     f.render_widget(block, area);
 
     // Header: "MIDTOWN OPS" in dim style, inside the border
@@ -733,7 +735,7 @@ fn draw_coworker_status(f: &mut Frame, app: &mut App, area: Rect) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .style(Style::default().fg(palette.fg)),
+                .style(Style::default().fg(palette.fg).bg(palette.bg)),
         )
         .column_spacing(1);
 


### PR DESCRIPTION
## Summary

- The board panel, ops mini-channel, and coworker status table blocks were missing `.style(Style::default().bg(palette.bg))`, so the sidebar always rendered against the terminal's default background regardless of the active theme
- The chat panel already applied `palette.bg`; this brings the sidebar into parity
- Result: switching themes now visibly changes the sidebar background (e.g. Nord's dark blue-gray, Dracula's dark purple, Gruvbox's warm dark tone)

## Test plan

- [ ] Set `theme = "dracula"` in `~/.midtown/config.toml`, restart TUI — sidebar background should be dark purple
- [ ] Set `theme = "nord"` — sidebar background should be dark blue-gray
- [ ] Set `theme = "catppuccin-latte"` (light theme) — sidebar background should be light
- [ ] All existing tests pass (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)