### PR TITLE
fix: consolidate legacy lead guards in rpc_auth.rs and effects.rs [Midtown !1814]

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -2807,13 +2807,8 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                     let ps = state.persistent_state.lock().await;
                     ps.channel_lead_sessions.contains_key(name.as_str())
                 };
-                let suffix = if name.eq_ignore_ascii_case(&state.repo_name) {
-                    " Headless session will respawn on the next tick."
-                } else if is_channel_lead {
-                    " Channel lead session will be respawned for its channel."
-                } else {
-                    " Session will be reassigned via normal task dispatch."
-                };
+                let suffix =
+                    auto_detach_suffix_message(name.as_str(), &state.repo_name, is_channel_lead);
                 let mut msg = crate::message::Message::system(format!(
                     "⚠️ Auto-detached stale attached session for {} — interactive session ended without detach.{}",
                     name, suffix
@@ -3141,6 +3136,21 @@ async fn spawn_with_resume_fallback(
                 }
             }
         }
+    }
+}
+
+/// Choose the suffix for an auto-detach warning message.
+///
+/// The lead session (both canonical repo name and legacy "lead") gets a
+/// respawn notice; channel leads get a channel-respawn notice; everyone
+/// else gets a task-dispatch notice.
+fn auto_detach_suffix_message(name: &str, repo_name: &str, is_channel_lead: bool) -> &'static str {
+    if super::helpers::is_project_lead(name, repo_name) {
+        " Headless session will respawn on the next tick."
+    } else if is_channel_lead {
+        " Channel lead session will be respawned for its channel."
+    } else {
+        " Session will be reassigned via normal task dispatch."
     }
 }
 

--- a/src/daemon/effects_tests.rs
+++ b/src/daemon/effects_tests.rs
@@ -1316,3 +1316,64 @@ async fn bind_coworker_to_worktree_collision_does_not_drop_subsequent_effects() 
          BindCoworkerToWorktree is blocked by the collision guard"
     );
 }
+
+// ============================================================================
+// auto_detach_suffix_message — legacy "lead" name coverage
+// ============================================================================
+
+/// The legacy "lead" session name must produce the same respawn suffix as the
+/// canonical repo name.
+///
+/// Regression: before the fix, `auto_detach_suffix_message` only checked
+/// `eq_ignore_ascii_case(repo_name)`, so a session named "lead" got the
+/// "Session will be reassigned via normal task dispatch." suffix instead of
+/// the correct "Headless session will respawn on the next tick." suffix.
+#[test]
+fn test_auto_detach_suffix_legacy_lead_gets_respawn_message() {
+    // Legacy name
+    assert_eq!(
+        auto_detach_suffix_message("lead", "midtown", false),
+        " Headless session will respawn on the next tick.",
+        "legacy 'lead' session must get the respawn suffix"
+    );
+    // Case-insensitive variants
+    assert_eq!(
+        auto_detach_suffix_message("Lead", "midtown", false),
+        " Headless session will respawn on the next tick."
+    );
+    assert_eq!(
+        auto_detach_suffix_message("LEAD", "midtown", false),
+        " Headless session will respawn on the next tick."
+    );
+}
+
+/// Canonical repo-named session must produce the respawn suffix.
+#[test]
+fn test_auto_detach_suffix_canonical_name_gets_respawn_message() {
+    assert_eq!(
+        auto_detach_suffix_message("midtown", "midtown", false),
+        " Headless session will respawn on the next tick."
+    );
+    assert_eq!(
+        auto_detach_suffix_message("Midtown", "midtown", false),
+        " Headless session will respawn on the next tick."
+    );
+}
+
+/// Regular coworker sessions must produce the task-dispatch suffix.
+#[test]
+fn test_auto_detach_suffix_coworker_gets_task_dispatch_message() {
+    assert_eq!(
+        auto_detach_suffix_message("lexington", "midtown", false),
+        " Session will be reassigned via normal task dispatch."
+    );
+}
+
+/// Channel-lead sessions must produce the channel-respawn suffix.
+#[test]
+fn test_auto_detach_suffix_channel_lead_gets_channel_message() {
+    assert_eq!(
+        auto_detach_suffix_message("auth", "midtown", true),
+        " Channel lead session will be respawned for its channel."
+    );
+}

