### PR TITLE
fix(tui): address 4 unreviewed scroll/vim issues from PR #1485 [Midtown !1752 !1753 !1754 !1755]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -349,10 +349,14 @@ pub struct App {
     /// Positive = up credits, negative = down credits.
     /// Resets to 0 when direction changes to prevent cross-direction bleed.
     mouse_scroll_accumulator: i8,
-    /// Timestamp of the last main-chat mouse scroll event. Used to distinguish deliberate
+    /// Timestamp of the last main-chat mouse scroll-up event. Used to distinguish deliberate
     /// mouse-wheel clicks (> MOUSE_INERTIA_THRESHOLD apart → scroll immediately) from
     /// trackpad inertia bursts (< threshold apart → use accumulator).
-    pub(crate) last_scroll_event: Option<Instant>,
+    pub(crate) last_scroll_up_event: Option<Instant>,
+    /// Timestamp of the last main-chat mouse scroll-down event. Kept separate from
+    /// last_scroll_up_event so that a quick direction reversal (up then down within
+    /// 50ms) still enters immediate mode for the new direction rather than inertia mode.
+    pub(crate) last_scroll_down_event: Option<Instant>,
     /// Separate accumulator for mouse wheel scroll events in the thread panel.
     /// Kept independent of mouse_scroll_accumulator so partial credits earned
     /// while scrolling one panel cannot bleed into the other panel's scroll.
