### PR TITLE
feat: thread input bar expands to multiple lines [Midtown !1727]

### DIFF
--- a/src/bin/midtown/cli/chat/ui/chat.rs
+++ b/src/bin/midtown/cli/chat/ui/chat.rs
@@ -439,7 +439,7 @@ fn draw_chat_messages(f: &mut Frame, app: &mut App, area: Rect) {
 /// Calculate the required height for the input bar based on wrapped text
 ///
 /// Returns total height including borders (2) and content lines (1 minimum, 6 maximum).
-fn calculate_input_bar_height(input_text: &str, area_width: u16) -> u16 {
+pub(super) fn calculate_input_bar_height(input_text: &str, area_width: u16) -> u16 {
     const PROMPT_WIDTH: usize = 3; // "› "
     const CURSOR_WIDTH: usize = 1; // "█"
     const MIN_CONTENT_LINES: u16 = 1;

--- a/src/bin/midtown/cli/chat/ui/thread.rs
+++ b/src/bin/midtown/cli/chat/ui/thread.rs
@@ -10,6 +10,7 @@ use ratatui::{
 use ratatui_themes::ThemePalette;
 
 use super::super::app::{App, FocusedPane};
+use super::chat::calculate_input_bar_height;
 use super::messages::{apply_mention_highlights, render_content_lines, render_message};
 
 /// Draw the thread panel showing a parent message's thread replies.
@@ -48,12 +49,14 @@ pub fn draw_thread_panel(f: &mut Frame, app: &mut App, area: Rect) {
         4
     };
 
+    let thread_input_height = calculate_input_bar_height(&app.thread_input_text, area.width);
+
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(header_height), // Parent message header (dynamic)
             Constraint::Min(3),                // Thread replies
-            Constraint::Length(3),             // Thread input bar (1 content line + 2 border lines)
+            Constraint::Length(thread_input_height), // Thread input bar (dynamic, 1–6 content lines + 2 borders)
         ])
         .split(area);
 

--- a/src/bin/midtown/cli/chat/ui/thread_tests.rs
+++ b/src/bin/midtown/cli/chat/ui/thread_tests.rs
@@ -103,6 +103,56 @@ fn test_thread_cursor_uses_palette_not_hardcoded_colors() {
     );
 }
 
+/// Thread input bar must expand to multiple lines for long input text,
+/// matching the behavior of the main channel input bar.
+///
+/// The thread input height was previously hardcoded to 3 (1 content line + 2 borders).
+/// With long input text that wraps to multiple lines, it must grow dynamically
+/// using the same calculate_input_bar_height logic as the main input.
+#[test]
+fn test_thread_input_expands_to_multiple_lines() {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::layout::Rect;
+
+    // 80-wide, 25-tall terminal — enough space for header + replies + tall input.
+    let backend = TestBackend::new(80, 25);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let mut app = test_app();
+    let parent_msg = midtown::Message::text("park", "hello");
+    let parent_id = parent_msg.id.clone();
+    app.messages.push_back(parent_msg);
+    app.thread_parent_id = Some(parent_id);
+
+    // 150 'a' chars should wrap to 3 content lines at 80-wide terminal
+    // (available inner width 78, minus prompt 3, minus cursor 1 = 74 chars/line → 3 lines)
+    app.thread_input_text = "a".repeat(150);
+
+    terminal
+        .draw(|f| {
+            let area = Rect::new(0, 0, 80, 25);
+            draw_thread_panel(f, &mut app, area);
+        })
+        .unwrap();
+
+    // The thread input area (including borders) must be > 3 rows for multi-line text.
+    // With 3 content lines + 2 border rows = 5 total.
+    let input_area = app
+        .thread_input_area
+        .expect("thread_input_area must be set");
+    assert!(
+        input_area.height > 3,
+        "Thread input height should expand beyond 3 for long text, got {}",
+        input_area.height
+    );
+    assert_eq!(
+        input_area.height, 5,
+        "150-char input should give 3 content lines + 2 borders = height 5, got {}",
+        input_area.height
+    );
+}
+
 /// When content_width is zero, header renders with minimum height (4), not maximum (12).
 /// This is the direct regression check: we measure the layout split produces a valid
 /// replies area rather than an overflowed/zero-height one.


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Made `calculate_input_bar_height` `pub(super)` in `chat.rs` so sibling UI modules can reuse it
- Updated `draw_thread_panel` in `thread.rs` to compute dynamic input height via `calculate_input_bar_height(&app.thread_input_text, area.width)` instead of the hardcoded `Constraint::Length(3)`
- Added a regression test (`test_thread_input_expands_to_multiple_lines`) verifying 150-char input expands the thread input to height 5 (3 content lines + 2 borders)

The thread input now grows to the same 1–6 content lines as the main channel input, using identical logic.

## Test plan
- [x] New test `test_thread_input_expands_to_multiple_lines` — fails before the fix, passes after
- [x] All existing thread panel tests pass (narrow terminal, cursor color)
- [x] All 165 UI tests pass (`cargo test --bin midtown -- cli::chat::ui`)
- [x] `cargo clippy` and `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)