### PR TITLE
feat: style insight messages [Midtown !1772]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -692,6 +692,29 @@
                 </div>
               {/if}
             {/each}
+          {:else if isInsight(msg)}
+            <div class="rounded-md border border-insight/40 bg-insight/8 px-3 py-2 my-1 ml-[0.5em]">
+              <div
+                class="flex items-center gap-1.5 mb-1.5 text-insight text-[0.72rem] font-bold uppercase tracking-wide"
+                aria-label="Insight"
+              >
+                <span aria-hidden="true">★</span>
+                <span>Insight</span>
+              </div>
+              {#if hasMermaid(msg.content || '')}
+                <div class="flex flex-col gap-2">
+                  {#each parseSegments(msg.content || '') as segment}
+                    {#if segment.type === 'mermaid'}
+                      <MermaidDiagram code={segment.content} />
+                    {:else}
+                      <div class="message-text text-foreground">{@html renderContent(segment.content)}</div>
+                    {/if}
+                  {/each}
+                </div>
+              {:else}
+                <div class="message-text text-foreground">{@html renderContent(msg.content || '')}</div>
+              {/if}
+            </div>
           {:else if hasMermaid(msg.content)}
             <!-- Message with mermaid diagram(s): gutter shows time only on minute change -->
             {#each parseSegments(msg.content) as segment, si}

--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -1,7 +1,8 @@
 <script>
   import { threadData } from './store.js'
   import { sendMessage, closeThread } from './api.js'
-  import { renderContent } from './markdown.js'
+  import { renderContent, hasMermaid, parseSegments } from './markdown.js'
+  import MermaidDiagram from './MermaidDiagram.svelte'
   import { tick, onMount } from 'svelte'
   import { getSenderColor, isDimSender, formatTime, senderChanged, timeChanged } from './messageUtils.js'
 
@@ -9,6 +10,10 @@
     midtown: '#585858',
   }
   const THREAD_DIM_SENDERS = ['midtown']
+
+  function isInsight(msg) {
+    return msg?.msg_type === 'insight' || msg?.type === 'insight'
+  }
 
   let replyText = $state('')
   let desktopScrollArea = $state(null)
@@ -79,6 +84,8 @@
 <svelte:window onkeydown={handleWindowKeydown} />
 
 {#if $threadData}
+  {@const parentMsg = $threadData.parentMessage}
+  {@const parentContent = parentMsg?.content || ''}
   <!-- Desktop: side panel -->
   <div class="hidden lg:flex flex-col h-full bg-background border-l-2 border-border w-[380px] shrink-0">
     <!-- Header -->
@@ -132,10 +139,35 @@
         {:else}
           <!-- Slack-style parent message (name + timestamp on one line) -->
           <div class="whitespace-nowrap overflow-hidden text-ellipsis flex items-center gap-[7px] mb-[2px]">
-            <span class="font-bold text-[0.82rem]" style="color: {getSenderColor($threadData.parentMessage.from, THREAD_SENDER_OVERRIDES)}">{$threadData.parentMessage.from}</span>
-            <span class="text-muted-foreground/50 text-[0.72rem] select-none">{formatTime($threadData.parentMessage.timestamp)}</span>
+            <span class="font-bold text-[0.82rem]" style="color: {getSenderColor(parentMsg?.from, THREAD_SENDER_OVERRIDES)}">{parentMsg?.from}</span>
+            <span class="text-muted-foreground/50 text-[0.72rem] select-none">{formatTime(parentMsg?.timestamp)}</span>
           </div>
-          <div class="text-foreground break-words">{@html renderContent($threadData.parentMessage.content || '')}</div>
+          {#if isInsight(parentMsg)}
+            <div class="rounded-md border border-insight/40 bg-insight/8 px-3 py-2 mt-1">
+              <div
+                class="flex items-center gap-1.5 mb-1.5 text-insight text-[0.72rem] font-bold uppercase tracking-wide"
+                aria-label="Insight"
+              >
+                <span aria-hidden="true">★</span>
+                <span>Insight</span>
+              </div>
+              {#if hasMermaid(parentContent)}
+                <div class="flex flex-col gap-2">
+                  {#each parseSegments(parentContent) as segment}
+                    {#if segment.type === 'mermaid'}
+                      <MermaidDiagram code={segment.content} />
+                    {:else}
+                      <div class="message-text text-foreground">{@html renderContent(segment.content)}</div>
+                    {/if}
+                  {/each}
+                </div>
+              {:else}
+                <div class="message-text text-foreground">{@html renderContent(parentContent)}</div>
+              {/if}
+            </div>
+          {:else}
+            <div class="text-foreground break-words">{@html renderContent(parentContent)}</div>
+          {/if}
         {/if}
       </div>
 
@@ -232,11 +264,36 @@
         {:else}
           <!-- Slack-style parent message (name + timestamp on one line) -->
           <div class="whitespace-nowrap overflow-hidden text-ellipsis flex items-center gap-[7px] mb-[2px]">
-            <span class="font-bold text-[0.82rem]" style="color: {getSenderColor($threadData.parentMessage.from, THREAD_SENDER_OVERRIDES)}">{$threadData.parentMessage.from}</span>
-            <span class="text-muted-foreground/50 text-[0.72rem] select-none">{formatTime($threadData.parentMessage.timestamp)}</span>
+            <span class="font-bold text-[0.82rem]" style="color: {getSenderColor(parentMsg?.from, THREAD_SENDER_OVERRIDES)}">{parentMsg?.from}</span>
+            <span class="text-muted-foreground/50 text-[0.72rem] select-none">{formatTime(parentMsg?.timestamp)}</span>
           </div>
-          <div class="text-foreground break-words">{@html renderContent($threadData.parentMessage.content || '')}</div>
-          <div class="text-muted-foreground text-[0.75rem] mt-1">{formatTime($threadData.parentMessage.timestamp)}</div>
+          {#if isInsight(parentMsg)}
+            <div class="rounded-md border border-insight/40 bg-insight/8 px-3 py-2 mt-1">
+              <div
+                class="flex items-center gap-1.5 mb-1.5 text-insight text-[0.72rem] font-bold uppercase tracking-wide"
+                aria-label="Insight"
+              >
+                <span aria-hidden="true">★</span>
+                <span>Insight</span>
+              </div>
+              {#if hasMermaid(parentContent)}
+                <div class="flex flex-col gap-2">
+                  {#each parseSegments(parentContent) as segment}
+                    {#if segment.type === 'mermaid'}
+                      <MermaidDiagram code={segment.content} />
+                    {:else}
+                      <div class="message-text text-foreground">{@html renderContent(segment.content)}</div>
+                    {/if}
+                  {/each}
+                </div>
+              {:else}
+                <div class="message-text text-foreground">{@html renderContent(parentContent)}</div>
+              {/if}
+            </div>
+          {:else}
+            <div class="text-foreground break-words">{@html renderContent(parentContent)}</div>
+          {/if}
+          <div class="text-muted-foreground text-[0.75rem] mt-1">{formatTime(parentMsg?.timestamp)}</div>
         {/if}
       </div>
 


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Render `msg_type === 'insight'` messages in a styled colored box in `Channel.svelte` — bordered card with a ★ Insight header using the `--insight` CSS token
- Add the same insight box in `ThreadPanel.svelte` (desktop and mobile sections) so insight parent messages stand out when a thread is open
- Support mermaid diagrams inside insight boxes via `parseSegments`/`MermaidDiagram`

## Changes
- `Channel.svelte`: adds `{:else if isInsight(msg)}` branch (after hasMermaid branch) rendering the styled insight card
- `ThreadPanel.svelte`: adds `hasMermaid`, `parseSegments` imports + `MermaidDiagram`; adds local `isInsight()` function; updates both desktop and mobile parent-message display to use the insight card

## Testing
- `npm run build` passes with no warnings

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)