### PR TITLE
feat: add --pr flag to midtown state pull-request [Midtown !1718]

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -38,7 +38,7 @@ midtown state <phase> [--task <id>]
 | **claiming** | `midtown state claiming --task 5` | Just claimed a task |
 | **developing** | `midtown state developing --task 5` | Actively writing code |
 | **testing** | `midtown state testing --task 5` | Running tests |
-| **pull-request** | `midtown state pull-request --task 5` | Opening or updating a PR |
+| **pull-request** | `midtown state pull-request --task 5 --pr <NUMBER>` | Opening or updating a PR |
 | **reviewing** | `midtown state reviewing --task 5` | Reviewing someone else's PR |
 | **debugging** | `midtown state debugging --task 5` | Investigating a bug |
 | **completed** | `midtown state completed --task 5` | Non-PR task finished (use `midtown task done` instead for explicit completion) |
@@ -56,7 +56,7 @@ midtown channel post "/me claimed task 5"
 midtown state developing --task 5
 midtown channel post "/me working on task 5"
 
-midtown state pull-request --task 5
+midtown state pull-request --task 5 --pr <PR_NUMBER>
 midtown channel post "/me opened PR for task 5"
 midtown state idle  # daemon completes the task when PR merges
 ```
@@ -69,7 +69,7 @@ Report your estimated progress percentage (0-100) as you work. This helps the te
 midtown state developing --task 5 --progress 20   # initial exploration/planning
 midtown state developing --task 5 --progress 50   # implementation underway
 midtown state testing --task 5 --progress 80      # tests passing
-midtown state pull-request --task 5 --progress 90 # PR opened
+midtown state pull-request --task 5 --pr <PR_NUMBER> --progress 90 # PR opened
 ```
 
 **Guidelines for progress milestones:**
@@ -242,9 +242,10 @@ EOF
 ## Requesting PR Reviews
 When your PR is ready for review:
 
-**Report your state and post to channel:**
+**Report your state and post to channel** (include `--pr` so the daemon can auto-complete the task when the PR merges):
 ```bash
-midtown state pull-request --task 42
+PR_NUMBER=$(gh pr view --json number --jq '.number')
+midtown state pull-request --task 42 --pr $PR_NUMBER
 midtown channel post "/me opened PR for task 42"
 ```
 

--- a/src/bin/midtown/cli/hooks.rs
+++ b/src/bin/midtown/cli/hooks.rs
@@ -649,7 +649,7 @@ fn handle_task_hook() -> Result<Response, String> {
                 });
 
             if let Some(phase_str) = phase_str {
-                let _ = client.coworker_report_state(&agent, phase_str, task_id_num, None);
+                let _ = client.coworker_report_state(&agent, phase_str, task_id_num, None, None);
             }
         }
 

--- a/src/bin/midtown/cli/mod.rs
+++ b/src/bin/midtown/cli/mod.rs
@@ -105,14 +105,16 @@ pub fn handle_chat() -> Result<(), String> {
     chat::run()
 }
 
-/// Handle `midtown state <phase> [--task <id>] [--progress <0-100>]` — reports coworker state via daemon RPC.
+/// Handle `midtown state <phase> [--task <id>] [--progress <0-100>] [--pr <number>]` — reports coworker state via daemon RPC.
 ///
 /// Called explicitly by coworkers to report their workflow phase and optional progress.
 /// Sends state to the daemon which stores it in memory and updates web UI status.
