### PR TITLE
fix: Skip large JSON fixture files in reviewer to prevent context limit failures [Midtown !1685]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Suppress diffs for large auto-generated test fixture files.
+# These files can be 10,000+ lines and cause reviewer context limit failures
+# when included in `gh pr diff` output. Marking them as non-diff keeps
+# them tracked in git while preventing reviewers from processing their content.
+tests/fixtures/snapshot/*.json -diff

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -40,6 +40,21 @@ COMMENT_ID=$(echo "$COMMENT_URL" | grep -o '[0-9]*$')
 midtown state --progress 20
 ```
 
+LARGE FILE CHECK: Before reviewing, detect any large JSON fixture files in the PR that would cause context limit failures. These files are auto-generated test snapshots — they don't need line-by-line code review, and attempting to read them risks exhausting your context window.
+
+```bash
+# Find JSON files with >500 added+deleted lines
+LARGE_JSON_FILES=$(gh pr view {pr_number} --json files \
+  --jq '[.files[] | select(.path | test("\\.json$")) | select((.additions + .deletions) > 500) | "\(.path) (+\(.additions)/-\(.deletions) lines)"] | join(", ")')
+echo "Large JSON files: $LARGE_JSON_FILES"
+```
+
+If `$LARGE_JSON_FILES` is non-empty:
+- Update your initial PR comment to add a line: `**Note**: Skipping large fixture file(s): {$LARGE_JSON_FILES} — auto-generated snapshots, trusting CI tests pass.`
+- Do NOT read or process the content of these files at any point in the review.
+- When the code-review skill runs, disregard any findings that are specific to those JSON fixture files — they are auto-generated and not hand-written code.
+- Do NOT call `gh pr diff` without verifying first that the output will be manageable. If large JSON files exist, use `gh pr view --json files` for file-level analysis instead of reading the full diff.
+
 **WHY NO FRONTMATTER AND DIFFERENT HEADING**: The initial comment deliberately:
 1. Omits `<!-- midtown: {name} -->` frontmatter
 2. Uses "Review Status" instead of "Code Review" as the heading


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary

- Add `LARGE FILE CHECK` step to `agents/reviewer.md`: before running the code-review skill, the reviewer uses `gh pr view --json files` to detect JSON files with >500 added+deleted lines. If found, it notes them as skipped in the PR comment and avoids calling `gh pr diff` unfiltered.
- Add `.gitattributes` with `tests/fixtures/snapshot/*.json -diff` to suppress content diffs for large auto-generated snapshot files at the git level — this is the root-cause fix. Reviewers (and any `gh pr diff` caller) will see these files as modified without getting 10,000+ lines of JSON content.

## Background

PRs that add snapshot fixture files (like PR #1384 with +11,530/+11,578 line JSON fixtures) caused 4 consecutive reviewer failures. The reviewers hit context limits trying to process the full diff and exited without completing. The `.gitattributes` change prevents this at the source; the reviewer.md change adds an explicit safety net for cases where the diff is large for other reasons.

## Test plan

- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` passes
- [x] Build succeeds
- [x] No Rust code changes — only agent prompt and git config

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)