### PR TITLE
fix: keep archived channels archived [Midtown !1694]

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -5,6 +5,7 @@ use crate::cursor::Cursor;
 use crate::message::Message;
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -324,9 +325,15 @@ impl Channel {
         // Run one-time migration from flat JSONL layout to per-channel directories.
         // This is idempotent and only runs once per base_dir per process.
         auto_migrate_channels(&base_dir);
+        cleanup_archived_channel_conflicts(&base_dir);
 
         // New layout: channels/<name>/history/current.jsonl
-        let channel_dir = base_dir.join("channels").join(&channel_name);
+        let channels_dir = base_dir.join("channels");
+        let channel_dir = channels_dir.join(&channel_name);
+        let archived_dir = channels_dir.join(format!("{}.archived", channel_name));
+        if archived_dir.exists() {
+            return Err(crate::Error::ChannelArchived(channel_name.clone()));
+        }
         let history_dir = channel_dir.join("history");
         fs::create_dir_all(&history_dir)?;
         fs::create_dir_all(channel_dir.join("notes"))?;
@@ -411,7 +418,9 @@ impl Channel {
         project_name: Option<&str>,
     ) -> Result<Vec<ChannelInfo>> {
         let base_dir = base_dir.into();
+        cleanup_archived_channel_conflicts(&base_dir);
         let mut channels: Vec<ChannelInfo> = Vec::new();
+        let mut channel_map: HashMap<String, ChannelInfo> = HashMap::new();
 
         let channels_dir = base_dir.join("channels");
         if channels_dir.exists() {
@@ -448,29 +457,33 @@ impl Channel {
                     continue;
                 }
 
+                // If an archived sibling exists (with real history), prefer it over the active dir.
+                if !is_archived {
+                    let archived_dir = channels_dir.join(format!("{}.archived", channel_name));
+                    if archived_dir.join("history").join("current.jsonl").exists() {
+                        // Skip this active entry — the archived directory is the source of truth.
+                        continue;
+                    }
+                }
+
                 // A channel exists only if it has a history/current.jsonl file
                 if !path.join("history").join("current.jsonl").exists() {
                     continue;
                 }
 
-                // If both active and archived directories exist for the same channel,
-                // the active one wins — the channel is not considered archived.
-                if let Some(existing) = channels.iter_mut().find(|c| c.name == channel_name) {
-                    if !is_archived {
-                        // Active directory found, override any previous archived entry
-                        existing.is_archived = false;
-                    }
-                    // Skip duplicate (archived entry when active already exists,
-                    // or second active entry)
-                    continue;
+                let entry = channel_map
+                    .entry(channel_name.clone())
+                    .or_insert(ChannelInfo {
+                        name: channel_name.clone(),
+                        is_archived,
+                    });
+                if is_archived {
+                    entry.is_archived = true;
                 }
-
-                channels.push(ChannelInfo {
-                    name: channel_name,
-                    is_archived,
-                });
             }
         }
+
+        channels.extend(channel_map.into_values());
 
         // Sort with main project channel pinned first, then alphabetically
         channels.sort_by(|a, b| {
@@ -495,6 +508,7 @@ impl Channel {
     /// `history/current.jsonl`.
     pub fn list_archived(base_dir: impl Into<PathBuf>) -> Result<Vec<String>> {
         let base_dir = base_dir.into();
+        cleanup_archived_channel_conflicts(&base_dir);
         let mut archived = Vec::new();
 
         let channels_dir = base_dir.join("channels");
@@ -1466,6 +1480,73 @@ impl Clone for ChannelRouter {
             default_channel_name: self.default_channel_name.clone(),
             // Arc::clone shares the same cache across clones
             channels: std::sync::Arc::clone(&self.channels),
+        }
+    }
+}
+
+/// Remove any active channel directories that have an archived counterpart.
+///
+/// Archived channels should only exist under `<name>.archived/`. A prior bug
+/// recreated `<name>/` when accessing archived channels, causing both directories
+/// to exist. This helper deletes the zombie active directory so the archived
+/// data remains authoritative.
+fn cleanup_archived_channel_conflicts(base_dir: &Path) {
+    let channels_dir = base_dir.join("channels");
+    if !channels_dir.exists() {
+        return;
+    }
+
+    let entries = match fs::read_dir(&channels_dir) {
+        Ok(entries) => entries,
+        Err(err) => {
+            tracing::warn!(
+                "Failed to scan channels directory '{:?}' for archived conflicts: {}",
+                channels_dir,
+                err
+            );
+            return;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let Some(dir_name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+
+        if !dir_name.ends_with(".archived") {
+            continue;
+        }
+
+        let channel_name = dir_name.trim_end_matches(".archived");
+        if !Channel::is_valid_channel_name(channel_name) {
+            continue;
+        }
+
+        let archived_history = path.join("history").join("current.jsonl");
+        if !archived_history.exists() {
+            continue;
+        }
+
+        let active_dir = channels_dir.join(channel_name);
+        if !active_dir.exists() {
+            continue;
+        }
+
+        match fs::remove_dir_all(&active_dir) {
+            Ok(_) => tracing::info!(
+                "Removed zombie active channel directory '{}' because an archived copy exists",
+                channel_name
+            ),
+            Err(err) => tracing::warn!(
+                "Failed to remove zombie active channel directory '{}': {}",
+                channel_name,
+                err
+            ),
         }
     }
 }

--- a/src/channel_tests.rs
+++ b/src/channel_tests.rs
@@ -844,57 +844,91 @@ fn test_list_skips_invalid_channel_names() {
 }
 
 #[test]
-fn test_both_active_and_archived_files_treats_channel_as_active() {
+fn test_archived_channel_cannot_be_recreated_or_listed_as_active() {
     let temp_dir = TempDir::new().unwrap();
 
     // Create a channel, then archive it
     let channel = Channel::new(temp_dir.path(), "tui").unwrap();
     channel.archive().unwrap();
 
-    // Verify it's archived
-    let channels = Channel::list(temp_dir.path(), true, None).unwrap();
-    let tui = channels.iter().find(|c| c.name == "tui").unwrap();
-    assert!(tui.is_archived, "Should be archived after archive()");
+    // Attempting to create it again should fail with ChannelArchived
+    let err = match Channel::new(temp_dir.path(), "tui") {
+        Ok(_) => panic!("Expected Channel::new to fail for archived channel"),
+        Err(err) => err,
+    };
+    match err {
+        crate::Error::ChannelArchived(name) => {
+            assert_eq!(name, "tui", "ChannelArchived error should include name")
+        }
+        other => panic!("Expected ChannelArchived error, got {other:?}"),
+    }
 
-    // Now also create an active file (simulating a channel that was
-    // re-created while the archived file still exists)
-    Channel::new(temp_dir.path(), "tui").unwrap();
-
-    // Both directories should exist
+    // Simulate a zombie active directory being re-created manually (without Channel::new()).
     let channels_dir = temp_dir.path().join("channels");
-    assert!(
-        channels_dir
-            .join("tui")
-            .join("history")
-            .join("current.jsonl")
-            .exists()
-    );
-    assert!(
-        channels_dir
-            .join("tui.archived")
-            .join("history")
-            .join("current.jsonl")
-            .exists()
-    );
+    let zombie_history = channels_dir.join("tui").join("history");
+    fs::create_dir_all(&zombie_history).unwrap();
+    File::create(zombie_history.join("current.jsonl")).unwrap();
 
-    // Channel::list should treat it as active (not archived)
+    // Channel::list should ignore the zombie active directory and only surface the archived entry.
     let channels = Channel::list(temp_dir.path(), true, None).unwrap();
     let tui_entries: Vec<_> = channels.iter().filter(|c| c.name == "tui").collect();
     assert_eq!(
         tui_entries.len(),
         1,
-        "Should have exactly one entry for 'tui'"
+        "Should have exactly one entry for 'tui' even with a zombie directory"
     );
     assert!(
-        !tui_entries[0].is_archived,
-        "Channel with both active and archived files should be treated as active"
+        tui_entries[0].is_archived,
+        "Archived directory should win when both active and archived exist"
     );
 
-    // Also verify without include_archived — the channel should still appear
+    // Archived channels remain hidden when include_archived = false.
     let channels = Channel::list(temp_dir.path(), false, None).unwrap();
     assert!(
-        channels.iter().any(|c| c.name == "tui"),
-        "Active channel with stale archived file should appear in non-archived list"
+        !channels.iter().any(|c| c.name == "tui"),
+        "Archived channels should not appear without include_archived"
+    );
+}
+
+#[test]
+fn test_channel_list_removes_zombie_active_directory() {
+    let temp_dir = TempDir::new().unwrap();
+
+    // Create and archive a channel.
+    let channel = Channel::new(temp_dir.path(), "frontend").unwrap();
+    channel.archive().unwrap();
+
+    // Recreate a zombie active directory manually.
+    let zombie_history = temp_dir
+        .path()
+        .join("channels")
+        .join("frontend")
+        .join("history");
+    std::fs::create_dir_all(&zombie_history).unwrap();
+    let zombie_file = zombie_history.join("current.jsonl");
+    std::fs::write(&zombie_file, b"ghost\n").unwrap();
+    assert!(
+        zombie_file.exists(),
+        "Precondition: zombie active channel file should exist"
+    );
+
+    // Listing channels should clean up the zombie directory.
+    let channels = Channel::list(temp_dir.path(), true, None).unwrap();
+    assert!(
+        !temp_dir.path().join("channels").join("frontend").exists(),
+        "Channel::list should remove zombie active directories that shadow archived channels"
+    );
+    assert_eq!(
+        1,
+        channels.iter().filter(|c| c.name == "frontend").count(),
+        "Only the archived channel entry should remain"
+    );
+    assert!(
+        channels
+            .iter()
+            .find(|c| c.name == "frontend")
+            .is_some_and(|c| c.is_archived),
+        "The surviving entry should be marked as archived"
     );
 }
 
@@ -909,11 +943,21 @@ fn test_archive_replaces_existing_archived_dir() {
         .unwrap();
     channel.archive().unwrap();
 
-    // Re-create the active channel with a different message
+    let channels_dir = temp_dir.path().join("channels");
+    let archived_dir = channels_dir.join("test-channel.archived");
+    let archived_backup = channels_dir.join("test-channel.archived.saved");
+
+    // Simulate an intentional unarchive: temporarily move the archived directory
+    // out of the way so Channel::new can recreate the active directory.
+    std::fs::rename(&archived_dir, &archived_backup).unwrap();
+
     let channel2 = Channel::new(temp_dir.path(), "test-channel").unwrap();
     channel2
         .send(&Message::text("agent1", "new message"))
         .unwrap();
+
+    // Bring back the original archived directory to simulate a zombie leftover.
+    std::fs::rename(&archived_backup, &archived_dir).unwrap();
 
     // Archiving again should succeed, replacing the old archive
     channel2.archive().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,6 +220,10 @@ pub enum Error {
     /// Invalid message format
     #[error("Invalid message format: {0}")]
     InvalidMessage(String),
+
+    /// Channel exists only in archived form
+    #[error("Channel '{0}' is archived")]
+    ChannelArchived(String),
 }
 
 /// Result type alias for Midtown operations.


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- guard Channel::new() against resurrecting archived directories and add cleanup to remove existing zombies
- ensure Channel::list/list_archived prefer archived entries whenever both copies exist and expose a ChannelArchived error
- add regression tests that cover the guard, cleanup helper, and archive flow with intentional unarchive/resurrection attempts

## Testing
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)
