### PR TITLE
fix: re-dispatch PR reviews when associated task is completed

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -2171,6 +2171,24 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 description,
                 pr,
             } => {
+                // If a PR number is associated, skip creation if a non-completed task
+                // already exists for that PR. This prevents duplicate follow-up tasks
+                // when multiple review comments arrive in quick succession (e.g., after
+                // a daemon restart resets the in-memory cooldown).
+                if let Some(pr_num) = pr {
+                    let existing = crate::tasks::read_tasks_for_repo(Some(&repo_name));
+                    let already_has_task = existing.iter().any(|t| {
+                        t.pr == Some(pr_num) && t.status != crate::tasks::TaskStatus::Completed
+                    });
+                    if already_has_task {
+                        debug!(
+                            "Skipping CreateTask for PR #{}: non-completed task already exists",
+                            pr_num
+                        );
+                        return;
+                    }
+                }
+
                 // Derive active_form from subject (simple present progressive form)
                 let active_form = if subject.starts_with("Merge") {
                     subject.replace("Merge", "Merging")

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -1932,6 +1932,36 @@ async fn collect_comment_notification_effects(
             (PrContext::from_persistent_state(&ps, pr_number), cl_names)
         };
 
+        // If the linked task is completed, create a follow-up task rather than
+        // trying to spawn/resume the original coworker with stale session context.
+        if let Some(task_id) = pr_ctx.pr_task_associations.get(&pr_number)
+            && let Some(task) = crate::tasks::read_task(task_id)
+            && crate::rules::review_comment_creates_followup(&task.status)
+        {
+            let subject = format!("Address review feedback on PR #{}", pr_number);
+            let description = format!(
+                "PR #{} ({}) received review feedback after task !{} was completed. Please check the PR and address the feedback.",
+                pr_number,
+                truncate_str(title, 40),
+                task_id
+            );
+            debug!(
+                "Polling: PR #{} linked to completed task !{} — creating follow-up task",
+                pr_number, task_id
+            );
+            effects.push(Effect::CreateTask {
+                repo_name: state.repo_name.clone(),
+                subject,
+                description,
+                pr: Some(pr_number),
+            });
+            effects.push(Effect::RecordPrNudge {
+                pr_number,
+                issue_type: PrIssueType::ReviewComment,
+            });
+            continue;
+        }
+
         // Decide action using handoff-aware decision function (preserves session
         // resume and idle-coworker handoff capabilities)
         let action = crate::rules::decide_pr_comment_action_with_handoff(
@@ -3278,10 +3308,7 @@ pub(super) async fn handle_pr_comment_nudge(
         return;
     };
 
-    // Check if this PR is linked to a task with an active owner.
-    // If so, route the review feedback to the task owner instead of the PR owner.
-    // This handles cases where a task was reassigned (e.g., via orphan recovery)
-    // and the PR metadata still shows the original author.
+    // Check if this PR is linked to a task, and handle based on task status.
     if let Some(task_id) = {
         let ps = state.persistent_state.lock().await;
         ps.github
@@ -3289,26 +3316,64 @@ pub(super) async fn handle_pr_comment_nudge(
             .get(&pr_number)
             .and_then(|session| session.task_id.as_ref())
             .cloned()
-    } {
-        // Check if the task has an active owner in_progress
-        if let Some(task) = crate::tasks::read_task(&task_id)
-            && task.status == crate::tasks::TaskStatus::InProgress
-            && let Some(task_owner) = task.owner
-        {
-            // Check if the task owner is active
-            let task_owner_active = state
-                .coworkers
-                .list()
-                .iter()
-                .any(|c| c.name.eq_ignore_ascii_case(&task_owner));
+    } && let Some(task) = crate::tasks::read_task(&task_id)
+    {
+        if task.status == crate::tasks::TaskStatus::InProgress {
+            // Route the review feedback to the task owner instead of the PR owner.
+            // This handles cases where a task was reassigned (e.g., via orphan recovery)
+            // and the PR metadata still shows the original author.
+            if let Some(task_owner) = task.owner {
+                let task_owner_active = state
+                    .coworkers
+                    .list()
+                    .iter()
+                    .any(|c| c.name.eq_ignore_ascii_case(&task_owner));
 
-            if task_owner_active {
-                debug!(
-                    "PR #{} linked to task !{} with active owner {} — routing review feedback to task owner instead of PR owner {}",
-                    pr_number, task_id, task_owner, owner
-                );
-                owner = task_owner;
+                if task_owner_active {
+                    debug!(
+                        "PR #{} linked to task !{} with active owner {} — routing review feedback to task owner instead of PR owner {}",
+                        pr_number, task_id, task_owner, owner
+                    );
+                    owner = task_owner;
+                }
             }
+        } else if crate::rules::review_comment_creates_followup(&task.status) {
+            // Task is completed — the original coworker session is gone.
+            // Create a follow-up task so normal dispatch handles it cleanly
+            // instead of trying to resume a stale session.
+            {
+                let tracker = state.pr_issue_tracker.lock().await;
+                if !tracker.should_nudge(pr_number, PrIssueType::ReviewComment) {
+                    debug!(
+                        "PR #{} review comment nudge on cooldown (completed task), skipping",
+                        pr_number
+                    );
+                    return;
+                }
+            }
+            let subject = format!("Address review feedback on PR #{}", pr_number);
+            let description = format!(
+                "PR #{} received review feedback from {} after task !{} was completed. Please check the PR and address the feedback.",
+                pr_number, activity.actor, task_id
+            );
+            debug!(
+                "PR #{} linked to completed task !{} — creating follow-up task for review feedback from {}",
+                pr_number, task_id, activity.actor
+            );
+            let effects = vec![
+                Effect::CreateTask {
+                    repo_name: state.repo_name.clone(),
+                    subject,
+                    description,
+                    pr: Some(pr_number),
+                },
+                Effect::RecordPrNudge {
+                    pr_number,
+                    issue_type: PrIssueType::ReviewComment,
+                },
+            ];
+            super::effects::execute_effects(effects, state).await;
+            return;
         }
     }
 

--- a/src/daemon/pr_review_feedback_tests.rs
+++ b/src/daemon/pr_review_feedback_tests.rs
@@ -82,6 +82,31 @@ mod tests {
         }
     }
 
+    /// Test that when a PR's linked task is completed, a follow-up task should
+    /// be created instead of trying to spawn/resume the original coworker.
+    ///
+    /// Bug !1794: Review comments on PRs with completed tasks were silently dropped
+    /// because the daemon tried to spawn/resume the original coworker with stale
+    /// session context. The correct behavior is to create a new follow-up task.
+    #[test]
+    fn test_completed_task_requires_followup_task() {
+        use crate::rules::review_comment_creates_followup;
+        use crate::tasks::TaskStatus;
+
+        assert!(
+            review_comment_creates_followup(&TaskStatus::Completed),
+            "A completed task's PR receiving review feedback should trigger a follow-up task"
+        );
+        assert!(
+            !review_comment_creates_followup(&TaskStatus::InProgress),
+            "An in-progress task's PR should handle review feedback via normal dispatch"
+        );
+        assert!(
+            !review_comment_creates_followup(&TaskStatus::Pending),
+            "A pending task's PR should handle review feedback via normal dispatch"
+        );
+    }
+
     /// Test that when the task owner is inactive, the decision function
     /// spawns them (assuming dev limit allows).
     #[test]

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1090,6 +1090,17 @@ pub fn decide_review_complete_action(
     )
 }
 
+/// Returns true if a review comment on this PR's task should create a follow-up
+/// task rather than trying to dispatch to the original coworker.
+///
+/// When a task is `Completed`, the coworker session has ended and the worktree
+/// may be cleaned up. Trying to spawn or resume the original coworker with stale
+/// session context is unreliable. Creating a new follow-up task lets the normal
+/// dispatch system assign it to an available coworker with full context.
+pub fn review_comment_creates_followup(task_status: &crate::tasks::TaskStatus) -> bool {
+    matches!(task_status, crate::tasks::TaskStatus::Completed)
+}
+
 // ---------------------------------------------------------------------------
 // Task assignment decision types and functions
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- When a PR receives a review comment after its task is marked `done`, the daemon now creates a new follow-up task instead of trying to spawn/resume the original coworker with stale session context
- Added PR-based deduplication to `Effect::CreateTask` so multiple review comments don't generate duplicate follow-up tasks
- Both the webhook path (`handle_pr_comment_nudge`) and polling path (`collect_comment_notification_effects`) are fixed

## Root cause

When `midtown task done` completes a task, `pr_author_sessions` is retained in persistent state. So when a review comment arrives on the associated PR:

1. `handle_pr_comment_nudge` finds the task_id via `pr_author_sessions`
2. The existing status check only handled `InProgress` tasks — for `Completed` tasks it fell through
3. The code tried to spawn/resume the original coworker using a stale session ID
4. The spawn could fail silently (expired session), leaving the review unaddressed indefinitely

## Fix

Expanded the task-status branch in `handle_pr_comment_nudge` (and polling equivalent) to detect `Completed` tasks and emit `Effect::CreateTask` instead of spawning the original coworker. The new task is unassigned and picked up by normal dispatch on the next tick.

Added a new pure helper `review_comment_creates_followup(task_status)` in `rules.rs` (returns true for `Completed`) so the decision logic is testable and reusable.

## Test plan

- [x] `test_completed_task_requires_followup_task` — new test verifying the pure decision function returns true for Completed, false for InProgress/Pending
- [x] All existing `daemon::pr` tests pass (67 tests)
- [x] All existing `daemon::effects` tests pass (31 tests)  
- [x] All existing `rules` tests pass (163 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt` clean

Closes !1794

🤖 Generated with [Claude Code](https://claude.com/claude-code)