### PR TITLE
feat: mark auth profile limited on usage-limit detection [Midtown !1778]

### DIFF
--- a/src/daemon/dispatch_dev_limit_tests.rs
+++ b/src/daemon/dispatch_dev_limit_tests.rs
@@ -203,6 +203,7 @@ fn make_dev_limit_snapshot(
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     }
 }
 

--- a/src/daemon/dispatch_tests.rs
+++ b/src/daemon/dispatch_tests.rs
@@ -1290,6 +1290,7 @@ fn test_spawn_for_pending_tasks_generates_registry_effects_new_task() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -1455,6 +1456,7 @@ fn test_spawn_for_pending_tasks_reuses_worktree_for_owned_task() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -1595,6 +1597,7 @@ fn test_spawn_for_pending_tasks_skips_when_owner_has_pending_task() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -1705,6 +1708,7 @@ fn test_spawn_owner_includes_record_task_assignment_for_cross_tick_dedup() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -1819,6 +1823,7 @@ fn test_cross_tick_dedup_skips_in_flight_owned_task() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -1962,6 +1967,7 @@ fn test_cross_case_dedup_prevents_same_coworker_from_case1_and_case2() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -2082,6 +2088,7 @@ fn test_spawn_for_pending_tasks_skips_via_snapshot_assignment_check() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -2185,6 +2192,7 @@ fn test_orphan_recovery_reuses_existing_task_worktree() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -2346,6 +2354,7 @@ fn test_orphan_recovery_creates_new_worktree_when_none_exists() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -2530,6 +2539,7 @@ fn test_spawn_for_pending_unowned_reuses_existing_worktree() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -2695,6 +2705,7 @@ fn make_reconcile_snapshot(
         spawn_failure_cooldown_names: HashSet::new(),
         recently_recovered_session_ids: HashSet::new(),
         stale_working_dir_sessions: HashSet::new(),
+        session_profile_map: HashMap::new(),
     }
 }
 
@@ -3333,6 +3344,7 @@ fn test_spawn_for_pending_tasks_when_all_coworkers_are_gone() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -4010,6 +4022,7 @@ fn test_spawn_extracts_model_alias_from_provider_model_format() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -4130,6 +4143,7 @@ fn test_orphan_recovery_marks_task_in_flight() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -4423,6 +4437,7 @@ fn test_stale_task_cleanup_false_positive_task_about_merged_pr() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -4537,6 +4552,7 @@ fn test_stale_task_cleanup_correct_behavior_with_explicit_pr_field() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -4816,6 +4832,7 @@ fn make_session_dispatch_snapshot(
         spawn_failure_cooldown_names: HashSet::new(),
         recently_recovered_session_ids: HashSet::new(),
         stale_working_dir_sessions: HashSet::new(),
+        session_profile_map: HashMap::new(),
     }
 }
 

--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -367,6 +367,22 @@ pub enum Effect {
         channel_name: String,
         session_id: String,
     },
+    /// Mark an auth profile as usage-limited in persistent `profile_pool_state`.
+    ///
+    /// Emitted by `check_for_usage_limits()` when a coworker with a pool-selected
+    /// profile hits its usage limit. The profile is skipped for future spawns until
+    /// a `ClearProfileLimit` effect fires (triggered by `maybe_nudge_usage_limit_expiry`).
+    MarkProfileLimited {
+        profile_email: String,
+        reset_at: Option<chrono::DateTime<chrono::Utc>>,
+    },
+    /// Clear usage-limited status for an auth profile in `profile_pool_state`.
+    ///
+    /// Emitted by `maybe_nudge_usage_limit_expiry()` when the usage limit reset
+    /// timer fires for a coworker that was spawned from a pool profile. Allows
+    /// the profile to be selected again for future coworker spawns.
+    ClearProfileLimit { profile_email: String },
+
     /// Remove a coworker from the attached set when their interactive session
     /// appears to have ended without a proper `midtown session detach`.
     ///
