### PR TITLE
feat: add playwright screenshot workflow for web-based coworkers [Midtown !1790]

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -486,3 +486,65 @@ midtown channel post "@{project_name} should I handle the error case here, or le
 # Another coworker actively working on something related
 midtown channel post "@amsterdam you're working on the auth module - does it export a validate function?"
 ```
+
+## Visual Documentation
+
+For web-based tasks, capture screenshots and videos of your work and share them inline in the channel. This gives the team and user a clear view of what you've built.
+
+### Setup (once per worktree)
+
+```bash
+cd web-app && npm install && npx playwright install chromium
+```
+
+### Capturing a screenshot
+
+```bash
+# 1. Start the dev server if it isn't running yet
+cd web-app && npm run dev &
+
+# 2. Take a screenshot of the running app
+REPO=$(midtown channel read 2>/dev/null | head -1 | true; git rev-parse --show-toplevel | xargs basename)
+npx playwright screenshot --browser chromium http://localhost:5173 /tmp/screenshot.png
+
+# 3. Save to the shared per-project assets directory
+ASSETS=~/.midtown/projects/$REPO/assets
+mkdir -p "$ASSETS"
+cp /tmp/screenshot.png "$ASSETS/screenshot-$(date +%s).png"
+
+# 4. Post inline to the channel — the web UI renders markdown images
+FILENAME=$(basename /tmp/screenshot.png)
+midtown channel post "/me here's the result: ![screenshot](http://localhost:47022/api/projects/$REPO/assets/$FILENAME)"
+```
+
+The assets directory (`~/.midtown/projects/<repo>/assets/`) is served by the webserver at `/api/projects/<repo>/assets/<path>`, so any file you copy there is immediately accessible via URL.
+
+### Capturing a video (optional)
+
+Use `playwright test` with `--video on` for recorded interactions:
+
+```bash
+# Write a quick test that navigates to the page
+cat > /tmp/screenshot-test.spec.ts << 'EOF'
+import { test } from '@playwright/test';
+test('capture', async ({ page }) => {
+  await page.goto('http://localhost:5173');
+  await page.waitForTimeout(2000);
+});
+EOF
+
+cd web-app && npx playwright test /tmp/screenshot-test.spec.ts \
+  --project=chromium --video=on --output=/tmp/pw-results
+
+# Copy the video to the assets dir
+REPO=$(git rev-parse --show-toplevel | xargs basename)
+ASSETS=~/.midtown/projects/$REPO/assets
+mkdir -p "$ASSETS"
+cp /tmp/pw-results/*/video.webm "$ASSETS/recording-$(date +%s).webm"
+```
+
+### Tips
+
+- Screenshots go stale — take a new one after each significant change
+- Use descriptive filenames (e.g. `sidebar-collapsed.png`) rather than timestamps when posting multiple views
+- The dev server is usually at `http://localhost:5173` (Vite default); check `web-app/package.json` scripts if it differs

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -32,7 +32,8 @@
 //!         │       ├── workflow.py            # Channel-specific workflow script (local, optional)
 //!         │       └── workflow-state.json    # Persistent workflow state between invocations
 //!         ├── logs/         # Daemon logs
-//!         └── daemon.pid    # Daemon PID file
+//!         ├── daemon.pid    # Daemon PID file
+//!         └── assets/       # Coworker-generated screenshots and videos
 //! ```
 //!
 //! ## Workflow Scripts
@@ -215,6 +216,18 @@ pub fn midtown_base_dir() -> PathBuf {
 pub fn projects_dir_for_repo(repo: &str) -> PathBuf {
     auto_migrate(repo);
     midtown_base_dir().join("projects").join(repo)
+}
+
+/// Get the assets directory for a specific repository.
+///
+/// Returns `~/.midtown/projects/<repo>/assets/`.
+///
+/// This is where coworker-generated screenshots and videos are stored.
+/// It lives outside `web-app/dist/` so it persists across rebuilds and
+/// worktree recreations. Files here are served by the webserver at
+/// `/api/projects/<repo>/assets/<path>`.
+pub fn assets_dir_for_repo(repo: &str) -> PathBuf {
+    projects_dir_for_repo(repo).join("assets")
 }
 
 /// Get the coworkers directory for a specific repository.

--- a/src/paths_tests.rs
+++ b/src/paths_tests.rs
@@ -358,6 +358,32 @@ fn test_workflow_script_project_default_repo_over_local() {
     assert_eq!(result, Some(project_default_repo));
 }
 
+// ── assets_dir_for_repo ───────────────────────────────────────────────
+
+#[test]
+fn test_assets_dir_for_repo_path_structure() {
+    let path = assets_dir_for_repo("myproject");
+    let s = path.to_string_lossy();
+    assert!(s.contains(".midtown"), "should be under .midtown: {s}");
+    assert!(s.contains("projects"), "should be under projects/: {s}");
+    assert!(s.contains("myproject"), "should include repo name: {s}");
+    assert!(s.ends_with("assets"), "should end with 'assets': {s}");
+}
+
+#[test]
+fn test_assets_dir_for_repo_is_under_projects_dir() {
+    let assets = assets_dir_for_repo("myproject");
+    let projects = projects_dir_for_repo("myproject");
+    assert_eq!(assets, projects.join("assets"));
+}
+
+#[test]
+fn test_assets_dir_different_repos_differ() {
+    let path_a = assets_dir_for_repo("repo-a");
+    let path_b = assets_dir_for_repo("repo-b");
+    assert_ne!(path_a, path_b);
+}
+
 // ── workflow_state_file ────────────────────────────────────────────────
 
 #[test]

--- a/src/webserver.rs
+++ b/src/webserver.rs
@@ -10,6 +10,7 @@
 //! - `GET /api/projects/:name/status` - Proxy to per-project daemon status
 //! - `GET /api/projects/:name/channel` - Proxy to per-project channel data
 //! - `GET /api/projects/:name/zellij-web-url` - Get Zellij web client URL for project
+//! - `GET /api/projects/:name/assets/*path` - Serve per-project asset files (screenshots, videos)
 //! - `GET /api/health` - Health check
 //! - `GET /` - Serve static web UI (SPA)
 
@@ -21,9 +22,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::Router;
+use axum::body::Body;
 use axum::extract::{Path, State};
-use axum::http::StatusCode;
-use axum::response::Json;
+use axum::http::{HeaderValue, StatusCode, header};
+use axum::response::{Json, Response};
 use axum::routing::get;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
@@ -281,6 +283,80 @@ async fn project_channel(
     Ok(Json(serde_json::Value::Array(data)))
 }
 
+/// Serve a static asset file from the per-project assets directory.
+///
+/// Path: `/api/projects/:name/assets/*path`
+///
+/// Serves files from `~/.midtown/projects/<name>/assets/<path>`.
+/// Includes path traversal protection: the resolved file path must remain
+/// within the assets directory.
+async fn project_asset(
+    Path((name, asset_path)): Path<(String, String)>,
+) -> Result<Response<Body>, StatusCode> {
+    let assets_dir = crate::paths::assets_dir_for_repo(&name);
+
+    // Strip any leading slashes from the requested path component
+    let asset_path = asset_path.trim_start_matches('/');
+
+    // Reject paths containing ".." components before joining
+    if asset_path.contains("..") {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let file_path = assets_dir.join(asset_path);
+
+    // Verify the resolved path stays within the assets directory.
+    // Use canonicalize on the assets dir (create it first if needed) and
+    // compare prefixes on the non-symlink-resolved joined path for the
+    // existence check, then canonicalize the actual file path once we
+    // confirm it exists.
+    let canonical_assets = match std::fs::canonicalize(&assets_dir) {
+        Ok(p) => p,
+        Err(_) => {
+            // Assets dir doesn't exist yet — no files to serve
+            return Err(StatusCode::NOT_FOUND);
+        }
+    };
+
+    if !file_path.exists() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let canonical_file = std::fs::canonicalize(&file_path).map_err(|_| StatusCode::NOT_FOUND)?;
+
+    if !canonical_file.starts_with(&canonical_assets) {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let content = tokio::fs::read(&canonical_file)
+        .await
+        .map_err(|_| StatusCode::NOT_FOUND)?;
+
+    let content_type = mime_type_for_path(&canonical_file);
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, HeaderValue::from_static(content_type))
+        .body(Body::from(content))
+        .unwrap())
+}
+
+/// Return a best-effort MIME type for a file path based on its extension.
+fn mime_type_for_path(path: &std::path::Path) -> &'static str {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("png") => "image/png",
+        Some("jpg") | Some("jpeg") => "image/jpeg",
+        Some("gif") => "image/gif",
+        Some("webp") => "image/webp",
+        Some("mp4") => "video/mp4",
+        Some("webm") => "video/webm",
+        Some("svg") => "image/svg+xml",
+        Some("json") => "application/json",
+        Some("txt") | Some("log") => "text/plain",
+        _ => "application/octet-stream",
+    }
+}
+
 /// Get the Zellij web client URL for a project.
 ///
 /// Returns the URL and session name for the Zellij web client embed.
@@ -320,7 +396,8 @@ pub async fn run(config: WebserverConfig) -> std::result::Result<(), Box<dyn std
         .route(
             "/projects/{name}/zellij-web-url",
             get(project_zellij_web_url),
-        );
+        )
+        .route("/projects/{name}/assets/{*path}", get(project_asset));
 
     let mut app = Router::new().nest("/api", api).layer(cors);
 
@@ -522,5 +599,77 @@ mod tests {
 
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains("\"status\":\"stopped\""));
+    }
+
+    #[test]
+    fn test_mime_type_for_path() {
+        let cases = [
+            ("screenshot.png", "image/png"),
+            ("photo.jpg", "image/jpeg"),
+            ("photo.jpeg", "image/jpeg"),
+            ("anim.gif", "image/gif"),
+            ("anim.webp", "image/webp"),
+            ("clip.mp4", "video/mp4"),
+            ("clip.webm", "video/webm"),
+            ("icon.svg", "image/svg+xml"),
+            ("data.json", "application/json"),
+            ("notes.txt", "text/plain"),
+            ("daemon.log", "text/plain"),
+            ("unknown.xyz", "application/octet-stream"),
+        ];
+        for (filename, expected) in cases {
+            let path = std::path::Path::new(filename);
+            assert_eq!(
+                mime_type_for_path(path),
+                expected,
+                "wrong MIME type for {filename}"
+            );
+        }
+    }
+
+    /// Test that the path traversal check rejects ".." in the path component.
+    #[tokio::test]
+    async fn test_project_asset_rejects_path_traversal() {
+        // A path with ".." should return BAD_REQUEST before touching the filesystem
+        let result =
+            project_asset(Path(("myproject".to_string(), "../etc/passwd".to_string()))).await;
+        assert_eq!(result.unwrap_err(), StatusCode::BAD_REQUEST);
+    }
+
+    /// Test that requesting a non-existent asset returns NOT_FOUND.
+    #[tokio::test]
+    async fn test_project_asset_not_found_for_missing_file() {
+        // Use a repo name that definitely has no assets dir
+        let result = project_asset(Path((
+            "nonexistent-repo-xyz-test-123".to_string(),
+            "image.png".to_string(),
+        )))
+        .await;
+        assert_eq!(result.unwrap_err(), StatusCode::NOT_FOUND);
+    }
+
+    /// Test that a valid asset file is served with the correct content type.
+    #[tokio::test]
+    async fn test_project_asset_serves_existing_file() {
+        use crate::paths::{assets_dir_for_repo, set_test_midtown_base_dir};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = set_test_midtown_base_dir(tmp.path().to_path_buf());
+
+        let assets_dir = assets_dir_for_repo("test-proj");
+        std::fs::create_dir_all(&assets_dir).unwrap();
+
+        let content = b"\x89PNG\r\n\x1a\n"; // minimal PNG header
+        std::fs::write(assets_dir.join("shot.png"), content).unwrap();
+
+        let result = project_asset(Path(("test-proj".to_string(), "shot.png".to_string())))
+            .await
+            .unwrap();
+
+        assert_eq!(result.status(), StatusCode::OK);
+        assert_eq!(
+            result.headers().get(header::CONTENT_TYPE).unwrap(),
+            "image/png"
+        );
     }
 }


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary

- **`src/paths.rs`**: Added `assets_dir_for_repo()` returning `~/.midtown/projects/<repo>/assets/` — persists across worktree recreations and `web-app/dist/` rebuilds
- **`src/webserver.rs`**: Added `GET /api/projects/:name/assets/*path` route that serves per-project screenshots/videos with path traversal protection and extension-based MIME type detection
- **`agents/coworker.md`**: Added "Visual Documentation" section with the full playwright screenshot workflow for coworkers working on web UI tasks

## How it works

Coworkers capture screenshots and copy them to `~/.midtown/projects/$REPO/assets/`. The new webserver route serves those files at `http://localhost:47022/api/projects/$REPO/assets/<filename>`. Markdown image tags in channel messages (`![alt](url)`) can then render inline in the web UI.

## Security

The asset handler validates that the resolved file path starts with the canonicalized assets directory, rejecting path components containing `..` and any symlink-based escapes.

## Test plan

- [x] `test_assets_dir_for_repo_path_structure` — correct path structure
- [x] `test_assets_dir_for_repo_is_under_projects_dir` — relationship to projects dir
- [x] `test_assets_dir_different_repos_differ` — repo isolation
- [x] `test_mime_type_for_path` — extension → MIME mapping for all supported types
- [x] `test_project_asset_rejects_path_traversal` — `..` rejected with 400
- [x] `test_project_asset_not_found_for_missing_file` — 404 for missing assets dir
- [x] `test_project_asset_serves_existing_file` — correct content + Content-Type header
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)