### PR TITLE
style(web): dark-mode-aware scrollbar styling [Midtown !1834]

### DIFF
--- a/web-app/src/app.css
+++ b/web-app/src/app.css
@@ -148,6 +148,26 @@
 
 * {
   border-color: hsl(var(--border));
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: hsl(var(--muted-foreground) / 0.3);
+  border-radius: 3px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: hsl(var(--muted-foreground) / 0.5);
 }
 
 html, body {


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Adds thin, theme-adaptive scrollbar styling to `web-app/src/app.css`
- Covers both modern CSS standard (`scrollbar-width` / `scrollbar-color` for Firefox + Chrome 121+) and WebKit vendor prefix (`::-webkit-scrollbar-*` for older Chromium/WebViews)
- Uses existing `--muted-foreground` CSS custom property with opacity, so scrollbars automatically adapt to light and dark themes with no media query needed

## Implementation notes
The CSS variables follow the shadcn bare-channels pattern (`240 3.8% 46.1%`), enabling opacity composition via `hsl(var(--muted-foreground) / 0.3)`. In dark mode `--muted-foreground` resolves to a light value; in light mode it resolves to a mid-grey — the same rule produces the right result in both themes.

## Test plan
- [x] Verify scrollbars appear thin and muted in dark mode
- [x] Verify scrollbars appear thin and muted in light mode
- [x] Verify scrollbar thumb brightens on hover

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)