### PR TITLE
docs: fix garbled doc comment on validate_channel_name [Midtown !1817]

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -420,13 +420,6 @@ struct CreateChannelRequest {
     name: String,
 }
 
-/// Create a new channel
-///
-/// Accepts a POST request with JSON body `{"name": "channel-name"}`.
-/// Returns 201 Created on success, 400 Bad Request if the name is invalid.
-///
-/// Channel names must:
-/// Validate a channel name for use in API endpoints.
 /// Validate a channel name for read operations (history, thread fetching).
 ///
 /// Accepts any non-empty name containing only alphanumeric characters, hyphens, and
@@ -477,6 +470,10 @@ fn validate_channel_name(name: &str) -> Result<(), (StatusCode, axum::Json<serde
     Ok(())
 }
 
+/// Create a new channel.
+///
+/// Accepts a POST request with JSON body `{"name": "channel-name"}`.
+/// Returns 201 Created on success, 400 Bad Request if the name is invalid.
 async fn api_channels_create(
     State(state): State<Arc<WebState>>,
     Json(body): Json<CreateChannelRequest>,


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- The doc comment on `validate_channel_name` in `web.rs` was a garbled merge of two doc comments from a prior refactor: it began with text for `api_channels_create`, then continued with the actual helper's comment
- Orphaned bullet-list lines were floating between the two functions as the implicit doc comment for `api_channels_create`
- Each function now has its own clean, standalone doc comment

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` passes

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)