### PR TITLE
fix: Move 'Spawning isolated coworker' debug log below collision guard [Midtown !1692]

### DIFF
--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -2385,13 +2385,6 @@ pub(crate) async fn collect_reviewer_effects_with_source(
             continue;
         }
 
-        let title = pr.get("title").and_then(|s| s.as_str()).unwrap_or("");
-        debug!(
-            "Spawning isolated coworker to review PR #{}: {}",
-            pr_number,
-            truncate_str(title, 40)
-        );
-
         // Extract channel lead names for coworker limit check
         let channel_lead_names: std::collections::HashSet<String> = {
             let ps = state.persistent_state.lock().await;
@@ -2443,6 +2436,13 @@ pub(crate) async fn collect_reviewer_effects_with_source(
             );
             continue;
         }
+
+        let title = pr.get("title").and_then(|s| s.as_str()).unwrap_or("");
+        debug!(
+            "Spawning isolated coworker to review PR #{}: {}",
+            pr_number,
+            truncate_str(title, 40)
+        );
 
         // reviewer() now takes the PR number and generates both the system prompt
         // (with merged reviewer.md instructions) and the launch prompt internally.


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Moves the `debug!("Spawning isolated coworker...")` log from before the worktree collision guard to after it
- The log previously fired even when spawning was aborted by the collision guard, causing misleading log output
- Now the log only fires when a spawn actually proceeds past all guards

## Test plan
- [x] Cargo build passes
- [x] All unit tests pass
- [x] No clippy warnings

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)