### PR TITLE
fix: warn PR author not to auto-merge when reviewer is spawned [Midtown !1793]

### DIFF
--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -2492,8 +2492,9 @@ pub(crate) async fn collect_reviewer_effects_with_source(
         // Also exclude the PR author from reviewer selection to prevent self-review.
         // The author is identified by the branch prefix (e.g., "riverside" from "riverside/feature").
         let mut excluded_names = channel_lead_names.clone();
-        if let Some(author) = coworker_from_branch_with_map(head_ref, branch_owners_map) {
-            excluded_names.insert(author);
+        let pr_author = coworker_from_branch_with_map(head_ref, branch_owners_map);
+        if let Some(ref author) = pr_author {
+            excluded_names.insert(author.clone());
         }
 
         let reviewer_name = match state
@@ -2568,7 +2569,7 @@ pub(crate) async fn collect_reviewer_effects_with_source(
             reviewer_session_id: None,
         });
 
-        let on_success = vec![
+        let mut on_success = vec![
             // Register the review worktree assignment
             Effect::RegisterWorktreeAssignment {
                 assignment: crate::worktree_registry::WorktreeAssignment {
@@ -2597,6 +2598,21 @@ pub(crate) async fn collect_reviewer_effects_with_source(
                 channel: Some(OPS_CHANNEL.to_string()),
             },
         ];
+
+        // Warn the PR author not to enable auto-merge while the review is in progress.
+        // Without this warning, the author may run `gh pr merge --auto --squash` before
+        // the reviewer finishes, causing the PR to merge as soon as CI passes — bypassing
+        // the review entirely (as happened with PR #1523).
+        if let Some(ref author) = pr_author {
+            on_success.push(Effect::DeliverMailboxMessage {
+                name: author.clone(),
+                message: daemon_messages::reviewer_spawned_author_warning(
+                    &reviewer_name,
+                    pr_number,
+                ),
+                summary: Some(format!("Review in progress on PR #{}", pr_number)),
+            });
+        }
 
         let on_failure = vec![
             // Clean up the optimistic assignment we made before spawning

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -2774,3 +2774,86 @@ async fn test_review_mode_both_allows_local_reviewer_spawn() {
         "execution.review_mode=both should keep local reviewer spawning enabled"
     );
 }
+
+/// Bug (task !1793): When a reviewer is spawned for a coworker's PR, the PR author
+/// receives no warning and can enable auto-merge before the review completes.
+///
+/// Root cause: `collect_reviewer_effects_with_source` builds `on_success` effects
+/// for the reviewer spawn but never notifies the PR author that review is starting.
+/// The coworker system prompt says not to enable auto-merge before review completes,
+/// but without an explicit notification the warning can be missed.
+///
+/// Fix: Add a `DeliverMailboxMessage` to `on_success` warning the PR author not to
+/// enable auto-merge until the review is complete.
+#[tokio::test]
+async fn test_reviewer_spawn_warns_pr_author_via_mailbox() {
+    // PR authored by "madison" (branch: madison/fix-polling)
+    let pr_number = 99994u64;
+    let pr_json = serde_json::json!({
+        "number": pr_number,
+        "headRefName": "madison/fix-polling",
+        "title": "Fix polling reconciliation [Midtown !200]",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": null,
+        "reviewDecision": null,
+        "isDraft": false,
+        "createdAt": "2026-01-01T00:00:00Z",
+        "state": "OPEN",
+    });
+
+    let branch_owners: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let registry = crate::worktree_registry::WorktreeRegistry::new();
+    // madison is active (owns the PR) so the PR is not orphaned
+    let active_names: std::collections::HashSet<String> =
+        ["madison".to_string()].into_iter().collect();
+
+    let (state, _tmp, _guard) = make_test_state("test-repo");
+
+    let effects = collect_reviewer_effects_with_source(
+        Some(&branch_owners),
+        &registry,
+        &active_names,
+        &state,
+        &[pr_json],
+        crate::github_state::AssignmentSource::PollingFallback,
+    )
+    .await;
+
+    // Find the SpawnCoworkerWithCallbacks effect and inspect its on_success effects
+    let spawn_effect = effects.iter().find_map(|e| {
+        if let Effect::SpawnCoworkerWithCallbacks { on_success, .. } = e {
+            Some(on_success)
+        } else {
+            None
+        }
+    });
+
+    assert!(
+        spawn_effect.is_some(),
+        "Expected a SpawnCoworkerWithCallbacks effect for PR #{}. Effects: {:#?}",
+        pr_number,
+        effects
+    );
+
+    let on_success = spawn_effect.unwrap();
+
+    // The on_success effects must include a DeliverMailboxMessage to "madison" warning
+    // them not to enable auto-merge while the review is in progress.
+    let has_author_warning = on_success.iter().any(|e| {
+        if let Effect::DeliverMailboxMessage { name, message, .. } = e {
+            name == "madison" && message.contains(&pr_number.to_string())
+        } else {
+            false
+        }
+    });
+
+    assert!(
+        has_author_warning,
+        "on_success effects must include a DeliverMailboxMessage to 'madison' warning \
+         them not to enable auto-merge while review is in progress. \
+         Before fix: no such warning was sent, allowing the author to merge while \
+         the reviewer was still working (as happened with PR #1523). \
+         on_success effects: {:#?}",
+        on_success
+    );
+}

--- a/src/daemon_messages.rs
+++ b/src/daemon_messages.rs
@@ -27,6 +27,16 @@ pub fn called_in_reviewer(name: &str, pr_number: u64) -> String {
     format!("\u{1f50d} Called in {} to review PR #{}", name, pr_number)
 }
 
+/// Warning sent to PR author when a reviewer is spawned for their PR.
+///
+/// The author must not enable auto-merge until the review is complete.
+pub fn reviewer_spawned_author_warning(reviewer_name: &str, pr_number: u64) -> String {
+    format!(
+        "\u{26a0}\u{fe0f} {} is now reviewing your PR #{}. Do NOT enable auto-merge (`gh pr merge --auto --squash`) until the review is complete.",
+        reviewer_name, pr_number
+    )
+}
+
 /// Called in coworker {name} for pending task !{task_id}.
 pub fn called_in_pending_task(name: &str, task_id: &str) -> String {
     format!(
@@ -155,6 +165,12 @@ mod tests {
         assert!(
             msg.contains("waiting"),
             "idle message must contain 'waiting' keyword: {msg}"
+        );
+
+        let msg = reviewer_spawned_author_warning("columbus", 1523);
+        assert!(
+            msg.contains("columbus") && msg.contains("1523"),
+            "reviewer warning must contain reviewer name and PR number: {msg}"
         );
     }
 }


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary

- When a reviewer is spawned for a PR, the daemon now delivers a mailbox message to the PR author warning them not to enable `gh pr merge --auto --squash` until the review is complete
- The warning fires in `on_success` of `SpawnCoworkerWithCallbacks`, so it only reaches the author when a reviewer is actually spawned successfully
- Author is identified from the PR's `headRefName` using the existing `coworker_from_branch_with_map` call (already used for self-review exclusion)

## Root cause (task !1793)

madison merged PR #1523 while columbus was actively reviewing it (review started 03:04 UTC, PR merged 03:08 UTC). The coworker system prompt already says not to enable auto-merge before review completes, but without an explicit, real-time notification the reminder can be missed — especially mid-task when the author isn't re-reading the full prompt.

## Test plan

- [x] Added `test_reviewer_spawn_warns_pr_author_via_mailbox` — verifies `on_success` effects for the reviewer spawn include a `DeliverMailboxMessage` to the PR author (wrote failing test first, per CLAUDE.md)
- [x] Added test coverage for the new `reviewer_spawned_author_warning` message in `daemon_messages.rs`
- [x] All existing PR tests pass (53 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)