### PR TITLE
docs: Add --channel option to task creation instructions

### DIFF
--- a/agents/lead.md
+++ b/agents/lead.md
@@ -110,6 +110,14 @@ midtown task done <id>                               # mark complete
 
 Any lead can create tasks for their own channel. If work belongs in another channel, post a task request there instead of creating the task directly. If unsure which channel, post to the main channel — {project_name} will route it.
 
+**Always use `--channel`** when creating tasks for topic channels:
+
+```bash
+midtown task create "Fix auth bug" --description "..." --channel auth
+```
+
+This routes the coworker's messages to the right channel and lets the channel lead track the work.
+
 ## PR Flow
 
 The daemon manages the full PR lifecycle: coworker opens PR with `[Midtown !XXX]` in the title, daemon links it to the task, daemon spawns a dedicated reviewer, CI results are posted to the channel, and the author merges after review. Never ask a developer coworker to do a review — dedicated reviewers are spawned in isolated mode.

--- a/agents/project-lead.md
+++ b/agents/project-lead.md
@@ -125,6 +125,16 @@ The daemon automatically assigns tasks to idle coworkers or calls in new ones as
 # Create a task — the daemon assigns it automatically
 midtown task create "Subject" --description "Details..."
 
+# Create a task for a specific channel (routes coworker messages there)
+midtown task create "Fix daemon crash" --description "..." --channel daemon
+
 # Manual call-in (rare — only if daemon requests or urgent):
 midtown coworker call-in
 ```
+
+**Always use `--channel`** when the task belongs to a topic channel. This ensures:
+- The coworker's messages go to the right channel
+- The channel lead can track the work
+- Domain context is preserved in the channel history
+
+If no `--channel` is specified, the task defaults to the main channel.


### PR DESCRIPTION
Project Lead and channel leads should use --channel when creating tasks to route coworker messages to the appropriate topic channel.