### PR TITLE
feat: Include diagnostic reason in 'couldn't assign reviewer' message [Midtown !1679]

### DIFF
--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -1022,7 +1022,10 @@ pub(super) async fn poll_prs_for_issues(
     );
 
     // Check for stuck conditions and nudge lead if self-healing has failed
-    effects.extend(collect_stuck_condition_effects(state, &prs, &reviewed_prs).await);
+    effects.extend(
+        collect_stuck_condition_effects(state, &prs, &reviewed_prs, &snap.worktree_branch_owners)
+            .await,
+    );
 
     // Detect stale CI checks and trigger re-runs
     effects.extend(collect_stale_check_effects(state, &prs).await);
@@ -1326,6 +1329,7 @@ async fn collect_stuck_condition_effects(
     state: &DaemonState,
     prs: &[serde_json::Value],
     reviewed_prs: &HashSet<u64>,
+    branch_owners: &HashMap<String, String>,
 ) -> Vec<Effect> {
     let mut effects: Vec<Effect> = Vec::new();
     let mut tracker = state.stuck_tracker.lock().await;
@@ -1390,7 +1394,8 @@ async fn collect_stuck_condition_effects(
                         "A reviewer was assigned but hasn't posted a review.".to_string()
                     } else {
                         let head_ref = pr.get("headRefName").and_then(|s| s.as_str()).unwrap_or("");
-                        let pr_author = coworker_from_branch(head_ref);
+                        let pr_author =
+                            coworker_from_branch_with_map(head_ref, Some(branch_owners));
                         let running = state.coworkers.list_running();
                         let mut busy: Vec<String> = running
                             .iter()
@@ -1419,7 +1424,8 @@ async fn collect_stuck_condition_effects(
                         "I assigned a reviewer but no review has been posted yet".to_string()
                     } else {
                         let head_ref = pr.get("headRefName").and_then(|s| s.as_str()).unwrap_or("");
-                        let pr_author = coworker_from_branch(head_ref);
+                        let pr_author =
+                            coworker_from_branch_with_map(head_ref, Some(branch_owners));
                         let running = state.coworkers.list_running();
                         let mut busy: Vec<String> = running
                             .iter()

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -279,6 +279,39 @@ fn format_no_reviewer_reason_only_author_excluded() {
     );
 }
 
+/// Task-based branches (the common case in Midtown) require the worktree_branch_owners
+/// map to resolve to a coworker name. Without the map, `coworker_from_branch` returns
+/// None, so the diagnostic message omits the `excluded-author` annotation even when the
+/// PR author is identifiable. This test verifies the full resolution path works correctly.
+#[test]
+fn format_no_reviewer_reason_task_based_branch_resolves_with_map() {
+    let mut branch_owners = std::collections::HashMap::new();
+    branch_owners.insert("task-42-fix-auth".to_string(), "york".to_string());
+
+    // Without the map, coworker_from_branch returns None for task-based branches
+    let without_map = coworker_from_branch("task-42-fix-auth");
+    assert_eq!(
+        without_map, None,
+        "coworker_from_branch should return None for task-based branches"
+    );
+
+    // With the map, coworker_from_branch_with_map resolves correctly
+    let with_map = coworker_from_branch_with_map("task-42-fix-auth", Some(&branch_owners));
+    assert_eq!(
+        with_map,
+        Some("york".to_string()),
+        "coworker_from_branch_with_map should resolve task-based branch via map"
+    );
+
+    // The resolved author should appear as excluded-author in the diagnostic
+    let busy = vec!["madison".to_string(), "york".to_string()];
+    let reason = format_no_reviewer_reason(&busy, with_map.as_deref());
+    assert_eq!(
+        reason, "no eligible reviewers (busy: [madison, york], excluded-author: york)",
+        "excluded-author should appear when task-based branch resolves via map"
+    );
+}
+
 /// Bug: When a coworker goes on break, their PR's branch is no longer in
 /// worktree_branch_owners. The poll_prs_for_issues loop (lines 664-669) skips
 /// any PR whose branch doesn't map to an active coworker via


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

When the daemon can't assign a reviewer to a PR, the `@ops` message previously said only "I couldn't assign a reviewer" with no context about why. This made it hard for ops to triage — they had to read daemon logs to discover whether all coworker slots were full or the PR author was the only eligible name.

This PR extends both the normal warning and escalation message to include:
- **`busy`**: coworker names currently running (non-lead, non-channel-lead)
- **`excluded-author`**: the PR author's coworker name, if determinable from the branch prefix

### Example output

**Before:**
```
@ops PR #42 (Add feature) has been open for 30 minutes with no review — I couldn't assign a reviewer
```

**After:**
```
@ops PR #42 (Add feature) has been open for 30 minutes with no review — I couldn't assign a reviewer — no eligible reviewers (busy: [madison, york], excluded-author: york)
```

The same improvement is applied to the escalation path ("No reviewer could be assigned...").

## Changes

- `src/daemon/pr.rs`: Added `format_no_reviewer_reason()` helper and updated both the normal warning and escalation branches of `collect_stuck_condition_effects()`
- `src/daemon/pr_tests.rs`: 4 unit tests covering the new helper

## Test plan

- [x] `cargo test format_no_reviewer_reason` — 4 new unit tests pass
- [x] `cargo test stuck` — all existing stuck-condition tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt -- --check` — clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)