### PR TITLE
feat(web): DM channels — frontend sidebar, routing, clickable coworker names [Midtown !1831]

### DIFF
--- a/web-app/src/lib/ChannelList.svelte
+++ b/web-app/src/lib/ChannelList.svelte
@@ -1,7 +1,7 @@
 <script>
   import { SvelteSet } from 'svelte/reactivity'
   import { channels, activeChannel, kanbanData, activeProject, messagesByChannel, showArchivedChannels } from './store.js'
-  import { fetchHistory, fetchChannels, getApiBase, closeThread } from './api.js'
+  import { fetchHistory, fetchChannels, getApiBase, closeThread, selectDm } from './api.js'
   import {
     getChannelTaskCount,
     getChannelCiStatus,
@@ -20,6 +20,9 @@
   $: {
     fetchChannels($showArchivedChannels)
   }
+
+  $: regularChannels = $channels.filter((ch) => !ch.is_dm)
+  $: dmChannels = $channels.filter((ch) => ch.is_dm)
 
   // Track which channels have their task lists expanded (default: collapsed)
   // Using SvelteSet for reactivity — plain Set mutations don't trigger re-renders in Svelte 5
@@ -68,6 +71,10 @@
 
   function formatChannelName(name) {
     return `#${name}`
+  }
+
+  function formatDmName(name) {
+    return `@${name.replace(/^dm-/, '')}`
   }
 
   function toggleCreateInput() {
@@ -210,7 +217,7 @@
     </div>
   {/if}
 
-  {#each $channels as channel}
+  {#each regularChannels as channel}
     {@const counts = getChannelTaskCount(channel.name, $kanbanData)}
     {@const ciStatus = getChannelCiStatus(channel.name, $kanbanData)}
     {@const isActive = $activeChannel === channel.name}
@@ -260,4 +267,29 @@
       {/if}
     </div>
   {/each}
+
+  {#if dmChannels.length > 0}
+    <div class="flex items-center px-3 pt-3 pb-1">
+      <div class="text-xs font-bold text-muted-foreground uppercase tracking-wide">Direct Messages</div>
+    </div>
+    {#each dmChannels as channel}
+      {@const isActive = $activeChannel === channel.name}
+      {@const hasUnread = channel.unread > 0}
+      <div class="mb-0.5">
+        <div class="flex items-center rounded-md {isActive ? 'bg-accent text-primary' : 'text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground'}">
+          <!-- Fixed-width gutter (no triangle for DMs — they have no tasks) -->
+          <div class="w-[28px] ml-1 shrink-0"></div>
+          <button
+            class="flex items-center flex-1 min-w-0 pl-1 pr-3 py-2 border-none bg-transparent text-sm font-mono cursor-pointer transition-all duration-150 text-left text-inherit"
+            aria-label="Open DM with {channel.name.replace(/^dm-/, '')}"
+            onclick={() => selectChannel(channel.name)}
+          >
+            <div class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap {hasUnread ? 'font-bold' : ''}">
+              {formatDmName(channel.name)}
+            </div>
+          </button>
+        </div>
+      </div>
+    {/each}
+  {/if}
 </div>

--- a/web-app/src/lib/CoworkerStatus.svelte
+++ b/web-app/src/lib/CoworkerStatus.svelte
@@ -1,6 +1,6 @@
 <script>
   import { coworkers, maxCoworkers, repoStatus, kanbanData } from './store.js'
-  import { openTaskThread } from './api.js'
+  import { openTaskThread, selectDm } from './api.js'
   import { getSenderColor } from './messageUtils.js'
   import * as Tooltip from '$lib/components/ui/tooltip/index.js'
 
@@ -84,6 +84,11 @@
               </Tooltip.Trigger>
               <Tooltip.Content side="top">{cw.name}</Tooltip.Content>
             </Tooltip.Root>
+            <button
+              class="bg-transparent border-none p-0 m-0 cursor-pointer text-inherit text-[0.75rem] font-mono hover:underline leading-none"
+              onclick={() => selectDm(cw.name)}
+              title="Open DM with {cw.name}"
+            >{cw.name}</button>
             {#if cw.phase}
               <span class="hidden text-[0.75rem] text-muted-foreground sm:inline">{cw.phase}</span>
             {/if}

--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -68,6 +68,7 @@ export async function fetchChannels(includeArchived = false) {
         has_pr: false,
         ci_status: null,
         is_archived: typeof ch === 'object' && ch.is_archived,
+        is_dm: typeof ch === 'object' && !!ch.is_dm,
       }))
       // Backend already returns channels sorted with main project channel first
       channels.set(channelList)
@@ -873,4 +874,47 @@ export function openTaskThread(task, channelName) {
 // Close the thread panel
 export function closeThread() {
   threadData.set(null)
+}
+
+// Select (or create-then-select) a DM channel for the given coworker name.
+// DM channels are named `dm-<coworkerName>` on the backend.
+// If the channel doesn't exist yet, it's created first, then selected.
+export async function selectDm(coworkerName) {
+  const channelName = `dm-${coworkerName}`
+
+  closeThread()
+
+  const currentChannels = get(channels)
+  const exists = currentChannels.some((ch) => ch.name === channelName)
+
+  if (!exists) {
+    try {
+      const res = await fetch(`${getApiBase()}/channels/create`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: channelName }),
+      })
+      if (!res.ok) {
+        const errorData = await res.json()
+        console.error('Failed to create DM channel:', errorData.error)
+        return
+      }
+      // Refresh channel list so the new DM channel appears in the sidebar
+      await fetchChannels(get(showArchivedChannels))
+    } catch (err) {
+      console.error('Failed to create DM channel:', err)
+      return
+    }
+  }
+
+  activeChannel.set(channelName)
+
+  channels.update((channelList) =>
+    channelList.map((ch) => (ch.name === channelName ? { ...ch, unread: 0 } : ch))
+  )
+
+  const currentMessages = get(messagesByChannel)[channelName]
+  if (!currentMessages || currentMessages.length === 0) {
+    fetchHistory(channelName)
+  }
 }

--- a/web-app/src/lib/api.test.js
+++ b/web-app/src/lib/api.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { get } from 'svelte/store'
-import { messagesByChannel, threadData } from './store.js'
-import { fetchHistory, handleUpdate } from './api.js'
+import { messagesByChannel, threadData, channels, activeChannel } from './store.js'
+import { fetchHistory, handleUpdate, fetchChannels, selectDm } from './api.js'
 
 describe('fetchHistory', () => {
   let originalFetch
@@ -290,5 +290,116 @@ describe('handleUpdate — optimistic message deduplication', () => {
     // Panel is for otherParentId — should be untouched
     expect(td.messages).toHaveLength(1)
     expect(td.messages[0].id).toBe('pending-reply-2')
+  })
+})
+
+describe('fetchChannels — is_dm field', () => {
+  let originalFetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    channels.set([{ name: 'midtown', unread: 0, has_pr: false, ci_status: null }])
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('propagates is_dm=true from the API response', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        channels: [
+          { name: 'midtown', is_archived: false, is_dm: false },
+          { name: 'dm-alice', is_archived: false, is_dm: true },
+        ],
+      }),
+    })
+
+    await fetchChannels()
+
+    const ch = get(channels)
+    const dmChannel = ch.find((c) => c.name === 'dm-alice')
+    expect(dmChannel).toBeTruthy()
+    expect(dmChannel.is_dm).toBe(true)
+    expect(ch.find((c) => c.name === 'midtown').is_dm).toBe(false)
+  })
+
+  it('defaults is_dm to false for string-format channels (legacy API)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ channels: ['midtown', 'other'] }),
+    })
+
+    await fetchChannels()
+
+    const ch = get(channels)
+    expect(ch.every((c) => c.is_dm === false)).toBe(true)
+  })
+})
+
+describe('selectDm', () => {
+  let originalFetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    channels.set([
+      { name: 'midtown', unread: 0, has_pr: false, ci_status: null, is_dm: false },
+      { name: 'dm-alice', unread: 3, has_pr: false, ci_status: null, is_dm: true },
+    ])
+    activeChannel.set('midtown')
+    messagesByChannel.set({ midtown: [], 'dm-alice': [{ id: 1, content: 'hey', channel: 'dm-alice' }] })
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('switches to existing DM channel without creating it', async () => {
+    const fetchMock = vi.fn()
+    globalThis.fetch = fetchMock
+
+    await selectDm('alice')
+
+    // No create call should have been made
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(get(activeChannel)).toBe('dm-alice')
+  })
+
+  it('clears the unread count when switching to a DM channel', async () => {
+    globalThis.fetch = vi.fn()
+
+    await selectDm('alice')
+
+    const ch = get(channels).find((c) => c.name === 'dm-alice')
+    expect(ch.unread).toBe(0)
+  })
+
+  it('creates the DM channel if it does not exist, then switches to it', async () => {
+    channels.set([{ name: 'midtown', unread: 0, has_pr: false, ci_status: null, is_dm: false }])
+
+    globalThis.fetch = vi.fn()
+      // First call: POST create
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      // Second call: GET fetchChannels
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          channels: [
+            { name: 'midtown', is_archived: false, is_dm: false },
+            { name: 'dm-bob', is_archived: false, is_dm: true },
+          ],
+        }),
+      })
+      // Third call: GET fetchHistory for dm-bob
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+
+    await selectDm('bob')
+
+    expect(get(activeChannel)).toBe('dm-bob')
+    // Create endpoint should have been called with the right name
+    const createCall = globalThis.fetch.mock.calls[0]
+    expect(createCall[0]).toContain('/channels/create')
+    expect(JSON.parse(createCall[1].body).name).toBe('dm-bob')
   })
 })


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- **api.js**: propagate `is_dm` field from channel list API response; add `selectDm(coworkerName)` helper that creates `dm-<name>` channel if needed, then switches to it
- **ChannelList.svelte**: split channels into regular / DM groups; render a "Direct Messages" section below the channel list with `@coworker-name` format entries (no triangle, unread bold)
- **CoworkerStatus.svelte**: coworker name rendered as a clickable `<button>` that opens/switches to the DM for that coworker

## Changes in detail

### api.js
- `fetchChannels()` now maps `is_dm` from backend `ChannelInfo` into the channels store (defaults `false` for legacy string-format responses)
- `selectDm(coworkerName)`: closes thread panel, creates `dm-<name>` channel via POST if absent, refreshes channel list, then switches `activeChannel` to the DM

### ChannelList.svelte
- `$: regularChannels` / `$: dmChannels` derived from the flat `$channels` store
- "Direct Messages" heading appears only when DM channels exist
- DM entries use `@name` format (stripping `dm-` prefix), no CI badge, no expand triangle
- Unread state uses same `font-bold` treatment as regular channels

### CoworkerStatus.svelte
- Coworker name shown as a `<button>` with `hover:underline`, no background, calls `selectDm(cw.name)` on click

## Test plan
- [x] 5 new unit tests: `is_dm` propagation (object + legacy string format), `selectDm` switching to existing channel, clearing unread, creating missing channel
- [x] All 16 api.test.js tests pass

**Note:** Backend `is_dm` field is implemented in task !1830 (madison). This PR is written to handle the field being absent (defaults to `false`) so it can be merged independently.

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)