### PR TITLE
fix: Block cursor overlays character instead of inserting before it

### DIFF
--- a/src/bin/midtown/cli/chat/ui/chat.rs
+++ b/src/bin/midtown/cli/chat/ui/chat.rs
@@ -488,20 +488,6 @@ fn draw_input_bar(f: &mut Frame, app: &App, area: Rect) {
 
     let prompt = "› ";
     let char_count = app.input_text.chars().count();
-    let text_with_cursor = if is_focused && app.input_cursor == char_count {
-        format!("{}█", app.input_text)
-    } else if is_focused {
-        let byte_idx = app
-            .input_text
-            .char_indices()
-            .nth(app.input_cursor)
-            .map(|(idx, _)| idx)
-            .unwrap_or(app.input_text.len());
-        let (before, after) = app.input_text.split_at(byte_idx);
-        format!("{}█{}", before, after)
-    } else {
-        app.input_text.clone()
-    };
 
     // Build the line with optional pending image indicator
     let mut spans: Vec<Span> = vec![Span::raw(prompt)];
@@ -520,7 +506,26 @@ fn draw_input_bar(f: &mut Frame, app: &App, area: Rect) {
                 .add_modifier(Modifier::DIM),
         ));
     }
-    spans.push(Span::raw(text_with_cursor));
+    let cursor_style = Style::default().fg(palette.bg).bg(palette.fg);
+    if is_focused && app.input_cursor == char_count {
+        spans.push(Span::raw(app.input_text.clone()));
+        spans.push(Span::styled("█", cursor_style));
+    } else if is_focused {
+        let byte_idx = app
+            .input_text
+            .char_indices()
+            .nth(app.input_cursor)
+            .map(|(idx, _)| idx)
+            .unwrap_or(app.input_text.len());
+        let (before, after_str) = app.input_text.split_at(byte_idx);
+        let cursor_char = after_str.chars().next().unwrap_or(' ');
+        let rest = &after_str[cursor_char.len_utf8()..];
+        spans.push(Span::raw(before.to_string()));
+        spans.push(Span::styled(cursor_char.to_string(), cursor_style));
+        spans.push(Span::raw(rest.to_string()));
+    } else {
+        spans.push(Span::raw(app.input_text.clone()));
+    }
 
     let paragraph = Paragraph::new(Line::from(spans)).wrap(Wrap { trim: false });
 

--- a/src/bin/midtown/cli/chat/ui/chat_tests.rs
+++ b/src/bin/midtown/cli/chat/ui/chat_tests.rs
@@ -1,8 +1,102 @@
-//! Tests for `draw_lead_indicator` rendering.
+//! Tests for `draw_lead_indicator` rendering and input bar cursor behavior.
 
 use super::super::super::app::ToolActivityEntry;
 use super::super::super::app::tests::test_app;
 use super::*;
