### PR TITLE
fix: build reviewer_pr_assignments from persistent state to include dead reviewers [Midtown !1684]

### DIFF
--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -532,6 +532,7 @@ pub fn check_and_restart_dead_reviewers(snap: &snapshot::WorldSnapshot) -> Vec<E
         &snap.reviewer_restart_counts,
         MAX_REVIEWER_RESTARTS,
         &snap.name_session_map,
+        &snap.usage_limited_coworkers,
     );
 
     let escalations = crate::rules::decide_dead_reviewer_escalations(

--- a/src/daemon/health_tests.rs
+++ b/src/daemon/health_tests.rs
@@ -2031,3 +2031,68 @@ fn dead_reviewer_escalation_not_repeated_after_recorded() {
         effects
     );
 }
+
+/// `check_and_restart_dead_reviewers` must produce both a respawn and an
+/// escalation in the same tick when two dead reviewers are present: one below
+/// max restarts (→ respawn) and one at max restarts (→ escalation).
+///
+/// This covers the combined-effects code path where the early-return guard
+/// checks both respawns and escalations.
+#[test]
+fn check_and_restart_dead_reviewers_emits_respawn_and_escalation_in_same_tick() {
+    let mut snap = empty_snap();
+
+    // Reviewer "riverside" — dead, below max restarts → should be respawned.
+    snap.headless_process_health.insert(
+        "riverside".to_string(),
+        snapshot::ProcessHealth {
+            is_alive: false,
+            exit_code: Some(0),
+            ..Default::default()
+        },
+    );
+    snap.reviewer_pr_assignments
+        .insert("riverside".to_string(), 100u64);
+    // restart_count = 0, below MAX_REVIEWER_RESTARTS
+
+    // Reviewer "broadway" — dead, at max restarts → should be escalated.
+    snap.headless_process_health.insert(
+        "broadway".to_string(),
+        snapshot::ProcessHealth {
+            is_alive: false,
+            exit_code: Some(0),
+            ..Default::default()
+        },
+    );
+    snap.reviewer_pr_assignments
+        .insert("broadway".to_string(), 200u64);
+    snap.reviewer_restart_counts
+        .insert(200u64, MAX_REVIEWER_RESTARTS);
+    // escalation not yet posted for PR 200
+
+    let effects = check_and_restart_dead_reviewers(&snap);
+
+    // Must contain a SpawnCoworkerWithCallbacks for riverside (the respawn).
+    let has_respawn = effects.iter().any(|e| {
+        if let Effect::SpawnCoworkerWithCallbacks { config, .. } = e {
+            config.name == "riverside"
+        } else {
+            false
+        }
+    });
+    assert!(
+        has_respawn,
+        "Expected SpawnCoworkerWithCallbacks for 'riverside' (below max restarts), got: {:#?}",
+        effects
+    );
+
+    // Must contain a RecordReviewerEscalation for broadway's PR (the escalation).
+    let has_escalation = effects
+        .iter()
+        .any(|e| matches!(e, Effect::RecordReviewerEscalation { pr_number } if *pr_number == 200));
+    assert!(
+        has_escalation,
+        "Expected RecordReviewerEscalation for PR 200 ('broadway' at max restarts), got: {:#?}",
+        effects
+    );
+}

--- a/src/daemon/snapshot.rs
+++ b/src/daemon/snapshot.rs
@@ -1019,12 +1019,20 @@ pub(super) fn minimal_snapshot_for_test() -> WorldSnapshot {
 /// are still included in the map. This is required for
 /// `decide_dead_reviewer_respawns` to detect and respawn reviewers that died
 /// before posting their review.
+///
+/// Applies the same `PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS` filter as
+/// `active_reviewers()` to exclude stale assignments and stay consistent with
+/// the rest of the reviewer logic.
 pub(crate) fn build_reviewer_pr_assignments(
     github: &crate::github_state::GitHubState,
 ) -> HashMap<String, u64> {
+    let now = chrono::Utc::now();
+    let timeout =
+        chrono::Duration::seconds(crate::github_state::PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS as i64);
     github
         .pr_reviewers
         .iter()
+        .filter(|(_, assignment)| now.signed_duration_since(assignment.assigned_at) < timeout)
         .map(|(&pr_number, assignment)| (assignment.reviewer.clone(), pr_number))
         .collect()
 }

--- a/src/daemon/snapshot_tests.rs
+++ b/src/daemon/snapshot_tests.rs
@@ -702,3 +702,49 @@ fn reviewer_pr_assignments_includes_dead_reviewers() {
         "assignment should map reviewer to the correct PR number"
     );
 }