@@ -933,6 +949,37 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
             Effect::ClearUsageLimitNudge => {
                 let mut nudge_at = state.usage_limit_nudge_at.lock().await;
                 *nudge_at = None;
+            }
+            Effect::MarkProfileLimited {
+                profile_email,
+                reset_at,
+            } => {
+                let mut ps = state.persistent_state.lock().await;
+                let entry = ps
+                    .profile_pool_state
+                    .entry(profile_email.clone())
+                    .or_default();
+                entry.is_usage_limited = true;
+                entry.usage_limit_reset_at = reset_at;
+                if let Err(e) = ps.save_for_repo(&state.repo_name) {
+                    warn!(
+                        "Failed to persist MarkProfileLimited for {}: {}",
+                        profile_email, e
+                    );
+                }
+            }
+            Effect::ClearProfileLimit { profile_email } => {
+                let mut ps = state.persistent_state.lock().await;
+                if let Some(entry) = ps.profile_pool_state.get_mut(&profile_email) {
+                    entry.is_usage_limited = false;
+                    entry.usage_limit_reset_at = None;
+                }
+                if let Err(e) = ps.save_for_repo(&state.repo_name) {
+                    warn!(
+                        "Failed to persist ClearProfileLimit for {}: {}",
+                        profile_email, e
+                    );
+                }
             }
             Effect::ResetTaskToPending { task_id, repo_name } => {
                 if let Err(e) = crate::tasks::reset_task_to_pending_for_repo(&task_id, &repo_name) {

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -920,14 +920,32 @@ pub fn check_for_usage_limits(snap: &snapshot::WorldSnapshot) -> Vec<Effect> {
         detected_coworker, nudge_time
     );
 
-    vec![
+    let mut effects = vec![
         Effect::SetUsageLimitNudge { at: nudge_time },
         Effect::PostToChannel {
             sender: "midtown".to_string(),
             message,
             channel: Some(OPS_CHANNEL.to_string()),
         },
-    ]
+    ];
+
+    // If this coworker was spawned from a pool profile, mark it usage-limited
+    // so future spawns skip it until the limit clears.
+    if let Some(profile_email) = snap
+        .session_profile_map
+        .get(&detected_coworker.to_lowercase())
+    {
+        info!(
+            "Marking pool profile '{}' as usage-limited (via {})",
+            profile_email, detected_coworker
+        );
+        effects.push(Effect::MarkProfileLimited {
+            profile_email: profile_email.clone(),
+            reset_at: reset_time_utc,
+        });
+    }
+
+    effects
 }
 
 /// Check if a scheduled usage limit nudge is due, and if so, nudge all running coworkers.
@@ -953,30 +971,43 @@ pub fn maybe_nudge_usage_limit_expiry(snap: &snapshot::WorldSnapshot) -> Vec<Eff
         })
         .collect();
 
+    let mut effects = vec![Effect::ClearUsageLimitNudge];
+
     if eligible_session_ids.is_empty() {
         info!("Usage limit expired — no running sessions to nudge");
-        return vec![Effect::ClearUsageLimitNudge];
-    }
+    } else {
+        info!(
+            "Usage limit expired — nudging {} running sessions",
+            eligible_session_ids.len()
+        );
 
-    info!(
-        "Usage limit expired — nudging {} running sessions",
-        eligible_session_ids.len()
-    );
-
-    let mut effects = vec![
-        Effect::ClearUsageLimitNudge,
-        Effect::PostToChannel {
+        effects.push(Effect::PostToChannel {
             sender: "midtown".to_string(),
             message: format!(
                 "🔔 Usage limit expired — nudging {} running sessions to resume work",
                 eligible_session_ids.len()
             ),
             channel: Some(OPS_CHANNEL.to_string()),
-        },
-    ];
+        });
 
-    for session_id in eligible_session_ids {
-        effects.push(Effect::nudge_session(session_id, "continue"));
+        for session_id in eligible_session_ids {
+            effects.push(Effect::nudge_session(session_id, "continue"));
+        }
+    }
+
+    // Clear profile-level limits for any pool profiles that were associated
+    // with usage-limited coworkers. The usage limit has now expired, so these
+    // profiles are available for future coworker spawns again.
+    for (coworker_name, profile_email) in &snap.session_profile_map {
+        if snap.usage_limited_coworkers.contains(coworker_name) {
+            info!(
+                "Clearing usage-limit on pool profile '{}' (coworker: {})",
+                profile_email, coworker_name
+            );
+            effects.push(Effect::ClearProfileLimit {
+                profile_email: profile_email.clone(),
+            });
+        }
     }
 
     effects

--- a/src/daemon/health_tests.rs
+++ b/src/daemon/health_tests.rs
@@ -118,6 +118,7 @@ fn test_usage_limit_nudge_only_targets_running_coworkers() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let effects = maybe_nudge_usage_limit_expiry(&snap);
@@ -263,6 +264,7 @@ fn test_usage_limit_nudge_includes_reviewers_and_leads_with_sessions() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let effects = maybe_nudge_usage_limit_expiry(&snap);
@@ -435,6 +437,7 @@ fn test_check_for_usage_limits_with_reset_time() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let effects = check_for_usage_limits(&snap);
@@ -534,6 +537,7 @@ fn test_check_for_usage_limits_already_scheduled() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let effects = check_for_usage_limits(&snap);
@@ -668,6 +672,7 @@ fn empty_snap() -> snapshot::WorldSnapshot {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     }
 }
 
