### PR TITLE
fix: Exclude PR author from reviewer selection to prevent self-review [Midtown !1673]

### DIFF
--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -2350,9 +2350,16 @@ pub(crate) async fn collect_reviewer_effects_with_source(
             continue;
         }
 
+        // Also exclude the PR author from reviewer selection to prevent self-review.
+        // The author is identified by the branch prefix (e.g., "riverside" from "riverside/feature").
+        let mut excluded_names = channel_lead_names.clone();
+        if let Some(author) = coworker_from_branch_with_map(head_ref, branch_owners_map) {
+            excluded_names.insert(author);
+        }
+
         let reviewer_name = match state
             .coworkers
-            .next_available_name_excluding(&channel_lead_names)
+            .next_available_name_excluding(&excluded_names)
         {
             Some(name) => name,
             None => {

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -2238,3 +2238,94 @@ async fn test_resolve_pr_owner_via_session_preferred_name_fallback() {
         "Should fall back to preferred_name when current_name is None"
     );
 }
+
+/// Bug: Reviewer spawning selects the PR author's name as the reviewer, causing a coworker
+/// to review its own PR.
+///
+/// Root cause: `collect_reviewer_effects_with_source` calls `next_available_name_excluding`
+/// with only channel lead names excluded. When all other avenue names are in use, the PR
+/// author's name is the only available avenue name and gets selected as the reviewer.
+///
+/// Example: "riverside" opens PR, finishes task, goes idle. Next poll cycle finds PR needs
+/// review. All other avenue names are in use. "riverside" is the only available name →
+/// "riverside" is spawned to review its own PR.
+///
+/// Fix: Also exclude the PR author's name (extracted from the branch) from reviewer selection.
+#[tokio::test]
+async fn test_reviewer_not_assigned_to_pr_author() {
+    // PR whose branch identifies "riverside" as the author
+    let pr = json!({
+        "number": 9998,  // Non-existent PR — gh call fails gracefully → is_pr_reviewed returns false
+        "headRefName": "riverside/some-feature",
+        "title": "feat: Some feature [Midtown !100]",
+        "isDraft": false,
+        "createdAt": "2026-01-01T00:00:00Z",
+        "state": "OPEN",
+    });
+
+    let (state, _tmp, _guard) = make_test_state("midtown");
+
+    // Register all AVENUE_NAMES except "riverside" as active coworkers.
+    // This forces next_available_name_excluding to see "riverside" as the only
+    // available avenue name — reproducing the collision deterministically.
+    // (The function prefers avenue names over overflow names, so with all other
+    // avenue names in use, it would always pick "riverside" before the fix.)
+    for (i, name) in crate::coworker::AVENUE_NAMES
+        .iter()
+        .filter(|&&n| n != "riverside")
+        .enumerate()
+    {
+        state
+            .coworkers
+            .register(
+                &format!("slot-{i}"),
+                name,
+                "/tmp".to_string(),
+                None,
+                "claude-sonnet".to_string(),
+                crate::auth::AuthProvider::Claude,
+                "default".to_string(),
+            )
+            .unwrap();
+    }
+
+    let branch_owners: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let registry = crate::worktree_registry::WorktreeRegistry::new();
+    // "riverside" is active (it's the PR author), so the PR is not orphaned
+    let active_names: std::collections::HashSet<String> =
+        ["riverside".to_string()].into_iter().collect();
+
+    let effects = collect_reviewer_effects_with_source(
+        Some(&branch_owners),
+        &registry,
+        &active_names,
+        &state,
+        &[pr],
+        crate::github_state::AssignmentSource::PollingFallback,
+    )
+    .await;
+
+    // A reviewer should be spawned (overflow names are available) — assert there IS an assignment
+    let reviewer_name = effects.iter().find_map(|e| {
+        if let Effect::AssignReviewer { reviewer_name, .. } = e {
+            Some(reviewer_name.clone())
+        } else {
+            None
+        }
+    });
+
+    assert!(
+        reviewer_name.is_some(),
+        "Expected a reviewer to be assigned (overflow names are still available). \
+         Before fix: 'riverside' was incorrectly selected as reviewer for its own PR. \
+         After fix: an overflow name should be selected instead."
+    );
+
+    assert_ne!(
+        reviewer_name.unwrap().as_str(),
+        "riverside",
+        "PR author 'riverside' should NOT be assigned as reviewer for their own PR. \
+         Before fix: 'riverside' was the only available avenue name and was selected. \
+         After fix: the author's name is excluded from reviewer selection."
+    );
+}


### PR DESCRIPTION
<!-- midtown: york -->

## Summary

- The daemon could assign a reviewer with the same name as the PR author, causing a coworker to review its own PR
- Root cause: `next_available_name_excluding` only excluded channel lead names, not the PR author
- Fix: extract the PR author's name from the branch prefix and add it to the exclusion set before selecting a reviewer

## Changes

**`src/daemon/pr.rs`** — Before calling `next_available_name_excluding`, build a combined exclusion set from channel lead names + the PR author's name (extracted via `coworker_from_branch_with_map`).

**`src/daemon/pr_tests.rs`** — New test `test_reviewer_not_assigned_to_pr_author` that reproduces the bug deterministically: registers all avenue names except "riverside" as active coworkers, then asserts "riverside" is never selected as reviewer for its own PR.

## Reproduction scenario

1. "riverside" opens a PR and completes its task, going idle
2. All other avenue names are in use as active coworkers
3. Next polling cycle finds the PR needs review
4. `next_available_name_excluding` sees "riverside" as the only available avenue name
5. **Before fix:** "riverside" is spawned to review its own PR
6. **After fix:** an overflow name is used instead

## Test plan
- [x] `test_reviewer_not_assigned_to_pr_author` fails before fix, passes after
- [x] All 46 `daemon::pr` tests pass
- [x] Full test suite passes (`cargo test`)
- [x] `cargo clippy -- -D warnings` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)