### PR TITLE
fix(web): replace class: directive with class prop on MessageRow [Midtown !1835]

### DIFF
--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -261,7 +261,7 @@
             senderSpacing="0.8em"
             senderClass="mb-[2px]"
             channelName={$threadData?.channelName}
-            class:opacity-60={msg.pending}
+            class={msg.pending ? 'opacity-60' : ''}
           >
             {#if isAction(msg) && !hasMermaid(msg.content)}
               <div class="flex gap-0 break-words">
@@ -401,7 +401,7 @@
             senderSpacing="0.8em"
             senderClass="mb-[2px]"
             channelName={$threadData?.channelName}
-            class:opacity-60={msg.pending}
+            class={msg.pending ? 'opacity-60' : ''}
           >
             {#if isAction(msg) && !hasMermaid(msg.content)}
               <div class="flex gap-0 break-words">


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Fixes Svelte 5 build error (`component_invalid_directive`) in `ThreadPanel.svelte`
- `class:opacity-60` directives on the `MessageRow` component are invalid in Svelte 5 — class directives only work on HTML elements
- Replaced both occurrences (desktop and mobile panels) with `class={msg.pending ? 'opacity-60' : ''}` prop syntax
- `MessageRow` already accepted a `class` prop (`extraClass`) and applied it to root elements — no changes needed to that component

## Test plan
- [x] `npm run build` in `web-app/` completes with no errors
- [x] Pending messages in thread panel still render with `opacity-60` when `msg.pending` is true

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)