### PR TITLE
fix: hide unread count badge for #ops channel in sidebar [Midtown !1698]

### DIFF
--- a/web-app/src/lib/ChannelList.svelte
+++ b/web-app/src/lib/ChannelList.svelte
@@ -212,7 +212,7 @@
             {formatChannelName(channel.name)}
           </div>
           <div class="flex items-center gap-1.5">
-            {#if channel.unread > 0}
+            {#if channel.unread > 0 && channel.name !== 'ops'}
               <span class="text-xs px-1.5 py-0.5 rounded-[10px] bg-[#ff6b6b] text-white min-w-[1.5em] text-center font-semibold" title="{channel.unread} unread messages">{channel.unread}</span>
             {/if}
             {#if totalTasks > 0}


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Hide the red unread count badge for the `#ops` channel in the sidebar channel list
- The `#ops` channel is always visible via the dedicated `OpsChannel.svelte` component, making the sidebar badge duplicative

## Visual change
- **Before**: `#ops` shows a red unread count badge (e.g., "3") in the sidebar, same as topic channels
- **After**: Badge is hidden for `#ops` only. All other channels retain their badges. The unread count still accumulates in the store — only the rendering is suppressed.

*(Headless agent — unable to capture screenshots)*

## Test plan
- [x] Verify `#ops` channel no longer shows unread badge in sidebar
- [x] Verify other channels still show unread badges normally
- [x] Codecov confirms all modified lines covered

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)