### PR TITLE
fix: deterministic reviewer assignment map when reviewer has multiple entries

### DIFF
--- a/src/daemon/snapshot.rs
+++ b/src/daemon/snapshot.rs
@@ -1207,13 +1207,28 @@ pub(super) fn minimal_snapshot_for_test() -> WorldSnapshot {
 /// `decide_dead_reviewer_respawns` and cause the review to be permanently lost.
 /// Use `active_reviewers()` when you need the timeout-filtered list for display
 /// or logging.
+///
+/// When a reviewer has multiple entries in `pr_reviewers` (e.g., a stale assignment
+/// from one PR and a fresh assignment for another), the most recently assigned entry
+/// is kept to ensure the map is deterministic regardless of `HashMap` iteration order.
 pub(crate) fn build_reviewer_pr_assignments(
     github: &crate::github_state::GitHubState,
 ) -> HashMap<String, u64> {
-    github
-        .pr_reviewers
-        .iter()
-        .map(|(&pr_number, assignment)| (assignment.reviewer.clone(), pr_number))
+    let mut result: HashMap<String, (u64, chrono::DateTime<chrono::Utc>)> = HashMap::new();
+    for (&pr_number, assignment) in &github.pr_reviewers {
+        let is_newer = result
+            .get(&assignment.reviewer)
+            .is_none_or(|(_, existing_at)| assignment.assigned_at > *existing_at);
+        if is_newer {
+            result.insert(
+                assignment.reviewer.clone(),
+                (pr_number, assignment.assigned_at),
+            );
+        }
+    }
+    result
+        .into_iter()
+        .map(|(reviewer, (pr, _))| (reviewer, pr))
         .collect()
 }
 

--- a/src/daemon/snapshot_tests.rs
+++ b/src/daemon/snapshot_tests.rs
@@ -880,6 +880,31 @@ fn test_build_reviewer_pr_assignments_includes_expired_for_dead_reviewer_respawn
     assert_eq!(assignments["park"], 1515);
 }
 
+/// When a reviewer has two entries (stale + fresh for different PRs), the most recently
+/// assigned entry must win — the result must be deterministic regardless of HashMap
+/// iteration order.
+#[test]
+fn test_build_reviewer_pr_assignments_prefers_newest_when_duplicate_reviewer() {
+    use crate::github_state::{AssignmentSource, GitHubState};
+
+    let mut github = GitHubState::default();
+    // Assign park to PR 1515 with a stale timestamp.
+    github.assign_reviewer(1515, "park", AssignmentSource::PollingFallback);
+    if let Some(a) = github.pr_reviewers.get_mut(&1515) {
+        a.assigned_at = chrono::Utc::now() - chrono::Duration::seconds(3600);
+    }
+    // Assign park again to PR 1520 with a fresh timestamp (newer).
+    github.assign_reviewer(1520, "park", AssignmentSource::PollingFallback);
+
+    let assignments = super::build_reviewer_pr_assignments(&github);
+
+    assert_eq!(
+        assignments.get("park"),
+        Some(&1520),
+        "should keep the most recently assigned PR (1520), not the stale one (1515)"
+    );
+}
+
 /// Test that recently_recovered_session_ids is correctly populated from CooldownTracker.
 ///
 /// The collect_world_snapshot() function builds this set by checking the


### PR DESCRIPTION
## Summary

Follow-up to #1525 addressing a Codex P2 review comment.

`build_reviewer_pr_assignments` collects `pr_reviewers` (keyed by PR number) into a `HashMap<reviewer, pr>`. When a reviewer appears in multiple PR entries (e.g., a stale assignment for PR 1515 and a fresh one for PR 1520), the result was last-write-wins on `HashMap` iteration order — nondeterministic.

The fix uses an explicit most-recent-wins pass: iterate all entries and keep the one with the greatest `assigned_at` timestamp, producing a deterministic output regardless of iteration order.

## Test plan

- [x] `test_build_reviewer_pr_assignments_prefers_newest_when_duplicate_reviewer` — new test verifying stale 1515 + fresh 1520 → 1520 wins
- [x] Existing `build_reviewer_pr_assignments` tests still pass
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)