--- a/src/daemon/rpc_auth.rs
+++ b/src/daemon/rpc_auth.rs
@@ -92,8 +92,9 @@ fn execution_role_for_coworker(
     coworker: &crate::coworker::Coworker,
     reviewer_pr_by_name: &HashMap<String, u64>,
     channel_lead_session_names: &HashSet<String>,
+    repo_name: &str,
 ) -> crate::config::ExecutionRole {
-    if coworker.name.eq_ignore_ascii_case("lead") {
+    if super::helpers::is_project_lead(&coworker.name, repo_name) {
         crate::config::ExecutionRole::Lead
     } else if reviewer_pr_by_name.contains_key(&coworker.name) {
         crate::config::ExecutionRole::Reviewer
@@ -251,15 +252,15 @@ pub(super) async fn handle_auth_switch(
     let running_coworkers: Vec<crate::coworker::Coworker> =
         filter_coworkers_by_provider(&state.coworkers.list(), provider)
             .into_iter()
-            .filter(|cw| !cw.name.eq_ignore_ascii_case("lead"))
+            .filter(|cw| !super::helpers::is_project_lead(&cw.name, &state.repo_name))
             .collect();
 
-    let current_lead_provider = state
+    let current_lead = state
         .coworkers
         .list()
         .into_iter()
-        .find(|cw| cw.name.eq_ignore_ascii_case("lead"))
-        .map(|cw| cw.provider);
+        .find(|cw| super::helpers::is_project_lead(&cw.name, &state.repo_name));
+    let current_lead_provider = current_lead.as_ref().map(|cw| cw.provider);
 
     let shutdown_count = running_coworkers.len();
     for coworker in &running_coworkers {
@@ -317,10 +318,14 @@ pub(super) async fn handle_auth_switch(
         crate::config::ExecutionRole::Lead,
     );
     let lead_relaunch_status = if current_lead_provider == Some(provider) {
-        // Shut down the existing headless lead session if running
-        if state.session_manager.is_alive("lead").await {
-            let _ = state.session_manager.shutdown("lead").await;
-            state.coworkers.deregister("lead");
+        // Shut down the existing headless lead session if running.
+        // Use the actual registered name (canonical repo name or legacy "lead").
+        if let Some(lead) = current_lead.as_ref() {
+            let lead_name = lead.name.as_str();
+            if state.session_manager.is_alive(lead_name).await {
+                let _ = state.session_manager.shutdown(lead_name).await;
+                state.coworkers.deregister(lead_name);
+            }
         }
         let mut lead_config = crate::launch::LaunchConfig::lead(&state.repo_name, None);
         lead_config.auth_provider = configured_lead_provider;
@@ -359,6 +364,7 @@ pub(super) async fn handle_auth_switch(
             coworker,
             &reviewer_pr_by_name,
             &channel_lead_session_names,
+            &state.repo_name,
         );
         let target_provider =
             crate::config::get_execution_provider_for_role(&state.repo_name, role);

--- a/src/daemon/rpc_auth_tests.rs
+++ b/src/daemon/rpc_auth_tests.rs
@@ -440,6 +440,66 @@ async fn test_pool_toggle_enable_is_idempotent_via_handler() {
     );
 }
 
+// ============================================================================
+// execution_role_for_coworker — canonical lead name
+// ============================================================================
+
+/// A session named after the repo (e.g., "midtown") must be identified as Lead.
+///
+/// Regression: before this fix, `execution_role_for_coworker` only checked for
+/// the legacy literal "lead", so a modern canonical session got `Coworker` role
+/// and was restarted with coworker credentials after an auth-profile switch.
+#[test]
+fn test_execution_role_for_canonical_lead_name() {
+    let reviewer_pr: HashMap<String, u64> = HashMap::new();
+    let channel_leads: HashSet<String> = HashSet::new();
+
+    let canonical_lead = crate::coworker::Coworker {
+        slot_id: "1".to_string(),
+        name: "midtown".to_string(), // canonical name — NOT the legacy "lead"
+        status: crate::coworker::CoworkerStatus::Running,
+        working_dir: "/tmp/midtown".to_string(),
+        started_at: chrono::Utc::now(),
+        current_task: None,
+        session_id: None,
+        model: "opus".to_string(),
+        provider: crate::auth::AuthProvider::Claude,
+        profile: "default".to_string(),
+    };
+
+    assert_eq!(
+        execution_role_for_coworker(&canonical_lead, &reviewer_pr, &channel_leads, "midtown"),
+        crate::config::ExecutionRole::Lead,
+        "canonical repo-named session must be classified as Lead, not Coworker"
+    );
+}
+
+/// Legacy "lead" name must still be identified as Lead after the refactor.
+#[test]
+fn test_execution_role_for_legacy_lead_name_still_works() {
+    let reviewer_pr: HashMap<String, u64> = HashMap::new();
+    let channel_leads: HashSet<String> = HashSet::new();
+
+    let legacy_lead = crate::coworker::Coworker {
+        slot_id: "1".to_string(),
+        name: "lead".to_string(),
+        status: crate::coworker::CoworkerStatus::Running,
+        working_dir: "/tmp/lead".to_string(),
+        started_at: chrono::Utc::now(),
+        current_task: None,
+        session_id: None,
+        model: "opus".to_string(),
+        provider: crate::auth::AuthProvider::Claude,
+        profile: "default".to_string(),
+    };
+
+    assert_eq!(
+        execution_role_for_coworker(&legacy_lead, &reviewer_pr, &channel_leads, "midtown"),
+        crate::config::ExecutionRole::Lead,
+        "legacy 'lead' session must still be classified as Lead"
+    );
+}
+
 /// After a successful toggle, the handler broadcasts to the ops channel so web
 /// UI clients receive the update without polling.
 #[tokio::test]
@@ -644,7 +704,12 @@ fn test_execution_role_for_coworker() {
         profile: "default".to_string(),
     };
     assert_eq!(
-        execution_role_for_coworker(&lead, &reviewer_pr_by_name, &channel_lead_session_names),
+        execution_role_for_coworker(
+            &lead,
+            &reviewer_pr_by_name,
+            &channel_lead_session_names,
+            "myrepo"
+        ),
         crate::config::ExecutionRole::Lead
     );
 
@@ -653,7 +718,12 @@ fn test_execution_role_for_coworker() {
         ..lead.clone()
     };
     assert_eq!(
-        execution_role_for_coworker(&reviewer, &reviewer_pr_by_name, &channel_lead_session_names),
+        execution_role_for_coworker(
+            &reviewer,
+            &reviewer_pr_by_name,
+            &channel_lead_session_names,
+            "myrepo"
+        ),
         crate::config::ExecutionRole::Reviewer
     );
 
@@ -665,7 +735,8 @@ fn test_execution_role_for_coworker() {
         execution_role_for_coworker(
             &channel_lead,
             &reviewer_pr_by_name,
-            &channel_lead_session_names
+            &channel_lead_session_names,
+            "myrepo"
         ),
         crate::config::ExecutionRole::ChannelLead
     );
@@ -675,7 +746,12 @@ fn test_execution_role_for_coworker() {
         ..lead
     };
     assert_eq!(
-        execution_role_for_coworker(&coworker, &reviewer_pr_by_name, &channel_lead_session_names),
+        execution_role_for_coworker(
+            &coworker,
+            &reviewer_pr_by_name,
+            &channel_lead_session_names,
+            "myrepo"
+        ),
         crate::config::ExecutionRole::Coworker
     );
 }


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

Four sites in `rpc_auth.rs` and one in `effects.rs` hardcoded the legacy `"lead"` session name instead of using `is_project_lead()`, causing modern canonical sessions (named after the repo, e.g., `"midtown"`) to be misclassified.

- **`execution_role_for_coworker()`** — add `repo_name` param, use `is_project_lead()` so canonical-named leads get `ExecutionRole::Lead`
- **Running-coworkers filter** (line 254) — use `is_project_lead()` so canonical leads aren't treated as coworkers during auth-profile switch
- **Lead lookup** (line 261) — use `is_project_lead()`, capture full `Coworker` struct to get the actual session name
- **Lead shutdown** (lines 321-323) — use the actual lead name from the lookup instead of hardcoded `"lead"` — modern sessions would not have been shut down otherwise
- **`effects.rs` auto-detach suffix** — extract to testable helper `auto_detach_suffix_message()`, use `is_project_lead()` so legacy `"lead"` sessions get the correct "Headless session will respawn" suffix

## Test plan

- [x] Wrote failing tests first per CLAUDE.md convention
- [x] `test_execution_role_for_canonical_lead_name` — canonical repo name classified as Lead
- [x] `test_execution_role_for_legacy_lead_name_still_works` — legacy "lead" still works
- [x] `test_auto_detach_suffix_legacy_lead_gets_respawn_message` — legacy "lead" gets respawn suffix
- [x] `test_auto_detach_suffix_canonical_name_gets_respawn_message` — canonical name still works
- [x] All 24 existing `rpc_auth` tests pass; all 42 effects tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)