### PR TITLE
docs: auth profile pool architecture + README config example [Midtown !1779]

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,19 @@ Review execution mode controls how PR reviews are sourced:
 - `execution.review_mode = "github_app"`: daemon does not spawn local reviewers; waits for formal GitHub App reviews
 - `execution.review_mode = "both"`: local reviewers are enabled and GitHub App/formal reviews also count
 
+#### Multi-Account Profile Pool
+
+To rotate across multiple Claude accounts and avoid usage-limit bottlenecks, configure profile pools per role:
+
+```toml
+[execution]
+coworker_profiles = ["alice@example.com", "bob@example.com", "team@example.com"]
+reviewer_profiles = ["alice@example.com", "bob@example.com"]
+channel_lead_profiles = ["alice@example.com"]
+```
+
+Midtown picks the least-recently-used available profile for each new coworker spawn. When a profile hits its usage limit, it's automatically skipped until the limit resets. Pool configuration takes precedence over `coworker_provider` for auth resolution.
+
 Model aliases are auto-normalized per provider at launch:
 
 - Generic sizes:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -151,9 +151,11 @@ On daemon startup, the `NamePool` is restored from persisted session records: na
 1. Filter profiles where `ProfileState.is_usage_limited` is `true` in `DaemonPersistentState.profile_pool_state`.
 2. Among available profiles, pick LRU by `ProfileState.last_used_at` (never-used profiles preferred with `last_used_at = None`).
 3. If all profiles are limited, fall back to the single-profile path (existing behavior).
-4. On success, update `last_used_at` in `profile_pool_state` and save state.
+4. On success, update `last_used_at` in `profile_pool_state`, record `session_name → profile_email` in `session_profile_map`, and save state.
 
-`DaemonPersistentState.profile_pool_state` (`HashMap<String, ProfileState>`) persists per-profile usage state across daemon restarts. `ProfileState` tracks `is_usage_limited`, `usage_limit_reset_at`, and `last_used_at`. Tasks 2 and 3 of the pool feature wire up limit detection and clearing (see tasks !1777, !1778).
+**Limit detection and clearing**: When `check_for_usage_limits()` detects a session has hit its usage limit, it looks up the session's profile in `session_profile_map` and emits a `MarkProfileLimited` effect — setting `is_usage_limited: true` and recording `usage_limit_reset_at` in `profile_pool_state`. Limit clearing is explicit: when the scheduled `UsageLimitNudge` handler fires (after the reset timer), it emits `ClearProfileLimit`, which sets `is_usage_limited: false` and clears `usage_limit_reset_at`. A profile with a past `reset_at` remains limited until this effect fires — the pool selection logic reads only `is_usage_limited`, never the timestamp directly.
+
+`DaemonPersistentState.profile_pool_state` (`HashMap<String, ProfileState>`) persists per-profile usage state across daemon restarts. `ProfileState` tracks `is_usage_limited`, `usage_limit_reset_at`, and `last_used_at`. The in-memory `session_profile_map` (`HashMap<String, String>`) tracks `session_name → profile_email` for limit attribution; it is not persisted (profiles become available again on daemon restart).
 
 ## Prompt Architecture
 


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary

- **`docs/architecture.md`**: Replaces the "Tasks 2 and 3 wire up limit detection" placeholder with complete documentation of the full detection→marking→clearing cycle:
  - `check_for_usage_limits()` → `MarkProfileLimited` effect
  - `UsageLimitNudge` handler → `ClearProfileLimit` effect
  - Clarifies that `session_profile_map` is in-memory only (profiles become available on daemon restart)
- **`README.md`**: Adds a "Multi-Account Profile Pool" subsection to the configuration section with `coworker_profiles`, `reviewer_profiles`, and `channel_lead_profiles` TOML examples

## Notes

The three edge-case tests (`single_profile_pool_behaves_like_no_pool`, `pool_with_unknown_profiles_treats_them_as_available`, `reset_at_expired_profile_still_limited_until_explicitly_cleared`) were already present in `profile_pool_tests.rs` from task !1777's implementation — no test changes needed.

## Test plan
- [x] All 9 `daemon::profile_pool` tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)