@@ -622,7 +626,8 @@ impl App {
             tasks_cache_hash: 0,
             intentionally_at_top: false,
             mouse_scroll_accumulator: 0,
-            last_scroll_event: None,
+            last_scroll_up_event: None,
+            last_scroll_down_event: None,
             thread_mouse_scroll_accumulator: 0,
             last_thread_scroll_event: None,
             mermaid_cache: MermaidCache::new(),
@@ -1075,10 +1080,10 @@ impl App {
     ///   decrements it toward 0 (absorbing the event) before normal accumulation resumes.
     pub fn mouse_scroll_up(&mut self) {
         let elapsed = self
-            .last_scroll_event
+            .last_scroll_up_event
             .map(|t| t.elapsed())
             .unwrap_or(Duration::MAX);
-        self.last_scroll_event = Some(Instant::now());
+        self.last_scroll_up_event = Some(Instant::now());
 
         if elapsed > MOUSE_INERTIA_THRESHOLD {
             // Deliberate mouse-wheel click: scroll immediately, same as a key press.
@@ -1124,10 +1129,10 @@ impl App {
     /// Same time-based detection and burst-absorption logic as mouse_scroll_up.
     pub fn mouse_scroll_down(&mut self) {
         let elapsed = self
-            .last_scroll_event
+            .last_scroll_down_event
             .map(|t| t.elapsed())
             .unwrap_or(Duration::MAX);
-        self.last_scroll_event = Some(Instant::now());
+        self.last_scroll_down_event = Some(Instant::now());
 
         if elapsed > MOUSE_INERTIA_THRESHOLD {
             // Deliberate mouse-wheel click: scroll immediately.
@@ -3722,7 +3727,8 @@ pub(super) mod tests {
             tasks_cache_hash: 0,
             intentionally_at_top: false,
             mouse_scroll_accumulator: 0,
-            last_scroll_event: None,
+            last_scroll_up_event: None,
+            last_scroll_down_event: None,
             thread_mouse_scroll_accumulator: 0,
             last_thread_scroll_event: None,
             mermaid_cache: MermaidCache::new(),

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -587,14 +587,17 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                     KeyCode::Char('d') => {
                         // Ctrl+D: delete character under cursor when in InputBar with text,
                         // otherwise half-page scroll down (vim Ctrl+D behavior).
-                        if app.focused_pane == FocusedPane::InputBar && !app.input_text.is_empty() {
+                        if app.focused_pane == FocusedPane::InputBar
+                            && !app.input_text.is_empty()
+                            && !app.channel_switcher.show
+                        {
                             if app.input_cursor < app.input_text.chars().count() {
                                 let byte_idx =
                                     char_index_to_byte_index(&app.input_text, app.input_cursor);
                                 app.input_text.remove(byte_idx);
                                 app.detect_autocomplete_trigger();
                             }
-                        } else {
+                        } else if !app.channel_switcher.show {
                             // Input is empty or not in InputBar: half-page scroll down.
                             app.half_page_down();
                         }
@@ -975,10 +978,11 @@ fn handle_event(app: &mut App, event: Event) -> EventResult {
                         app.thread_input_cursor += 1;
                         EventResult::Continue
                     } else {
-                        // Vim-style scroll bindings when there is no pending input text.
-                        // Guarded by input_text.is_empty() so a draft composed in the InputBar
-                        // is never lost if focus shifts to Chat/Board while the user is typing.
-                        if app.input_text.is_empty() {
+                        // Vim-style scroll bindings when not typing in InputBar and no draft.
+                        // Two guards prevent character loss:
+                        // - focused_pane != InputBar: typing 'got it' with InputBar focused inserts, not scrolls.
+                        // - input_text.is_empty(): a draft survives even when focus shifts to Chat/Board.
+                        if app.focused_pane != FocusedPane::InputBar && app.input_text.is_empty() {
                             match c {
                                 'j' => {
                                     app.scroll_down();
@@ -1703,284 +1707,6 @@ mod tests {
 
         handle_event(&mut app, key_press(KeyCode::PageDown));
         assert_eq!(app.focused_pane, FocusedPane::Chat);
-    }
-
-    // -----------------------------------------------------------------------
-    // Vim-style scroll bindings
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_vim_j_scrolls_down_when_unfocused() {
-        use app::FocusedPane;
-        use midtown::Message;
-        let mut app = test_app();
-        for i in 0..30 {
-            app.messages
-                .push_back(Message::text("test", format!("msg {i}")));
-        }
-        app.focused_pane = FocusedPane::Chat;
-        app.scroll_offset = 10;
-
-        handle_event(&mut app, key_press(KeyCode::Char('j')));
-        assert!(
-            app.scroll_offset < 10,
-            "j should scroll down (decrease offset)"
-        );
-        // Focus should not move to InputBar
-        assert_eq!(
-            app.focused_pane,
-            FocusedPane::Chat,
-            "j should not focus InputBar"
-        );
-        assert_eq!(app.input_text, "", "j should not insert into input");
-    }
-
-    #[test]
-    fn test_vim_k_scrolls_up_when_unfocused() {
-        use app::FocusedPane;
-        use midtown::Message;
-        let mut app = test_app();
-        for i in 0..30 {
-            app.messages
-                .push_back(Message::text("test", format!("msg {i}")));
-        }
-        app.focused_pane = FocusedPane::Chat;
-        app.scroll_offset = 0;
-
-        handle_event(&mut app, key_press(KeyCode::Char('k')));
-        assert!(
-            app.scroll_offset > 0,
-            "k should scroll up (increase offset)"
-        );
-        assert_eq!(
-            app.focused_pane,
-            FocusedPane::Chat,
-            "k should not focus InputBar"
-        );
-        assert_eq!(app.input_text, "", "k should not insert into input");
-    }
-
-    #[test]
-    fn test_vim_g_scrolls_to_top_when_unfocused() {
-        use app::FocusedPane;
-        use midtown::Message;
-        let mut app = test_app();
-        for i in 0..30 {
-            app.messages
-                .push_back(Message::text("test", format!("msg {i}")));
-        }
-        app.focused_pane = FocusedPane::Chat;
-        app.scroll_offset = 0;
-
-        handle_event(&mut app, key_press(KeyCode::Char('g')));
-        assert!(app.scroll_offset > 0, "g should scroll to top (offset > 0)");
-        assert_eq!(
-            app.focused_pane,
-            FocusedPane::Chat,
-            "g should not focus InputBar"
-        );
-    }
-
-    #[test]
-    #[allow(non_snake_case)]
-    fn test_vim_G_scrolls_to_bottom_when_unfocused() {
-        use app::FocusedPane;
-        use midtown::Message;
-        let mut app = test_app();
-        for i in 0..30 {
-            app.messages
-                .push_back(Message::text("test", format!("msg {i}")));
-        }
-        app.focused_pane = FocusedPane::Chat;
-        app.scroll_offset = 20;
-        // 'G' with kitty protocol comes as Char('G') via the shift transform
-        handle_event(
-            &mut app,
-            Event::Key(crossterm::event::KeyEvent::new(
-                KeyCode::Char('g'),
-                crossterm::event::KeyModifiers::SHIFT,
-            )),
-        );
-        assert_eq!(app.scroll_offset, 0, "G should scroll to bottom");
-        assert_eq!(
-            app.focused_pane,
-            FocusedPane::Chat,
-            "G should not focus InputBar"
-        );
-    }
-
-    #[test]
-    fn test_vim_j_scrolls_when_input_is_empty_and_focused() {
-        // Even when InputBar is focused, j/k should scroll if input text is empty.
-        use app::FocusedPane;
-        use midtown::Message;
-        let mut app = test_app();
-        for i in 0..30 {
-            app.messages
-                .push_back(Message::text("test", format!("msg {i}")));
-        }
-        app.focused_pane = FocusedPane::InputBar;
-        app.input_text = String::new();
-        app.scroll_offset = 10;
-
-        handle_event(&mut app, key_press(KeyCode::Char('j')));
-        assert!(
-            app.scroll_offset < 10,
-            "j with empty input should scroll down"
-        );
-        assert_eq!(app.input_text, "", "j with empty input must not insert 'j'");
-    }
-
-    #[test]
-    fn test_vim_j_inserts_when_input_has_text() {
-        // When InputBar has content, j/k must NOT scroll — they should insert into the input.
-        use app::FocusedPane;
-        let mut app = test_app();
-        app.focused_pane = FocusedPane::InputBar;
-        app.input_text = "hello".to_string();
-        app.input_cursor = 5;
-
-        handle_event(&mut app, key_press(KeyCode::Char('j')));
-        assert_eq!(
-            app.input_text, "helloj",
-            "j with non-empty input should insert into the text"
-        );
-    }
-
-    #[test]
-    fn test_vim_j_inserts_when_chat_focused_but_draft_exists() {
-        // Regression: the original condition was `input_text.is_empty() || focused_pane !=
-        // InputBar`, which meant j/k would SCROLL when focus moved to Chat even if the user
-        // had a draft in the input bar — silently losing those keystrokes.
-        // The fix changes the gate to `input_text.is_empty()` only.
-        use app::FocusedPane;
-        use midtown::Message;
-        let mut app = test_app();
-        for i in 0..30 {
-            app.messages
-                .push_back(Message::text("test", format!("msg {i}")));
-        }
-        app.focused_pane = FocusedPane::Chat; // focus shifted away from InputBar
-        app.input_text = "draft message".to_string(); // but draft exists
-        app.input_cursor = 13;
-        app.scroll_offset = 5;
-
-        handle_event(&mut app, key_press(KeyCode::Char('j')));
-        // Should NOT scroll — should insert 'j' into the draft
-        assert_eq!(
-            app.input_text, "draft messagej",
-            "j with existing draft should insert even when focus is on Chat"
-        );
-        assert_eq!(
-            app.scroll_offset, 5,
-            "scroll_offset must not change when a draft exists"
-        );
-    }
-
-    // -----------------------------------------------------------------------
-    // Ctrl+U / Ctrl+D half-page scroll when input is empty
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_ctrl_u_half_page_up_when_input_empty() {
-        use app::FocusedPane;
-        use midtown::Message;
-        let mut app = test_app();
-        for i in 0..60 {
-            app.messages
-                .push_back(Message::text("test", format!("msg {i}")));
-        }
-        app.focused_pane = FocusedPane::InputBar;
-        app.input_text = String::new();
-        app.visible_height = 20;
-        app.scroll_offset = 0;
-
-        handle_event(
-            &mut app,
-            Event::Key(crossterm::event::KeyEvent::new(
-                KeyCode::Char('u'),
-                crossterm::event::KeyModifiers::CONTROL,
-            )),
-        );
-        let expected = 20 / 2; // half_page = visible_height / 2
-        assert_eq!(
-            app.scroll_offset, expected,
-            "Ctrl+U with empty input should scroll half-page up"
-        );
-        assert_eq!(
-            app.input_text, "",
-            "Ctrl+U should not modify empty input text"
-        );
-    }
-
-    #[test]
-    fn test_ctrl_u_kills_text_when_input_has_content() {
-        use app::FocusedPane;
-        let mut app = test_app();
-        app.focused_pane = FocusedPane::InputBar;
-        app.input_text = "hello world".to_string();
-        app.input_cursor = 5;
-
-        handle_event(
-            &mut app,
-            Event::Key(crossterm::event::KeyEvent::new(
-                KeyCode::Char('u'),
-                crossterm::event::KeyModifiers::CONTROL,
-            )),
-        );
-        assert_eq!(
-            app.input_text, " world",
-            "Ctrl+U should kill to beginning when input has text"
-        );
-    }
-
-    #[test]
-    fn test_ctrl_d_half_page_down_when_input_empty() {
-        use app::FocusedPane;
-        use midtown::Message;
-        let mut app = test_app();
-        for i in 0..60 {
-            app.messages
-                .push_back(Message::text("test", format!("msg {i}")));
-        }
-        app.focused_pane = FocusedPane::InputBar;
-        app.input_text = String::new();
-        app.visible_height = 20;
-        app.scroll_offset = 20;
-
-        handle_event(
-            &mut app,
-            Event::Key(crossterm::event::KeyEvent::new(
-                KeyCode::Char('d'),
-                crossterm::event::KeyModifiers::CONTROL,
-            )),
-        );
-        let expected = 20 - 20 / 2; // 20 - half_page
-        assert_eq!(
-            app.scroll_offset, expected,
-            "Ctrl+D with empty input should scroll half-page down"
-        );
-    }
-
-    #[test]
-    fn test_ctrl_d_deletes_char_when_input_has_content() {
-        use app::FocusedPane;
-        let mut app = test_app();
-        app.focused_pane = FocusedPane::InputBar;
-        app.input_text = "hello".to_string();
-        app.input_cursor = 0;
-
-        handle_event(
-            &mut app,
-            Event::Key(crossterm::event::KeyEvent::new(
-                KeyCode::Char('d'),
-                crossterm::event::KeyModifiers::CONTROL,
-            )),
-        );
-        assert_eq!(
-            app.input_text, "ello",
-            "Ctrl+D should delete char under cursor when input has text"
-        );
     }
 
     #[test]
@@ -3123,3 +2849,7 @@ mod post_message_tests;
 #[path = "channel_create_tests.rs"]
 #[cfg(test)]
 mod channel_create_tests;
+
+#[path = "vim_scroll_tests.rs"]
+#[cfg(test)]
+mod vim_scroll_tests;

--- a/src/bin/midtown/cli/chat/mouse_scroll_tests.rs
+++ b/src/bin/midtown/cli/chat/mouse_scroll_tests.rs
@@ -17,10 +17,11 @@ use super::{MOUSE_INERTIA_THRESHOLD, MOUSE_SCROLL_STEP, MOUSE_SCROLL_THRESHOLD, 
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Make `app.last_scroll_event` look like it was set "just now" so subsequent
-/// mouse scroll calls enter inertia/accumulator mode (elapsed ≤ threshold).
+/// Make `app.last_scroll_up_event` and `app.last_scroll_down_event` look like they were set
+/// "just now" so subsequent mouse scroll calls enter inertia/accumulator mode (elapsed ≤ threshold).
 fn set_recent_scroll(app: &mut super::App) {
-    app.last_scroll_event = Some(Instant::now());
+    app.last_scroll_up_event = Some(Instant::now());
+    app.last_scroll_down_event = Some(Instant::now());
 }
 
 /// Make `app.last_thread_scroll_event` look like it was set "just now".
@@ -28,11 +29,12 @@ fn set_recent_thread_scroll(app: &mut super::App) {
     app.last_thread_scroll_event = Some(Instant::now());
 }
 
-/// Make `app.last_scroll_event` look like it happened long ago so subsequent
-/// mouse scroll calls enter immediate mode (elapsed > threshold).
+/// Make `app.last_scroll_up_event` and `app.last_scroll_down_event` look like they happened
+/// long ago so subsequent mouse scroll calls enter immediate mode (elapsed > threshold).
 fn set_old_scroll(app: &mut super::App) {
-    app.last_scroll_event =
-        Some(Instant::now() - MOUSE_INERTIA_THRESHOLD - Duration::from_millis(10));
+    let old = Some(Instant::now() - MOUSE_INERTIA_THRESHOLD - Duration::from_millis(10));
+    app.last_scroll_up_event = old;
+    app.last_scroll_down_event = old;
 }
 
 /// Make `app.last_thread_scroll_event` look like it happened long ago.
@@ -486,5 +488,70 @@ fn test_inertia_still_works_after_burst_absorption_window() {
         app.scroll_offset,
         after_immediate + MOUSE_SCROLL_STEP,
         "After burst absorbed, THRESHOLD more inertia events should produce one fine scroll"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Direction reversal — separate up/down timestamps
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_scroll_down_is_immediate_after_recent_scroll_up() {
+    // Regression: when last_scroll_event was shared between up and down, a quick
+    // direction reversal (up then down within 50ms) would enter accumulator mode
+    // for the down scroll instead of scrolling immediately.
+    // With separate last_scroll_up_event / last_scroll_down_event each direction
+    // tracks its own timestamp independently.
+    let mut app = test_app();
+    for i in 0..30 {
+        app.messages
+            .push_back(Message::text("test", format!("msg {i}")));
+    }
+    app.scroll_offset = SCROLL_STEP * 2;
+
+    // Simulate a deliberate scroll-up (no prior event → immediate)
+    app.mouse_scroll_up();
+    let after_up = app.scroll_offset;
+    assert_eq!(
+        after_up,
+        SCROLL_STEP * 3,
+        "scroll-up should be immediate (no prior up event)"
+    );
+
+    // Immediately after (within 50ms), scroll down.
+    // Since last_scroll_down_event is still None, this should ALSO be immediate.
+    app.mouse_scroll_down();
+    assert_eq!(
+        app.scroll_offset,
+        SCROLL_STEP * 2,
+        "scroll-down immediately after scroll-up should be immediate (separate timestamps)"
+    );
+}
+
+#[test]
+fn test_scroll_up_is_immediate_after_recent_scroll_down() {
+    // Symmetric: a scroll-up after a recent scroll-down is also immediate
+    // because last_scroll_up_event is independent of last_scroll_down_event.
+    let mut app = test_app();
+    for i in 0..30 {
+        app.messages
+            .push_back(Message::text("test", format!("msg {i}")));
+    }
+    app.scroll_offset = SCROLL_STEP * 3;
+
+    // Deliberate scroll-down (no prior down event → immediate)
+    app.mouse_scroll_down();
+    assert_eq!(
+        app.scroll_offset,
+        SCROLL_STEP * 2,
+        "scroll-down should be immediate (no prior down event)"
+    );
+
+    // Immediately after, scroll up — should also be immediate
+    app.mouse_scroll_up();
+    assert_eq!(
+        app.scroll_offset,
+        SCROLL_STEP * 3,
+        "scroll-up immediately after scroll-down should be immediate (separate timestamps)"
     );
 }

--- a/src/bin/midtown/cli/chat/vim_scroll_tests.rs
+++ b/src/bin/midtown/cli/chat/vim_scroll_tests.rs
@@ -1,0 +1,349 @@
+//! Tests for vim-style keyboard scroll bindings and Ctrl+U/Ctrl+D half-page scroll.
+//!
+//! Covers:
+//! - j/k/g/G bindings when Chat pane is focused (should scroll, not insert)
+//! - j/k/g/G bindings when InputBar is focused (should insert, not scroll)
+//! - j/k when a draft exists in InputBar but focus is elsewhere (should insert into draft)
+//! - Ctrl+U / Ctrl+D half-page scroll when input is empty
+//! - Ctrl+U / Ctrl+D text editing when InputBar has content
+//! - Ctrl+D / Ctrl+U blocked by channel_switcher overlay
+
+use super::*;
+use app::FocusedPane;
+use app::tests::test_app;
+use crossterm::event::{KeyEvent, KeyModifiers};
+use midtown::Message;
+
+fn ctrl_key(code: KeyCode) -> Event {
+    Event::Key(KeyEvent::new(code, KeyModifiers::CONTROL))
+}
+
+fn shift_key(code: KeyCode) -> Event {
+    Event::Key(KeyEvent::new(code, KeyModifiers::SHIFT))
+}
+
+// ---------------------------------------------------------------------------
+// Vim-style scroll bindings — Chat pane focused
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_vim_j_scrolls_down_when_unfocused() {
+    let mut app = test_app();
+    for i in 0..30 {
+        app.messages
+            .push_back(Message::text("test", format!("msg {i}")));
+    }
+    app.focused_pane = FocusedPane::Chat;
+    app.scroll_offset = 10;
+
+    handle_event(&mut app, key_press(KeyCode::Char('j')));
+    assert!(
+        app.scroll_offset < 10,
+        "j should scroll down (decrease offset)"
+    );
+    assert_eq!(
+        app.focused_pane,
+        FocusedPane::Chat,
+        "j should not focus InputBar"
+    );
+    assert_eq!(app.input_text, "", "j should not insert into input");
+}
+
+#[test]
+fn test_vim_k_scrolls_up_when_unfocused() {
+    let mut app = test_app();
+    for i in 0..30 {
+        app.messages
+            .push_back(Message::text("test", format!("msg {i}")));
+    }
+    app.focused_pane = FocusedPane::Chat;
+    app.scroll_offset = 0;
+
+    handle_event(&mut app, key_press(KeyCode::Char('k')));
+    assert!(
+        app.scroll_offset > 0,
+        "k should scroll up (increase offset)"
+    );
+    assert_eq!(
+        app.focused_pane,
+        FocusedPane::Chat,
+        "k should not focus InputBar"
+    );
+    assert_eq!(app.input_text, "", "k should not insert into input");
+}
+
+#[test]
+fn test_vim_g_scrolls_to_top_when_unfocused() {
+    let mut app = test_app();
+    for i in 0..30 {
+        app.messages
+            .push_back(Message::text("test", format!("msg {i}")));
+    }
+    app.focused_pane = FocusedPane::Chat;
+    app.scroll_offset = 0;
+
+    handle_event(&mut app, key_press(KeyCode::Char('g')));
+    assert!(app.scroll_offset > 0, "g should scroll to top (offset > 0)");
+    assert_eq!(
+        app.focused_pane,
+        FocusedPane::Chat,
+        "g should not focus InputBar"
+    );
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn test_vim_G_scrolls_to_bottom_when_unfocused() {
+    let mut app = test_app();
+    for i in 0..30 {
+        app.messages
+            .push_back(Message::text("test", format!("msg {i}")));
+    }
+    app.focused_pane = FocusedPane::Chat;
+    app.scroll_offset = 20;
+    // 'G' with kitty protocol comes as Char('G') via the shift transform
+    handle_event(&mut app, shift_key(KeyCode::Char('g')));
+    assert_eq!(app.scroll_offset, 0, "G should scroll to bottom");
+    assert_eq!(
+        app.focused_pane,
+        FocusedPane::Chat,
+        "G should not focus InputBar"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Vim-style bindings — InputBar focused (should insert, never scroll)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_vim_j_inserts_when_inputbar_focused_and_empty() {
+    // Regression: pressing 'j' with InputBar focused and empty input
+    // used to scroll instead of inserting — causing "got it" → "ot it".
+    let mut app = test_app();
+    for i in 0..30 {
+        app.messages
+            .push_back(Message::text("test", format!("msg {i}")));
+    }
+    app.focused_pane = FocusedPane::InputBar;
+    app.input_text = String::new();
+    app.scroll_offset = 10;
+
+    handle_event(&mut app, key_press(KeyCode::Char('j')));
+    assert_eq!(
+        app.input_text, "j",
+        "j with InputBar focused should insert 'j', not scroll"
+    );
+    assert_eq!(
+        app.scroll_offset, 10,
+        "scroll_offset must not change when InputBar is focused"
+    );
+}
+
+#[test]
+fn test_vim_k_inserts_when_inputbar_focused_and_empty() {
+    // "k sounds good" should not lose the 'k'.
+    let mut app = test_app();
+    app.focused_pane = FocusedPane::InputBar;
+    app.input_text = String::new();
+    app.scroll_offset = 5;
+
+    handle_event(&mut app, key_press(KeyCode::Char('k')));
+    assert_eq!(
+        app.input_text, "k",
+        "k with InputBar focused should insert 'k', not scroll"
+    );
+    assert_eq!(app.scroll_offset, 5, "scroll_offset must not change");
+}
+
+#[test]
+fn test_vim_g_inserts_when_inputbar_focused_and_empty() {
+    // "got it" should not scroll to top when InputBar is focused.
+    let mut app = test_app();
+    for i in 0..30 {
+        app.messages
+            .push_back(Message::text("test", format!("msg {i}")));
+    }
+    app.focused_pane = FocusedPane::InputBar;
+    app.input_text = String::new();
+    app.scroll_offset = 5;
+
+    handle_event(&mut app, key_press(KeyCode::Char('g')));
+    assert_eq!(
+        app.input_text, "g",
+        "g with InputBar focused should insert 'g', not scroll to top"
+    );
+    assert_eq!(app.scroll_offset, 5, "scroll_offset must not change");
+}
+
+#[test]
+fn test_vim_j_inserts_when_input_has_text() {
+    // When InputBar has content, j must NOT scroll — it should insert.
+    let mut app = test_app();
+    app.focused_pane = FocusedPane::InputBar;
+    app.input_text = "hello".to_string();
+    app.input_cursor = 5;
+
+    handle_event(&mut app, key_press(KeyCode::Char('j')));
+    assert_eq!(
+        app.input_text, "helloj",
+        "j with non-empty input should insert into the text"
+    );
+}
+
+#[test]
+fn test_vim_j_inserts_when_chat_focused_but_draft_exists() {
+    // Regression: a draft in InputBar must be preserved even when Chat has focus.
+    // The `input_text.is_empty()` guard ensures scrolling is only gated on text
+    // presence, not on which pane has focus.
+    let mut app = test_app();
+    for i in 0..30 {
+        app.messages
+            .push_back(Message::text("test", format!("msg {i}")));
+    }
+    app.focused_pane = FocusedPane::Chat; // focus shifted away from InputBar
+    app.input_text = "draft message".to_string(); // but draft exists
+    app.input_cursor = 13;
+    app.scroll_offset = 5;
+
+    handle_event(&mut app, key_press(KeyCode::Char('j')));
+    // Should NOT scroll — should insert 'j' into the draft
+    assert_eq!(
+        app.input_text, "draft messagej",
+        "j with existing draft should insert even when focus is on Chat"
+    );
+    assert_eq!(
+        app.scroll_offset, 5,
+        "scroll_offset must not change when a draft exists"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Ctrl+U / Ctrl+D half-page scroll when input is empty
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_ctrl_u_half_page_up_when_input_empty() {
+    let mut app = test_app();
+    for i in 0..60 {
+        app.messages
+            .push_back(Message::text("test", format!("msg {i}")));
+    }
+    app.focused_pane = FocusedPane::InputBar;
+    app.input_text = String::new();
+    app.visible_height = 20;
+    app.scroll_offset = 0;
+
+    handle_event(&mut app, ctrl_key(KeyCode::Char('u')));
+    let expected = 20 / 2; // half_page = visible_height / 2
+    assert_eq!(
+        app.scroll_offset, expected,
+        "Ctrl+U with empty input should scroll half-page up"
+    );
+    assert_eq!(
+        app.input_text, "",
+        "Ctrl+U should not modify empty input text"
+    );
+}
+
+#[test]
+fn test_ctrl_u_kills_text_when_input_has_content() {
+    let mut app = test_app();
+    app.focused_pane = FocusedPane::InputBar;
+    app.input_text = "hello world".to_string();
+    app.input_cursor = 5;
+
+    handle_event(&mut app, ctrl_key(KeyCode::Char('u')));
+    assert_eq!(
+        app.input_text, " world",
+        "Ctrl+U should kill to beginning when input has text"
+    );
+}
+
+#[test]
+fn test_ctrl_d_half_page_down_when_input_empty() {
+    let mut app = test_app();
+    for i in 0..60 {
+        app.messages
+            .push_back(Message::text("test", format!("msg {i}")));
+    }
+    app.focused_pane = FocusedPane::InputBar;
+    app.input_text = String::new();
+    app.visible_height = 20;
+    app.scroll_offset = 20;
+
+    handle_event(&mut app, ctrl_key(KeyCode::Char('d')));
+    let expected = 20 - 20 / 2; // 20 - half_page
+    assert_eq!(
+        app.scroll_offset, expected,
+        "Ctrl+D with empty input should scroll half-page down"
+    );
+}
+
+#[test]
+fn test_ctrl_d_deletes_char_when_input_has_content() {
+    let mut app = test_app();
+    app.focused_pane = FocusedPane::InputBar;
+    app.input_text = "hello".to_string();
+    app.input_cursor = 0;
+
+    handle_event(&mut app, ctrl_key(KeyCode::Char('d')));
+    assert_eq!(
+        app.input_text, "ello",
+        "Ctrl+D should delete char under cursor when input has text"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Ctrl+D / Ctrl+U blocked by channel_switcher overlay
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_ctrl_d_does_not_scroll_when_channel_switcher_open() {
+    // Regression: Ctrl+D lacked the !channel_switcher.show guard that Ctrl+U had.
+    // Pressing Ctrl+D with the channel switcher open was scrolling chat behind the overlay.
+    let mut app = test_app();
+    for i in 0..60 {
+        app.messages
+            .push_back(Message::text("test", format!("msg {i}")));
+    }
+    app.focused_pane = FocusedPane::InputBar;
+    app.input_text = String::new();
+    app.visible_height = 20;
+    app.scroll_offset = 20;
+    app.channel_switcher.show = true; // overlay is open
+
+    handle_event(&mut app, ctrl_key(KeyCode::Char('d')));
+    assert_eq!(
+        app.scroll_offset, 20,
+        "Ctrl+D must not scroll when channel switcher is open"
+    );
+}
+
+#[test]
+fn test_ctrl_u_does_not_scroll_when_channel_switcher_open() {
+    // Symmetric check: Ctrl+U also must not scroll behind the overlay.
+    let mut app = test_app();
+    for i in 0..60 {
+        app.messages
+            .push_back(Message::text("test", format!("msg {i}")));
+    }
+    app.focused_pane = FocusedPane::InputBar;
+    app.input_text = String::new();
+    app.visible_height = 20;
+    app.scroll_offset = 20;
+    app.channel_switcher.show = true;
+
+    handle_event(&mut app, ctrl_key(KeyCode::Char('u')));
+    assert_eq!(
+        app.scroll_offset, 20,
+        "Ctrl+U must not scroll when channel switcher is open"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Helper — duplicated from mod.rs tests module so external file compiles
+// ---------------------------------------------------------------------------
+
+fn key_press(code: KeyCode) -> Event {
+    Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+}


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary

Addresses all four issues from riverside's code review of PR #1485 that merged without the review feedback being acknowledged or acted on.

- **!1752 Ctrl+D scroll guard**: Added `!channel_switcher.show` check matching the existing guard on Ctrl+U. Previously, pressing Ctrl+D while the channel switcher overlay was open would scroll the chat behind it — asymmetric with Ctrl+U.

- **!1753 Vim j/k/g/G eat first character**: Added `focused_pane != InputBar` to the scroll activation gate. Previously, focusing InputBar and then typing 'got it', 'just a sec', or 'k sounds good' would lose the first letter (g/j/k triggered scrolling instead of character insertion). The `input_text.is_empty()` guard is retained so drafts are protected when focus shifts away from InputBar.

- **!1754 Test file organization**: Moved 10 inline test functions (vim scroll + Ctrl+U/D) from the mod `tests{}` block into a new `vim_scroll_tests.rs` file, matching the CLAUDE.md convention. The test that codified the old wrong InputBar behavior (`test_vim_j_scrolls_when_input_is_empty_and_focused`) was replaced with tests covering the correct behavior.

- **!1755 Shared scroll timestamp**: Split `last_scroll_event` into `last_scroll_up_event` and `last_scroll_down_event`. Previously, scrolling up then immediately reversing direction within 50ms entered inertia/accumulator mode for the new direction instead of scrolling immediately. 2 new direction-reversal tests added.

## Test plan

- [x] `test_ctrl_d_does_not_scroll_when_channel_switcher_open` — !1752 regression
- [x] `test_ctrl_u_does_not_scroll_when_channel_switcher_open` — symmetric check
- [x] `test_vim_j_inserts_when_inputbar_focused_and_empty` — !1753 regression
- [x] `test_vim_k_inserts_when_inputbar_focused_and_empty` — !1753
- [x] `test_vim_g_inserts_when_inputbar_focused_and_empty` — !1753
- [x] `test_vim_j_inserts_when_chat_focused_but_draft_exists` — draft protection regression
- [x] `test_scroll_down_is_immediate_after_recent_scroll_up` — !1755 regression
- [x] `test_scroll_up_is_immediate_after_recent_scroll_down` — !1755 symmetric
- [x] All pre-existing tests still pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)