### PR TITLE
fix: improve scroll UX — time-based mouse sensitivity, vim bindings [Midtown !1749]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -1065,9 +1065,14 @@ impl App {
     /// Uses time-based detection to distinguish deliberate mouse-wheel clicks from
     /// trackpad inertia:
     /// - Events arriving > MOUSE_INERTIA_THRESHOLD apart → deliberate click → scroll
-    ///   immediately by SCROLL_STEP (same as a keyboard arrow key press).
+    ///   immediately by SCROLL_STEP (same as a keyboard arrow key press). The accumulator
+    ///   is set to the burst-absorption sentinel (-MOUSE_SCROLL_THRESHOLD) so that
+    ///   follow-up events from the same hardware notch are absorbed rather than
+    ///   triggering an extra fine scroll.
     /// - Events arriving ≤ MOUSE_INERTIA_THRESHOLD apart → inertia/trackpad burst →
     ///   use the accumulator (MOUSE_SCROLL_THRESHOLD events = MOUSE_SCROLL_STEP lines).
+    ///   If the accumulator is at the post-immediate sentinel, each burst event
+    ///   decrements it toward 0 (absorbing the event) before normal accumulation resumes.
     pub fn mouse_scroll_up(&mut self) {
         let elapsed = self
             .last_scroll_event
@@ -1077,7 +1082,8 @@ impl App {
 
         if elapsed > MOUSE_INERTIA_THRESHOLD {
             // Deliberate mouse-wheel click: scroll immediately, same as a key press.
-            self.mouse_scroll_accumulator = 0;
+            // Set sentinel so burst follow-ups are absorbed rather than accumulated.
+            self.mouse_scroll_accumulator = -MOUSE_SCROLL_THRESHOLD;
             let max_scroll = self.max_scroll();
             if self.scroll_offset < max_scroll {
                 self.scroll_offset = (self.scroll_offset + SCROLL_STEP).min(max_scroll);
@@ -1088,7 +1094,14 @@ impl App {
             self.maybe_load_more_history();
         } else {
             // Inertia/trackpad burst: accumulate until threshold.
+            if self.mouse_scroll_accumulator <= -MOUSE_SCROLL_THRESHOLD {
+                // Post-immediate burst absorption: move sentinel toward 0 one step at a time,
+                // discarding this event rather than counting it toward the next scroll.
+                self.mouse_scroll_accumulator += 1;
+                return;
+            }
             if self.mouse_scroll_accumulator < 0 {
+                // Direction changed; discard down credits and start fresh.
                 self.mouse_scroll_accumulator = 0;
             }
             self.mouse_scroll_accumulator += 1;
@@ -1108,7 +1121,7 @@ impl App {
 
     /// Mouse wheel scroll down in the main chat panel.
     ///
-    /// Same time-based detection as mouse_scroll_up.
+    /// Same time-based detection and burst-absorption logic as mouse_scroll_up.
     pub fn mouse_scroll_down(&mut self) {
         let elapsed = self
             .last_scroll_event
@@ -1118,14 +1131,21 @@ impl App {
 
         if elapsed > MOUSE_INERTIA_THRESHOLD {
             // Deliberate mouse-wheel click: scroll immediately.
-            self.mouse_scroll_accumulator = 0;
+            // Set sentinel so burst follow-ups are absorbed.
+            self.mouse_scroll_accumulator = MOUSE_SCROLL_THRESHOLD;
             if self.scroll_offset > 0 {
                 self.scroll_offset = self.scroll_offset.saturating_sub(SCROLL_STEP);
                 self.intentionally_at_top = false;
             }
         } else {
             // Inertia/trackpad burst: accumulate until threshold.
+            if self.mouse_scroll_accumulator >= MOUSE_SCROLL_THRESHOLD {
+                // Post-immediate burst absorption.
+                self.mouse_scroll_accumulator -= 1;
+                return;
+            }
             if self.mouse_scroll_accumulator > 0 {
+                // Direction changed; discard up credits and start fresh.
                 self.mouse_scroll_accumulator = 0;
             }
             self.mouse_scroll_accumulator -= 1;
@@ -1141,7 +1161,7 @@ impl App {
 
     /// Mouse wheel scroll up in the thread panel.
     ///
-    /// Same time-based detection as mouse_scroll_up.
+    /// Same time-based detection and burst-absorption logic as mouse_scroll_up.
     pub fn thread_mouse_scroll_up(&mut self) {
         let elapsed = self
             .last_thread_scroll_event
@@ -1150,9 +1170,13 @@ impl App {
         self.last_thread_scroll_event = Some(Instant::now());
 
         if elapsed > MOUSE_INERTIA_THRESHOLD {
-            self.thread_mouse_scroll_accumulator = 0;
+            self.thread_mouse_scroll_accumulator = -MOUSE_SCROLL_THRESHOLD;
             self.thread_scroll_offset = self.thread_scroll_offset.saturating_add(SCROLL_STEP);
         } else {
+            if self.thread_mouse_scroll_accumulator <= -MOUSE_SCROLL_THRESHOLD {
+                self.thread_mouse_scroll_accumulator += 1;
+                return;
+            }
             if self.thread_mouse_scroll_accumulator < 0 {
                 self.thread_mouse_scroll_accumulator = 0;
             }
@@ -1167,7 +1191,7 @@ impl App {
 
     /// Mouse wheel scroll down in the thread panel.
     ///
-    /// Same time-based detection as mouse_scroll_up.
+    /// Same time-based detection and burst-absorption logic as mouse_scroll_up.
     pub fn thread_mouse_scroll_down(&mut self) {
         let elapsed = self
             .last_thread_scroll_event
@@ -1176,9 +1200,13 @@ impl App {
         self.last_thread_scroll_event = Some(Instant::now());
 
         if elapsed > MOUSE_INERTIA_THRESHOLD {
-            self.thread_mouse_scroll_accumulator = 0;
+            self.thread_mouse_scroll_accumulator = MOUSE_SCROLL_THRESHOLD;
             self.thread_scroll_offset = self.thread_scroll_offset.saturating_sub(SCROLL_STEP);
         } else {
+            if self.thread_mouse_scroll_accumulator >= MOUSE_SCROLL_THRESHOLD {
+                self.thread_mouse_scroll_accumulator -= 1;
+                return;
+            }
             if self.thread_mouse_scroll_accumulator > 0 {
                 self.thread_mouse_scroll_accumulator = 0;
             }

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -975,9 +975,10 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                         app.thread_input_cursor += 1;
                         EventResult::Continue
                     } else {
-                        // Vim-style scroll bindings when the chat input is empty or unfocused.
-                        // Only fires when there is no pending text to protect against eating input.
-                        if app.input_text.is_empty() || app.focused_pane != FocusedPane::InputBar {
+                        // Vim-style scroll bindings when there is no pending input text.
+                        // Guarded by input_text.is_empty() so a draft composed in the InputBar
+                        // is never lost if focus shifts to Chat/Board while the user is typing.
+                        if app.input_text.is_empty() {
                             match c {
                                 'j' => {
                                     app.scroll_down();
@@ -1843,6 +1844,36 @@ mod tests {
         assert_eq!(
             app.input_text, "helloj",
             "j with non-empty input should insert into the text"
+        );
+    }
+
+    #[test]
+    fn test_vim_j_inserts_when_chat_focused_but_draft_exists() {
+        // Regression: the original condition was `input_text.is_empty() || focused_pane !=
+        // InputBar`, which meant j/k would SCROLL when focus moved to Chat even if the user
+        // had a draft in the input bar — silently losing those keystrokes.
+        // The fix changes the gate to `input_text.is_empty()` only.
+        use app::FocusedPane;
+        use midtown::Message;
+        let mut app = test_app();
+        for i in 0..30 {
+            app.messages
+                .push_back(Message::text("test", format!("msg {i}")));
+        }
+        app.focused_pane = FocusedPane::Chat; // focus shifted away from InputBar
+        app.input_text = "draft message".to_string(); // but draft exists
+        app.input_cursor = 13;
+        app.scroll_offset = 5;
+
+        handle_event(&mut app, key_press(KeyCode::Char('j')));
+        // Should NOT scroll — should insert 'j' into the draft
+        assert_eq!(
+            app.input_text, "draft messagej",
+            "j with existing draft should insert even when focus is on Chat"
+        );
+        assert_eq!(
+            app.scroll_offset, 5,
+            "scroll_offset must not change when a draft exists"
         );
     }
 

--- a/src/bin/midtown/cli/chat/mouse_scroll_tests.rs
+++ b/src/bin/midtown/cli/chat/mouse_scroll_tests.rs
@@ -381,3 +381,110 @@ fn test_thread_immediate_mode() {
         "Thread immediate-mode scroll should move by SCROLL_STEP"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Burst absorption after immediate scroll
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_burst_events_absorbed_after_immediate_scroll_up() {
+    // After an immediate scroll, burst follow-up events (< 50ms) should NOT trigger
+    // an extra MOUSE_SCROLL_STEP. A 4-event-per-notch device must still produce
+    // exactly SCROLL_STEP lines per physical notch.
+    let mut app = test_app();
+    for i in 0..30 {
+        app.messages
+            .push_back(Message::text("test", format!("msg {i}")));
+    }
+    app.scroll_offset = 0;
+    set_old_scroll(&mut app);
+
+    // Event 1: immediate scroll (elapsed > threshold)
+    app.mouse_scroll_up();
+    let after_immediate = app.scroll_offset;
+    assert_eq!(
+        after_immediate, SCROLL_STEP,
+        "Immediate event should scroll SCROLL_STEP"
+    );
+
+    // Events 2..=THRESHOLD: burst follow-ups (set recent so they're in inertia mode)
+    // These should be absorbed by the post-immediate sentinel, not fire again.
+    // With THRESHOLD=3, we send THRESHOLD burst events (one more than needed to fire
+    // in normal inertia mode) and verify no extra scroll fires.
+    set_recent_scroll(&mut app);
+    for _ in 0..MOUSE_SCROLL_THRESHOLD as usize {
+        app.mouse_scroll_up();
+    }
+    assert_eq!(
+        app.scroll_offset, after_immediate,
+        "Burst follow-up events after immediate scroll must not trigger extra fine scroll"
+    );
+}
+
+#[test]
+fn test_burst_events_absorbed_after_immediate_scroll_down() {
+    // Same burst-absorption guarantee for the down direction.
+    let mut app = test_app();
+    for i in 0..30 {
+        app.messages
+            .push_back(Message::text("test", format!("msg {i}")));
+    }
+    app.scroll_offset = SCROLL_STEP * 5;
+    set_old_scroll(&mut app);
+
+    // Event 1: immediate scroll down
+    app.mouse_scroll_down();
+    let after_immediate = app.scroll_offset;
+    assert_eq!(
+        after_immediate,
+        SCROLL_STEP * 4,
+        "Immediate down event should scroll SCROLL_STEP"
+    );
+
+    // Burst follow-ups
+    set_recent_scroll(&mut app);
+    for _ in 0..MOUSE_SCROLL_THRESHOLD as usize {
+        app.mouse_scroll_down();
+    }
+    assert_eq!(
+        app.scroll_offset, after_immediate,
+        "Burst follow-up events after immediate down scroll must not trigger extra fine scroll"
+    );
+}
+
+#[test]
+fn test_inertia_still_works_after_burst_absorption_window() {
+    // After burst absorption ends (enough events consumed), normal inertia accumulation
+    // should resume so that a sustained trackpad swipe continues to scroll.
+    let mut app = test_app();
+    for i in 0..60 {
+        app.messages
+            .push_back(Message::text("test", format!("msg {i}")));
+    }
+    app.scroll_offset = 0;
+    set_old_scroll(&mut app);
+
+    // Immediate scroll
+    app.mouse_scroll_up();
+    let after_immediate = app.scroll_offset;
+
+    // Absorb the burst (THRESHOLD events)
+    set_recent_scroll(&mut app);
+    for _ in 0..MOUSE_SCROLL_THRESHOLD as usize {
+        app.mouse_scroll_up();
+    }
+    assert_eq!(
+        app.scroll_offset, after_immediate,
+        "Burst absorbed: no extra scroll yet"
+    );
+
+    // After burst is fully absorbed, THRESHOLD more events should trigger one fine scroll
+    for _ in 0..MOUSE_SCROLL_THRESHOLD as usize {
+        app.mouse_scroll_up();
+    }
+    assert_eq!(
+        app.scroll_offset,
+        after_immediate + MOUSE_SCROLL_STEP,
+        "After burst absorbed, THRESHOLD more inertia events should produce one fine scroll"
+    );
+}


### PR DESCRIPTION
<!-- midtown: park -->

## Summary

- **Mouse sensitivity**: replaces the fixed 3-event accumulator with time-based detection. Events > 50ms apart (real mouse wheel) scroll immediately by `SCROLL_STEP` (3 lines per click). Events ≤ 50ms apart (trackpad inertia) continue using the accumulator. Single mouse-wheel click now feels like pressing an arrow key.
- **Vim bindings** (`j`/`k`/`g`/`G`) when the input bar is empty or unfocused: `j` scrolls down, `k` scrolls up, `g` jumps to oldest messages, `G` jumps to newest.
- **Ctrl+U / Ctrl+D** scroll half a page when the input is empty or unfocused; existing emacs kill/delete behavior is preserved when the input has text.

## Implementation

Two files changed:
- `app.rs`: adds `last_scroll_event` / `last_thread_scroll_event` timestamp fields, `MOUSE_INERTIA_THRESHOLD` constant (50ms), rewrites the four mouse scroll methods, adds `half_page_up` / `half_page_down` methods.
- `mod.rs`: Ctrl+U and Ctrl+D updated to fall through to scroll when input is empty; vim bindings added in the `Char` catch-all handler before `auto_focus_and_insert_char`.

## Test plan

- [x] New `mouse_scroll_tests.rs` tests for immediate mode (single event scrolls `SCROLL_STEP`) and inertia mode (accumulator unchanged)
- [x] Existing inertia regression tests updated to force inertia mode via `last_scroll_event = Some(Instant::now())`
- [x] `mod.rs` tests for j/k/g/G: fires when unfocused, fires on empty input, inserts when input has text
- [x] `mod.rs` tests for Ctrl+U / Ctrl+D: scrolls when empty, preserves emacs behavior when non-empty
- [x] All 651 tests pass; `cargo clippy -D warnings` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)