### PR TITLE
feat: auth profile pool config fields + ProfileState type [!1776]

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,6 +143,14 @@ On daemon startup, the `NamePool` is restored from persisted session records: na
 
 **Daemon-controlled session IDs**: `spawn_coworker()` returns `Result<String>` — the session ID used for the spawn. For fresh sessions, a UUID is generated upfront and passed to the CLI via `--session-id`, so the daemon knows the session ID immediately at spawn time. For resumed sessions, the existing session ID from `SessionMode::ResumeSession` is reused. This eliminates the race window where `name_to_session`, `session_to_name`, and `channel_lead_sessions` were empty until the init StreamEvent arrived. All callers of `spawn_coworker` (effects.rs handlers, `expedite_lead_respawn_on_user_message`) capture the returned session ID and update their state eagerly.
 
+**Auth Profile Pool** (optional): When `[execution].coworker_profiles` (or `reviewer_profiles`, `channel_lead_profiles`) is set in config, `spawn_coworker()` selects an auth profile using an LRU-among-available strategy before resolving `auth_profile_dir`:
+1. Filter profiles where `ProfileState.is_usage_limited` is `true` in `DaemonPersistentState.profile_pool_state`.
+2. Among available profiles, pick LRU by `ProfileState.last_used_at` (never-used profiles preferred with `last_used_at = None`).
+3. If all profiles are limited, fall back to the single-profile path (existing behavior).
+4. On success, update `last_used_at` in `profile_pool_state` and save state.
+
+`DaemonPersistentState.profile_pool_state` (`HashMap<String, ProfileState>`) persists per-profile usage state across daemon restarts. `ProfileState` tracks `is_usage_limited`, `usage_limit_reset_at`, and `last_used_at`. Tasks 2 and 3 of the pool feature wire up limit detection and clearing (see tasks !1777, !1778).
+
 ## Prompt Architecture
 
 Prompts are assembled from composable markdown files in `agents/` and loaded at runtime by `src/agents.rs`. The file-based approach allows customization without recompilation: the binary embeds defaults, but `agents/` in the git repo root (or `~/.midtown/agents/`) takes precedence.

--- a/src/config.rs
+++ b/src/config.rs
@@ -3057,67 +3057,8 @@ name = "test"
             "sonnet"
         );
     }
-
-    #[test]
-    fn coworker_profiles_pool_parses() {
-        let toml = r#"
-[execution]
-coworker_profiles = ["alice@example.com", "bob@example.com"]
-"#;
-        let config: FullProjectConfig = toml::from_str(toml).unwrap();
-        assert_eq!(
-            config.execution.coworker_profiles,
-            Some(vec![
-                "alice@example.com".to_string(),
-                "bob@example.com".to_string()
-            ])
-        );
-    }
-
-    #[test]
-    fn coworker_profiles_empty_is_none() {
-        let toml = r#"
-[execution]
-"#;
-        let config: FullProjectConfig = toml::from_str(toml).unwrap();
-        assert!(config.execution.coworker_profiles.is_none());
-    }
-
-    #[test]
-    fn reviewer_and_channel_lead_profiles_parse() {
-        let toml = r#"
-[execution]
-reviewer_profiles = ["reviewer@example.com"]
-channel_lead_profiles = ["lead@example.com", "lead2@example.com"]
-"#;
-        let config: FullProjectConfig = toml::from_str(toml).unwrap();
-        assert_eq!(
-            config.execution.reviewer_profiles,
-            Some(vec!["reviewer@example.com".to_string()])
-        );
-        assert_eq!(
-            config.execution.channel_lead_profiles,
-            Some(vec![
-                "lead@example.com".to_string(),
-                "lead2@example.com".to_string()
-            ])
-        );
-    }
-
-    #[test]
-    fn profile_pool_fields_merge_correctly() {
-        let base = ExecutionSection {
-            coworker_profiles: Some(vec!["base@example.com".to_string()]),
-            ..ExecutionSection::default()
-        };
-        let override_section = ExecutionSection {
-            coworker_profiles: Some(vec!["override@example.com".to_string()]),
-            ..ExecutionSection::default()
-        };
-        let merged = base.merge(&override_section);
-        assert_eq!(
-            merged.coworker_profiles,
-            Some(vec!["override@example.com".to_string()])
-        );
-    }
 }
+
+#[path = "config_tests.rs"]
+#[cfg(test)]
+mod config_tests;

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -1,0 +1,64 @@
+use super::*;
+
+#[test]
+fn coworker_profiles_pool_parses() {
+    let toml = r#"
+[execution]
+coworker_profiles = ["alice@example.com", "bob@example.com"]
+"#;
+    let config: FullProjectConfig = toml::from_str(toml).unwrap();
+    assert_eq!(
+        config.execution.coworker_profiles,
+        Some(vec![
+            "alice@example.com".to_string(),
+            "bob@example.com".to_string()
+        ])
+    );
+}
+
+#[test]
+fn coworker_profiles_empty_is_none() {
+    let toml = r#"
+[execution]
+"#;
+    let config: FullProjectConfig = toml::from_str(toml).unwrap();
+    assert!(config.execution.coworker_profiles.is_none());
+}
+
+#[test]
+fn reviewer_and_channel_lead_profiles_parse() {
+    let toml = r#"
+[execution]
+reviewer_profiles = ["reviewer@example.com"]
+channel_lead_profiles = ["lead@example.com", "lead2@example.com"]
+"#;
+    let config: FullProjectConfig = toml::from_str(toml).unwrap();
+    assert_eq!(
+        config.execution.reviewer_profiles,
+        Some(vec!["reviewer@example.com".to_string()])
+    );
+    assert_eq!(
+        config.execution.channel_lead_profiles,
+        Some(vec![
+            "lead@example.com".to_string(),
+            "lead2@example.com".to_string()
+        ])
+    );
+}
+
+#[test]
+fn profile_pool_fields_merge_correctly() {
+    let base = ExecutionSection {
+        coworker_profiles: Some(vec!["base@example.com".to_string()]),
+        ..ExecutionSection::default()
+    };
+    let override_section = ExecutionSection {
+        coworker_profiles: Some(vec!["override@example.com".to_string()]),
+        ..ExecutionSection::default()
+    };
+    let merged = base.merge(&override_section);
+    assert_eq!(
+        merged.coworker_profiles,
+        Some(vec!["override@example.com".to_string()])
+    );
+}

