### PR TITLE
feat(web): flat task list with ↳!XXXX dependency badge [Midtown !1781]

### DIFF
--- a/web-app/src/lib/TaskList.svelte
+++ b/web-app/src/lib/TaskList.svelte
@@ -4,60 +4,6 @@
   let { channelName = '' } = $props()
 
   /**
-   * Compute indentation level for each task based on dependency structure.
-   * Returns a Map of task ID to indentation level (0 = no indent, 1+ = nested)
-   *
-   * This mirrors the TUI implementation in src/bin/midtown/cli/chat/ui/board.rs
-   */
-  function computeTaskIndentation(tasks) {
-    const indentation = new Map()
-    const processed = new Set()
-    const taskMap = new Map(tasks.map(t => [t.id, t]))
-
-    function computeIndentationRecursive(taskId) {
-      // If already computed, return cached value
-      if (indentation.has(taskId)) {
-        return indentation.get(taskId)
-      }
-
-      // Guard against cycles
-      if (processed.has(taskId)) {
-        return 0
-      }
-      processed.add(taskId)
-
-      const task = taskMap.get(taskId)
-      if (!task) {
-        indentation.set(taskId, 0)
-        return 0
-      }
-
-      // If no dependencies, no indentation
-      if (!task.blocked_by || task.blocked_by.length === 0) {
-        indentation.set(taskId, 0)
-        return 0
-      }
-
-      // Find the first unresolved dependency in the current task list
-      const firstBlocker = task.blocked_by.find(blockerId => taskMap.has(blockerId))
-
-      const level = firstBlocker
-        ? computeIndentationRecursive(firstBlocker) + 1
-        : 0
-
-      indentation.set(taskId, level)
-      return level
-    }
-
-    // Process all tasks
-    for (const task of tasks) {
-      computeIndentationRecursive(task.id)
-    }
-
-    return indentation
-  }
-
-  /**
    * Filter tasks by channel field.
    * For 'midtown' channel, return all tasks.
    * For topic channels, only return tasks explicitly assigned to that channel.
@@ -84,8 +30,6 @@
     return filterTasksByChannel(allTasks, channelName)
   })
 
-  const indentMap = $derived(computeTaskIndentation(channelTasks))
-
   // Status marker for each task
   function getStatusMarker(status) {
     return status === 'in_progress' ? '\u2022' : '\u25CB'
@@ -98,14 +42,13 @@
 
 <div class="flex flex-col gap-px py-1">
   {#each channelTasks as task}
-    {@const indentLevel = indentMap.get(task.id) || 0}
-    {@const indentStyle = `padding-left: ${indentLevel * 16}px`}
-
     <div
       class="flex items-baseline gap-1.5 px-2 py-[3px] text-[0.75rem] leading-snug cursor-pointer transition-colors duration-100 rounded hover:bg-sidebar-accent"
-      style={indentStyle}
     >
       <span class="shrink-0 text-[0.6rem] {getStatusColor(task.status)}">{getStatusMarker(task.status)}</span>
+      {#if task.blocked_by?.length > 0}
+        <span class="shrink-0 text-[0.65rem] text-[#505050]">↳!{task.blocked_by[0]}</span>
+      {/if}
       <span class="shrink-0 text-muted-foreground font-medium">!{task.id}</span>
       <span class="flex-1 text-muted-foreground truncate {task.status === 'in_progress' ? 'text-foreground' : ''}">{task.subject}</span>
       {#if task.owner}


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary

- Remove `computeTaskIndentation()` and `indentMap` derived (55 lines deleted) — the recursive indent algorithm was producing confusing 4-level nesting for simple dependency chains like 1776→1777→1778→1779
- Remove `padding-left` inline style binding from task rows
- Add compact `↳!{blocked_by[0]}` span (0.65rem, `text-[#505050]`) between the status marker and task ID — shows dependency without nesting

**Before:**
```
• !1776  Auth profile pool: config...
  ○ !1777  Auth profile pool: selec...
    ○ !1778  Auth profile pool: mark...
      ○ !1779  Auth profile pool: int...
```

**After:**
```
• !1776  Auth profile pool: config...
○ ↳!1776  !1777  Auth profile pool: selec...
○ ↳!1777  !1778  Auth profile pool: mark...
○ ↳!1778  !1779  Auth profile pool: int...
```

All tasks sit at the same indentation level. Dependency is conveyed by the muted badge rather than spatial nesting.

## Test plan
- [x] Verify flat list renders correctly for tasks with no dependencies
- [x] Verify `↳!XXXX` badge appears for tasks with `blocked_by`
- [x] Verify deep chains (A→B→C→D) all appear at the same indent with correct blocker IDs
- [x] Verify tasks with no `blocked_by` show no badge
- [x] Pre-commit hooks (clippy + fmt) pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)