### PR TITLE
fix: suppress insight.report for channel lead sessions [Midtown !1747]

### DIFF
--- a/src/daemon/rpc_insight.rs
+++ b/src/daemon/rpc_insight.rs
@@ -27,6 +27,25 @@ pub(super) async fn handle_insight_report(
     channel: Option<&str>,
     state: &DaemonState,
 ) -> Response {
+    // Channel leads auto-post all output to their channel already.
+    // Suppress insight.report from channel leads to avoid double-posting.
+    {
+        let ps = state.persistent_state.lock().await;
+        if ps.channel_lead_sessions.contains_key(agent) {
+            debug!(
+                "insight.report: suppressing insight from channel lead '{}' (auto-posted via output)",
+                agent
+            );
+            return Response::success(
+                id,
+                serde_json::json!({
+                    "posted": false,
+                    "reason": "channel_lead",
+                }),
+            );
+        }
+    }
+
     // Deduplicate: normalize and hash the insight content
     let hash = hash_insight(insight);
     {

--- a/src/daemon/rpc_insight_tests.rs
+++ b/src/daemon/rpc_insight_tests.rs
@@ -201,6 +201,32 @@ async fn test_insight_routes_to_task_channel_when_no_explicit_channel() {
     );
 }
 
+/// Insights from channel lead sessions should be suppressed — they already
+/// auto-post their output to the channel, so insight.report is redundant.
+#[tokio::test]
+async fn test_insight_suppressed_for_channel_lead() {
+    let (state, _temp_dir, _guard) = make_test_state("testrepo");
+
+    {
+        let mut ps = state.persistent_state.lock().await;
+        ps.channel_lead_sessions
+            .insert("auth".to_string(), "session-id-abc".to_string());
+    }
+
+    let response = handle_insight_report(
+        RequestId::Number(1),
+        "auth",
+        "An insight from channel lead",
+        None,
+        &state,
+    )
+    .await;
+
+    let result = response.result.expect("should return success result");
+    assert_eq!(result["posted"], false);
+    assert_eq!(result["reason"], "channel_lead");
+}
+
 /// Duplicate insights should be deduplicated and return posted=false.
 #[tokio::test]
 async fn test_insight_deduplication() {


### PR DESCRIPTION
<!-- midtown: daemon -->

## Summary

- Channel lead sessions auto-post all output to their channel already — the `insight.report` RPC path was redundant and caused insights to spill into the main channel
- Added an early-exit check in `handle_insight_report`: if the reporting agent is in `channel_lead_sessions`, return `posted: false / reason: channel_lead` immediately
- Added test `test_insight_suppressed_for_channel_lead` covering this case

## Root cause

`rpc_insight.rs` routed insights using only `headless_sessions` (coworker task-to-channel map). Channel leads are tracked in `channel_lead_sessions` instead, so they had no channel entry and fell through to the main channel default.

## Test plan

- [x] `cargo test test_insight_suppressed_for_channel_lead` passes
- [x] All existing insight tests pass
- [x] `cargo clippy` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)