### PR TITLE
feat(web): channel lead always gets #E3BD3F avatar color [Midtown !1827]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -693,11 +693,12 @@
             index={i}
             senderClass="mt-1"
             currentTask={currentTasks[msg.from.toLowerCase()]}
+            channelName={$activeChannel}
           >
             {#if isAction(msg) && !hasMermaid(msg.content)}
               <div class="flex gap-0 break-words">
-                <span class="flex-shrink-0 mr-[0.3em]" style="color: {getSenderColor(msg.from)}">*</span>
-                <span class="action-text flex-1 min-w-0" style="color: {getSenderColor(msg.from)}">{@html renderContent(getActionContent(msg), getApiBase())}</span>
+                <span class="flex-shrink-0 mr-[0.3em]" style="color: {getSenderColor(msg.from, undefined, $activeChannel)}">*</span>
+                <span class="action-text flex-1 min-w-0" style="color: {getSenderColor(msg.from, undefined, $activeChannel)}">{@html renderContent(getActionContent(msg), getApiBase())}</span>
               </div>
             {:else if isAction(msg) && hasMermaid(msg.content)}
               {#each parseSegments(getActionContent(msg)) as segment, si}
@@ -706,18 +707,18 @@
                 {:else}
                   <div class="flex gap-0 break-words">
                     {#if si === 0}
-                      <span class="flex-shrink-0 mr-[0.3em]" style="color: {getSenderColor(msg.from)}">*</span>
+                      <span class="flex-shrink-0 mr-[0.3em]" style="color: {getSenderColor(msg.from, undefined, $activeChannel)}">*</span>
                     {:else}
                       <span class="flex-shrink-0 mr-[0.3em] invisible">*</span>
                     {/if}
-                    <span class="action-text flex-1 min-w-0" style="color: {getSenderColor(msg.from)}">{@html renderContent(segment.content, getApiBase())}</span>
+                    <span class="action-text flex-1 min-w-0" style="color: {getSenderColor(msg.from, undefined, $activeChannel)}">{@html renderContent(segment.content, getApiBase())}</span>
                   </div>
                 {/if}
               {/each}
             {:else}
               {#each parseInsightSegments(msg.content) as segment}
                 {#if segment.type === 'insight'}
-                  <div class="border-l-2 pl-3 max-w-[85%] my-0.5" style="border-color: {getSenderColor(msg.from)}80">
+                  <div class="border-l-2 pl-3 max-w-[85%] my-0.5" style="border-color: {getSenderColor(msg.from, undefined, $activeChannel)}80">
                     {#if hasMermaid(segment.content)}
                       {#each parseSegments(segment.content) as mseg}
                         {#if mseg.type === 'mermaid'}

--- a/web-app/src/lib/MessageRow.svelte
+++ b/web-app/src/lib/MessageRow.svelte
@@ -15,6 +15,7 @@
     senderSpacing = '1.5em',
     senderClass = '',
     currentTask = undefined,
+    channelName = undefined,
     children = undefined,
   } = $props()
 
@@ -28,7 +29,7 @@
     <!-- Avatar -->
     <div
       class="flex-shrink-0 rounded-md flex items-center justify-center text-white font-bold text-[1rem] select-none mt-[0.15rem]"
-      style="width: {AVATAR_SIZE}; height: {AVATAR_SIZE}; background-color: {getSenderColor(msg.from, senderOverrides)}"
+      style="width: {AVATAR_SIZE}; height: {AVATAR_SIZE}; background-color: {getSenderColor(msg.from, senderOverrides, channelName)}"
     >{avatarLetter(msg.from)}</div>
     <!-- Header + content -->
     <div class="flex-1 min-w-0">

--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -195,12 +195,13 @@
             dimSenders={THREAD_DIM_SENDERS}
             senderSpacing="0.8em"
             senderClass="mb-[2px]"
+            channelName={$threadData?.channelName}
           >
             {#if isAction(msg) && !hasMermaid(msg.content)}
               <div class="flex gap-0 break-words">
                 <span class="text-muted-foreground/50 flex-shrink-0 w-[3.2em] text-right mr-[0.4em] select-none text-[0.78rem]">{timeChanged($threadData.messages, i) ? formatTime(msg.timestamp) : ''}</span>
-                <span class="flex-shrink-0 mr-[0.3em]" style="color: {getSenderColor(msg.from, THREAD_SENDER_OVERRIDES)}">*</span>
-                <span class="action-text flex-1 min-w-0" style="color: {getSenderColor(msg.from, THREAD_SENDER_OVERRIDES)}">{@html renderContent(getActionContent(msg), getApiBase())}</span>
+                <span class="flex-shrink-0 mr-[0.3em]" style="color: {getSenderColor(msg.from, THREAD_SENDER_OVERRIDES, $threadData?.channelName)}">*</span>
+                <span class="action-text flex-1 min-w-0" style="color: {getSenderColor(msg.from, THREAD_SENDER_OVERRIDES, $threadData?.channelName)}">{@html renderContent(getActionContent(msg), getApiBase())}</span>
               </div>
             {:else if isAction(msg) && hasMermaid(msg.content)}
               {#each parseSegments(getActionContent(msg)) as segment, si}
@@ -212,12 +213,12 @@
                   <div class="flex gap-0 break-words">
                     {#if si === 0}
                       <span class="text-muted-foreground/50 flex-shrink-0 w-[3.2em] text-right mr-[0.4em] select-none text-[0.78rem]">{timeChanged($threadData.messages, i) ? formatTime(msg.timestamp) : ''}</span>
-                      <span class="flex-shrink-0 mr-[0.3em]" style="color: {getSenderColor(msg.from, THREAD_SENDER_OVERRIDES)}">*</span>
+                      <span class="flex-shrink-0 mr-[0.3em]" style="color: {getSenderColor(msg.from, THREAD_SENDER_OVERRIDES, $threadData?.channelName)}">*</span>
                     {:else}
                       <span class="flex-shrink-0 w-[3.2em] mr-[0.4em]"></span>
                       <span class="flex-shrink-0 mr-[0.3em] invisible">*</span>
                     {/if}
-                    <span class="action-text flex-1 min-w-0" style="color: {getSenderColor(msg.from, THREAD_SENDER_OVERRIDES)}">{@html renderContent(segment.content, getApiBase())}</span>
+                    <span class="action-text flex-1 min-w-0" style="color: {getSenderColor(msg.from, THREAD_SENDER_OVERRIDES, $threadData?.channelName)}">{@html renderContent(segment.content, getApiBase())}</span>
                   </div>
                 {/if}
               {/each}
@@ -346,12 +347,13 @@
             dimSenders={THREAD_DIM_SENDERS}
             senderSpacing="0.8em"
             senderClass="mb-[2px]"
+            channelName={$threadData?.channelName}
           >
             {#if isAction(msg) && !hasMermaid(msg.content)}
               <div class="flex gap-0 break-words">
                 <span class="text-muted-foreground/50 flex-shrink-0 w-[3.2em] text-right mr-[0.4em] select-none text-[0.78rem]">{timeChanged($threadData.messages, i) ? formatTime(msg.timestamp) : ''}</span>
-                <span class="flex-shrink-0 mr-[0.3em]" style="color: {getSenderColor(msg.from, THREAD_SENDER_OVERRIDES)}">*</span>
-                <span class="action-text flex-1 min-w-0" style="color: {getSenderColor(msg.from, THREAD_SENDER_OVERRIDES)}">{@html renderContent(getActionContent(msg), getApiBase())}</span>
+                <span class="flex-shrink-0 mr-[0.3em]" style="color: {getSenderColor(msg.from, THREAD_SENDER_OVERRIDES, $threadData?.channelName)}">*</span>
+                <span class="action-text flex-1 min-w-0" style="color: {getSenderColor(msg.from, THREAD_SENDER_OVERRIDES, $threadData?.channelName)}">{@html renderContent(getActionContent(msg), getApiBase())}</span>
               </div>
             {:else if isAction(msg) && hasMermaid(msg.content)}
               {#each parseSegments(getActionContent(msg)) as segment, si}
@@ -363,12 +365,12 @@
                   <div class="flex gap-0 break-words">
                     {#if si === 0}
                       <span class="text-muted-foreground/50 flex-shrink-0 w-[3.2em] text-right mr-[0.4em] select-none text-[0.78rem]">{timeChanged($threadData.messages, i) ? formatTime(msg.timestamp) : ''}</span>
-                      <span class="flex-shrink-0 mr-[0.3em]" style="color: {getSenderColor(msg.from, THREAD_SENDER_OVERRIDES)}">*</span>
+                      <span class="flex-shrink-0 mr-[0.3em]" style="color: {getSenderColor(msg.from, THREAD_SENDER_OVERRIDES, $threadData?.channelName)}">*</span>
                     {:else}
                       <span class="flex-shrink-0 w-[3.2em] mr-[0.4em]"></span>
                       <span class="flex-shrink-0 mr-[0.3em] invisible">*</span>
                     {/if}
-                    <span class="action-text flex-1 min-w-0" style="color: {getSenderColor(msg.from, THREAD_SENDER_OVERRIDES)}">{@html renderContent(segment.content, getApiBase())}</span>
+                    <span class="action-text flex-1 min-w-0" style="color: {getSenderColor(msg.from, THREAD_SENDER_OVERRIDES, $threadData?.channelName)}">{@html renderContent(segment.content, getApiBase())}</span>
                   </div>
                 {/if}
               {/each}

--- a/web-app/src/lib/messageUtils.js
+++ b/web-app/src/lib/messageUtils.js
@@ -44,8 +44,11 @@ function getOverride(overrides, key) {
   return undefined
 }
 
-export function getSenderColor(name, overrides) {
+export function getSenderColor(name, overrides, channelName) {
   const normalized = normalizeName(name)
+  if (channelName && normalized === normalizeName(channelName)) {
+    return AVENUE_COLORS.lead
+  }
   return getOverride(overrides, normalized) || AVENUE_COLORS[normalized] || '#d0d0d0'
 }
 

--- a/web-app/src/lib/messageUtils.test.js
+++ b/web-app/src/lib/messageUtils.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { getSenderColor, AVENUE_COLORS } from './messageUtils.js'
+
+describe('getSenderColor', () => {
+  it('returns gold for sender matching channel name (channel lead rule)', () => {
+    expect(getSenderColor('web', undefined, 'web')).toBe(AVENUE_COLORS.lead)
+  })
+
+  it('returns gold for midtown sender in midtown channel via channel lead rule', () => {
+    expect(getSenderColor('midtown', undefined, 'midtown')).toBe(AVENUE_COLORS.lead)
+  })
+
+  it('returns gold for midtown sender even without channelName (AVENUE_COLORS fallback)', () => {
+    expect(getSenderColor('midtown', undefined)).toBe(AVENUE_COLORS.lead)
+  })
+
+  it('does not color a non-lead sender gold when channelName is provided', () => {
+    expect(getSenderColor('lexington', undefined, 'web')).toBe(AVENUE_COLORS.lexington)
+  })
+
+  it('is case-insensitive for channel name matching', () => {
+    expect(getSenderColor('Web', undefined, 'web')).toBe(AVENUE_COLORS.lead)
+    expect(getSenderColor('web', undefined, 'Web')).toBe(AVENUE_COLORS.lead)
+  })
+
+  it('returns fallback gray for unknown sender with no channel match', () => {
+    expect(getSenderColor('unknown', undefined, 'web')).toBe('#d0d0d0')
+  })
+
+  it('respects overrides before AVENUE_COLORS lookup', () => {
+    const overrides = { lexington: '#ff0000' }
+    expect(getSenderColor('lexington', overrides, 'web')).toBe('#ff0000')
+  })
+
+  it('channel lead rule takes priority over overrides', () => {
+    // Even if an override exists for 'web', sender=channel → gold wins
+    const overrides = { web: '#ff0000' }
+    expect(getSenderColor('web', overrides, 'web')).toBe(AVENUE_COLORS.lead)
+  })
+})


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Adds an optional `channelName` param to `getSenderColor()` in `messageUtils.js`
- When the sender's name equals the channel name, always returns `AVENUE_COLORS.lead` (`#E3BD3F`) — the gold/amber color reserved for leads
- Threads the `channelName` param through `MessageRow` (new prop), `Channel` (passes `$activeChannel`), and `ThreadPanel` (passes `$threadData?.channelName`), including inline `getSenderColor` calls for action messages and insight borders

**Before:** Topic channel leads (e.g. sender `web` in #web) fell through to the `#d0d0d0` gray fallback. Only `midtown` worked because it had a hardcoded entry in `AVENUE_COLORS`. All other channel leads showed gray avatars.

**After:** Any sender whose name matches the channel they're posting in gets the gold (`#E3BD3F`) avatar, consistently across the main channel, topic channels, and thread panels.

**OpsChannel.svelte** is intentionally not updated — the `ops` channel is a system log (daemon messages, GitHub events) with no "ops" channel lead sender. The channel-lead rule would never trigger there in practice.

## Test plan
- [x] `messageUtils.test.js` — 8 new tests covering the rule, case-insensitivity, fallback behavior, and override priority
- [x] All 126 tests pass (`vitest run`)
- [x] `vite build` succeeds cleanly

## Screenshots

**Before:** topic channel lead (e.g. `web` in #web) — gray avatar (#d0d0d0 fallback, same as unknown senders)

**After:** topic channel lead — gold avatar (#E3BD3F, matching #midtown and the AVENUE_COLORS.lead value)

![after: channel lead color](http://localhost:47022/api/projects/midtown/assets/channel-lead-color-1772058345.png)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)