### PR TITLE
fix: decouple profile-limit clearing from ephemeral state [Midtown !1788] [Midtown !1789]

### DIFF
--- a/src/daemon/dispatch_dev_limit_tests.rs
+++ b/src/daemon/dispatch_dev_limit_tests.rs
@@ -204,6 +204,7 @@ fn make_dev_limit_snapshot(
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: std::collections::HashSet::new(),
     }
 }
 

--- a/src/daemon/dispatch_tests.rs
+++ b/src/daemon/dispatch_tests.rs
@@ -1291,6 +1291,7 @@ fn test_spawn_for_pending_tasks_generates_registry_effects_new_task() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -1457,6 +1458,7 @@ fn test_spawn_for_pending_tasks_reuses_worktree_for_owned_task() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -1598,6 +1600,7 @@ fn test_spawn_for_pending_tasks_skips_when_owner_has_pending_task() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -1709,6 +1712,7 @@ fn test_spawn_owner_includes_record_task_assignment_for_cross_tick_dedup() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -1824,6 +1828,7 @@ fn test_cross_tick_dedup_skips_in_flight_owned_task() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -1968,6 +1973,7 @@ fn test_cross_case_dedup_prevents_same_coworker_from_case1_and_case2() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -2089,6 +2095,7 @@ fn test_spawn_for_pending_tasks_skips_via_snapshot_assignment_check() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -2193,6 +2200,7 @@ fn test_orphan_recovery_reuses_existing_task_worktree() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -2355,6 +2363,7 @@ fn test_orphan_recovery_creates_new_worktree_when_none_exists() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -2540,6 +2549,7 @@ fn test_spawn_for_pending_unowned_reuses_existing_worktree() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -2706,6 +2716,7 @@ fn make_reconcile_snapshot(
         recently_recovered_session_ids: HashSet::new(),
         stale_working_dir_sessions: HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     }
 }
 
@@ -3345,6 +3356,7 @@ fn test_spawn_for_pending_tasks_when_all_coworkers_are_gone() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -4023,6 +4035,7 @@ fn test_spawn_extracts_model_alias_from_provider_model_format() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -4144,6 +4157,7 @@ fn test_orphan_recovery_marks_task_in_flight() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -4438,6 +4452,7 @@ fn test_stale_task_cleanup_false_positive_task_about_merged_pr() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -4553,6 +4568,7 @@ fn test_stale_task_cleanup_correct_behavior_with_explicit_pr_field() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let (state, _tmp, _guard) = make_test_state();
@@ -4833,6 +4849,7 @@ fn make_session_dispatch_snapshot(
         recently_recovered_session_ids: HashSet::new(),
         stale_working_dir_sessions: HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     }
 }
 

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -874,14 +874,23 @@ pub fn check_for_usage_limits(snap: &snapshot::WorldSnapshot) -> Vec<Effect> {
         return vec![];
     }
 
-    // Find the first coworker with a usage limit flag and extract reset time
-    let (detected_coworker, reset_time_utc) = match snap
+    // Collect all coworkers with a usage limit flag. Usage limits are account-wide
+    // so multiple coworkers may hit the limit simultaneously.
+    let limited: Vec<_> = snap
         .headless_process_health
         .iter()
-        .find(|(_, health)| health.has_usage_limit)
-    {
-        Some((name, health)) => (name.clone(), health.usage_limit_reset_at),
-        None => return vec![],
+        .filter(|(_, health)| health.has_usage_limit)
+        .collect();
+
+    if limited.is_empty() {
+        return vec![];
+    }
+
+    // Use the first detected coworker for nudge scheduling and the channel message.
+    // The reset time is account-wide, so any coworker's value is representative.
+    let (detected_coworker, reset_time_utc) = {
+        let (name, health) = limited[0];
+        (name.clone(), health.usage_limit_reset_at)
     };
 
     // Calculate nudge time based on reset time or default to 15 minutes
@@ -929,20 +938,19 @@ pub fn check_for_usage_limits(snap: &snapshot::WorldSnapshot) -> Vec<Effect> {
         },
     ];
 
