### PR TITLE
fix: make cursor color theme-aware in input bars [Midtown !1722]

### DIFF
--- a/src/bin/midtown/cli/chat/ui/chat.rs
+++ b/src/bin/midtown/cli/chat/ui/chat.rs
@@ -502,10 +502,16 @@ fn draw_input_bar(f: &mut Frame, app: &App, area: Rect) {
                 .add_modifier(Modifier::DIM),
         ));
     }
-    let cursor_style = Style::default().fg(palette.bg).bg(palette.fg);
+    // Two cursor styles: `█` fills the entire cell with the *foreground* color, so using
+    // fg=palette.bg (dark in dark themes) makes the block invisible. The block cursor
+    // uses fg=palette.fg (light in dark themes) to appear as a solid visible block.
+    // The character cursor (mid-text) uses inverted colors so the background highlights
+    // the character position — the background (palette.fg) is visible around the char glyph.
+    let block_cursor_style = Style::default().fg(palette.fg).bg(palette.bg);
+    let char_cursor_style = Style::default().fg(palette.bg).bg(palette.fg);
     if is_focused && app.input_cursor == char_count {
         spans.push(Span::raw(app.input_text.clone()));
-        spans.push(Span::styled("█", cursor_style));
+        spans.push(Span::styled("█", block_cursor_style));
     } else if is_focused {
         let byte_idx = app
             .input_text
@@ -517,7 +523,7 @@ fn draw_input_bar(f: &mut Frame, app: &App, area: Rect) {
         let cursor_char = after_str.chars().next().unwrap_or(' ');
         let rest = &after_str[cursor_char.len_utf8()..];
         spans.push(Span::raw(before.to_string()));
-        spans.push(Span::styled(cursor_char.to_string(), cursor_style));
+        spans.push(Span::styled(cursor_char.to_string(), char_cursor_style));
         spans.push(Span::raw(rest.to_string()));
     } else {
         spans.push(Span::raw(app.input_text.clone()));

--- a/src/bin/midtown/cli/chat/ui/chat_tests.rs
+++ b/src/bin/midtown/cli/chat/ui/chat_tests.rs
@@ -5,6 +5,59 @@ use super::super::super::app::tests::test_app;
 use super::*;
 
 #[test]
+fn test_block_cursor_uses_palette_fg_not_palette_bg() {
+    // The `█` (FULL BLOCK) end-of-text cursor must use palette.fg as its foreground color.
+    // U+2588 FULL BLOCK fills the entire character cell with the *foreground* color,
+    // so using palette.bg (dark in dark themes) makes the cursor invisible.
+    // The cursor must be styled with fg=palette.fg so it appears light/white in dark themes.
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::layout::Rect;
+
+    let backend = TestBackend::new(40, 3);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let mut app = test_app();
+    app.focused_pane = FocusedPane::InputBar;
+    app.input_text = "hi".to_string();
+    app.input_cursor = 2; // at end of "hi" — renders █
+
+    let palette = app.theme.palette();
+
+    terminal
+        .draw(|f| {
+            let area = Rect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 3,
+            };
+            draw_input_bar(f, &app, area);
+        })
+        .unwrap();
+
+    let buffer = terminal.backend().buffer();
+    // border(x=0) + prompt "› "(x=1,2) + "hi"(x=3,4) + cursor(x=5), content row y=1
+    let cursor_cell = buffer.cell((5, 1)).unwrap();
+
+    assert_eq!(
+        cursor_cell.symbol(),
+        "█",
+        "Cursor at end of text should show '█'"
+    );
+    assert_eq!(
+        cursor_cell.fg, palette.fg,
+        "Block cursor '█' must use palette.fg as foreground — '█' fills the entire cell with fg, \
+         so using palette.bg (dark in dark themes) makes it invisible. Got fg={:?}, expected palette.fg={:?}",
+        cursor_cell.fg, palette.fg
+    );
+    assert_ne!(
+        cursor_cell.fg, palette.bg,
+        "Block cursor must NOT use palette.bg as foreground — that makes '█' invisible in dark themes"
+    );
+}
+
+#[test]
 fn test_cursor_renders_over_character_not_before_it() {
     // When cursor is in the middle of text, it should overlay the character
     // at the cursor position (with highlighting), not insert '█' before it.

--- a/src/bin/midtown/cli/chat/ui/thread.rs
+++ b/src/bin/midtown/cli/chat/ui/thread.rs
@@ -3,10 +3,11 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
 };
+use ratatui_themes::ThemePalette;
 
 use super::super::app::{App, FocusedPane};
 use super::messages::{apply_mention_highlights, render_content_lines, render_message};
@@ -17,10 +18,12 @@ pub fn draw_thread_panel(f: &mut Frame, app: &mut App, area: Rect) {
         return;
     };
 
+    let palette = app.theme.palette();
+
     // Pre-render parent message content upfront to get actual line count and avoid
     // borrow conflicts with &mut App. Content width is area width minus 2 (for borders).
     let content_width = area.width.saturating_sub(2) as usize;
-    let content_style = Style::default().fg(Color::White);
+    let content_style = Style::default().fg(palette.fg);
 
     let parent_msg_data: Option<(String, Vec<Line<'static>>)> = app
         .messages
@@ -54,7 +57,7 @@ pub fn draw_thread_panel(f: &mut Frame, app: &mut App, area: Rect) {
         ])
         .split(area);
 
-    draw_thread_header(f, parent_msg_data, chunks[0]);
+    draw_thread_header(f, parent_msg_data, chunks[0], palette);
     draw_thread_messages(f, app, chunks[1]);
     draw_thread_input(f, app, chunks[2]);
 }
