### PR TITLE
fix: change return to continue in execute_effects BindCoworkerToWorktree collision guard [Midtown !1804]

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -1774,8 +1774,10 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                                     "WORKTREE COLLISION BLOCKED: Refusing to bind {} to worktree {} - already bound to ACTIVE coworker {}",
                                     coworker, worktree_id, current_coworker
                                 );
-                                // Do NOT bind - this would crash both Claude Code sessions
-                                return;
+                                // Do NOT bind - this would crash both Claude Code sessions.
+                                // Use `continue` (not `return`) so remaining effects in the
+                                // batch are still processed.
+                                continue;
                             } else {
                                 debug!(
                                     "Worktree {} was bound to {} but they're not active - allowing rebind to {}",

--- a/src/daemon/effects_tests.rs
+++ b/src/daemon/effects_tests.rs
@@ -1245,3 +1245,74 @@ fn create_task_duplicate_exists_ignores_tasks_without_pr() {
         "task with no PR → not a duplicate"
     );
 }
+
+// ---------------------------------------------------------------------------
+// BindCoworkerToWorktree collision guard — batch-level regression test
+//
+// When a worktree collision is detected (the target worktree is already bound
+// to a different ACTIVE coworker), the guard must skip only the colliding
+// effect and continue processing the remaining effects in the batch.  Using
+// `return` instead of `continue` would silently drop every subsequent effect.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bind_coworker_to_worktree_collision_does_not_drop_subsequent_effects() {
+    let (state, _project_dir, _guard) = make_workflow_test_state("myrepo-collision");
+
+    // Register a worktree and bind it to "old-coworker".
+    {
+        let mut ps = state.persistent_state.lock().await;
+        ps.worktree_registry
+            .assign_worktree(crate::worktree_registry::WorktreeAssignment {
+                worktree_id: "wt-collision-test".to_string(),
+                branch_name: "old-coworker/task-1".to_string(),
+                task_id: None,
+                current_coworker: None,
+                pr_number: None,
+                created_at: chrono::Utc::now(),
+                completed_at: None,
+            })
+            .expect("assign worktree");
+        ps.worktree_registry
+            .bind_coworker("wt-collision-test", "old-coworker")
+            .expect("bind old-coworker");
+    }
+
+    // Make the session manager report "old-coworker" as alive so the collision
+    // guard fires.
+    state
+        .session_manager
+        .set_test_is_alive_hook(Some(std::sync::Arc::new(|name: &str| {
+            name == "old-coworker"
+        })));
+
+    // Batch: first effect will be blocked (collision), second must still run.
+    let sentinel_channel = "sentinel-ch".to_string();
+    let sentinel_session = "sess-sentinel-99".to_string();
+    execute_effects(
+        vec![
+            Effect::BindCoworkerToWorktree {
+                worktree_id: "wt-collision-test".to_string(),
+                coworker: "new-coworker".to_string(),
+            },
+            Effect::SaveChannelLeadSession {
+                channel_name: sentinel_channel.clone(),
+                session_id: sentinel_session.clone(),
+            },
+        ],
+        &state,
+    )
+    .await;
+
+    // The SaveChannelLeadSession effect must have executed — if the collision
+    // guard used `return` instead of `continue`, this would be None.
+    let ps = state.persistent_state.lock().await;
+    assert_eq!(
+        ps.channel_lead_sessions
+            .get(&sentinel_channel)
+            .map(String::as_str),
+        Some(sentinel_session.as_str()),
+        "SaveChannelLeadSession must execute even when a preceding \
+         BindCoworkerToWorktree is blocked by the collision guard"
+    );
+}

--- a/src/daemon/sessions.rs
+++ b/src/daemon/sessions.rs
@@ -303,12 +303,17 @@ impl CoworkerSession {
 type TestSendMessageToSessionIdHook =
     std::sync::Arc<dyn Fn(&str, &str) -> crate::Result<()> + Send + Sync>;
 
+#[cfg(test)]
+type TestIsAliveHook = std::sync::Arc<dyn Fn(&str) -> bool + Send + Sync>;
+
 #[allow(dead_code)]
 pub struct SessionManager {
     sessions: RwLock<HashMap<String, CoworkerSession>>,
     repo_name: String,
     #[cfg(test)]
     test_send_message_to_session_id_hook: std::sync::Mutex<Option<TestSendMessageToSessionIdHook>>,
+    #[cfg(test)]
+    test_is_alive_hook: std::sync::Mutex<Option<TestIsAliveHook>>,
 }
 
 #[allow(dead_code)]
@@ -320,6 +325,8 @@ impl SessionManager {
             repo_name,
             #[cfg(test)]
             test_send_message_to_session_id_hook: std::sync::Mutex::new(None),
+            #[cfg(test)]
+            test_is_alive_hook: std::sync::Mutex::new(None),
         }
     }
 
@@ -332,6 +339,15 @@ impl SessionManager {
             .test_send_message_to_session_id_hook
             .lock()
             .expect("session hook mutex poisoned");
+        *guard = hook;
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_test_is_alive_hook(&self, hook: Option<TestIsAliveHook>) {
+        let mut guard = self
+            .test_is_alive_hook
+            .lock()
+            .expect("is_alive hook mutex poisoned");
         *guard = hook;
     }
 
@@ -939,6 +955,15 @@ impl SessionManager {
 
     /// Check if a coworker has a running session (by name).
     pub async fn is_alive(&self, name: &str) -> bool {
+        #[cfg(test)]
+        if let Some(hook) = self
+            .test_is_alive_hook
+            .lock()
+            .expect("is_alive hook mutex poisoned")
+            .as_ref()
+        {
+            return hook(name);
+        }
         let sessions = self.sessions.read().await;
         sessions
             .values()


### PR DESCRIPTION
<!-- midtown: park -->

## Summary

- `BindCoworkerToWorktree` handler in `execute_effects` used `return` inside the `for effect in effects` loop when a worktree collision was detected (target worktree already bound to an active coworker). This exited the entire function, silently dropping all remaining effects.
- Fixed by changing `return` to `continue` with an explanatory comment.
- Added `test_is_alive_hook` to `SessionManager` following the existing `test_send_message_to_session_id_hook` pattern, enabling the `is_alive` path to be controlled in tests without spawning real processes.
- Added a batch-level regression test (`bind_coworker_to_worktree_collision_does_not_drop_subsequent_effects`) that directly reproduces the bug: collision guard fires on the first effect, but the subsequent `SaveChannelLeadSession` effect must still run.

Same bug class as the `CreateTask` dedup guard fixed in #1537.

## Test plan

- [x] New test `bind_coworker_to_worktree_collision_does_not_drop_subsequent_effects` fails before the fix (left: `None`) and passes after (`Some("sess-sentinel-99")`)
- [x] All 1938 unit tests pass
- [x] Clippy and fmt clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)