@@ -1611,6 +1616,7 @@ fn test_idle_shutdown_emits_shutdown_session_when_mapping_exists() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let effects = check_and_shutdown_idle_coworkers(&snap);
@@ -1749,6 +1755,7 @@ fn test_idle_shutdown_falls_back_to_shutdown_coworker_without_mapping() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     let effects = check_and_shutdown_idle_coworkers(&snap);
@@ -2557,4 +2564,253 @@ fn test_stuck_reviewer_restart_emits_coworker_stuck_workflow_event() {
     assert_eq!(ch, "proj-reviews");
     assert_eq!(tid, Some("55".to_string()));
     assert_eq!(cw, "amsterdam");
+}
+
+// ── Auth profile pool: usage-limit marking ────────────────────────────────────
+
+#[test]
+fn usage_limit_marks_pool_profile_limited() {
+    // When a coworker with a usage limit is mapped to a pool profile,
+    // check_for_usage_limits() should emit MarkProfileLimited for that profile.
+    use crate::coworker::{Coworker, CoworkerStatus};
+    use std::collections::{HashMap, HashSet};
+
+    let reset_time = chrono::Utc::now() + chrono::Duration::hours(2);
+    let mut health = HashMap::new();
+    health.insert(
+        "lexington".to_string(),
+        snapshot::ProcessHealth {
+            is_alive: true,
+            last_event_at: Some(chrono::Utc::now()),
+            has_usage_limit: true,
+            usage_limit_reset_at: Some(reset_time),
+            has_api_error: false,
+            has_auth_error: false,
+            has_running_subagent: false,
+            has_pending_tool: false,
+            has_tool_name_conflict: false,
+            has_pending_api_call: false,
+            exit_code: None,
+        },
+    );
+
+    let coworker = Coworker {
+        slot_id: uuid::Uuid::new_v4().to_string(),
+        name: "lexington".to_string(),
+        status: CoworkerStatus::Running,
+        working_dir: "/tmp/test".to_string(),
+        started_at: chrono::Utc::now(),
+        current_task: None,
+        session_id: None,
+        model: "sonnet".to_string(),
+        provider: crate::auth::AuthProvider::Claude,
+        profile: crate::auth::DEFAULT_PROFILE.to_string(),
+    };
+
+    let mut profile_map = HashMap::new();
+    profile_map.insert("lexington".to_string(), "alice@example.com".to_string());
+
+    let snap = snapshot::minimal_snapshot_for_test();
+    let snap = snapshot::WorldSnapshot {
+        active_coworkers: vec![coworker],
+        headless_process_health: health,
+        active_names: HashSet::from(["lexington".to_string()]),
+        usage_limited_coworkers: HashSet::from(["lexington".to_string()]),
+        session_profile_map: profile_map,
+        ..snap
+    };
+
+    let effects = check_for_usage_limits(&snap);
+
+    assert!(!effects.is_empty(), "Should produce effects");
+
+    let has_mark_limited = effects.iter().any(|e| {
+        matches!(e, Effect::MarkProfileLimited { profile_email, .. } if profile_email == "alice@example.com")
+    });
+    assert!(
+        has_mark_limited,
+        "Should emit MarkProfileLimited for alice@example.com, got: {:#?}",
+        effects
+    );
+}
+
+#[test]
+fn usage_limit_without_profile_map_skips_mark_limited() {
+    // When a coworker hits a usage limit but is NOT in session_profile_map
+    // (single-profile mode, no pool), check_for_usage_limits() should NOT
+    // emit MarkProfileLimited.
+    use crate::coworker::{Coworker, CoworkerStatus};
+    use std::collections::{HashMap, HashSet};
+
+    let mut health = HashMap::new();
+    health.insert(
+        "lexington".to_string(),
+        snapshot::ProcessHealth {
+            is_alive: true,
+            last_event_at: Some(chrono::Utc::now()),
+            has_usage_limit: true,
+            usage_limit_reset_at: None,
+            has_api_error: false,
+            has_auth_error: false,
+            has_running_subagent: false,
+            has_pending_tool: false,
+            has_tool_name_conflict: false,
+            has_pending_api_call: false,
+            exit_code: None,
+        },
+    );
+
+    let coworker = Coworker {
+        slot_id: uuid::Uuid::new_v4().to_string(),
+        name: "lexington".to_string(),
+        status: CoworkerStatus::Running,
+        working_dir: "/tmp/test".to_string(),
+        started_at: chrono::Utc::now(),
+        current_task: None,
+        session_id: None,
+        model: "sonnet".to_string(),
+        provider: crate::auth::AuthProvider::Claude,
+        profile: crate::auth::DEFAULT_PROFILE.to_string(),
+    };
+
+    let snap = snapshot::minimal_snapshot_for_test();
+    let snap = snapshot::WorldSnapshot {
+        active_coworkers: vec![coworker],
+        headless_process_health: health,
+        active_names: HashSet::from(["lexington".to_string()]),
+        usage_limited_coworkers: HashSet::from(["lexington".to_string()]),
+        session_profile_map: HashMap::new(), // no pool mapping
+        ..snap
+    };
+
+    let effects = check_for_usage_limits(&snap);
+
+    assert!(
+        !effects.is_empty(),
+        "Should produce SetUsageLimitNudge and PostToChannel effects"
+    );
+
+    let has_mark_limited = effects
+        .iter()
+        .any(|e| matches!(e, Effect::MarkProfileLimited { .. }));
+    assert!(
+        !has_mark_limited,
+        "Should NOT emit MarkProfileLimited when no profile is mapped"
+    );
+}
+
+#[test]
+fn maybe_nudge_usage_limit_expiry_clears_pool_profile_limit() {
+    // When the usage limit reset fires, maybe_nudge_usage_limit_expiry() should
+    // emit ClearProfileLimit for profiles mapped to usage-limited coworkers.
+    use std::collections::{HashMap, HashSet};
+
+    let past_instant = tokio::time::Instant::now()
+        .checked_sub(std::time::Duration::from_secs(1))
+        .unwrap_or_else(tokio::time::Instant::now);
+
+    let mut profile_map = HashMap::new();
+    profile_map.insert("lexington".to_string(), "alice@example.com".to_string());
+    profile_map.insert("amsterdam".to_string(), "bob@example.com".to_string());
+
+    let snap = snapshot::minimal_snapshot_for_test();
+    let snap = snapshot::WorldSnapshot {
+        // At least one running coworker so eligibility check passes
+        running_coworkers: vec![crate::coworker::Coworker {
+            slot_id: uuid::Uuid::new_v4().to_string(),
+            name: "lexington".to_string(),
+            status: crate::coworker::CoworkerStatus::Running,
+            working_dir: "/tmp/test".to_string(),
+            started_at: chrono::Utc::now(),
+            current_task: None,
+            session_id: None,
+            model: "sonnet".to_string(),
+            provider: crate::auth::AuthProvider::Claude,
+            profile: crate::auth::DEFAULT_PROFILE.to_string(),
+        }],
+        usage_limit_nudge_scheduled: true,
+        usage_limit_nudge_at: Some(past_instant),
+        // Both coworkers were usage-limited, but only lexington has a profile map entry
+        usage_limited_coworkers: HashSet::from(["lexington".to_string(), "amsterdam".to_string()]),
+        session_profile_map: profile_map,
+        ..snap
+    };
+
+    let effects = maybe_nudge_usage_limit_expiry(&snap);
+
+    assert!(!effects.is_empty(), "Should produce effects");
+
+    let has_clear_alice = effects.iter().any(|e| {
+        matches!(e, Effect::ClearProfileLimit { profile_email } if profile_email == "alice@example.com")
+    });
+    assert!(
+        has_clear_alice,
+        "Should emit ClearProfileLimit for alice@example.com, got: {:#?}",
+        effects
+    );
+
+    let has_clear_bob = effects.iter().any(|e| {
+        matches!(e, Effect::ClearProfileLimit { profile_email } if profile_email == "bob@example.com")
+    });
+    assert!(
+        has_clear_bob,
+        "Should emit ClearProfileLimit for bob@example.com, got: {:#?}",
+        effects
+    );
+}
+
+#[test]
+fn maybe_nudge_usage_limit_expiry_no_clear_for_non_limited_profiles() {
+    // Profiles mapped to coworkers that are NOT usage-limited should not get
+    // ClearProfileLimit — only limited coworkers have profiles to clear.
+    use std::collections::{HashMap, HashSet};
+
+    let past_instant = tokio::time::Instant::now()
+        .checked_sub(std::time::Duration::from_secs(1))
+        .unwrap_or_else(tokio::time::Instant::now);
+
+    let mut profile_map = HashMap::new();
+    // lexington is usage-limited (has profile alice)
+    profile_map.insert("lexington".to_string(), "alice@example.com".to_string());
+    // amsterdam is NOT usage-limited (has profile bob — should not be cleared)
+    profile_map.insert("amsterdam".to_string(), "bob@example.com".to_string());
+
+    let snap = snapshot::minimal_snapshot_for_test();
+    let snap = snapshot::WorldSnapshot {
+        running_coworkers: vec![crate::coworker::Coworker {
+            slot_id: uuid::Uuid::new_v4().to_string(),
+            name: "lexington".to_string(),
+            status: crate::coworker::CoworkerStatus::Running,
+            working_dir: "/tmp/test".to_string(),
+            started_at: chrono::Utc::now(),
+            current_task: None,
+            session_id: None,
+            model: "sonnet".to_string(),
+            provider: crate::auth::AuthProvider::Claude,
+            profile: crate::auth::DEFAULT_PROFILE.to_string(),
+        }],
+        usage_limit_nudge_scheduled: true,
+        usage_limit_nudge_at: Some(past_instant),
+        usage_limited_coworkers: HashSet::from(["lexington".to_string()]), // only lexington
+        session_profile_map: profile_map,
+        ..snap
+    };
+
+    let effects = maybe_nudge_usage_limit_expiry(&snap);
+
+    let has_clear_alice = effects.iter().any(|e| {
+        matches!(e, Effect::ClearProfileLimit { profile_email } if profile_email == "alice@example.com")
+    });
+    assert!(
+        has_clear_alice,
+        "Should clear alice (lexington was limited)"
+    );
+
+    let has_clear_bob = effects.iter().any(|e| {
+        matches!(e, Effect::ClearProfileLimit { profile_email } if profile_email == "bob@example.com")
+    });
+    assert!(
+        !has_clear_bob,
+        "Should NOT clear bob (amsterdam was not usage-limited)"
+    );
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -992,7 +992,8 @@ impl DaemonState {
         }
         // Clear profile pool mapping (prevents stale profile attribution on name reuse)
         {
-            self.session_profile_map.lock().unwrap().remove(name);
+            let mut map = self.session_profile_map.lock().unwrap();
+            map.remove(&name.to_lowercase());
         }
         // Clear the inbox for this name so the next session that gets
         // allocated this name does not inherit unread messages from this session.
@@ -1388,10 +1389,10 @@ impl DaemonState {
             if let Some(email) = self.select_profile_from_pool(&c).await {
                 tracing::debug!("Pool selected profile '{}' for coworker '{}'", email, name);
                 // Record session→profile mapping for usage-limit attribution.
-                self.session_profile_map
-                    .lock()
-                    .unwrap()
-                    .insert(name.clone(), email.clone());
+                {
+                    let mut map = self.session_profile_map.lock().unwrap();
+                    map.insert(name.to_lowercase(), email.clone());
+                }
                 // Mark last_used_at so future spawns use LRU ordering.
                 {
                     let mut ps = self.persistent_state.lock().await;

--- a/src/daemon/snapshot.rs
+++ b/src/daemon/snapshot.rs
@@ -406,6 +406,15 @@ pub struct WorldSnapshot {
     /// performing `Path::exists()` calls themselves.
     #[serde(default)]
     pub stale_working_dir_sessions: HashSet<String>,
+
+    // ── Auth profile pool ─────────────────────────────────────────────────
+    /// Maps coworker name (lowercase) → auth profile email.
+    ///
+    /// Populated from `DaemonState::session_profile_map` during snapshot collection.
+    /// Used by `check_for_usage_limits()` to attribute usage limits to specific
+    /// pool profiles and emit `MarkProfileLimited` effects.
+    #[serde(default)]
+    pub session_profile_map: HashMap<String, String>,
 }
 
 /// Read the last N lines from the daemon log file.
@@ -981,6 +990,15 @@ pub(crate) async fn collect_world_snapshot(state: &DaemonState) -> WorldSnapshot
         .map(|(session_id, _)| session_id.clone())
         .collect();
 
+    // ── Auth profile pool ─────────────────────────────────────────────────
+    // Snapshot the session→profile mapping so pure decision functions
+    // (check_for_usage_limits) can emit MarkProfileLimited effects without
+    // accessing DaemonState directly.
+    let session_profile_map: HashMap<String, String> = {
+        let map = state.session_profile_map.lock().unwrap();
+        map.clone()
+    };
+
     let snapshot = WorldSnapshot {
         active_coworkers,
         running_coworkers,
@@ -1055,6 +1073,7 @@ pub(crate) async fn collect_world_snapshot(state: &DaemonState) -> WorldSnapshot
         spawn_failure_cooldown_names,
         recently_recovered_session_ids,
         stale_working_dir_sessions,
+        session_profile_map,
     };
 
     // Log full snapshot at trace level for debugging and test case generation
@@ -1145,6 +1164,7 @@ pub(super) fn minimal_snapshot_for_test() -> WorldSnapshot {
         spawn_failure_cooldown_names: HashSet::new(),
         recently_recovered_session_ids: HashSet::new(),
         stale_working_dir_sessions: HashSet::new(),
+        session_profile_map: HashMap::new(),
     }
 }
 

--- a/src/daemon/snapshot_tests.rs
+++ b/src/daemon/snapshot_tests.rs
@@ -118,6 +118,7 @@ fn test_world_snapshot_has_coworker_stop_times() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     assert_eq!(snapshot.coworker_stop_times.len(), 2);
@@ -233,6 +234,7 @@ fn test_snapshot_debug_context_empty_by_default() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     assert!(snapshot.channel_messages.is_empty());
@@ -492,6 +494,7 @@ fn test_sessions_for_name() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     // "lexington" has two sessions
@@ -591,6 +594,7 @@ fn test_active_session_ids_in_snapshot() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     assert_eq!(snapshot.active_session_ids.len(), 2);
@@ -684,6 +688,7 @@ fn test_snapshot_includes_session_fields() {
         spawn_failure_cooldown_names: std::collections::HashSet::new(),
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
+        session_profile_map: HashMap::new(),
     };
 
     assert!(snapshot.sessions.is_empty());


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary

- Adds `MarkProfileLimited` and `ClearProfileLimit` Effect variants with execution arms that update `profile_pool_state` in persistent state
- Extends `check_for_usage_limits()` to emit `MarkProfileLimited` when a pool-spawned coworker hits its usage limit (looked up via `session_profile_map`)
- Extends `maybe_nudge_usage_limit_expiry()` to emit `ClearProfileLimit` when the reset timer fires, clearing profiles mapped to usage-limited coworkers
- Adds `session_profile_map` to `WorldSnapshot` (populated from `DaemonState`) so pure decision functions can look up session → profile associations
- Uses consistent lowercase keys in `session_profile_map` lookups
- Adds four new tests covering all marking/clearing paths including the no-pool single-profile case

## Test plan

- [x] `usage_limit_marks_pool_profile_limited` — emits MarkProfileLimited when coworker in session_profile_map hits limit
- [x] `usage_limit_without_profile_map_skips_mark_limited` — no MarkProfileLimited in single-profile mode
- [x] `maybe_nudge_usage_limit_expiry_clears_pool_profile_limit` — ClearProfileLimit emitted for all usage-limited mapped coworkers
- [x] `maybe_nudge_usage_limit_expiry_no_clear_for_non_limited_profiles` — non-limited coworker profiles not cleared
- [x] All existing tests pass (1901 unit tests, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)