### PR TITLE
fix: inject MIDTOWN_SESSION_ID into coworker env [Midtown !1756]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1427,7 +1427,20 @@ impl DaemonState {
         }
         // Inject MIDTOWN_SESSION_ID so coworkers can call `midtown session fork`
         // without passing --session-id explicitly.
-        if let Some(ref sid) = session_id {
+        //
+        // Only inject for stable session IDs: Claude sessions adopt the pre-generated
+        // UUID via --session-id so the env var always matches the real session ID.
+        // Codex sessions use a provisional UUID that is replaced by the real ID on init,
+        // so we skip injection there to avoid a stale reference after migration.
+        // Resumed sessions have a real, stable ID regardless of provider.
+        let is_stable_id = matches!(
+            config.session_mode,
+            crate::launch::SessionMode::ResumeSession(_)
+        ) || crate::platform::Platform::from_provider(config.auth_provider)
+            == crate::platform::Platform::Claude;
+        if let Some(ref sid) = session_id
+            && is_stable_id
+        {
             crate::launch::inject_session_id_env(&mut headless_config.env, sid);
         }
         let persisted_session_id = session_id.clone().unwrap_or_default();

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1216,32 +1216,6 @@ mod tests {
             "System prompt should reference the channel name"
         );
     }
-
-    #[test]
-    fn test_inject_session_id_env_sets_midtown_session_id() {
-        let mut env = std::collections::BTreeMap::new();
-        assert!(
-            !env.contains_key("MIDTOWN_SESSION_ID"),
-            "MIDTOWN_SESSION_ID must not be present before injection"
-        );
-        inject_session_id_env(&mut env, "test-uuid-abc123");
-        assert_eq!(
-            env.get("MIDTOWN_SESSION_ID").map(String::as_str),
-            Some("test-uuid-abc123"),
-            "inject_session_id_env must insert MIDTOWN_SESSION_ID into the env map"
-        );
-    }
-
-    #[test]
-    fn test_inject_session_id_env_overwrites_existing_value() {
-        let mut env = std::collections::BTreeMap::new();
-        env.insert("MIDTOWN_SESSION_ID".to_string(), "old-uuid".to_string());
-        inject_session_id_env(&mut env, "new-uuid-xyz");
-        assert_eq!(
-            env.get("MIDTOWN_SESSION_ID").map(String::as_str),
-            Some("new-uuid-xyz"),
-        );
-    }
 }
 
 #[path = "launch_tests.rs"]

--- a/src/launch_tests.rs
+++ b/src/launch_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for lead system prompt persistence on attach and channel lead model selection
 
-use crate::launch::{CoworkerRole, LaunchConfig, SessionMode};
+use crate::launch::{CoworkerRole, LaunchConfig, SessionMode, inject_session_id_env};
 use crate::paths;
 use std::fs;
 
@@ -70,4 +70,30 @@ fn test_lead_system_prompt_file_path() {
         .join("system-prompt.txt");
 
     assert_eq!(prompt_file, expected);
+}
+
+#[test]
+fn test_inject_session_id_env_sets_midtown_session_id() {
+    let mut env = std::collections::BTreeMap::new();
+    assert!(
+        !env.contains_key("MIDTOWN_SESSION_ID"),
+        "MIDTOWN_SESSION_ID must not be present before injection"
+    );
+    inject_session_id_env(&mut env, "test-uuid-abc123");
+    assert_eq!(
+        env.get("MIDTOWN_SESSION_ID").map(String::as_str),
+        Some("test-uuid-abc123"),
+        "inject_session_id_env must insert MIDTOWN_SESSION_ID into the env map"
+    );
+}
+
+#[test]
+fn test_inject_session_id_env_overwrites_existing_value() {
+    let mut env = std::collections::BTreeMap::new();
+    env.insert("MIDTOWN_SESSION_ID".to_string(), "old-uuid".to_string());
+    inject_session_id_env(&mut env, "new-uuid-xyz");
+    assert_eq!(
+        env.get("MIDTOWN_SESSION_ID").map(String::as_str),
+        Some("new-uuid-xyz"),
+    );
 }


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary

- `build_agent_env_vars` only set `MIDTOWN_AGENT` and `MIDTOWN_CHANNEL` — never `MIDTOWN_SESSION_ID`
- Coworkers calling `midtown session fork <thread_parent_id>` hit: "Missing session ID. Pass --session-id or set $MIDTOWN_SESSION_ID"
- Fix: extract `inject_session_id_env()` in `launch.rs` and call it from `spawn_coworker()` after the pre-generated UUID is assigned to `headless_config.session_id`

## Test plan

- [x] Added `test_inject_session_id_env_sets_midtown_session_id` — confirmed FAILS (compile error) before fix
- [x] Added `test_inject_session_id_env_overwrites_existing_value` — guards against double-spawn edge case
- [x] Both tests pass after fix
- [x] Full `cargo test` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)