### PR TITLE
fix: unify PATH_LOCK to eliminate flaky test_lead_pr_without_task_id_should_not_be_orphaned [Midtown !1801]

### DIFF
--- a/src/daemon/effects_tests.rs
+++ b/src/daemon/effects_tests.rs
@@ -963,9 +963,6 @@ fn clear_session_working_dir_noop_for_missing_session() {
 
 // ── invoke_workflow_script ────────────────────────────────────────────────────
 
-/// Mutex to serialize tests that modify the PATH environment variable.
-static WORKFLOW_PATH_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
 /// Build a minimal DaemonState for workflow-script tests.
 ///
 /// Returns the state, the project root temp dir (which becomes `all_repo_paths[0]`),
@@ -1055,7 +1052,7 @@ async fn emit_workflow_event_noop_when_no_script_configured() {
 async fn emit_workflow_event_posts_error_on_nonzero_exit() {
     use std::os::unix::fs::PermissionsExt;
 
-    let _path_guard = WORKFLOW_PATH_LOCK.lock().unwrap();
+    let _path_guard = crate::daemon::PATH_LOCK.lock().unwrap();
     let (state, project_dir, _guard) = make_workflow_test_state("myrepo-err");
 
     // Write a workflow script that exits non-zero with a stderr message.
@@ -1119,7 +1116,7 @@ async fn emit_workflow_event_posts_error_on_nonzero_exit() {
 async fn emit_workflow_event_no_error_message_on_success() {
     use std::os::unix::fs::PermissionsExt;
 
-    let _path_guard = WORKFLOW_PATH_LOCK.lock().unwrap();
+    let _path_guard = crate::daemon::PATH_LOCK.lock().unwrap();
     let (state, project_dir, _guard) = make_workflow_test_state("myrepo-ok");
 
     // Write a workflow script that exits 0 (success).

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3854,6 +3854,15 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
 // in `rules.rs` handle the full coworker set; these single-coworker variants
 // make individual test cases easier to write.
 
+/// Shared mutex for tests that modify the `PATH` environment variable.
+///
+/// All test modules (pr_tests, effects_tests, etc.) must use this single lock
+/// so that PATH-mocking tests in different files serialize against each other.
+/// Two separate per-file statics would allow tests from different files to run
+/// concurrently and corrupt each other's `gh` CLI mock.
+#[cfg(test)]
+pub(crate) static PATH_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[path = "mod_tests.rs"]
 #[cfg(test)]
 mod tests;

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -1,11 +1,11 @@
 use super::*;
 use serde_json::json;
-use std::sync::Mutex;
 
-// Global mutex to serialize tests that modify PATH environment variable.
-// Without this, parallel test execution causes gh CLI mocks to interfere
-// with each other (one test's mock returns data to a different test).
-static PATH_LOCK: Mutex<()> = Mutex::new(());
+// Use the shared PATH_LOCK from daemon/mod.rs so that PATH-mocking tests in
+// pr_tests.rs and effects_tests.rs serialize against each other.  Two
+// separate per-file statics would allow them to run concurrently and corrupt
+// each other's gh CLI mock.
+use crate::daemon::PATH_LOCK;
 
 /// Helper to create minimal DaemonState for testing
 fn make_test_state(


### PR DESCRIPTION
<!-- midtown: bleecker -->

## Summary

- `pr_tests.rs` had its own `PATH_LOCK` and `effects_tests.rs` had its own `WORKFLOW_PATH_LOCK` — two **independent** mutexes protecting the same shared resource (`PATH` env var)
- Tests from the two files could run concurrently while each held its own lock, letting parallel `gh` CLI mocks corrupt each other's output
- Moved a single `pub(crate) static PATH_LOCK` into `daemon/mod.rs` and replaced both per-file statics with imports of this shared lock
- All 7 PATH-mocking tests now compete for the same mutex and are guaranteed to serialize

## Root Cause

The flaky failure in `test_lead_pr_without_task_id_should_not_be_orphaned` was: `is_pr_reviewed()` shells out to `gh pr view --json reviews,comments`. The test mocks `gh` by prepending a temp dir to `PATH`. When a concurrent test in `effects_tests.rs` also prepended its own `gh` mock to `PATH` (while holding a *different* mutex), the PR test's `gh` call could get the wrong mock's output and return "already reviewed" — causing the test to skip reviewer assignment and return an empty effects list, failing the `assert!(!effects.is_empty())`.

## Test plan
- [x] `test_lead_pr_without_task_id_should_not_be_orphaned` passes
- [x] All 53 `daemon::pr::tests` pass
- [x] All 31 `daemon::effects::tests` pass  
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)