+/// When `--pr` is provided, the daemon writes the PR number to `task.pr` for auto-completion on merge.
 pub fn handle_state(
     phase: midtown::coworker_state::WorkflowPhase,
     task_id: Option<u32>,
     progress: Option<u8>,
+    pr_number: Option<u64>,
 ) -> Result<Response, String> {
     let agent = std::env::var("MIDTOWN_AGENT").unwrap_or_else(|_| "unknown".to_string());
 
@@ -137,7 +139,7 @@ pub fn handle_state(
 
     let client = crate::client::DaemonClient::connect()
         .map_err(|_| "Daemon is not running. Start with: midtown".to_string())?;
-    client.coworker_report_state(&agent, phase_str, task_id, progress)
+    client.coworker_report_state(&agent, phase_str, task_id, progress, pr_number)
 }
 
 /// Handle hook commands (insight, idle, task, ask) - no daemon required

--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -366,6 +366,7 @@ impl DaemonClient {
         phase: &str,
         task_id: Option<u32>,
         progress: Option<u8>,
+        pr_number: Option<u64>,
     ) -> Result<Response, String> {
         let mut params = serde_json::json!({ "name": name, "phase": phase });
         if let Some(id) = task_id {
@@ -373,6 +374,9 @@ impl DaemonClient {
         }
         if let Some(p) = progress {
             params["progress"] = serde_json::json!(p);
+        }
+        if let Some(pr) = pr_number {
+            params["pr_number"] = serde_json::json!(pr);
         }
         self.send("coworker.report-state", Some(params))
     }

--- a/src/bin/midtown/main.rs
+++ b/src/bin/midtown/main.rs
@@ -200,6 +200,10 @@ enum Commands {
         /// Progress percentage (0-100)
         #[arg(long)]
         progress: Option<u8>,
+
+        /// PR number associated with this task (links task.pr for auto-completion on merge)
+        #[arg(long)]
+        pr: Option<u64>,
     },
     /// Hook handlers (insight, idle, task, ask) - called by Claude Code hooks
     #[command(hide = true)]
@@ -634,9 +638,10 @@ fn main() {
         phase,
         task,
         progress,
+        pr,
     } = &command
     {
-        let result = cli::handle_state(*phase, *task, *progress);
+        let result = cli::handle_state(*phase, *task, *progress, *pr);
         handle_result(format, result);
         return;
     }

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -393,8 +393,9 @@ async fn dispatch_request(request: Request, state: &DaemonState) -> Response {
             let phase = require_str!(params, "phase", request.id);
             let task_id = params.u64_param("task_id").map(|v| v as u32);
             let progress = params.u64_param("progress").map(|v| v as u8);
+            let pr_number = params.u64_param("pr_number");
             super::rpc_coworker::handle_coworker_report_state(
-                request.id, name, phase, task_id, progress, state,
+                request.id, name, phase, task_id, progress, pr_number, state,
             )
             .await
         }

--- a/src/daemon/rpc_coworker.rs
+++ b/src/daemon/rpc_coworker.rs
@@ -300,12 +300,15 @@ pub(super) async fn handle_coworker_view(
 /// Stores the coworker's workflow phase and progress in daemon memory and updates the
 /// web UI status. When a coworker reports `Idle`, they are immediately
 /// sent on break. When they report `Completed`, task cleanup is handled.
+/// When `pr_number` is provided, writes it to `task.pr` so the daemon can
+/// auto-complete the task when the PR merges.
 pub(super) async fn handle_coworker_report_state(
     id: RequestId,
     name: &str,
     phase_str: &str,
     task_id: Option<u32>,
     progress: Option<u8>,
+    pr_number: Option<u64>,
     state: &DaemonState,
 ) -> Response {
     // Parse the phase string via FromStr (implemented in coworker_state.rs)
@@ -313,6 +316,42 @@ pub(super) async fn handle_coworker_report_state(
         Ok(p) => p,
         Err(e) => return Response::error(id, RpcError::new(-32602, e)),
     };
+
+    // If --pr was provided, write it to task.pr so the daemon can auto-complete
+    // the task when the PR merges (the merge handler checks task.pr against merged PR numbers).
+    if let Some(pr_num) = pr_number {
+        let effective_task_id: Option<String> = task_id.map(|id| id.to_string()).or_else(|| {
+            let assignments = state.coworker_task_assignments.lock().unwrap();
+            assignments
+                .get(&name.to_lowercase())
+                .map(|a| a.task_id.clone())
+        });
+
+        if let Some(ref tid) = effective_task_id {
+            if let Err(e) = crate::tasks::update_task_fields_for_repo(
+                tid,
+                &state.repo_name,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(pr_num),
+            ) {
+                warn!(
+                    "Failed to write pr_number {} to task {}: {}",
+                    pr_num, tid, e
+                );
+            } else {
+                info!("Set task !{} pr={} (reported by {})", tid, pr_num, name);
+            }
+        } else {
+            warn!(
+                "Coworker {} reported pr_number {} but has no task assignment to update",
+                name, pr_num
+            );
+        }
+    }
 
     // For Idle phase, immediately send the coworker on break.
     if phase == crate::coworker_state::WorkflowPhase::Idle && state.coworkers.get(name).is_some() {

--- a/src/daemon/rpc_coworker_tests.rs
+++ b/src/daemon/rpc_coworker_tests.rs
@@ -379,6 +379,7 @@ async fn test_report_idle_keeps_project_lead_running() {
         "idle",
         None,
         None,
+        None,
         &state,
     )
     .await;
@@ -410,9 +411,16 @@ async fn test_report_idle_still_breaks_non_lead_coworker() {
         });
     assert!(inserted, "coworker should be inserted for test");
 
-    let response =
-        handle_coworker_report_state(RequestId::Number(1), "park", "idle", None, None, &state)
-            .await;
+    let response = handle_coworker_report_state(
+        RequestId::Number(1),
+        "park",
+        "idle",
+        None,
+        None,
+        None,
+        &state,
+    )
+    .await;
 
     assert!(!response.is_error(), "idle report should succeed");
     let message = response
@@ -424,5 +432,104 @@ async fn test_report_idle_still_breaks_non_lead_coworker() {
     assert!(
         message.contains("break (idle)"),
         "non-lead coworker idle report should still take the break path"
+    );
+}
+
+// ============================================================================
+// handle_coworker_report_state — pr_number wiring
+// ============================================================================
+
+#[tokio::test]
+async fn test_report_state_pr_number_writes_task_pr() {
+    let (state, _tmp, _guard) = make_test_state();
+
+    // Create the task file on disk so update_task_fields_for_repo can write to it.
+    let home = dirs::home_dir().expect("home dir");
+    let task_list_id = crate::paths::task_list_id_for_repo(&state.repo_name);
+    let tasks_dir = home.join(".claude").join("tasks").join(&task_list_id);
+    std::fs::create_dir_all(&tasks_dir).expect("create tasks dir");
+    let task_id = "9901"; // unique ID unlikely to conflict with real tasks
+    let task_file = tasks_dir.join(format!("{}.json", task_id));
+    std::fs::write(
+        &task_file,
+        serde_json::to_string(&serde_json::json!({
+            "id": task_id,
+            "subject": "Test PR wiring",
+            "status": "in_progress",
+            "owner": "park"
+        }))
+        .unwrap(),
+    )
+    .expect("write task file");
+
+    // Call with task_id and pr_number
+    let response = handle_coworker_report_state(
+        RequestId::Number(1),
+        "park",
+        "pull_request",
+        Some(9901u32),
+        Some(90),
+        Some(456u64),
+        &state,
+    )
+    .await;
+
+    assert!(!response.is_error(), "report state should succeed");
+
+    // Verify task.pr was written to the file
+    let content = std::fs::read_to_string(&task_file).expect("read task file");
+    let parsed: serde_json::Value = serde_json::from_str(&content).expect("parse task json");
+    assert_eq!(
+        parsed["pr"],
+        serde_json::json!(456u64),
+        "task.pr should be set to the reported PR number"
+    );
+
+    // Cleanup
+    let _ = std::fs::remove_file(&task_file);
+}
+
+#[tokio::test]
+async fn test_report_state_pr_number_no_task_assignment_succeeds() {
+    let (state, _tmp, _guard) = make_test_state();
+
+    // No task assignment set up — handler should log a warning but still succeed
+    let response = handle_coworker_report_state(
+        RequestId::Number(1),
+        "park",
+        "pull_request",
+        None, // no task_id
+        Some(90),
+        Some(789u64),
+        &state,
+    )
+    .await;
+
+    // Should still succeed even when no task can be found to update
+    assert!(
+        !response.is_error(),
+        "report state with unresolvable task should still succeed"
+    );
+}
+
+#[tokio::test]
+async fn test_report_state_without_pr_number_succeeds() {
+    let (state, _tmp, _guard) = make_test_state();
+
+    // pr_number = None should behave identically to pre-feature behavior
+    let response = handle_coworker_report_state(
+        RequestId::Number(1),
+        "park",
+        "pull_request",
+        None,
+        Some(90),
+        None,
+        &state,
+    )
+    .await;
+
+    assert!(
+        !response.is_error(),
+        "report state without pr_number should succeed"
     );
 }


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Adds `--pr <NUMBER>` flag to `midtown state pull-request` CLI command
- When provided, the daemon writes the PR number to `task.pr` via `update_task_fields_for_repo`
- This enables the existing auto-completion logic (which checks `task.pr` against merged PR numbers) to fire correctly — previously `task.pr` was never set by coworkers
- Updates `agents/coworker.md` to instruct coworkers to always pass `--pr $PR_NUMBER` after opening a PR

## How it works

The change flows through 5 layers:
1. **CLI arg** — `--pr <NUMBER>` added to `Commands::State` in `main.rs`
2. **Handler** — `handle_state()` passes `pr_number` to the RPC client
3. **RPC client** — `coworker_report_state()` includes `pr_number` in JSON params
4. **RPC dispatch** — `rpc.rs` extracts `pr_number` from params and passes to handler
5. **Domain handler** — `handle_coworker_report_state()` calls `update_task_fields_for_repo()` to persist `task.pr`

The daemon already had auto-completion logic for tasks when their PR merges (in `pr.rs`), but it only fires when `task.pr` is set. This PR closes that gap.

## Test plan
- [x] 3 new unit tests in `rpc_coworker_tests.rs`:
  - `test_report_state_pr_number_writes_task_pr` — verifies disk write of `task.pr`
  - `test_report_state_pr_number_no_task_assignment_succeeds` — no task to update → still succeeds
  - `test_report_state_without_pr_number_succeeds` — existing behavior unchanged
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] All existing tests pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)