### PR TITLE
fix(coworker): check midtown-frontmatter issue comments before merging [Midtown !1771]

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -387,7 +387,8 @@ Creating a new branch when a PR already exists leaves orphaned remote branches t
 
 **1. Check for human (midtown) reviews in issue comments:**
 ```bash
-gh api repos/btucker/midtown/issues/<PR_NUMBER>/comments \
+repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+gh api "repos/$repo/issues/<PR_NUMBER>/comments" \
   --jq '.[] | select(.body | contains("<!-- midtown:")) | "\(.user.login): \(.body[:500])"'
 ```
 Human coworker reviews are posted as issue comments with `<!-- midtown: reviewer_name -->` frontmatter — they do **NOT** appear in `gh pr view --json reviews`. You MUST check issue comments explicitly and address every issue listed in those reviews before merging. Treat them exactly like formal review feedback.


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Adds an explicit 3-step pre-merge checklist to the coworker prompt that requires checking issue comments for `<!-- midtown: -->` human reviews before enabling auto-merge
- Adds a channel check step so coworkers don't merge when the lead/user has said to hold
- Expands the "Don't Poll GitHub" section with bullet reminders about the issue comment check and lead override

## Root Cause
Human coworker reviews are posted as issue comments with `<!-- midtown: reviewer_name -->` frontmatter. They do **NOT** appear in `gh pr view --json reviews` (which only captures formal GitHub APPROVED/CHANGES_REQUESTED reviews). Coworkers were only checking `reviewDecision`, so human review feedback was invisible — causing PRs to merge with unaddressed issues (#1485, #1491, #1496).

## Changes
`agents/coworker.md`:
- Replaced the single "check for late comments" step with a numbered 3-step checklist:
  1. Check issue comments for `<!-- midtown: -->` reviews via `gh api`
  2. Check the channel for any lead/user "don't merge" instructions  
  3. Check for late-arriving user comments (bumped from `[-2:]` to `[-3:]`)
- Updated "Verify a completed review exists" to accept issue comments with `<!-- midtown: -->` as valid review evidence
- Added two bullet points to the "Don't Poll GitHub" section reinforcing the issue comment check and lead override

## Test plan
- [x] Pre-commit hooks pass (clippy + fmt)
- [x] The new `gh api repos/btucker/midtown/issues/<PR>/comments` command filters on `<!-- midtown:` to find only completed human reviews (incomplete reviews lack the frontmatter — see reviewer.md)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)