### PR TITLE
fix: correct screenshot script FILENAME and REPO variable bugs [Midtown !1800]

### DIFF
--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -504,16 +504,16 @@ cd web-app && npm install && npx playwright install chromium
 cd web-app && npm run dev &
 
 # 2. Take a screenshot of the running app
-REPO=$(midtown channel read 2>/dev/null | head -1 | true; git rev-parse --show-toplevel | xargs basename)
+REPO=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}' | xargs basename)
 npx playwright screenshot --browser chromium http://localhost:5173 /tmp/screenshot.png
 
 # 3. Save to the shared per-project assets directory
 ASSETS=~/.midtown/projects/$REPO/assets
 mkdir -p "$ASSETS"
-cp /tmp/screenshot.png "$ASSETS/screenshot-$(date +%s).png"
+FILENAME="screenshot-$(date +%s).png"
+cp /tmp/screenshot.png "$ASSETS/$FILENAME"
 
 # 4. Post inline to the channel — the web UI renders markdown images
-FILENAME=$(basename /tmp/screenshot.png)
 midtown channel post "/me here's the result: ![screenshot](http://localhost:47022/api/projects/$REPO/assets/$FILENAME)"
 ```
 


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

Two bugs in the coworker screenshot workflow script (`agents/coworker.md`, added in #1523):

- **FILENAME mismatch**: The file was saved as `screenshot-$(date +%s).png` (timestamped) but `FILENAME` was set from `basename /tmp/screenshot.png` = `screenshot.png`. The URL posted to the channel referenced the wrong filename, causing a 404.
- **REPO variable wrong in worktrees**: `git rev-parse --show-toplevel | xargs basename` returns the worktree directory name (e.g. `task-1800-fix-screenshot-url-scheme-for-coworker`) instead of the project name (e.g. `midtown`). Fixed by using `git worktree list --porcelain | awk '/^worktree/{print $2; exit}' | xargs basename`, which always returns the main worktree's basename regardless of whether we're in a worktree or the main repo.

## Test plan

- [x] Existing webserver asset tests pass (`cargo test test_project_asset`)
- [x] All unit tests pass (`cargo test`)
- [x] Manual verification: script now sets `FILENAME` before `cp` and uses worktree-safe `REPO` computation

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)