### PR TITLE
fix: change @mention style to bold-only, no background [Midtown !1725]

### DIFF
--- a/src/bin/midtown/cli/chat/ui/messages.rs
+++ b/src/bin/midtown/cli/chat/ui/messages.rs
@@ -272,7 +272,7 @@ fn split_span_at_mentions(span: Span<'static>, mention_style: Style) -> Vec<Span
         if word_end > 0 {
             result.push(Span::styled(
                 after_at[..word_end].to_string(),
-                mention_style,
+                base_style.patch(mention_style),
             ));
             remaining = &after_at[word_end..];
         } else {


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Removed `bg(Color::Blue)` and `fg(Color::White)` from the mention highlight style in `apply_mention_highlights()`
- Mentions now render as bold text only, without a background color pill
- Updated all three mention-related tests to assert `bg.is_none()` and `Modifier::BOLD` present

## Test plan
- [x] Added/updated tests asserting bold-only style (no background)
- [x] Confirmed tests failed with old code, pass with new code
- [x] Full test suite: 627 tests passing
- [x] `cargo clippy` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)