+
+/// `build_reviewer_pr_assignments` must apply the same timeout filter as
+/// `active_reviewers()` so that stale assignments are excluded from both.
+///
+/// An expired assignment (assigned_at older than PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS)
+/// must NOT appear in the result — consistent with `active_reviewers()` which
+/// also excludes expired entries.
+#[test]
+fn build_reviewer_pr_assignments_excludes_expired_entries() {
+    use crate::github_state::{AssignmentSource, GitHubState, PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS};
+
+    let mut github = GitHubState::default();
+    // Assign reviewer for PR 100 with a fresh timestamp (non-expired).
+    github.assign_reviewer(100, "riverside", AssignmentSource::PollingFallback);
+
+    // Assign reviewer for PR 200 with an expired timestamp.
+    github.assign_reviewer(200, "broadway", AssignmentSource::PollingFallback);
+    // Backdate broadway's assignment past the timeout.
+    if let Some(assignment) = github.pr_reviewers.get_mut(&200) {
+        assignment.assigned_at = chrono::Utc::now()
+            - chrono::Duration::seconds(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS as i64 + 1);
+    }
+
+    let assignments = super::build_reviewer_pr_assignments(&github);
+    let active = github.active_reviewers();
+
+    // Fresh assignment must appear in both.
+    assert!(
+        assignments.contains_key("riverside"),
+        "non-expired reviewer 'riverside' must appear in build_reviewer_pr_assignments"
+    );
+    assert!(
+        active.contains("riverside"),
+        "non-expired reviewer 'riverside' must appear in active_reviewers"
+    );
+
+    // Expired assignment must be excluded from both (consistent behavior).
+    assert!(
+        !assignments.contains_key("broadway"),
+        "expired reviewer 'broadway' must NOT appear in build_reviewer_pr_assignments"
+    );
+    assert!(
+        !active.contains("broadway"),
+        "expired reviewer 'broadway' must NOT appear in active_reviewers"
+    );
+}

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -615,6 +615,7 @@ pub(crate) fn decide_dead_reviewer_respawns(
     reviewer_restart_counts: &HashMap<u64, u32>,
     max_restarts: u32,
     name_session_map: &HashMap<String, String>,
+    usage_limited_coworkers: &HashSet<String>,
 ) -> Vec<StuckReviewerRestart> {
     let mut respawns = Vec::new();
 
@@ -632,6 +633,12 @@ pub(crate) fn decide_dead_reviewer_respawns(
 
         // Review was already posted — no need to respawn.
         if reviewed_prs.contains(&pr_number) {
+            continue;
+        }
+
+        // Skip rate-limited reviewers — respawning into the same limit would fail
+        // immediately and burn the restart budget.
+        if hashset_contains_icase(usage_limited_coworkers, name) {
             continue;
         }
 
@@ -3469,6 +3476,7 @@ mod tests {
             &HashMap::new(),
             2,
             &HashMap::new(),
+            &HashSet::new(),
         );
 
         assert_eq!(
@@ -3505,6 +3513,7 @@ mod tests {
             &HashMap::new(),
             2,
             &HashMap::new(),
+            &HashSet::new(),
         );
 
         assert!(
@@ -3539,6 +3548,7 @@ mod tests {
             &restart_counts,
             2,
             &HashMap::new(),
+            &HashSet::new(),
         );
 
         assert!(
@@ -3572,11 +3582,49 @@ mod tests {
             &HashMap::new(),
             2,
             &HashMap::new(),
+            &HashSet::new(),
         );
 
         assert!(
             respawns.is_empty(),
             "alive reviewer should not be handled by dead reviewer detection"
+        );
+    }
+
+    #[test]
+    fn dead_reviewer_not_respawned_when_usage_limited() {
+        let now = Utc::now();
+        let mut process_health = HashMap::new();
+        process_health.insert(
+            "riverside".to_string(),
+            crate::daemon::snapshot::ProcessHealth {
+                is_alive: false,
+                exit_code: Some(0),
+                last_event_at: Some(now - chrono::Duration::minutes(5)),
+                ..Default::default()
+            },
+        );
+        let mut reviewer_pr_assignments = HashMap::new();
+        reviewer_pr_assignments.insert("riverside".to_string(), 1352u64);
+        let reviewed_prs: HashSet<u64> = HashSet::new();
+
+        // Riverside is rate-limited — respawning into the same limit would fail.
+        let mut usage_limited = HashSet::new();
+        usage_limited.insert("riverside".to_string());
+
+        let respawns = decide_dead_reviewer_respawns(
+            &process_health,
+            &reviewer_pr_assignments,
+            &reviewed_prs,
+            &HashMap::new(),
+            2,
+            &HashMap::new(),
+            &usage_limited,
+        );
+
+        assert!(
+            respawns.is_empty(),
+            "usage-limited dead reviewer should NOT be respawned"
         );
     }
 


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary

- `reviewer_pr_assignments` in `snapshot.rs` was built by iterating `active_coworkers` and looking each up in `persistent_state.github.pr_reviewers`
- When a reviewer's process died, it was removed from `active_coworkers`, dropping its entry from `reviewer_pr_assignments`
- This caused `decide_dead_reviewer_respawns` to never fire for dead reviewers — a reviewer that exited before posting its review would go undetected and unrecovered
- The escalation logic in `check_and_restart_stuck_reviewers` also uses this map and would miss dead reviewers

The fix extracts the map-building into a pure helper `build_reviewer_pr_assignments()` that reads from `pr_reviewers` directly (which persists across coworker lifecycle changes). Dead reviewers now remain in the map.

This bug was flagged on PR #1353 and PR #1392.

## Test plan

- [x] Added regression test `reviewer_pr_assignments_includes_dead_reviewers` in `snapshot_tests.rs` that verifies dead reviewers (absent from `active_coworkers`) appear in `reviewer_pr_assignments`
- [x] All existing tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Format check passes (`cargo fmt --all -- --check`)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)