-    // If this coworker was spawned from a pool profile, mark it usage-limited
-    // so future spawns skip it until the limit clears.
-    if let Some(profile_email) = snap
-        .session_profile_map
-        .get(&detected_coworker.to_lowercase())
-    {
-        info!(
-            "Marking pool profile '{}' as usage-limited (via {})",
-            profile_email, detected_coworker
-        );
-        effects.push(Effect::MarkProfileLimited {
-            profile_email: profile_email.clone(),
-            reset_at: reset_time_utc,
-        });
+    // Mark pool profiles for ALL usage-limited coworkers, not just the first.
+    // Multiple coworkers may hit the limit simultaneously when they share an account.
+    for (coworker_name, health) in &limited {
+        if let Some(profile_email) = snap.session_profile_map.get(&coworker_name.to_lowercase()) {
+            info!(
+                "Marking pool profile '{}' as usage-limited (via {})",
+                profile_email, coworker_name
+            );
+            effects.push(Effect::MarkProfileLimited {
+                profile_email: profile_email.clone(),
+                reset_at: health.usage_limit_reset_at,
+            });
+        }
     }
 
     effects
@@ -995,19 +1003,20 @@ pub fn maybe_nudge_usage_limit_expiry(snap: &snapshot::WorldSnapshot) -> Vec<Eff
         }
     }
 
-    // Clear profile-level limits for any pool profiles that were associated
-    // with usage-limited coworkers. The usage limit has now expired, so these
-    // profiles are available for future coworker spawns again.
-    for (coworker_name, profile_email) in &snap.session_profile_map {
-        if snap.usage_limited_coworkers.contains(coworker_name) {
-            info!(
-                "Clearing usage-limit on pool profile '{}' (coworker: {})",
-                profile_email, coworker_name
-            );
-            effects.push(Effect::ClearProfileLimit {
-                profile_email: profile_email.clone(),
-            });
-        }
+    // Clear profile-level limits for ALL pool profiles currently marked
+    // is_usage_limited in persistent state. The usage limit has now expired.
+    //
+    // We iterate `limited_pool_profiles` (from DaemonPersistentState) rather
+    // than `session_profile_map` (from DaemonState) because session_profile_map
+    // is ephemeral: entries are removed when coworkers stop. If a coworker exited
+    // before the nudge timer fired, its profile would stay permanently excluded
+    // from pool selection. Persistent state survives both coworker exits and
+    // daemon restarts.
+    for profile_email in &snap.limited_pool_profiles {
+        info!("Clearing usage-limit on pool profile '{}'", profile_email);
+        effects.push(Effect::ClearProfileLimit {
+            profile_email: profile_email.clone(),
+        });
     }
 
     effects

--- a/src/daemon/health_tests.rs
+++ b/src/daemon/health_tests.rs
@@ -119,6 +119,7 @@ fn test_usage_limit_nudge_only_targets_running_coworkers() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let effects = maybe_nudge_usage_limit_expiry(&snap);
@@ -265,6 +266,7 @@ fn test_usage_limit_nudge_includes_reviewers_and_leads_with_sessions() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let effects = maybe_nudge_usage_limit_expiry(&snap);
@@ -438,6 +440,7 @@ fn test_check_for_usage_limits_with_reset_time() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let effects = check_for_usage_limits(&snap);
@@ -538,6 +541,7 @@ fn test_check_for_usage_limits_already_scheduled() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let effects = check_for_usage_limits(&snap);
@@ -673,6 +677,7 @@ fn empty_snap() -> snapshot::WorldSnapshot {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     }
 }
 
