### PR TITLE
docs(health): clarify build_reviewer_respawn_effects caller contract

### DIFF
--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -1444,9 +1444,16 @@ pub(super) fn check_for_stale_worktrees(
 /// worktree-setup → launch-config → spawn sequence; only the reason string
 /// embedded in an abandoned "Review in progress" comment differs.
 ///
-/// The caller is responsible for any additional effects that follow the spawn
-/// (e.g. the workflow event for stuck reviewers, or the channel message for
-/// dead reviewers).
+/// ## Caller responsibilities
+///
+/// **Pre-spawn (asymmetric):** `check_and_restart_stuck_reviewers` must push a
+/// [`shutdown_effect`] *before* calling this helper — the reviewer process is
+/// still alive and must be killed first.  `check_and_restart_dead_reviewers`
+/// must *not* — the process has already exited, so no shutdown is needed.
+///
+/// **Post-spawn:** each caller appends its own trailing effects after this
+/// helper returns (e.g. the `CoworkerStuck` workflow event for stuck reviewers,
+/// or the ops-channel message for dead reviewers).
 fn build_reviewer_respawn_effects(
     snap: &snapshot::WorldSnapshot,
     name: &str,


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary

Follow-up to #1531 addressing review feedback from madison.

Documents the asymmetric pre-spawn caller contract on `build_reviewer_respawn_effects()`:

- **Stuck reviewers** must push `shutdown_effect` *before* calling the helper — the reviewer process is still alive and must be killed first
- **Dead reviewers** must *not* — the process already exited, no shutdown needed

The original comment only mentioned post-spawn caller responsibilities ("The caller is responsible for any additional effects that follow the spawn"), which could mislead a future caller into skipping the shutdown step for alive reviewers.

No code changes — documentation only.

## Test plan

- [x] `cargo build` — clean (doc-only change)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)