### PR TITLE
fix: stop session dispatch recovery loop (stale is_running not cleared after spawn)

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -788,8 +788,14 @@ where
             }
         };
 
-        // If the session is running, the task is handled -- skip.
-        if record.is_running {
+        // If the session is running (either by persisted flag or live in active_session_ids),
+        // the task is handled — skip.
+        //
+        // active_session_ids is checked in addition to is_running because spawn_coworker
+        // uses or_insert_with for existing session records, leaving is_running=false even
+        // after a successful resume. The live process check ensures we don't loop on the
+        // same stopped-session record every tick while the coworker is actually running.
+        if record.is_running || snap.active_session_ids.contains(&record.session_id) {
             debug!(
                 "Task !{} has running session {} -- no recovery needed",
                 task_id, record.session_id

--- a/src/daemon/dispatch_session_tests.rs
+++ b/src/daemon/dispatch_session_tests.rs
@@ -497,3 +497,77 @@ fn test_session_dispatch_skips_active_reviewer() {
             .collect::<Vec<_>>()
     );
 }
+
+// ======================================================================
+// Recovery loop prevention tests
+// ======================================================================
+
+/// Regression test for task !1693: stale is_running=false causes infinite recovery loop.
+///
+/// After a successful recovery spawn, `spawn_coworker` uses `or_insert_with` which
+/// is a no-op for existing session records — leaving `is_running=false` in persistent
+/// state. The next tick sees the session as stopped and spawns again, ad infinitum.
+///
+/// The fix: `dispatch_via_sessions` must also check `active_session_ids`. If the
+/// session_id is in `active_session_ids`, the coworker is actually running (the
+/// session_manager has a live process for it), so recovery must be skipped even
+/// when `is_running` is stale.
+#[test]
+fn test_session_dispatch_skips_recovery_when_session_is_active_despite_stale_is_running() {
+    // Given: task !1690 has session e2bafbb6 (is_running=false — stale persistent flag)
+    // but the session is in active_session_ids (actually running after a prior recovery spawn).
+    let session = make_session_record(
+        "e2bafbb6-5fe5-4cfb-a98f-94caad0ff834",
+        Some("1690"),
+        Some("riverside"),
+        false, // is_running=false: stale flag not yet updated by spawn_coworker
+    );
+
+    let snap = snapshot::WorldSnapshot {
+        in_progress_tasks: vec![(
+            "1690".to_string(),
+            "Rebase PR #1404, address review feedback, and merge".to_string(),
+            "riverside".to_string(),
+        )],
+        active_names: ["riverside".to_string()].into_iter().collect(),
+        // Session is live in active_session_ids (successful recovery spawn happened)
+        active_session_ids: ["e2bafbb6-5fe5-4cfb-a98f-94caad0ff834".to_string()]
+            .into_iter()
+            .collect(),
+        sessions: [("e2bafbb6-5fe5-4cfb-a98f-94caad0ff834".to_string(), session)]
+            .into_iter()
+            .collect(),
+        session_task_map: [(
+            "1690".to_string(),
+            "e2bafbb6-5fe5-4cfb-a98f-94caad0ff834".to_string(),
+        )]
+        .into_iter()
+        .collect(),
+        ..snapshot::minimal_snapshot_for_test()
+    };
+
+    let effects = dispatch_via_sessions_for_test(&snap, None, |_| None);
+
+    // Then: must NOT emit another recovery spawn — the session is already live.
+    let spawn_effects: Vec<_> = effects
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                Effect::SpawnCoworkerWithCallbacks { .. }
+                    | Effect::SpawnCoworker(_)
+                    | Effect::AssignAndSpawn { .. }
+                    | Effect::ResumeCoworker { .. }
+            )
+        })
+        .collect();
+    assert!(
+        spawn_effects.is_empty(),
+        "Should NOT recover a session that is in active_session_ids (live process), \
+         even when is_running=false is stale. Got effects: {:?}",
+        spawn_effects
+            .iter()
+            .map(|e| format!("{:?}", e))
+            .collect::<Vec<_>>()
+    );
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1402,7 +1402,8 @@ impl DaemonState {
                     _ => "dev".to_string(),
                 };
                 let is_reviewer = matches!(config.role, crate::launch::CoworkerRole::Reviewer);
-                ps.sessions
+                let record = ps
+                    .sessions
                     .entry(session_id_for_record.clone())
                     .or_insert_with(|| {
                         crate::daemon::state::SessionRecord {
@@ -1424,6 +1425,11 @@ impl DaemonState {
                             resume_on_startup: !is_reviewer,
                         }
                     });
+                // or_insert_with is a no-op when the record already exists (resumed sessions).
+                // Explicitly mark as running so dispatch_via_sessions doesn't re-trigger
+                // recovery on the next tick seeing a stale is_running=false.
+                record.is_running = true;
+                record.current_name = Some(name.clone());
             }
             if let Err(e) = ps.save_for_repo(&self.repo_name) {
                 warn!("Failed to save persistent state after spawn: {}", e);


### PR DESCRIPTION
## Summary

- **Root cause**: `dispatch_via_sessions` only checked `record.is_running` to decide if a session needed recovery. After a successful resume spawn, `spawn_coworker` used `or_insert_with` which is a no-op for existing session records — leaving `is_running=false` forever. Every tick after the cooldown expired, dispatch saw the same "stopped" session and spawned again.
- **Fix 1 (dispatch layer)**: Also check `active_session_ids`. After a successful spawn, the live process registers in the session manager; `active_session_ids` reflects the true running state even when `is_running` is stale. Recovery is skipped when the session_id appears there.
- **Fix 2 (persistent state layer)**: In `spawn_coworker`, explicitly set `record.is_running = true` and `record.current_name` after `or_insert_with`, mirroring the pattern already used by the `SpawnSession` effect path. Belt-and-suspenders: keeps persistent state accurate for daemon restarts.

Fixes the ~5-second recovery loop observed for task !1690 (riverside session `e2bafbb6`) and task !1694 (broadway session `57bd3ea0`).

## Test plan

- [x] New regression test `test_session_dispatch_skips_recovery_when_session_is_active_despite_stale_is_running` in `dispatch_session_tests.rs` — confirmed failing before fix, passing after
- [x] All 1707 existing unit tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)