### PR TITLE
docs: require issue-comment reviews before merging [Midtown !1770]

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -444,8 +444,8 @@ We share a GitHub API rate limit across the daemon, lead, and all coworkers. **D
 - Don't run `gh pr list` to check PR status — read the channel instead
 - **NEVER merge before addressing review feedback.** Every review comment must be either addressed in the PR or deferred via `midtown task request` before merging.
 - If `gh pr view <number> --json reviewDecision --jq .reviewDecision` returns `CHANGES_REQUESTED`, do not merge yet.
-- **Also check issue comments for `<!-- midtown:` reviews** — human coworker reviews are posted there, not in the formal reviews list. `gh pr view --json reviews` alone is not enough.
-- **If the lead or user says NOT to merge**, that overrides CI, review approval, and everything else. Read the channel before merging.
+- **Also check issue comments for `<!-- midtown:` reviews** — human coworker reviews are posted there, not in the formal reviews list. Treat them exactly like formal review feedback: reply immediately, fix the issues (or `midtown task request` out-of-scope items), and never merge while anything remains unresolved.
+- **If the lead or user says NOT to merge**, stop immediately — that instruction overrides CI status, review approval, and everything else. Ask in the channel for clarification before proceeding.
 - Do NOT enable auto-merge when creating the PR — wait for review first
 - **NEVER enable auto-merge based on a "review in progress" placeholder** — see the verification steps above for how to confirm a review is complete.
 - After a completed review exists and all feedback is addressed/deferred, enable auto-merge: `gh pr merge --auto --squash`

--- a/src/agents_tests.rs
+++ b/src/agents_tests.rs
@@ -356,6 +356,18 @@ fn test_coworker_prompt_requires_issue_comment_reviews() {
         prompt.contains(r#"gh pr view <number> --comments --json comments"#),
         "Coworker prompt should instruct checking recent PR comments for late requests"
     );
+    assert!(
+        prompt.contains("never merge while anything remains unresolved"),
+        "Coworker prompt should emphasize no merging with unresolved review feedback"
+    );
+    assert!(
+        prompt.contains("stop immediately"),
+        "Coworker prompt should instruct stopping immediately when lead/user says not to merge"
+    );
+    assert!(
+        prompt.contains("Only after all three checks are clean"),
+        "Coworker prompt should gate auto-merge on all three pre-merge checks passing"
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- clarify the coworker pre-merge checklist so issue-comment reviews must be read and resolved, not just gh pr view --json reviews
- warn that lead/user do-not-merge directives override CI + automated reviews and to keep checking for late user comments
- add a regression test that asserts the prompt includes the gh api command, frontmatter reference, and channel grep instructions

## Test plan
- cargo test test_coworker_prompt_requires_issue_comment_reviews

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)