### PR TITLE
fix: syntax highlighting in thread panel + theme-aware colors [Midtown !1726]

### DIFF
--- a/src/bin/midtown/cli/chat/ui/chat.rs
+++ b/src/bin/midtown/cli/chat/ui/chat.rs
@@ -317,6 +317,8 @@ fn draw_chat_messages(f: &mut Frame, app: &mut App, area: Rect) {
         .chain(app.channel_lead_names.iter().cloned())
         .collect();
 
+    let use_light_theme = palette.is_light();
+
     for (idx, msg) in visible.iter().enumerate() {
         let segments = mermaid::parse_content_segments(&msg.content);
         let has_special = segments
@@ -353,6 +355,7 @@ fn draw_chat_messages(f: &mut Frame, app: &mut App, area: Rect) {
                 &mut lines,
                 &mut app.diagram_sources,
                 &mut mermaid_to_render,
+                use_light_theme,
             );
         }
 

--- a/src/bin/midtown/cli/chat/ui/highlight.rs
+++ b/src/bin/midtown/cli/chat/ui/highlight.rs
@@ -17,16 +17,21 @@ static THEME_SET: Lazy<ThemeSet> = Lazy::new(ThemeSet::load_defaults);
 
 /// Highlight source code and return ratatui Lines with colored spans.
 ///
-/// Uses syntect with the base16-ocean.dark theme. Falls back to plain text
-/// syntax highlighting if the language is unknown.
-pub fn highlight_code(language: &str, source: &str) -> Vec<Line<'static>> {
+/// Selects `InspiredGitHub` for light TUI themes and `base16-ocean.dark` for dark
+/// themes. Falls back to plain text syntax highlighting if the language is unknown.
+pub fn highlight_code(language: &str, source: &str, use_light_theme: bool) -> Vec<Line<'static>> {
     if source.is_empty() {
         return Vec::new();
     }
 
     let syntax = find_syntax(language);
 
-    let theme = &THEME_SET.themes["base16-ocean.dark"];
+    let theme_name = if use_light_theme {
+        "InspiredGitHub"
+    } else {
+        "base16-ocean.dark"
+    };
+    let theme = &THEME_SET.themes[theme_name];
     let mut h = HighlightLines::new(syntax, theme);
 
     let mut result = Vec::new();

--- a/src/bin/midtown/cli/chat/ui/highlight_tests.rs
+++ b/src/bin/midtown/cli/chat/ui/highlight_tests.rs
@@ -5,7 +5,7 @@ use super::highlight_code;
 #[test]
 fn test_highlight_rust_code() {
     let source = "fn main() {\n    let x = 42;\n    println!(\"{}\", x);\n}";
-    let lines = highlight_code("rust", source);
+    let lines = highlight_code("rust", source, false);
 
     assert!(!lines.is_empty(), "Should produce at least one line");
 
@@ -37,7 +37,7 @@ fn test_highlight_rust_code() {
 fn test_highlight_unknown_language_fallback() {
     let source = "some unknown language content\nwith multiple lines";
     // Should not panic; produces plain output
-    let lines = highlight_code("unknownlanguagexyz", source);
+    let lines = highlight_code("unknownlanguagexyz", source, false);
 
     assert!(
         !lines.is_empty(),
@@ -59,9 +59,37 @@ fn test_highlight_unknown_language_fallback() {
 
 #[test]
 fn test_highlight_empty_source() {
-    let lines = highlight_code("rust", "");
+    let lines = highlight_code("rust", "", false);
     // Empty source should produce empty lines without panicking
     assert!(lines.is_empty(), "Empty source should produce no lines");
+}
+
+#[test]
+fn test_highlight_light_theme_produces_different_colors_than_dark() {
+    // InspiredGitHub (light) and base16-ocean.dark use different color palettes,
+    // so the same source should produce visually distinct foreground colors.
+    let source = "fn main() {\n    let x = 42;\n    println!(\"{}\", x);\n}";
+    let dark_lines = highlight_code("rust", source, false);
+    let light_lines = highlight_code("rust", source, true);
+
+    assert!(!dark_lines.is_empty(), "Dark theme should produce lines");
+    assert!(!light_lines.is_empty(), "Light theme should produce lines");
+
+    let dark_colors: Vec<_> = dark_lines
+        .iter()
+        .flat_map(|l| l.spans.iter())
+        .filter_map(|s| s.style.fg)
+        .collect();
+    let light_colors: Vec<_> = light_lines
+        .iter()
+        .flat_map(|l| l.spans.iter())
+        .filter_map(|s| s.style.fg)
+        .collect();
+
+    assert_ne!(
+        dark_colors, light_colors,
+        "InspiredGitHub (light) and base16-ocean.dark should produce different span colors"
+    );
 }
 
 #[test]
@@ -107,6 +135,7 @@ fn test_code_block_segment_renders_with_borders() {
         &mut lines,
         &mut diagram_sources,
         &mut mermaid_to_render,
+        false,
     );
 
     // Collect all text per line to check content

--- a/src/bin/midtown/cli/chat/ui/messages_mermaid.rs
+++ b/src/bin/midtown/cli/chat/ui/messages_mermaid.rs
@@ -34,6 +34,7 @@ pub fn render_message_with_mermaid(
     lines: &mut Vec<Line<'static>>,
     diagram_sources: &mut Vec<String>,
     mermaid_to_render: &mut Vec<String>,
+    use_light_theme: bool,
 ) {
     let ctx = MessageRenderContext::new(msg, prev_sender, user_display_name, channel_lead_names);
 
@@ -83,6 +84,7 @@ pub fn render_message_with_mermaid(
                     content_width,
                     &mut is_first_content_line,
                     lines,
+                    use_light_theme,
                 );
             }
         }
@@ -167,6 +169,7 @@ fn render_mermaid_segment(
 /// Handles the timestamp gutter for the first line of the message when
 /// `is_first_content_line` is true (sets it to false after emitting the first line).
 /// Long code lines are truncated to `content_width` to prevent overflow on narrow terminals.
+#[allow(clippy::too_many_arguments)]
 fn render_code_block_segment(
     msg: &midtown::Message,
     language: &str,
@@ -175,6 +178,7 @@ fn render_code_block_segment(
     content_width: usize,
     is_first_content_line: &mut bool,
     lines: &mut Vec<Line<'static>>,
+    use_light_theme: bool,
 ) {
     let indent = " ".repeat(ctx.indent_width());
 
@@ -195,7 +199,7 @@ fn render_code_block_segment(
     }
 
     // Highlighted code lines, truncated to content_width
-    let highlighted = highlight_code(language, source);
+    let highlighted = highlight_code(language, source, use_light_theme);
     for hl_line in highlighted {
         let mut truncated_spans = Vec::new();
         let mut remaining = content_width;

--- a/src/bin/midtown/cli/chat/ui/messages_mermaid_tests.rs
+++ b/src/bin/midtown/cli/chat/ui/messages_mermaid_tests.rs
@@ -55,6 +55,7 @@ fn test_cached_diagram_shows_inline_ascii_art() {
         &mut lines,
         &mut diagram_sources,
         &mut mermaid_to_render,
+        false,
     );
 
     let all_text: String = lines
@@ -115,6 +116,7 @@ fn test_pending_diagram_shows_rendering_placeholder() {
         &mut lines,
         &mut diagram_sources,
         &mut mermaid_to_render,
+        false,
     );
 
     let placeholder_text: String = lines
@@ -165,6 +167,7 @@ fn test_unqueued_diagram_shows_plain_placeholder_and_queues() {
         &mut lines,
         &mut diagram_sources,
         &mut mermaid_to_render,
+        false,
     );
 
     let placeholder_text: String = lines
@@ -217,6 +220,7 @@ fn test_diagram_numbering_sequential() {
         &mut lines,
         &mut diagram_sources,
         &mut mermaid_to_render,
+        false,
     );
 
     assert_eq!(diagram_sources.len(), 3);
@@ -264,6 +268,7 @@ fn test_diagram_cap_at_9_shortcuts() {
         &mut lines,
         &mut diagram_sources,
         &mut mermaid_to_render,
+        false,
     );
 
     assert_eq!(diagram_sources.len(), 11);
@@ -319,6 +324,7 @@ fn test_mixed_text_and_mermaid_segments() {
         &mut lines,
         &mut diagram_sources,
         &mut mermaid_to_render,
+        false,
     );
 
     let all_text: String = lines
@@ -365,6 +371,7 @@ fn test_diagram_type_extracted_from_first_line() {
             &mut lines,
             &mut diagram_sources,
             &mut mermaid_to_render,
+            false,
         );
 
         let all_text: String = lines
@@ -416,6 +423,7 @@ fn test_action_message_mermaid_placeholder_extra_indent() {
         &mut lines,
         &mut diagram_sources,
         &mut mermaid_to_render,
+        false,
     );
 
     let action_indent = " ".repeat(TIMESTAMP_GUTTER_WIDTH + 2);
@@ -474,6 +482,7 @@ fn test_action_message_mermaid_placeholder_extra_indent() {
         &mut normal_lines,
         &mut normal_diagram_sources,
         &mut normal_mermaid_to_render,
+        false,
     );
 
     let normal_indent = " ".repeat(TIMESTAMP_GUTTER_WIDTH);
@@ -543,6 +552,7 @@ fn test_narrow_terminal_does_not_panic_on_unicode_ascii_art() {
             &mut lines,
             &mut diagram_sources,
             &mut mermaid_to_render,
+            false,
         );
 
         assert!(!lines.is_empty(), "Should produce lines at width {}", width);
@@ -580,6 +590,7 @@ fn test_code_block_first_segment_has_timestamp_gutter() {
         &mut lines,
         &mut diagram_sources,
         &mut mermaid_to_render,
+        false,
     );
 
     assert!(!lines.is_empty(), "Should produce at least one line");
@@ -635,6 +646,7 @@ fn test_code_block_long_line_truncated_to_content_width() {
         &mut lines,
         &mut diagram_sources,
         &mut mermaid_to_render,
+        false,
     );
 
     // Find the line that contains the code content (not borders)

--- a/src/bin/midtown/cli/chat/ui/thread.rs
+++ b/src/bin/midtown/cli/chat/ui/thread.rs
@@ -11,6 +11,8 @@ use ratatui_themes::ThemePalette;
 
 use super::super::app::{App, FocusedPane};
 use super::messages::{apply_mention_highlights, render_content_lines, render_message};
+use super::messages_mermaid::render_message_with_mermaid;
+use crate::cli::chat::mermaid;
 
 /// Draw the thread panel showing a parent message's thread replies.
 pub fn draw_thread_panel(f: &mut Frame, app: &mut App, area: Rect) {
@@ -132,27 +134,61 @@ fn draw_thread_messages(f: &mut Frame, app: &mut App, area: Rect) {
 
     let current_tasks = app.current_tasks().clone();
     let user_display_name = app.user_display_name.clone();
+    let use_light_theme = app.theme.palette().is_light();
 
     let lead_names: Vec<String> = std::iter::once(app.project_name.clone())
         .chain(app.channel_lead_names.iter().cloned())
         .collect();
 
+    // Clone to avoid borrow conflicts between iterating thread_messages and
+    // accessing app.mermaid_cache during render_message_with_mermaid.
+    let thread_messages = app.thread_messages.clone();
+
     let mut lines: Vec<Line> = Vec::new();
-    for (idx, msg) in app.thread_messages.iter().enumerate() {
+    let mut mermaid_to_render: Vec<String> = Vec::new();
+    let mut diagram_sources: Vec<String> = Vec::new();
+
+    for (idx, msg) in thread_messages.iter().enumerate() {
         let prev = if idx > 0 {
-            Some(app.thread_messages[idx - 1].from.as_str())
+            Some(thread_messages[idx - 1].from.as_str())
         } else {
             None
         };
-        let msg_lines = render_message(
-            msg,
-            inner.width as usize,
-            prev,
-            &current_tasks,
-            user_display_name.as_deref(),
-            &lead_names,
-        );
-        lines.extend(msg_lines);
+        let segments = mermaid::parse_content_segments(&msg.content);
+        let has_special = segments
+            .iter()
+            .any(|s| !matches!(s, mermaid::ContentSegment::Text(_)));
+
+        if has_special {
+            render_message_with_mermaid(
+                msg,
+                &segments,
+                inner.width as usize,
+                prev,
+                &current_tasks,
+                user_display_name.as_deref(),
+                &lead_names,
+                &app.mermaid_cache,
+                &mut lines,
+                &mut diagram_sources,
+                &mut mermaid_to_render,
+                use_light_theme,
+            );
+        } else {
+            let msg_lines = render_message(
+                msg,
+                inner.width as usize,
+                prev,
+                &current_tasks,
+                user_display_name.as_deref(),
+                &lead_names,
+            );
+            lines.extend(msg_lines);
+        }
+    }
+
+    for source in mermaid_to_render {
+        app.mermaid_cache.get_or_render(&source);
     }
 
     // Show N lines based on scroll offset (0 = bottom/newest, higher = older)

--- a/src/bin/midtown/cli/chat/ui/thread_tests.rs
+++ b/src/bin/midtown/cli/chat/ui/thread_tests.rs
@@ -1,3 +1,5 @@
+use midtown::MessageType;
+
 use super::super::super::app::FocusedPane;
 use super::super::super::app::tests::test_app;
 use super::draw_thread_panel;
@@ -133,4 +135,78 @@ fn test_draw_thread_panel_zero_content_width_does_not_inflate_header() {
         .unwrap();
 
     // Rendered without panic — the layout was valid (no overflow from inflated header)
+}
+
+/// Thread messages containing fenced code blocks must be syntax-highlighted,
+/// not shown as raw backtick fences. The rendered thread panel must contain
+/// "--- rust ---" (code block border) when a reply has a rust code block.
+///
+/// Before the fix: draw_thread_messages used render_message() which passed the
+/// raw content through minimad_ratatui::inline, showing "```rust" as plain text.
+/// After the fix: it calls parse_content_segments() + render_message_with_mermaid()
+/// which routes code blocks through highlight_code(), producing "--- lang ---" borders.
+#[test]
+fn test_thread_panel_renders_code_block_with_syntax_highlighting_borders() {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::layout::Rect;
+
+    let mut app = test_app();
+
+    // Add a parent message (thread header)
+    let parent_msg = midtown::Message::text("park", "Here is some code");
+    let parent_id = parent_msg.id.clone();
+    app.messages.push_back(parent_msg);
+    app.thread_parent_id = Some(parent_id.clone());
+
+    // Add a thread reply with a fenced rust code block
+    let reply = midtown::Message {
+        id: "reply-1".to_string(),
+        from: "madison".to_string(),
+        content: "```rust\nfn hello() {}\n```".to_string(),
+        timestamp: chrono::Utc::now(),
+        message_type: MessageType::Text,
+        channel: None,
+        session_id: None,
+        thread_parent_id: Some(parent_id),
+    };
+    app.thread_messages.push(reply);
+
+    let backend = TestBackend::new(80, 30);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    terminal
+        .draw(|f| {
+            let area = Rect::new(0, 0, 80, 30);
+            draw_thread_panel(f, &mut app, area);
+        })
+        .unwrap();
+
+    // Collect rendered buffer as text lines
+    let buf = terminal.backend().buffer();
+    let rendered_lines: Vec<String> = (0..30)
+        .map(|row| {
+            (0..80)
+                .filter_map(|col| buf.cell((col, row)).map(|c| c.symbol().to_string()))
+                .collect()
+        })
+        .collect();
+    let all_text = rendered_lines.join("\n");
+
+    assert!(
+        all_text.contains("--- rust ---"),
+        "Thread panel should render code blocks with '--- rust ---' border, got:\n{}",
+        all_text
+    );
+    assert!(
+        all_text.contains("--- end ---"),
+        "Thread panel should render code blocks with '--- end ---' border, got:\n{}",
+        all_text
+    );
+    // Should NOT show raw backtick fences
+    assert!(
+        !all_text.contains("```rust"),
+        "Thread panel should NOT show raw backtick fences, got:\n{}",
+        all_text
+    );
 }


### PR DESCRIPTION
<!-- midtown: york -->

## Summary

- **Thread panel code blocks**: `draw_thread_messages` now calls `parse_content_segments()` + `render_message_with_mermaid()` for messages that contain code fences or mermaid diagrams, matching the same routing used by the main chat panel. Previously it always called `render_message()` → `render_content_lines()`, which has no code block detection and rendered raw backtick fences as plain text.

- **Theme-aware syntax colors**: `highlight_code()` gains a `use_light_theme: bool` parameter. When `true` it selects syntect's `InspiredGitHub` theme (light-background palette) instead of `base16-ocean.dark`. Both `draw_chat_messages` and `draw_thread_messages` derive this flag from `palette.is_light()`, so the theme switches automatically with the active TUI color theme.

## Files changed

| File | Change |
|------|--------|
| `highlight.rs` | Add `use_light_theme: bool` param; select `InspiredGitHub` vs `base16-ocean.dark` |
| `messages_mermaid.rs` | Thread `use_light_theme` through `render_message_with_mermaid` → `render_code_block_segment` → `highlight_code` |
| `thread.rs` | Clone thread messages; detect special content; route to `render_message_with_mermaid` when needed; queue mermaid renders |
| `chat.rs` | Derive `use_light_theme = palette.is_light()` and pass to `render_message_with_mermaid` |

## Test plan

- [x] New test `test_thread_panel_renders_code_block_with_syntax_highlighting_borders` — confirms thread panel renders `--- rust ---` / `--- end ---` borders for fenced code blocks (was failing before fix)
- [x] New test `test_highlight_light_theme_produces_different_colors_than_dark` — confirms `InspiredGitHub` and `base16-ocean.dark` produce distinct foreground colors
- [x] All existing tests updated to pass `false` (dark) to `render_message_with_mermaid` callers
- [x] `cargo test` — 2529 tests pass, 0 fail
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)