@@ -68,16 +71,17 @@ fn draw_thread_header(
     f: &mut Frame,
     parent_msg_data: Option<(String, Vec<Line<'static>>)>,
     area: Rect,
+    palette: ThemePalette,
 ) {
     let block = Block::default()
         .title(" Thread ")
         .title_style(
             Style::default()
-                .fg(Color::Cyan)
+                .fg(palette.accent)
                 .add_modifier(Modifier::BOLD),
         )
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::DarkGray));
+        .border_style(Style::default().fg(palette.muted));
 
     let inner = block.inner(area);
 
@@ -85,7 +89,7 @@ fn draw_thread_header(
         let mut lines = vec![Line::from(Span::styled(
             from,
             Style::default()
-                .fg(Color::Yellow)
+                .fg(palette.warning)
                 .add_modifier(Modifier::BOLD),
         ))];
         lines.extend(content_lines);
@@ -93,7 +97,7 @@ fn draw_thread_header(
     } else {
         vec![Line::from(Span::styled(
             "Thread (parent not found)",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(palette.muted),
         ))]
     };
 
@@ -103,10 +107,11 @@ fn draw_thread_header(
 
 /// Draw thread reply messages
 fn draw_thread_messages(f: &mut Frame, app: &mut App, area: Rect) {
+    let palette = app.theme.palette();
     let border_color = if app.focused_pane == FocusedPane::Thread {
-        Color::Yellow
+        palette.accent
     } else {
-        Color::DarkGray
+        palette.muted
     };
 
     let block = Block::default()
@@ -118,7 +123,7 @@ fn draw_thread_messages(f: &mut Frame, app: &mut App, area: Rect) {
     if app.thread_messages.is_empty() {
         let empty = Paragraph::new(Line::from(Span::styled(
             " No replies yet",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(palette.muted),
         )));
         f.render_widget(block, area);
         f.render_widget(empty, inner);
@@ -174,10 +179,11 @@ fn draw_thread_input(f: &mut Frame, app: &mut App, area: Rect) {
     // Store for click-to-focus detection
     app.thread_input_area = Some(area);
     let is_focused = app.focused_pane == FocusedPane::Thread;
+    let palette = app.theme.palette();
     let border_color = if is_focused {
-        Color::Yellow
+        palette.accent
     } else {
-        Color::DarkGray
+        palette.muted
     };
 
     let block = Block::default()
@@ -188,11 +194,15 @@ fn draw_thread_input(f: &mut Frame, app: &mut App, area: Rect) {
 
     let prompt = "\u{21b3} "; // ↳
     let char_count = app.thread_input_text.chars().count();
-    let cursor_style = Style::default().fg(Color::Black).bg(Color::Yellow);
+    // `█` (FULL BLOCK) fills the entire cell with the foreground color — use palette.fg
+    // (light in dark themes) so the block cursor is visible. The char cursor uses inverted
+    // colors so the highlighted background (palette.fg) shows around the character glyph.
+    let block_cursor_style = Style::default().fg(palette.fg).bg(palette.bg);
+    let char_cursor_style = Style::default().fg(palette.bg).bg(palette.fg);
     let mut spans: Vec<Span> = vec![Span::raw(prompt)];
     if is_focused && app.thread_input_cursor == char_count {
         spans.push(Span::raw(app.thread_input_text.clone()));
-        spans.push(Span::styled("\u{2588}", cursor_style)); // █
+        spans.push(Span::styled("\u{2588}", block_cursor_style)); // █
     } else if is_focused {
         let byte_idx = app
             .thread_input_text
@@ -204,7 +214,7 @@ fn draw_thread_input(f: &mut Frame, app: &mut App, area: Rect) {
         let cursor_char = after_str.chars().next().unwrap_or(' ');
         let rest = &after_str[cursor_char.len_utf8()..];
         spans.push(Span::raw(before.to_string()));
-        spans.push(Span::styled(cursor_char.to_string(), cursor_style));
+        spans.push(Span::styled(cursor_char.to_string(), char_cursor_style));
         spans.push(Span::raw(rest.to_string()));
     } else {
         spans.push(Span::raw(app.thread_input_text.clone()));

--- a/src/bin/midtown/cli/chat/ui/thread_tests.rs
+++ b/src/bin/midtown/cli/chat/ui/thread_tests.rs
@@ -1,3 +1,4 @@
+use super::super::super::app::FocusedPane;
 use super::super::super::app::tests::test_app;
 use super::draw_thread_panel;
 
@@ -39,6 +40,67 @@ fn test_draw_thread_panel_narrow_terminal_header_height() {
     // (the Min(3) constraint). If the header inflated to 12, there'd be no space.
     // With a 20-row terminal: 12 header + 3 replies_min + 3 input = 18 minimum needed.
     // We verify the panel renders without panic — a panic means the layout overflowed.
+}
+
+/// Thread input cursor must use theme palette colors rather than hardcoded black/yellow.
+///
+/// The `█` (FULL BLOCK) cursor in draw_thread_input previously used
+/// `fg(Color::Black).bg(Color::Yellow)` — a solid black block that is invisible on dark
+/// backgrounds. The cursor must use `fg(palette.fg)` so it appears light/white in dark themes.
+#[test]
+fn test_thread_cursor_uses_palette_not_hardcoded_colors() {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::layout::Rect;
+    use ratatui::style::Color;
+
+    // 40-wide, 12-tall terminal.
+    // Layout: header(4) + replies(5) + input(3) = 12 rows.
+    let backend = TestBackend::new(40, 12);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let mut app = test_app();
+    // Set up a parent message so draw_thread_panel renders the full panel.
+    let parent_msg = midtown::Message::text("park", "hello");
+    let parent_id = parent_msg.id.clone();
+    app.messages.push_back(parent_msg);
+    app.thread_parent_id = Some(parent_id);
+    app.focused_pane = FocusedPane::Thread;
+    app.thread_input_text = "hi".to_string();
+    app.thread_input_cursor = 2; // at end of "hi" — renders the █ cursor
+
+    let palette = app.theme.palette();
+
+    terminal
+        .draw(|f| {
+            let area = Rect::new(0, 0, 40, 12);
+            draw_thread_panel(f, &mut app, area);
+        })
+        .unwrap();
+
+    let buffer = terminal.backend().buffer();
+    // Input chunk starts at y=9 (header=4, replies=5).
+    // Inside the input block: border at y=9, content at y=10, border at y=11.
+    // Content at y=10: left_border(x=0) + ↳(x=1) + space(x=2) + h(x=3) + i(x=4) + cursor(x=5).
+    let cursor_cell = buffer.cell((5, 10)).unwrap();
+
+    assert_eq!(
+        cursor_cell.symbol(),
+        "█",
+        "Thread cursor at end of text should show '█'"
+    );
+    assert_ne!(
+        cursor_cell.fg,
+        Color::Black,
+        "Thread cursor must NOT use hardcoded Color::Black — invisible in dark themes. Got fg={:?}",
+        cursor_cell.fg
+    );
+    assert_eq!(
+        cursor_cell.fg, palette.fg,
+        "Thread cursor must use palette.fg so it's visible in any theme. \
+         Got fg={:?}, expected palette.fg={:?}",
+        cursor_cell.fg, palette.fg
+    );
 }
 
 /// When content_width is zero, header renders with minimum height (4), not maximum (12).


### PR DESCRIPTION
<!-- midtown: park -->

## Summary

- The `█` (FULL BLOCK) cursor in both the main chat input and thread input was invisible in dark themes because it used `fg=palette.bg` (the dark background color) — FULL BLOCK fills the **entire cell** with the foreground color, hiding the background, making the cursor blend into the dark terminal background
- The character cursor (shown when pressing arrow keys to navigate mid-text) already worked correctly because the background color is visible around non-full-block glyphs
- Fixes the cursor in both input bars and also updates all hardcoded `Color::Yellow`/`DarkGray`/`Cyan`/`Black` colors in the thread panel to use `palette.accent`/`palette.muted`/`palette.warning`

### Root cause

`█` is a FULL BLOCK character — it fills 100% of the character cell with the **foreground** color. The previous style `fg(palette.bg).bg(palette.fg)` set the glyph color to the dark background (invisible in dark themes). The background color (`palette.fg`, light in dark themes) was hidden behind the glyph.

The fix uses **two cursor styles**:
- `block_cursor_style = fg(palette.fg).bg(palette.bg)` — solid light/white block for end-of-text cursor
- `char_cursor_style = fg(palette.bg).bg(palette.fg)` — inverted text for mid-text cursor (unchanged visually)

## Test plan

- [x] `test_block_cursor_uses_palette_fg_not_palette_bg`: verifies `█` cursor uses `palette.fg` as foreground (written before fix, confirmed failing, now passing)
- [x] `test_thread_cursor_uses_palette_not_hardcoded_colors`: verifies thread cursor is not hardcoded `Color::Black` (same red-green cycle)
- [x] All 629 existing tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)