### PR TITLE
refactor: add channel_lead_names() and pr_to_task_map() accessors [Midtown !1796]

### DIFF
--- a/src/daemon/chat.rs
+++ b/src/daemon/chat.rs
@@ -180,9 +180,9 @@ pub(super) async fn route_mentions(state: &DaemonState, msg: &Message) {
         owner
     });
 
-    let channel_lead_names: std::collections::HashSet<String> = {
+    let channel_lead_names = {
         let ps = state.persistent_state.lock().await;
-        ps.channel_lead_sessions.keys().cloned().collect()
+        ps.channel_lead_names()
     };
 
     let mut task_rerouted = false;

--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -454,8 +454,7 @@ where
         .collect();
 
     // Decide which orphan (if any) to recover using pure decision function
-    let channel_lead_names: std::collections::HashSet<String> =
-        snap.channel_lead_sessions.keys().cloned().collect();
+    let channel_lead_names = snap.channel_lead_names();
     let orphan_ctx = crate::rules::OrphanRecoveryContext {
         in_progress: &in_progress_tasks_active,
         active_names: &snap.active_names,
@@ -1033,8 +1032,7 @@ where
     // Use the same pure decision function from rules.rs that orphan recovery used.
     // This ensures identical filtering behavior (active check, attached check,
     // recently-stopped grace period, open PR without feedback check).
-    let channel_lead_names: std::collections::HashSet<String> =
-        snap.channel_lead_sessions.keys().cloned().collect();
+    let channel_lead_names = snap.channel_lead_names();
     let orphan_ctx = crate::rules::OrphanRecoveryContext {
         in_progress: &tasks_without_sessions,
         active_names: &snap.active_names,
@@ -2350,8 +2348,7 @@ pub(super) fn spawn_for_pending_tasks_excluding(
         let coworker_name = if let Some(name) = grouped_name {
             name
         } else {
-            let channel_lead_names: std::collections::HashSet<String> =
-                snap.channel_lead_sessions.keys().cloned().collect();
+            let channel_lead_names = snap.channel_lead_names();
             let Some(name) = state
                 .coworkers
                 .next_available_name_excluding(&channel_lead_names)

--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -2232,9 +2232,9 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 mut config,
             } => {
                 // 1. Allocate name from NamePool
-                let channel_lead_names: std::collections::HashSet<String> = {
+                let channel_lead_names = {
                     let ps = state.persistent_state.lock().await;
-                    ps.channel_lead_sessions.keys().cloned().collect()
+                    ps.channel_lead_names()
                 };
                 let name = {
                     let mut pool = state.name_pool.lock().unwrap();

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -112,17 +112,7 @@ fn resolve_pr_owner_from_session(
 /// Callers should fall back to branch-name parsing when this returns `None`.
 async fn resolve_pr_owner_via_session(state: &DaemonState, pr_number: u64) -> Option<String> {
     let ps = state.persistent_state.lock().await;
-    let pr_task_associations: HashMap<u64, String> = ps
-        .github
-        .pr_author_sessions
-        .iter()
-        .filter_map(|(pr_num, session)| {
-            session
-                .task_id
-                .as_ref()
-                .map(|task_id| (*pr_num, task_id.clone()))
-        })
-        .collect();
+    let pr_task_associations = ps.github.pr_to_task_map();
 
     // Build task_id → session_id reverse index from sessions map
     let session_task_map: HashMap<String, String> = ps
@@ -168,17 +158,7 @@ impl PrContext {
     /// channel routing data (shared across all PRs) and session context
     /// (specific to `pr_number`) in a single pass.
     fn from_persistent_state(ps: &super::state::DaemonPersistentState, pr_number: u64) -> Self {
-        let pr_task_associations: HashMap<u64, String> = ps
-            .github
-            .pr_author_sessions
-            .iter()
-            .filter_map(|(pr_num, session)| {
-                session
-                    .task_id
-                    .as_ref()
-                    .map(|task_id| (*pr_num, task_id.clone()))
-            })
-            .collect();
+        let pr_task_associations = ps.github.pr_to_task_map();
 
         let session_context =
             ps.github
@@ -208,20 +188,8 @@ impl PrContext {
 
     /// Extract only channel routing data (when session context isn't needed).
     fn routing_only(ps: &super::state::DaemonPersistentState) -> Self {
-        let pr_task_associations: HashMap<u64, String> = ps
-            .github
-            .pr_author_sessions
-            .iter()
-            .filter_map(|(pr_num, session)| {
-                session
-                    .task_id
-                    .as_ref()
-                    .map(|task_id| (*pr_num, task_id.clone()))
-            })
-            .collect();
-
         Self {
-            pr_task_associations,
+            pr_task_associations: ps.github.pr_to_task_map(),
             task_channel: ps.task_channel.clone(),
             session_context: None,
             task_session_id: None,
@@ -917,9 +885,10 @@ pub(super) async fn poll_prs_for_issues(
             // Extract all decision context from persistent state in one lock
             let (pr_ctx, channel_lead_names) = {
                 let ps = state.persistent_state.lock().await;
-                let cl_names: std::collections::HashSet<String> =
-                    ps.channel_lead_sessions.keys().cloned().collect();
-                (PrContext::from_persistent_state(&ps, pr_number), cl_names)
+                (
+                    PrContext::from_persistent_state(&ps, pr_number),
+                    ps.channel_lead_names(),
+                )
             };
 
             // Decide action using pure decision function with handoff support
@@ -1133,9 +1102,10 @@ async fn collect_green_with_feedback_effects(
         // Extract all decision context from persistent state in one lock
         let (pr_ctx, channel_lead_names) = {
             let ps = state.persistent_state.lock().await;
-            let cl_names: std::collections::HashSet<String> =
-                ps.channel_lead_sessions.keys().cloned().collect();
-            (PrContext::from_persistent_state(&ps, pr_number), cl_names)
+            (
+                PrContext::from_persistent_state(&ps, pr_number),
+                ps.channel_lead_names(),
+            )
         };
 
         // Decide action using handoff-aware decision function (matches webhook path)
@@ -1448,9 +1418,7 @@ async fn collect_stuck_condition_effects(
                     let (is_assigned, channel_lead_names) = {
                         let ps = state.persistent_state.lock().await;
                         let assigned = ps.github.is_assigned(pr_number);
-                        let cl_names: std::collections::HashSet<String> =
-                            ps.channel_lead_sessions.keys().cloned().collect();
-                        (assigned, cl_names)
+                        (assigned, ps.channel_lead_names())
                     };
                     let has_available_slots =
                         state.has_available_coworker_slot(&channel_lead_names);
@@ -1927,9 +1895,10 @@ async fn collect_comment_notification_effects(
         // Extract all decision context from persistent state in one lock
         let (pr_ctx, channel_lead_names) = {
             let ps = state.persistent_state.lock().await;
-            let cl_names: std::collections::HashSet<String> =
-                ps.channel_lead_sessions.keys().cloned().collect();
-            (PrContext::from_persistent_state(&ps, pr_number), cl_names)
+            (
+                PrContext::from_persistent_state(&ps, pr_number),
+                ps.channel_lead_names(),
+            )
         };
 
         // Decide action using handoff-aware decision function (preserves session
@@ -2320,9 +2289,7 @@ pub(crate) async fn collect_reviewer_effects_with_source(
 
                     let (channel_lead_names, pr_ctx) = {
                         let ps = state.persistent_state.lock().await;
-                        let cl_names: std::collections::HashSet<String> =
-                            ps.channel_lead_sessions.keys().cloned().collect();
-                        (cl_names, PrContext::routing_only(&ps))
+                        (ps.channel_lead_names(), PrContext::routing_only(&ps))
                     };
 
                     let action = crate::rules::decide_review_complete_action(
@@ -2475,9 +2442,9 @@ pub(crate) async fn collect_reviewer_effects_with_source(
         }
 
         // Extract channel lead names for coworker limit check
-        let channel_lead_names: std::collections::HashSet<String> = {
+        let channel_lead_names = {
             let ps = state.persistent_state.lock().await;
-            ps.channel_lead_sessions.keys().cloned().collect()
+            ps.channel_lead_names()
         };
 
         // Check max coworkers limit before spawning
@@ -3413,9 +3380,10 @@ pub(super) async fn handle_pr_comment_nudge(
     // Extract all decision context from persistent state in one lock
     let (pr_ctx, channel_lead_names) = {
         let ps = state.persistent_state.lock().await;
-        let cl_names: std::collections::HashSet<String> =
-            ps.channel_lead_sessions.keys().cloned().collect();
-        (PrContext::from_persistent_state(&ps, pr_number), cl_names)
+        (
+            PrContext::from_persistent_state(&ps, pr_number),
+            ps.channel_lead_names(),
+        )
     };
 
     // Decide action using pure decision function with handoff support
@@ -3529,9 +3497,10 @@ pub(super) async fn handle_webhook_review_state_change(
     // Extract all decision context from persistent state in one lock
     let (pr_ctx, channel_lead_names) = {
         let ps = state.persistent_state.lock().await;
-        let cl_names: std::collections::HashSet<String> =
-            ps.channel_lead_sessions.keys().cloned().collect();
-        (PrContext::from_persistent_state(&ps, pr_number), cl_names)
+        (
+            PrContext::from_persistent_state(&ps, pr_number),
+            ps.channel_lead_names(),
+        )
     };
 
     let action = crate::rules::decide_pr_issue_action_with_handoff(
@@ -3614,9 +3583,10 @@ pub(super) async fn handle_webhook_ci_failure(
     // Extract all decision context from persistent state in one lock
     let (pr_ctx, channel_lead_names) = {
         let ps = state.persistent_state.lock().await;
-        let cl_names: std::collections::HashSet<String> =
-            ps.channel_lead_sessions.keys().cloned().collect();
-        (PrContext::from_persistent_state(&ps, pr_number), cl_names)
+        (
+            PrContext::from_persistent_state(&ps, pr_number),
+            ps.channel_lead_names(),
+        )
     };
 
     let action = crate::rules::decide_pr_issue_action_with_handoff(

--- a/src/daemon/rpc_coworker.rs
+++ b/src/daemon/rpc_coworker.rs
@@ -24,9 +24,9 @@ pub(super) async fn handle_coworker_spawn(
     provider: crate::auth::AuthProvider,
 ) -> Response {
     // Check dev coworkers limit (reserve slots for reviewers)
-    let channel_lead_names: std::collections::HashSet<String> = {
+    let channel_lead_names = {
         let ps = state.persistent_state.lock().await;
-        ps.channel_lead_sessions.keys().cloned().collect()
+        ps.channel_lead_names()
     };
     if state.is_at_dev_limit(&channel_lead_names) {
         return Response::error(
@@ -234,9 +234,9 @@ pub(super) async fn handle_coworker_list(id: RequestId, state: &DaemonState) -> 
             })
             .collect();
 
-    let channel_lead_names: std::collections::HashSet<String> = {
+    let channel_lead_names = {
         let ps = state.persistent_state.lock().await;
-        ps.channel_lead_sessions.keys().cloned().collect()
+        ps.channel_lead_names()
     };
 
     let coworkers: Vec<serde_json::Value> = state

--- a/src/daemon/rpc_kanban.rs
+++ b/src/daemon/rpc_kanban.rs
@@ -186,8 +186,7 @@ async fn build_coworkers_data(
                     Some((coworker.clone(), pr_number))
                 })
                 .collect();
-            let cl_names: std::collections::HashSet<String> =
-                ps.channel_lead_sessions.keys().cloned().collect();
+            let cl_names = ps.channel_lead_names();
             (assignments, wt_map, cl_names)
         })
         .unwrap_or_default();

--- a/src/daemon/rpc_status.rs
+++ b/src/daemon/rpc_status.rs
@@ -61,8 +61,7 @@ pub(super) async fn handle_status(id: RequestId, state: &DaemonState) -> Respons
                 Some((coworker.clone(), pr_number))
             })
             .collect();
-        let channel_leads: std::collections::HashSet<String> =
-            ps.channel_lead_sessions.keys().cloned().collect();
+        let channel_leads = ps.channel_lead_names();
         let msg_ids = ps.task_message_id.clone();
         (
             rev_map,

--- a/src/daemon/snapshot.rs
+++ b/src/daemon/snapshot.rs
@@ -472,6 +472,11 @@ impl WorldSnapshot {
         map
     }
 
+    /// Returns the set of active channel lead names (keys of `channel_lead_sessions`).
+    pub fn channel_lead_names(&self) -> HashSet<String> {
+        self.channel_lead_sessions.keys().cloned().collect()
+    }
+
     /// Populate debug context fields (channel messages and daemon logs).
     ///
     /// This is only called when capturing a snapshot for debugging, NOT during
@@ -648,29 +653,7 @@ pub(crate) async fn collect_world_snapshot(state: &DaemonState) -> WorldSnapshot
     // ── PR author sessions (task → PR mapping) ────────────────────────
     let (tasks_with_open_prs, pr_task_associations) = {
         let ps = state.persistent_state.lock().await;
-        let tasks_to_prs: HashMap<String, u64> = ps
-            .github
-            .pr_author_sessions
-            .iter()
-            .filter_map(|(pr_number, session)| {
-                session
-                    .task_id
-                    .as_ref()
-                    .map(|tid| (tid.clone(), *pr_number))
-            })
-            .collect();
-        let prs_to_tasks: HashMap<u64, String> = ps
-            .github
-            .pr_author_sessions
-            .iter()
-            .filter_map(|(pr_number, session)| {
-                session
-                    .task_id
-                    .as_ref()
-                    .map(|tid| (*pr_number, tid.clone()))
-            })
-            .collect();
-        (tasks_to_prs, prs_to_tasks)
+        (ps.github.task_to_pr_map(), ps.github.pr_to_task_map())
     };
 
     // ── Reviewer state ──────────────────────────────────────────────────

--- a/src/daemon/state.rs
+++ b/src/daemon/state.rs
@@ -390,6 +390,11 @@ impl DaemonPersistentState {
             false
         }
     }
+
+    /// Returns the set of active channel lead names (keys of `channel_lead_sessions`).
+    pub fn channel_lead_names(&self) -> std::collections::HashSet<String> {
+        self.channel_lead_sessions.keys().cloned().collect()
+    }
 }
 
 #[path = "state_tests.rs"]

--- a/src/github_state.rs
+++ b/src/github_state.rs
@@ -611,6 +611,32 @@ impl GitHubState {
     pub fn remove_pr_author_session(&mut self, pr_number: u64) -> Option<PrAuthorSession> {
         self.pr_author_sessions.remove(&pr_number)
     }
+
+    /// Maps PR number → task ID for all author sessions that have a task ID.
+    pub fn pr_to_task_map(&self) -> HashMap<u64, String> {
+        self.pr_author_sessions
+            .iter()
+            .filter_map(|(pr_number, session)| {
+                session
+                    .task_id
+                    .as_ref()
+                    .map(|task_id| (*pr_number, task_id.clone()))
+            })
+            .collect()
+    }
+
+    /// Maps task ID → PR number for all author sessions that have a task ID.
+    pub fn task_to_pr_map(&self) -> HashMap<String, u64> {
+        self.pr_author_sessions
+            .iter()
+            .filter_map(|(pr_number, session)| {
+                session
+                    .task_id
+                    .as_ref()
+                    .map(|task_id| (task_id.clone(), *pr_number))
+            })
+            .collect()
+    }
 }
 
 /// Load GitHub state for a specific repository (legacy file).


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Adds `DaemonPersistentState::channel_lead_names()` to replace 13 inline `channel_lead_sessions.keys().cloned().collect()` expressions in chat.rs, effects.rs, pr.rs, rpc_coworker.rs, rpc_kanban.rs, rpc_status.rs
- Adds `WorldSnapshot::channel_lead_names()` to replace 3 inline expressions in dispatch.rs
- Adds `GitHubState::pr_to_task_map()` and `task_to_pr_map()` to replace 4 inline `filter_map` iterations over `pr_author_sessions` in pr.rs and snapshot.rs

Net: -21 lines across 10 files (81 insertions, 102 deletions)

## Test plan
- [x] `cargo build` — clean compile
- [x] `cargo test` — 1925 tests pass, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- [x] `cargo fmt --all -- --check` — passes pre-commit hook

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)