@@ -1617,6 +1622,7 @@ fn test_idle_shutdown_emits_shutdown_session_when_mapping_exists() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let effects = check_and_shutdown_idle_coworkers(&snap);
@@ -1756,6 +1762,7 @@ fn test_idle_shutdown_falls_back_to_shutdown_coworker_without_mapping() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     let effects = check_and_shutdown_idle_coworkers(&snap);
@@ -2702,16 +2709,13 @@ fn usage_limit_without_profile_map_skips_mark_limited() {
 #[test]
 fn maybe_nudge_usage_limit_expiry_clears_pool_profile_limit() {
     // When the usage limit reset fires, maybe_nudge_usage_limit_expiry() should
-    // emit ClearProfileLimit for profiles mapped to usage-limited coworkers.
-    use std::collections::{HashMap, HashSet};
+    // emit ClearProfileLimit for ALL profiles in limited_pool_profiles (from
+    // persistent state), not only those reachable via session_profile_map.
+    use std::collections::HashSet;
 
     let past_instant = tokio::time::Instant::now()
         .checked_sub(std::time::Duration::from_secs(1))
         .unwrap_or_else(tokio::time::Instant::now);
-
-    let mut profile_map = HashMap::new();
-    profile_map.insert("lexington".to_string(), "alice@example.com".to_string());
-    profile_map.insert("amsterdam".to_string(), "bob@example.com".to_string());
 
     let snap = snapshot::minimal_snapshot_for_test();
     let snap = snapshot::WorldSnapshot {
@@ -2730,9 +2734,12 @@ fn maybe_nudge_usage_limit_expiry_clears_pool_profile_limit() {
         }],
         usage_limit_nudge_scheduled: true,
         usage_limit_nudge_at: Some(past_instant),
-        // Both coworkers were usage-limited, but only lexington has a profile map entry
-        usage_limited_coworkers: HashSet::from(["lexington".to_string(), "amsterdam".to_string()]),
-        session_profile_map: profile_map,
+        // limited_pool_profiles is the source of truth for which profiles to clear.
+        // Both alice and bob are marked is_usage_limited in persistent state.
+        limited_pool_profiles: HashSet::from([
+            "alice@example.com".to_string(),
+            "bob@example.com".to_string(),
+        ]),
         ..snap
     };
 
@@ -2761,19 +2768,13 @@ fn maybe_nudge_usage_limit_expiry_clears_pool_profile_limit() {
 
 #[test]
 fn maybe_nudge_usage_limit_expiry_no_clear_for_non_limited_profiles() {
-    // Profiles mapped to coworkers that are NOT usage-limited should not get
-    // ClearProfileLimit — only limited coworkers have profiles to clear.
-    use std::collections::{HashMap, HashSet};
+    // Only profiles in limited_pool_profiles (is_usage_limited=true in persistent
+    // state) get ClearProfileLimit. Profiles not in that set are left untouched.
+    use std::collections::HashSet;
 
     let past_instant = tokio::time::Instant::now()
         .checked_sub(std::time::Duration::from_secs(1))
         .unwrap_or_else(tokio::time::Instant::now);
-
-    let mut profile_map = HashMap::new();
-    // lexington is usage-limited (has profile alice)
-    profile_map.insert("lexington".to_string(), "alice@example.com".to_string());
-    // amsterdam is NOT usage-limited (has profile bob — should not be cleared)
-    profile_map.insert("amsterdam".to_string(), "bob@example.com".to_string());
 
     let snap = snapshot::minimal_snapshot_for_test();
     let snap = snapshot::WorldSnapshot {
@@ -2791,8 +2792,8 @@ fn maybe_nudge_usage_limit_expiry_no_clear_for_non_limited_profiles() {
         }],
         usage_limit_nudge_scheduled: true,
         usage_limit_nudge_at: Some(past_instant),
-        usage_limited_coworkers: HashSet::from(["lexington".to_string()]), // only lexington
-        session_profile_map: profile_map,
+        // Only alice is in limited_pool_profiles — bob is NOT usage-limited.
+        limited_pool_profiles: HashSet::from(["alice@example.com".to_string()]),
         ..snap
     };
 
@@ -2803,7 +2804,7 @@ fn maybe_nudge_usage_limit_expiry_no_clear_for_non_limited_profiles() {
     });
     assert!(
         has_clear_alice,
-        "Should clear alice (lexington was limited)"
+        "Should clear alice (she is in limited_pool_profiles)"
     );
 
     let has_clear_bob = effects.iter().any(|e| {
@@ -2811,6 +2812,121 @@ fn maybe_nudge_usage_limit_expiry_no_clear_for_non_limited_profiles() {
     });
     assert!(
         !has_clear_bob,
-        "Should NOT clear bob (amsterdam was not usage-limited)"
+        "Should NOT clear bob (he is not in limited_pool_profiles)"
+    );
+}
+
+#[test]
+fn maybe_nudge_usage_limit_expiry_clears_profiles_even_when_session_map_empty() {
+    // Regression test for P1: profiles must be cleared from persistent state
+    // even when session_profile_map is empty (coworker exited before nudge fired,
+    // or daemon restarted). The fix is to iterate limited_pool_profiles (persistent)
+    // instead of session_profile_map (ephemeral).
+    use std::collections::HashSet;
+
+    let past_instant = tokio::time::Instant::now()
+        .checked_sub(std::time::Duration::from_secs(1))
+        .unwrap_or_else(tokio::time::Instant::now);
+
+    let snap = snapshot::minimal_snapshot_for_test();
+    let snap = snapshot::WorldSnapshot {
+        usage_limit_nudge_scheduled: true,
+        usage_limit_nudge_at: Some(past_instant),
+        // session_profile_map is empty — coworker already stopped or daemon restarted
+        // limited_pool_profiles is populated from persistent state (survives restarts)
+        limited_pool_profiles: HashSet::from(["alice@example.com".to_string()]),
+        ..snap
+    };
+
+    let effects = maybe_nudge_usage_limit_expiry(&snap);
+
+    let has_clear = effects.iter().any(|e| {
+        matches!(e, Effect::ClearProfileLimit { profile_email } if profile_email == "alice@example.com")
+    });
+    assert!(
+        has_clear,
+        "Should emit ClearProfileLimit even when session_profile_map is empty, got: {:#?}",
+        effects
+    );
+}
+
+#[test]
+fn check_for_usage_limits_marks_all_limited_coworker_profiles() {
+    // Regression test for P2: when multiple coworkers simultaneously hit the
+    // usage limit, ALL their pool profiles must be marked — not just the first.
+    use crate::coworker::{Coworker, CoworkerStatus};
+    use std::collections::{HashMap, HashSet};
+
+    let mut health = HashMap::new();
+    for name in &["amsterdam", "lexington"] {
+        health.insert(
+            name.to_string(),
+            snapshot::ProcessHealth {
+                is_alive: true,
+                last_event_at: Some(chrono::Utc::now()),
+                has_usage_limit: true,
+                usage_limit_reset_at: None,
+                has_api_error: false,
+                has_auth_error: false,
+                has_running_subagent: false,
+                has_pending_tool: false,
+                has_tool_name_conflict: false,
+                has_pending_api_call: false,
+                exit_code: None,
+            },
+        );
+    }
+
+    let make_coworker = |name: &str| Coworker {
+        slot_id: uuid::Uuid::new_v4().to_string(),
+        name: name.to_string(),
+        status: CoworkerStatus::Running,
+        working_dir: "/tmp/test".to_string(),
+        started_at: chrono::Utc::now(),
+        current_task: None,
+        session_id: None,
+        model: "sonnet".to_string(),
+        provider: crate::auth::AuthProvider::Claude,
+        profile: crate::auth::DEFAULT_PROFILE.to_string(),
+    };
+
+    let mut profile_map = HashMap::new();
+    profile_map.insert("amsterdam".to_string(), "alice@example.com".to_string());
+    profile_map.insert("lexington".to_string(), "bob@example.com".to_string());
+
+    let snap = snapshot::minimal_snapshot_for_test();
+    let snap = snapshot::WorldSnapshot {
+        active_coworkers: vec![make_coworker("amsterdam"), make_coworker("lexington")],
+        headless_process_health: health,
+        active_names: HashSet::from(["amsterdam".to_string(), "lexington".to_string()]),
+        session_profile_map: profile_map,
+        ..snap
+    };
+
+    let effects = check_for_usage_limits(&snap);
+
+    let marked: Vec<&str> = effects
+        .iter()
+        .filter_map(|e| match e {
+            Effect::MarkProfileLimited { profile_email, .. } => Some(profile_email.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        marked.contains(&"alice@example.com"),
+        "Should mark alice@example.com (amsterdam's profile), got: {:#?}",
+        marked
+    );
+    assert!(
+        marked.contains(&"bob@example.com"),
+        "Should mark bob@example.com (lexington's profile), got: {:#?}",
+        marked
+    );
+    assert_eq!(
+        marked.len(),
+        2,
+        "Should emit exactly 2 MarkProfileLimited effects, got: {:#?}",
+        marked
     );
 }

--- a/src/daemon/snapshot.rs
+++ b/src/daemon/snapshot.rs
@@ -415,6 +415,16 @@ pub struct WorldSnapshot {
     /// pool profiles and emit `MarkProfileLimited` effects.
     #[serde(default)]
     pub session_profile_map: HashMap<String, String>,
+
+    /// Pool profile emails that are currently marked `is_usage_limited=true`.
+    ///
+    /// Populated from `DaemonPersistentState::profile_pool_state` during snapshot
+    /// collection. Used by `maybe_nudge_usage_limit_expiry()` to clear ALL limited
+    /// profiles on expiry, regardless of whether the associated coworker session
+    /// is still running. Unlike `session_profile_map` (ephemeral, cleared on coworker
+    /// stop), this is derived from persistent state and survives daemon restarts.
+    #[serde(default)]
+    pub limited_pool_profiles: HashSet<String>,
 }
 
 /// Read the last N lines from the daemon log file.
@@ -999,6 +1009,19 @@ pub(crate) async fn collect_world_snapshot(state: &DaemonState) -> WorldSnapshot
         map.clone()
     };
 
+    // Snapshot the set of pool profiles currently marked is_usage_limited so
+    // maybe_nudge_usage_limit_expiry() can clear them directly from persistent
+    // state on expiry — without depending on session_profile_map entries that
+    // disappear when coworkers stop.
+    let limited_pool_profiles: HashSet<String> = {
+        let ps = state.persistent_state.lock().await;
+        ps.profile_pool_state
+            .iter()
+            .filter(|(_, s)| s.is_usage_limited)
+            .map(|(email, _)| email.clone())
+            .collect()
+    };
+
     let snapshot = WorldSnapshot {
         active_coworkers,
         running_coworkers,
@@ -1074,6 +1097,7 @@ pub(crate) async fn collect_world_snapshot(state: &DaemonState) -> WorldSnapshot
         recently_recovered_session_ids,
         stale_working_dir_sessions,
         session_profile_map,
+        limited_pool_profiles,
     };
 
     // Log full snapshot at trace level for debugging and test case generation
@@ -1165,6 +1189,7 @@ pub(super) fn minimal_snapshot_for_test() -> WorldSnapshot {
         recently_recovered_session_ids: HashSet::new(),
         stale_working_dir_sessions: HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     }
 }
 

--- a/src/daemon/snapshot_tests.rs
+++ b/src/daemon/snapshot_tests.rs
@@ -119,6 +119,7 @@ fn test_world_snapshot_has_coworker_stop_times() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     assert_eq!(snapshot.coworker_stop_times.len(), 2);
@@ -235,6 +236,7 @@ fn test_snapshot_debug_context_empty_by_default() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     assert!(snapshot.channel_messages.is_empty());
@@ -495,6 +497,7 @@ fn test_sessions_for_name() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     // "lexington" has two sessions
@@ -595,6 +598,7 @@ fn test_active_session_ids_in_snapshot() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     assert_eq!(snapshot.active_session_ids.len(), 2);
@@ -689,6 +693,7 @@ fn test_snapshot_includes_session_fields() {
         recently_recovered_session_ids: std::collections::HashSet::new(),
         stale_working_dir_sessions: std::collections::HashSet::new(),
         session_profile_map: HashMap::new(),
+        limited_pool_profiles: HashSet::new(),
     };
 
     assert!(snapshot.sessions.is_empty());


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

Two targeted fixes from Codex review of PR #1520 (auth profile pool usage-limit detection):

- **P1 (task !1788)**: `maybe_nudge_usage_limit_expiry()` now clears ALL `is_usage_limited` profiles from `profile_pool_state` (persistent) on expiry, rather than iterating `session_profile_map` (ephemeral). This prevents profiles from being permanently excluded from pool selection after a coworker exits before the nudge fires, or after a daemon restart.

- **P2 (task !1789)**: `check_for_usage_limits()` now iterates ALL coworkers with `has_usage_limit` (not just `.find()` the first) and emits `MarkProfileLimited` for each. Fixes the edge case where multiple pool-profile coworkers are simultaneously rate-limited but only one profile gets marked.

## Changes

**`snapshot.rs`**: Add `limited_pool_profiles: HashSet<String>` to `WorldSnapshot`, populated from `DaemonPersistentState::profile_pool_state` entries where `is_usage_limited=true`. Unlike `session_profile_map` (cleared when coworkers stop), this is derived from persistent state and survives restarts.

**`health.rs`**:
- `maybe_nudge_usage_limit_expiry()`: Replace `session_profile_map` loop with `limited_pool_profiles` iteration — clear ALL currently-limited profiles on expiry
- `check_for_usage_limits()`: Replace `.find()` with `.filter()` to collect all limited coworkers; emit `MarkProfileLimited` for each one with a session_profile_map entry

**`health_tests.rs`**: Update existing `ClearProfileLimit` tests to use `limited_pool_profiles`; add regression tests:
- `maybe_nudge_usage_limit_expiry_clears_profiles_even_when_session_map_empty` (P1)
- `check_for_usage_limits_marks_all_limited_coworker_profiles` (P2)

## Test plan

- [x] All existing tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] `maybe_nudge_usage_limit_expiry_clears_profiles_even_when_session_map_empty`: verifies P1 fix
- [x] `check_for_usage_limits_marks_all_limited_coworker_profiles`: verifies P2 fix

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)