+
+#[test]
+fn test_cursor_renders_over_character_not_before_it() {
+    // When cursor is in the middle of text, it should overlay the character
+    // at the cursor position (with highlighting), not insert '█' before it.
+    // Bug: previously the cursor block was inserted BEFORE the character,
+    // pushing subsequent characters one position to the right.
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::layout::Rect;
+    use ratatui::style::Color;
+
+    let backend = TestBackend::new(40, 3);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let mut app = test_app();
+    app.focused_pane = FocusedPane::InputBar;
+    app.input_text = "hello".to_string();
+    app.input_cursor = 2; // cursor on second 'l'
+
+    terminal
+        .draw(|f| {
+            let area = Rect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 3,
+            };
+            draw_input_bar(f, &app, area);
+        })
+        .unwrap();
+
+    let buffer = terminal.backend().buffer();
+    // Layout: x=1 (left border) + 2 (prompt "› ") = 3 for first char
+    // Cursor at position 2 => column 3 + 2 = 5
+    let cursor_cell = buffer.cell((5, 1)).unwrap();
+
+    assert_eq!(
+        cursor_cell.symbol(),
+        "l",
+        "Cursor position should show 'l' (the character under the cursor), not '█'. Got: {:?}",
+        cursor_cell.symbol()
+    );
+    assert_ne!(
+        cursor_cell.bg,
+        Color::Reset,
+        "Cursor position should have a background color to highlight the cursor"
+    );
+}
+
+#[test]
+fn test_cursor_at_end_renders_block() {
+    // When cursor is at the end of text (past last char), a standalone '█' should appear.
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::layout::Rect;
+    use ratatui::style::Color;
+
+    let backend = TestBackend::new(40, 3);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let mut app = test_app();
+    app.focused_pane = FocusedPane::InputBar;
+    app.input_text = "hi".to_string();
+    app.input_cursor = 2; // past end of "hi"
+
+    terminal
+        .draw(|f| {
+            let area = Rect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 3,
+            };
+            draw_input_bar(f, &app, area);
+        })
+        .unwrap();
+
+    let buffer = terminal.backend().buffer();
+    // "hi" occupies columns 3, 4; cursor block at column 5
+    let cursor_cell = buffer.cell((5, 1)).unwrap();
+
+    assert_eq!(
+        cursor_cell.symbol(),
+        "█",
+        "Cursor at end of text should show '█'. Got: {:?}",
+        cursor_cell.symbol()
+    );
+    assert_ne!(
+        cursor_cell.bg,
+        Color::Reset,
+        "End-of-text cursor block should have a background color"
+    );
+}
 
 fn make_tool_entry(header: &str, completed: bool) -> ToolActivityEntry {
     ToolActivityEntry {

--- a/src/bin/midtown/cli/chat/ui/thread.rs
+++ b/src/bin/midtown/cli/chat/ui/thread.rs
@@ -159,8 +159,11 @@ fn draw_thread_input(f: &mut Frame, app: &mut App, area: Rect) {
 
     let prompt = "\u{21b3} "; // ↳
     let char_count = app.thread_input_text.chars().count();
-    let text_with_cursor = if is_focused && app.thread_input_cursor == char_count {
-        format!("{}{}\u{2588}", prompt, app.thread_input_text) // █
+    let cursor_style = Style::default().fg(Color::Black).bg(Color::Yellow);
+    let mut spans: Vec<Span> = vec![Span::raw(prompt)];
+    if is_focused && app.thread_input_cursor == char_count {
+        spans.push(Span::raw(app.thread_input_text.clone()));
+        spans.push(Span::styled("\u{2588}", cursor_style)); // █
     } else if is_focused {
         let byte_idx = app
             .thread_input_text
@@ -168,13 +171,17 @@ fn draw_thread_input(f: &mut Frame, app: &mut App, area: Rect) {
             .nth(app.thread_input_cursor)
             .map(|(idx, _)| idx)
             .unwrap_or(app.thread_input_text.len());
-        let (before, after) = app.thread_input_text.split_at(byte_idx);
-        format!("{}{}\u{2588}{}", prompt, before, after)
+        let (before, after_str) = app.thread_input_text.split_at(byte_idx);
+        let cursor_char = after_str.chars().next().unwrap_or(' ');
+        let rest = &after_str[cursor_char.len_utf8()..];
+        spans.push(Span::raw(before.to_string()));
+        spans.push(Span::styled(cursor_char.to_string(), cursor_style));
+        spans.push(Span::raw(rest.to_string()));
     } else {
-        format!("{}{}", prompt, app.thread_input_text)
-    };
+        spans.push(Span::raw(app.thread_input_text.clone()));
+    }
 
-    let paragraph = Paragraph::new(text_with_cursor).wrap(Wrap { trim: false });
+    let paragraph = Paragraph::new(Line::from(spans)).wrap(Wrap { trim: false });
     f.render_widget(block, area);
     f.render_widget(paragraph, inner);
 }


### PR DESCRIPTION
## Summary

- Input box cursor now renders **on top of** the character at the cursor position, rather than inserting a `█` block before it
- The character under the cursor is shown with inverted fg/bg colors so it's readable on the cursor background
- Same fix applied to the thread panel input bar

**Before:** moving left in `hello` with cursor at position 2 rendered `he█llo` — the cursor appeared one cell to the left of `l`

**After:** renders `he` + highlighted `l` + `lo` — cursor occupies the character's cell

## Test plan

- [x] `test_cursor_renders_over_character_not_before_it` — verifies the character at cursor position is shown (not `█`), and has a non-default background color
- [x] `test_cursor_at_end_renders_block` — verifies end-of-input cursor still shows `█` with background color
- [ ] Manually verify in TUI: type some text, move left with arrow keys, confirm cursor sits on the character

🤖 Generated with [Claude Code](https://claude.com/claude-code)