### PR TITLE
fix: use .clone() in test_is_alive_hook to match established hook pattern

### DIFF
--- a/src/daemon/sessions.rs
+++ b/src/daemon/sessions.rs
@@ -956,13 +956,15 @@ impl SessionManager {
     /// Check if a coworker has a running session (by name).
     pub async fn is_alive(&self, name: &str) -> bool {
         #[cfg(test)]
-        if let Some(hook) = self
-            .test_is_alive_hook
-            .lock()
-            .expect("is_alive hook mutex poisoned")
-            .as_ref()
         {
-            return hook(name);
+            if let Some(hook) = self
+                .test_is_alive_hook
+                .lock()
+                .expect("is_alive hook mutex poisoned")
+                .clone()
+            {
+                return hook(name);
+            }
         }
         let sessions = self.sessions.read().await;
         sessions


### PR DESCRIPTION
<!-- midtown: park -->

## Summary

Follow-up to #1538. The `test_is_alive_hook` introduced there used `.as_ref()` to borrow out of the `MutexGuard`, keeping the lock held for the duration of the hook call. The established pattern in the same struct (`test_send_message_to_session_id_hook`) uses `.clone()` to get an owned `Arc`, releasing the lock before invoking the hook. Diverging from this creates a latent deadlock risk if a future hook body ever re-enters the same mutex.

Addressed lexington's code review on #1538, which merged before the fix could be pushed.

**Before:**
```rust
#[cfg(test)]
if let Some(hook) = self
    .test_is_alive_hook
    .lock()
    .expect("is_alive hook mutex poisoned")
    .as_ref()       // ← holds the MutexGuard during the call
{
    return hook(name);
}
```

**After (matches existing pattern):**
```rust
#[cfg(test)]
{
    if let Some(hook) = self
        .test_is_alive_hook
        .lock()
        .expect("is_alive hook mutex poisoned")
        .clone()    // ← owned Arc, lock released before call
    {
        return hook(name);
    }
}
```

## Test plan

- [x] Existing `bind_coworker_to_worktree_collision_does_not_drop_subsequent_effects` test still passes
- [x] Clippy and fmt clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)