### PR TITLE
fix: Stop dimming lead messages now that lead posts as 'midtown' [Midtown !1695, !1697]

### DIFF
--- a/src/bin/midtown/cli/chat/ui/board.rs
+++ b/src/bin/midtown/cli/chat/ui/board.rs
@@ -602,8 +602,8 @@ fn draw_ops_mini_channel(
 /// Map a sender name to a dim TUI color for the ops mini-channel.
 fn ops_sender_color(name: &str) -> Color {
     match name.to_lowercase().as_str() {
-        "midtown" | "system" | "daemon" | "github" => Color::Rgb(80, 80, 80),
-        "lead" => Color::Rgb(180, 180, 100),
+        "system" | "daemon" | "github" => Color::Rgb(80, 80, 80),
+        "lead" | "midtown" => Color::Rgb(180, 180, 100),
         _ => Color::Rgb(120, 160, 120), // coworker names: muted green
     }
 }

--- a/src/bin/midtown/cli/chat/ui/messages.rs
+++ b/src/bin/midtown/cli/chat/ui/messages.rs
@@ -615,32 +615,50 @@ mod tests {
     fn test_system_message_format() {
         use chrono::Utc;
 
-        let msg = Message {
+        // Test system sender ("system") renders in DarkGray
+        let system_msg = Message {
             id: "1".to_string(),
-            from: "midtown".to_string(),
+            from: "system".to_string(),
             content: "Session started".to_string(),
             timestamp: Utc::now(),
             message_type: MessageType::System,
             channel: None,
-
             session_id: None,
             thread_parent_id: None,
         };
 
         let current_tasks = HashMap::new();
-
-        // System messages render through standard path: sender line + timestamp line
-        let lines = render_message(&msg, 80, None, &current_tasks, None, &[]);
+        let lines = render_message(&system_msg, 80, None, &current_tasks, None, &[]);
         assert_eq!(lines.len(), 2); // sender line + content line
 
-        // First line is the sender name
         let sender: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
-        assert_eq!(sender, "midtown");
+        assert_eq!(sender, "system");
         assert_eq!(lines[0].spans[0].style.fg, Some(Color::DarkGray));
 
-        // Second line has timestamp + content in DarkGray
         let content: String = lines[1].spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(content.contains("Session started"));
+
+        // Test lead sender ("midtown") renders in LightYellow (not dimmed)
+        let lead_msg = Message {
+            id: "2".to_string(),
+            from: "midtown".to_string(),
+            content: "Working on your request".to_string(),
+            timestamp: Utc::now(),
+            message_type: MessageType::Text,
+            channel: None,
+            session_id: None,
+            thread_parent_id: None,
+        };
+
+        let lead_lines = render_message(&lead_msg, 80, None, &current_tasks, None, &[]);
+        assert_eq!(lead_lines.len(), 2);
+        let lead_sender: String = lead_lines[0]
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert_eq!(lead_sender, "midtown");
+        assert_eq!(lead_lines[0].spans[0].style.fg, Some(Color::LightYellow));
     }
 
     #[test]
@@ -933,7 +951,7 @@ mod tests {
         assert!(is_system_like_sender("daemon"));
         assert!(!is_system_like_sender("github"));
         assert!(is_system_like_sender("system"));
-        assert!(is_system_like_sender("midtown"));
+        assert!(!is_system_like_sender("midtown")); // midtown is now the lead, not a system sender
         assert!(is_system_like_sender("DAEMON"));
         assert!(!is_system_like_sender("madison"));
         assert!(!is_system_like_sender("park"));

--- a/src/bin/midtown/cli/chat/ui/styles.rs
+++ b/src/bin/midtown/cli/chat/ui/styles.rs
@@ -24,17 +24,14 @@ const AVENUE_COLORS: &[(&str, Color)] = &[
 ];
 
 /// Check if a sender is a "system-like" sender that should be grouped together
-/// (daemon, midtown, system) without blank lines between consecutive messages.
+/// (daemon, system) without blank lines between consecutive messages.
 ///
 /// Note: "github" was previously included here but is now treated like a regular
 /// sender for spacing purposes, so github messages get blank line separation
 /// matching coworker messages. GitHub content is still styled DarkGray via
 /// `is_dim_sender`.
 pub fn is_system_like_sender(sender: &str) -> bool {
-    matches!(
-        sender.to_lowercase().as_str(),
-        "daemon" | "midtown" | "system"
-    )
+    matches!(sender.to_lowercase().as_str(), "daemon" | "system")
 }
 
 /// Check if a sender's message content should be rendered in DarkGray.
@@ -42,7 +39,7 @@ pub fn is_system_like_sender(sender: &str) -> bool {
 pub fn is_dim_sender(sender: &str) -> bool {
     matches!(
         sender.to_lowercase().as_str(),
-        "daemon" | "github" | "midtown" | "system"
+        "daemon" | "github" | "system"
     )
 }
 
@@ -53,9 +50,9 @@ pub fn is_dim_sender(sender: &str) -> bool {
 /// main lead. Pass an empty slice when no channel lead context is available.
 pub fn get_sender_color_with_leads(name: &str, channel_lead_names: &[String]) -> Color {
     match name.to_lowercase().as_str() {
-        "lead" => Color::LightYellow,
+        "lead" | "midtown" => Color::LightYellow,
         "user" => Color::White,
-        "daemon" | "github" | "midtown" | "system" => Color::DarkGray,
+        "daemon" | "github" | "system" => Color::DarkGray,
         _ => {
             // Check avenue colors
             for (avenue, color) in AVENUE_COLORS {

--- a/src/message.rs
+++ b/src/message.rs
@@ -192,7 +192,7 @@ impl Message {
 
     /// Create a system message.
     ///
-    /// System messages automatically use "midtown" as the sender.
+    /// System messages automatically use "system" as the sender.
     ///
     /// # Examples
     ///
@@ -200,10 +200,10 @@ impl Message {
     /// use midtown::Message;
     ///
     /// let msg = Message::system("Daemon started");
-    /// assert_eq!(msg.from, "midtown");
+    /// assert_eq!(msg.from, "system");
     /// ```
     pub fn system(content: impl Into<String>) -> Self {
-        Self::new("midtown", content, MessageType::System)
+        Self::new("system", content, MessageType::System)
     }
 
     /// Create a command message.
@@ -310,7 +310,7 @@ mod tests {
     #[test]
     fn test_system_message() {
         let msg = Message::system("System initialized");
-        assert_eq!(msg.from, "midtown");
+        assert_eq!(msg.from, "system");
         assert_eq!(msg.message_type, MessageType::System);
     }
 

--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -364,13 +364,13 @@
     prince: '#d7afff',      // lavender (Indexed 183)
     mercer: '#ffaf87',      // salmon (Indexed 216)
     lead: '#d7d787',        // LightYellow
+    midtown: '#d7d787',     // LightYellow (project lead posts as project name)
     github: '#585858',      // DarkGray
     system: '#585858',      // DarkGray
-    midtown: '#585858',     // DarkGray (daemon renamed to midtown)
   }
 
   // Senders whose content is rendered in DarkGray (system infrastructure actors)
-  const DIM_SENDERS = new Set(['daemon', 'midtown', 'github', 'system'])
+  const DIM_SENDERS = new Set(['daemon', 'github', 'system'])
 
   function getSenderColor(name) {
     return AVENUE_COLORS[name?.toLowerCase()] || '#d0d0d0'
@@ -745,7 +745,7 @@
            the TUI braille spinner) to drive the dots. In topic channels, InProgress tool
            items drive the dots (channel leads don't have a separate lead_working signal). -->
       {#if activeChannelToolItems.length > 0 || channelLeadThinking || ($activeChannel === 'midtown' && !!$daemonStatus?.lead_working)}
-        {@const agentName = $activeChannel === 'midtown' ? 'lead' : $activeChannel}
+        {@const agentName = $activeChannel}
         {@const isLeadWorking = $activeChannel === 'midtown' ? !!$daemonStatus?.lead_working : false}
         {@const hasInProgressItems = activeChannelToolItems.some((item) => item.status === 'InProgress')}
         {@const showDots = isLeadWorking || hasInProgressItems || channelLeadThinking}


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

PR #1404 renamed the lead session to post as the project name ('midtown'), but the display logic still treated 'midtown' as a dim system sender, causing all lead messages to appear in DarkGray.

- **TUI (styles.rs)**: Remove 'midtown' from `is_dim_sender()` and `is_system_like_sender()`; give 'midtown' LightYellow color alongside 'lead'
- **TUI (board.rs)**: Move 'midtown' from dim group to lead color in `ops_sender_color()`
- **Web app (Channel.svelte)**: Remove 'midtown' from `DIM_SENDERS`; update color from DarkGray to LightYellow; fix tool activity display to use channel name directly instead of hardcoding 'lead'
- **Message::system()**: Change sender from 'midtown' to 'system' so infrastructure messages remain distinct from lead messages
- **Tests**: Update to reflect new behavior

## Test plan

- [x] `cargo test -- test_system` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Lead messages in TUI now render in LightYellow instead of DarkGray
- [x] Tool activity strip shows 'midtown' instead of 'lead' in web app
- [x] System infrastructure messages still render in DarkGray (via 'system' sender)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)