### PR TITLE
fix: change return to continue in execute_effects CreateTask dedup guard [Midtown !1802]

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -537,6 +537,18 @@ impl Effect {
     }
 }
 
+/// Returns true if a non-completed task already exists for the given PR number.
+///
+/// Used by the `CreateTask` handler in `execute_effects` to skip duplicate task
+/// creation when multiple review comments arrive in quick succession.  The caller
+/// must pass `continue` (not `return`) after this returns `true` so that remaining
+/// effects in the batch are still processed.
+pub(crate) fn create_task_duplicate_exists(tasks: &[crate::tasks::Task], pr_num: u64) -> bool {
+    tasks
+        .iter()
+        .any(|t| t.pr == Some(pr_num) && t.status != crate::tasks::TaskStatus::Completed)
+}
+
 /// Deduplicate nudge effects targeting the same session within a single batch.
 ///
 /// When multiple PR issue types (CI green, review complete, merge conflict)
@@ -2177,15 +2189,12 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 // a daemon restart resets the in-memory cooldown).
                 if let Some(pr_num) = pr {
                     let existing = crate::tasks::read_tasks_for_repo(Some(&repo_name));
-                    let already_has_task = existing.iter().any(|t| {
-                        t.pr == Some(pr_num) && t.status != crate::tasks::TaskStatus::Completed
-                    });
-                    if already_has_task {
+                    if create_task_duplicate_exists(&existing, pr_num) {
                         debug!(
                             "Skipping CreateTask for PR #{}: non-completed task already exists",
                             pr_num
                         );
-                        return;
+                        continue;
                     }
                 }
 

--- a/src/daemon/effects_tests.rs
+++ b/src/daemon/effects_tests.rs
@@ -1164,3 +1164,84 @@ async fn emit_workflow_event_no_error_message_on_success() {
         "no channel message should be written on successful script exit"
     );
 }
+
+// ---------------------------------------------------------------------------
+// CreateTask dedup guard tests
+//
+// The `create_task_duplicate_exists` helper is used inside the `for effect in
+// effects` loop in `execute_effects`.  The caller uses `continue` (not
+// `return`) so that only the duplicate CreateTask is skipped and subsequent
+// effects in the batch still execute.
+// ---------------------------------------------------------------------------
+
+fn mk_task(pr: Option<u64>, status: crate::tasks::TaskStatus) -> crate::tasks::Task {
+    crate::tasks::Task {
+        id: "1".to_string(),
+        subject: "test task".to_string(),
+        status,
+        owner: None,
+        description: None,
+        blocked_by: vec![],
+        channel: None,
+        pr,
+        created_at: None,
+    }
+}
+
+#[test]
+fn create_task_duplicate_exists_returns_false_for_empty_list() {
+    assert!(
+        !super::create_task_duplicate_exists(&[], 42),
+        "no tasks → not a duplicate"
+    );
+}
+
+#[test]
+fn create_task_duplicate_exists_returns_false_when_only_completed_tasks() {
+    let tasks = vec![
+        mk_task(Some(42), crate::tasks::TaskStatus::Completed),
+        mk_task(Some(42), crate::tasks::TaskStatus::Completed),
+    ];
+    assert!(
+        !super::create_task_duplicate_exists(&tasks, 42),
+        "only completed tasks for this PR → allowed to create a new one"
+    );
+}
+
+#[test]
+fn create_task_duplicate_exists_returns_true_for_pending_task() {
+    let tasks = vec![mk_task(Some(42), crate::tasks::TaskStatus::Pending)];
+    assert!(
+        super::create_task_duplicate_exists(&tasks, 42),
+        "pending task for PR → skip creation"
+    );
+}
+
+#[test]
+fn create_task_duplicate_exists_returns_true_for_in_progress_task() {
+    let tasks = vec![mk_task(Some(42), crate::tasks::TaskStatus::InProgress)];
+    assert!(
+        super::create_task_duplicate_exists(&tasks, 42),
+        "in-progress task for PR → skip creation"
+    );
+}
+
+#[test]
+fn create_task_duplicate_exists_ignores_other_pr_numbers() {
+    // Task exists for PR 99, not PR 42 — must not block PR 42.
+    let tasks = vec![mk_task(Some(99), crate::tasks::TaskStatus::Pending)];
+    assert!(
+        !super::create_task_duplicate_exists(&tasks, 42),
+        "task for a different PR → not a duplicate"
+    );
+}
+
+#[test]
+fn create_task_duplicate_exists_ignores_tasks_without_pr() {
+    // Task with no associated PR must not block a PR-specific CreateTask.
+    let tasks = vec![mk_task(None, crate::tasks::TaskStatus::Pending)];
+    assert!(
+        !super::create_task_duplicate_exists(&tasks, 42),
+        "task with no PR → not a duplicate"
+    );
+}


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary

- **Bug**: The `CreateTask` dedup guard in `execute_effects` used `return` (exits function) instead of `continue` (skips one effect). Any effects after a duplicate `CreateTask` in a batch were silently dropped.
- **Fix**: Change `return` to `continue` at `effects.rs:2200`.
- **Extraction**: Pull the duplicate-check predicate into `create_task_duplicate_exists()` for clarity and testability.
- **Tests**: Add 6 unit tests covering empty list, completed-only, pending, in-progress, different PR number, and no-PR cases.

Introduced by PR #1527.

## Test plan

- [x] `cargo test create_task_duplicate_exists` — 6 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)