--- a/src/daemon/state.rs
+++ b/src/daemon/state.rs
@@ -237,7 +237,7 @@ impl DaemonPersistentState {
                 // Rebuild reverse indexes that aren't serialized
                 state.worktree_registry.rebuild_indexes();
                 debug!(
-                    "Loaded daemon state: {} PR reviewers, {} reminders, CI stats: {}, {} worktree assignments, {} task-channel mappings, {} task-model mappings, {} task-plan mappings, {} task-execution-skill mappings, {} task-thread-id mappings, {} task-message-id mappings, {} channel-lead sessions",
+                    "Loaded daemon state: {} PR reviewers, {} reminders, CI stats: {}, {} worktree assignments, {} task-channel mappings, {} task-model mappings, {} task-plan mappings, {} task-execution-skill mappings, {} task-thread-id mappings, {} task-message-id mappings, {} channel-lead sessions, {} profile-pool entries",
                     state.github.pr_reviewers.len(),
                     state.reminders.reminders.len(),
                     state.ci_stats.summary(),
@@ -248,7 +248,8 @@ impl DaemonPersistentState {
                     state.task_execution_skill.len(),
                     state.task_thread_id.len(),
                     state.task_message_id.len(),
-                    state.channel_lead_sessions.len()
+                    state.channel_lead_sessions.len(),
+                    state.profile_pool_state.len()
                 );
                 Ok(state)
             }
@@ -271,7 +272,7 @@ impl DaemonPersistentState {
         fs::write(&tmp_path, &contents)?;
         crate::paths::atomic_rename(&tmp_path, &path)?;
         debug!(
-            "Saved daemon state: {} PR reviewers, {} reminders, CI stats: {}, {} worktree assignments, {} task-channel mappings, {} task-model mappings, {} task-plan mappings, {} task-execution-skill mappings, {} channel-lead sessions",
+            "Saved daemon state: {} PR reviewers, {} reminders, CI stats: {}, {} worktree assignments, {} task-channel mappings, {} task-model mappings, {} task-plan mappings, {} task-execution-skill mappings, {} channel-lead sessions, {} profile-pool entries",
             self.github.pr_reviewers.len(),
             self.reminders.reminders.len(),
             self.ci_stats.summary(),
@@ -280,7 +281,8 @@ impl DaemonPersistentState {
             self.task_model.len(),
             self.task_plan.len(),
             self.task_execution_skill.len(),
-            self.channel_lead_sessions.len()
+            self.channel_lead_sessions.len(),
+            self.profile_pool_state.len()
         );
         Ok(())
     }

--- a/src/daemon/state_tests.rs
+++ b/src/daemon/state_tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::collections::HashMap;
 use tempfile::tempdir;
 
 #[test]
@@ -741,7 +740,3 @@ fn profile_state_default_is_not_limited() {
     assert!(state.usage_limit_reset_at.is_none());
     assert!(state.last_used_at.is_none());
 }
-
-// Ensure HashMap import is used to suppress dead_code warning in test context
-#[allow(dead_code)]
-fn _use_hashmap(_: HashMap<String, ProfileState>) {}


### PR DESCRIPTION
## Summary

- Adds `coworker_profiles`, `reviewer_profiles`, `channel_lead_profiles` (`Option<Vec<String>>`) to `ExecutionSection` in `src/config.rs` — pool fields that take precedence over the corresponding `_provider` fields when set
- Adds `ProfileState` struct (`is_usage_limited`, `usage_limit_reset_at`, `last_used_at`) and `profile_pool_state: HashMap<String, ProfileState>` to `DaemonPersistentState` in `src/daemon/state.rs`
- All new fields use `#[serde(default)]` for forward/backward compatibility with existing state files
- `ExecutionSection::merge()` updated to propagate pool fields with the same "other takes precedence" semantics as existing fields

## Test plan

- [x] `coworker_profiles_pool_parses` — TOML pool field round-trips through serde
- [x] `coworker_profiles_empty_is_none` — missing pool field deserializes to `None`
- [x] `reviewer_and_channel_lead_profiles_parse` — all three pool fields parse correctly
- [x] `profile_pool_fields_merge_correctly` — merge semantics work as expected
- [x] `profile_state_serializes_round_trip` — `ProfileState` serde round-trip
- [x] `profile_state_with_timestamps_round_trips` — optional timestamps preserved
- [x] `profile_pool_state_in_daemon_persistent_state` — map round-trips in full state
- [x] `profile_pool_state_default_empty` — old state files without the field deserialize fine
- [x] `profile_state_default_is_not_limited` — default state is not limited
- [x] Full test suite passes, clippy clean

Closes task !1776. Tasks 2 and 3 depend on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)