### PR TITLE
docs: Channel lead Topic Sessions prompt + forked session docs [Midtown !1702]

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ Each topic channel can have a **channel lead** — a headless Claude Code sessio
 
 **What channel leads don't do:** Channel leads don't write code, open PRs, or create tasks. When implementation work is needed, they escalate to @lead.
 
-**Forked sessions:** Channel leads can fork themselves into thread-specific sessions via `midtown session fork --thread <id>`. A forked session inherits the parent's conversation context but gets an independent session ID bound to a specific thread. Thread replies are automatically routed to the fork, and the fork's channel posts are auto-tagged with the bound thread ID.
+**Forked sessions:** Channel leads can fork themselves into thread-specific sessions via `midtown session fork <thread-id>`. A forked session inherits the parent's conversation context but gets an independent session ID bound to a specific thread. Thread replies are automatically routed to the fork, and the fork's channel posts are auto-tagged with the bound thread ID.
 
 Coworkers use `@{channel-name}` for domain questions (e.g., `@auth-refactor can you explain the token expiry logic?`) and reserve `@lead` for coordination and priority questions.
 

--- a/agents/channel-lead.md
+++ b/agents/channel-lead.md
@@ -78,7 +78,9 @@ The daemon creates an independent session that:
 
 **After forking:** You are now in a thread-scoped session. Write your responses directly — they are automatically posted to the thread. You do not need `--thread` on your channel posts.
 
-**Nudge format:** Nudges include the message ID in the format `sender (message-id): content`. Use that ID with `session fork`.
+**Fork latency:** `session fork` blocks while the daemon spawns the new session (typically a few seconds). For complex questions, post a brief thread acknowledgment first ("Looking into this...") before forking, so the user sees immediate feedback.
+
+**Nudge format:** Nudges include the message ID in the format `sender (message-id): content`. For top-level messages, use that ID directly with `session fork`. For thread replies, the nudge message-id is the reply's own ID — use the thread's root message ID instead (visible in the channel log or via `midtown channel read`).
 
 ## Posting to the Channel
 
@@ -96,7 +98,7 @@ When replying in a thread from the **root session** (before forking):
 midtown channel post "reply text" --thread <message-id> --channel {channel_name}
 ```
 
-**Always reply in a thread** when responding to user messages or @mentions — this keeps the channel organized. Note: your text output is still auto-posted as a top-level message, so writing text alongside a `--thread` reply produces a duplicate. Keep your text output brief or omit it when the thread reply covers everything.
+**In the root session, always reply in a thread** when responding to user messages or @mentions — this keeps the channel organized. Note: your text output is still auto-posted as a top-level message, so writing text alongside a `--thread` reply produces a duplicate. Keep your text output brief or omit it when the thread reply covers everything. (Forked sessions auto-tag posts with their bound thread — no `--thread` needed.)
 
 ## Awareness
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -196,7 +196,7 @@ Channel leads can fork themselves into thread-specific sessions via the `session
 
 **Root session as router:** The root session stays lightweight — it handles top-level messages and decides when to fork. Once a fork exists for a thread, subsequent replies in that thread bypass the root session entirely and route directly to the fork.
 
-**Thread routing priority:** When a message arrives with `thread_parent_id` set, `handle_channel_post` checks `topic_sessions[thread_parent_id]` first. If a fork exists, it receives the message. If no fork exists, the root channel lead session receives it (normal on-demand channel lead behavior).
+**Thread routing priority:** When a message arrives with `thread_parent_id` set, `handle_channel_post` checks `topic_sessions[thread_parent_id]` first. If a fork exists, it receives the message. If no fork exists, the message routes to the root channel lead session — spawning it on-demand if it isn't already running (standard channel lead lifecycle).
 
 **Data flow:**
 - `topic_sessions` (in-memory `Mutex<HashMap<String, String>>`) maps `thread_parent_id → fork_session_id`. Used by `handle_channel_post` to route thread replies to the fork instead of the root channel lead.


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary

- Add **Topic Sessions** section to `agents/channel-lead.md`: instructs channel leads when and how to fork sessions into thread-specific contexts (`midtown session fork <message-id>`), including when-to-fork vs. when-to-reply-inline decision guide and behavior expectations for forked sessions (auto-posts to thread, no manual `--thread` needed)
- Update `docs/architecture.md` Forked Sessions section: add root session as router concept and explicit thread routing priority (topic session > root session)
- Fix `README.md` CLI table: `midtown session fork` uses a positional argument, not `--thread <id>` flag

## Test plan

- [x] Pre-commit hooks (clippy + fmt) pass cleanly
- [x] No Rust code changes — docs/prompt only

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)