### PR TITLE
Follow-up: enforce channel.unarchive reserved-name guard [Midtown !1712]

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -656,6 +656,13 @@ impl Channel {
             )));
         }
 
+        if crate::coworker::AVENUE_NAMES.contains(&name) {
+            return Err(crate::Error::InvalidMessage(format!(
+                "Channel name '{}' is reserved for coworker sessions and cannot be used as a channel name",
+                name
+            )));
+        }
+
         let base_dir = base_dir.into();
         let channels_dir = base_dir.join("channels");
         let archived_dir = channels_dir.join(format!("{}.archived", name));

--- a/tests/channel_archive_test.rs
+++ b/tests/channel_archive_test.rs
@@ -1,6 +1,7 @@
 //! Integration test for channel archiving when all tasks complete.
 
 use midtown::{Channel, Message};
+use std::fs;
 use tempfile::TempDir;
 
 #[test]
@@ -176,6 +177,20 @@ fn test_unarchive_non_archived_channel_errors() {
     Channel::new(base_dir, "tui").unwrap();
     let result = Channel::unarchive_channel(base_dir, "tui");
     assert!(result.is_err(), "Unarchiving an active channel should fail");
+}
+
+#[test]
+fn test_unarchive_rejects_reserved_names() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_dir = temp_dir.path();
+    let archived_dir = base_dir.join("channels").join("park.archived");
+    fs::create_dir_all(&archived_dir).unwrap();
+
+    let result = Channel::unarchive_channel(base_dir, "park");
+    assert!(
+        matches!(result, Err(midtown::Error::InvalidMessage(_))),
+        "Unarchiving reserved coworker names should fail"
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- follow-up to PR #1439 feedback: Channel::unarchive_channel now rejects names reserved for coworker sessions (AVENUE_NAMES)
- add regression coverage that pre-populates park.archived and asserts the guard triggers InvalidMessage

## Test Plan
- [x] cargo test channel_archive_test

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)
