### PR TITLE
test: add coverage for session recovery cooldown + headless provider [Midtown !1728]

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2421,24 +2421,31 @@ specialized_provider = "codex"
     }
 
     #[test]
-    fn test_specialized_override_fallback_order() {
-        let execution = ExecutionSection {
-            lead_provider: None,
-            project_lead_provider: None,
-            coworker_provider: None,
-            reviewer_provider: None,
-            review_mode: None,
-            channel_lead_provider: None,
+    fn test_headless_execute_provider_precedence() {
+        let specialized_only = ExecutionSection {
             specialized_provider: Some(crate::auth::AuthProvider::Codex),
-            headless_execute_provider: None,
+            ..ExecutionSection::default()
         };
+        assert_eq!(
+            resolve_execution_provider(&specialized_only, ExecutionRole::HeadlessExecute),
+            crate::auth::AuthProvider::Codex
+        );
 
-        // HeadlessExecute falls back to specialized_provider when no override set.
-        let headless = execution
-            .headless_execute_provider
-            .or(execution.specialized_provider)
-            .unwrap_or(crate::auth::AuthProvider::Claude);
-        assert_eq!(headless, crate::auth::AuthProvider::Codex);
+        let headless_override = ExecutionSection {
+            specialized_provider: Some(crate::auth::AuthProvider::Codex),
+            headless_execute_provider: Some(crate::auth::AuthProvider::Zai),
+            ..ExecutionSection::default()
+        };
+        assert_eq!(
+            resolve_execution_provider(&headless_override, ExecutionRole::HeadlessExecute),
+            crate::auth::AuthProvider::Zai
+        );
+
+        let default_only = ExecutionSection::default();
+        assert_eq!(
+            resolve_execution_provider(&default_only, ExecutionRole::HeadlessExecute),
+            crate::auth::AuthProvider::Claude
+        );
     }
 
     #[test]

--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -2231,16 +2231,7 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                             }
                         }
 
-                        // Record per-session-id recovery cooldown so the next tick skips
-                        // re-recovery if the session dies quickly. Only recorded for resume
-                        // spawns — fresh (non-recovery) spawns should not block future recovery
-                        // attempts. This mirrors the on_success RecordCooldown in Path 1
-                        // (dispatch_via_sessions_with_task_lookup) and prevents the retry loop
-                        // described in task !1728.
-                        if resume {
-                            let mut cooldowns = state.cooldowns.lock().unwrap();
-                            cooldowns.record("session_recovered", &session_id);
-                        }
+                        record_session_recovery_cooldown(&state.cooldowns, &session_id, resume);
 
                         state.broadcast_coworker_update(&name, "running", None);
                     }
@@ -2665,6 +2656,19 @@ async fn auto_merge_pr(state: &DaemonState, pr_number: u64, title: &str) {
             warn!("Failed to post auto-merge failure message: {}", e);
         }
     }
+}
+
+/// Record the `session_recovered` cooldown for resume spawns to prevent rapid retries.
+fn record_session_recovery_cooldown(
+    cooldowns: &std::sync::Mutex<crate::rules::CooldownTracker>,
+    session_id: &str,
+    resume: bool,
+) {
+    if !resume {
+        return;
+    }
+    let mut guard = cooldowns.lock().unwrap();
+    guard.record("session_recovered", session_id);
 }
 
 #[path = "effects_tests.rs"]

--- a/src/daemon/effects_tests.rs
+++ b/src/daemon/effects_tests.rs
@@ -26,6 +26,28 @@ fn count_nudge_session(effects: &[Effect], sid: &str) -> usize {
 }
 
 #[test]
+fn record_session_recovery_cooldown_records_resume_spawns() {
+    let tracker = std::sync::Mutex::new(crate::rules::CooldownTracker::new());
+    super::record_session_recovery_cooldown(&tracker, "sess-resume-1", true);
+    let guard = tracker.lock().unwrap();
+    assert!(
+        guard.has_entry("session_recovered", "sess-resume-1"),
+        "resume spawns should record the session_recovered cooldown"
+    );
+}
+
+#[test]
+fn record_session_recovery_cooldown_skips_fresh_spawns() {
+    let tracker = std::sync::Mutex::new(crate::rules::CooldownTracker::new());
+    super::record_session_recovery_cooldown(&tracker, "fresh-spawn-1", false);
+    let guard = tracker.lock().unwrap();
+    assert!(
+        !guard.has_entry("session_recovered", "fresh-spawn-1"),
+        "fresh spawns should not record session_recovered cooldowns"
+    );
+}
+
+#[test]
 fn clear_task_binding_in_records_clears_only_stale_when_no_expected_session() {
     use std::collections::HashMap;
 


### PR DESCRIPTION
<!-- midtown: park -->\n\nFollow-up to #1461 to satisfy Codecov's coverage feedback.\n\n## Summary\n- extract a helper for recording `session_recovered` cooldowns and test both resume/fresh paths\n- add a dedicated test for `resolve_execution_provider` when role = HeadlessExecute\n\n## Test plan\n- `cargo test record_session_recovery_cooldown`\n- `cargo test headless_execute_provider_precedence`\n\n🌃 Co-built with [Midtown](https://github.com/btucker/midtown)