### PR TITLE
fix: Show project name instead of 'lead' in tool activity display [Midtown !1697]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -746,6 +746,7 @@
            items drive the dots (channel leads don't have a separate lead_working signal). -->
       {#if activeChannelToolItems.length > 0 || channelLeadThinking || ($activeChannel === 'midtown' && !!$daemonStatus?.lead_working)}
         {@const agentName = $activeChannel}
+        {@const stripColor = agentName === 'midtown' ? AVENUE_COLORS.lead : getSenderColor(agentName)}
         {@const isLeadWorking = $activeChannel === 'midtown' ? !!$daemonStatus?.lead_working : false}
         {@const hasInProgressItems = activeChannelToolItems.some((item) => item.status === 'InProgress')}
         {@const showDots = isLeadWorking || hasInProgressItems || channelLeadThinking}
@@ -756,12 +757,12 @@
           <div class="flex items-center gap-[7px] whitespace-nowrap overflow-hidden text-ellipsis">
             {#if showDots}
               <span class="typing-dots flex gap-[3px] items-center">
-                <span class="dot w-[5px] h-[5px] rounded-full" style="background-color: {getSenderColor(agentName)}"></span>
-                <span class="dot w-[5px] h-[5px] rounded-full" style="background-color: {getSenderColor(agentName)}"></span>
-                <span class="dot w-[5px] h-[5px] rounded-full" style="background-color: {getSenderColor(agentName)}"></span>
+                <span class="dot w-[5px] h-[5px] rounded-full" style="background-color: {stripColor}"></span>
+                <span class="dot w-[5px] h-[5px] rounded-full" style="background-color: {stripColor}"></span>
+                <span class="dot w-[5px] h-[5px] rounded-full" style="background-color: {stripColor}"></span>
               </span>
             {/if}
-            <span class="font-bold text-[0.85rem]" style="color: {getSenderColor(agentName)}">{agentName}</span>
+            <span class="font-bold text-[0.85rem]" style="color: {stripColor}">{agentName}</span>
           </div>
         </div>
       {/if}


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Removes the special-case ternary that mapped the main channel (`'midtown'`) → `'lead'` in the tool activity strip
- Now uses `$activeChannel` directly, which already contains `'midtown'` for the main channel
- Since PR #1404 renamed the lead session to post as the project name, the display should follow suit

## Test plan
- [x] Verified the change in `web-app/src/lib/Channel.svelte` line 748
- [ ] Visually confirm the tool activity strip shows 'midtown' instead of 'lead' in the main channel

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)