### PR TITLE
feat(web): PR links open task thread; task description disclosure in thread header [Midtown !1829]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -330,9 +330,13 @@
       } else if (target.classList.contains('pr-link')) {
         e.preventDefault()
         const prNum = target.dataset.pr
-        const url = getPrUrl(prNum)
-        if (url) {
-          window.open(url, '_blank', 'noopener')
+        const pr = findPr(prNum)
+        const task = pr?.task_id ? findTask(pr.task_id) : null
+        if (task) {
+          openTaskThread(task, task.channel || $activeChannel)
+        } else {
+          const url = getPrUrl(prNum)
+          if (url) window.open(url, '_blank', 'noopener')
         }
       } else if (target.classList.contains('coworker-link')) {
         // Prevent the browser from following the '#' href; no detail panel action.
@@ -370,10 +374,21 @@
     // so blocking all <a> elements effectively breaks tap-to-reply on nearly every message.
     const link = target?.closest('a')
     if (link && !link.dataset.channel && !link.dataset.task && !link.dataset.pr && !link.dataset.coworker) return
-    // Task links open the task's thread (with task card); all other taps open the message thread.
+    // Task links open the task's thread (with task card); PR links open task thread or GitHub;
+    // all other taps open the message thread.
     if (link?.dataset.task) {
       const task = findTask(link.dataset.task)
       if (task) openTaskThread(task, task.channel || $activeChannel)
+    } else if (link?.dataset.pr) {
+      const prNum = link.dataset.pr
+      const pr = findPr(prNum)
+      const task = pr?.task_id ? findTask(pr.task_id) : null
+      if (task) {
+        openTaskThread(task, task.channel || $activeChannel)
+      } else {
+        const url = getPrUrl(prNum)
+        if (url) window.open(url, '_blank', 'noopener')
+      }
     } else {
       openThread(msg, $activeChannel)
     }

--- a/web-app/src/lib/TaskCard.svelte
+++ b/web-app/src/lib/TaskCard.svelte
@@ -54,6 +54,24 @@
           </span>
         {/if}
       </div>
+      {#if task.description}
+        <details class="mt-1.5">
+          <summary class="text-[0.72rem] text-muted-foreground/60 cursor-pointer select-none list-none flex items-center gap-1">
+            <span class="disclosure-triangle">▶</span>
+            <span>Description</span>
+          </summary>
+          <p class="text-[0.75rem] text-muted-foreground mt-1 whitespace-pre-wrap break-words leading-snug">
+            {task.description}
+          </p>
+        </details>
+      {/if}
     </div>
   </div>
 </div>
+
+<style>
+  details[open] .disclosure-triangle {
+    display: inline-block;
+    transform: rotate(90deg);
+  }
+</style>


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary

- **PR links → task thread**: PR #XXX links in Channel.svelte now route through task lookup on both desktop (`handleLinkClick`) and mobile (`handleMessageTap`). If the PR has a `task_id` and that task is active, clicking the link opens the task thread panel instead of navigating to GitHub. Falls back to GitHub when no task mapping exists.

- **Mobile path fixed**: Previously on mobile, tapping a PR link fell through to `openThread()` (showing the message thread, not the PR). Now it follows the same task-thread-or-GitHub logic.

- **Description disclosure in task cards**: TaskCard.svelte adds a collapsible `<details>/<summary>` section below task metadata. A CSS-rotated `▶` triangle (→ `▼` when open) reveals `task.description`. Only rendered when `task.description` is non-empty.

## Implementation notes

- No backend changes — `pr.task_id` and `task.description` are already in the API responses
- `openTaskThread()` already handles tasks without `message_id` (shows card-only thread), so the PR click path works for both old and new tasks
- The disclosure uses native HTML `<details>`/`<summary>` for zero-JS open/close behavior

## Test plan
- [ ] Click a PR link in the channel → task thread opens (not GitHub tab)
- [ ] Click a PR with no task mapping → GitHub opens in new tab
- [ ] Task card in thread header shows description toggle when description is present
- [ ] Clicking the ▶ triangle reveals description; clicking again collapses it
- [ ] Mobile: tap PR link → task thread opens (slide-in pane)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)