### PR TITLE
feat(web): DM channel header and thinking indicator polish [Midtown !1832]

### DIFF
--- a/web-app/src/App.svelte
+++ b/web-app/src/App.svelte
@@ -14,7 +14,7 @@
   import AccountPanel from '$lib/AccountPanel.svelte'
   import CelebrationEffects from '$lib/CelebrationEffects.svelte'
   import SwipeGestures from '$lib/SwipeGestures.svelte'
-  import { messages, connected, coworkers, projects, activeProject, activeChannel, activeChannelTab, threadData, isWideScreen } from '$lib/store.js'
+  import { messages, connected, coworkers, projects, activeProject, activeChannel, channels, activeChannelTab, threadData, isWideScreen } from '$lib/store.js'
   import { connectWebSocket, fetchHistory, fetchStatus, fetchProjects, switchProject } from '$lib/api.js'
   import { theme, toggleTheme } from '$lib/theme.js'
   import { Sun, Moon } from 'lucide-svelte'
@@ -29,6 +29,10 @@
 
   let activeView = $state('board') // 'board' (channel list + chat) or 'status' or 'tmux'
   let projectDropdownOpen = $state(false)
+
+  // DM channel detection for tab bar filtering
+  let activeChannelMeta = $derived($channels.find((ch) => ch.name === $activeChannel) ?? null)
+  let isActiveDm = $derived(activeChannelMeta?.is_dm ?? $activeChannel.startsWith('dm-'))
 
   function toggleProjectDropdown() {
     projectDropdownOpen = !projectDropdownOpen
@@ -180,7 +184,11 @@
           <SidebarTrigger />
           <span class="ml-2 text-sm text-muted-foreground">{$activeProject}</span>
           <div class="mobile-channel active-channel-display ml-4">
-            <span class="channel-hash">#</span>{$activeChannel}
+            {#if isActiveDm}
+              <span class="channel-hash">@</span>{$activeChannel.slice(3)}
+            {:else}
+              <span class="channel-hash">#</span>{$activeChannel}
+            {/if}
           </div>
         </header>
 
@@ -188,17 +196,19 @@
           <div class="board-content flex flex-1 min-h-0 overflow-hidden" class:thread-open-mobile={!!$threadData}>
             <div class="channel-main">
               <ChannelHeader />
-              <div class="channel-tab-bar">
-                {#each [['messages', 'Messages'], ['prs', 'PRs'], ['notes', 'Notes']] as [tab, label]}
-                  {@const isActive = ($activeChannelTab[$activeChannel] || 'messages') === tab}
-                  <button
-                    class="channel-tab"
-                    class:active={isActive}
-                    onclick={() => activeChannelTab.update((t) => ({ ...t, [$activeChannel]: tab }))}
-                  >{label}</button>
-                {/each}
-              </div>
-              {#if ($activeChannelTab[$activeChannel] || 'messages') === 'messages'}
+              {#if !isActiveDm}
+                <div class="channel-tab-bar">
+                  {#each [['messages', 'Messages'], ['prs', 'PRs'], ['notes', 'Notes']] as [tab, label]}
+                    {@const isActive = ($activeChannelTab[$activeChannel] || 'messages') === tab}
+                    <button
+                      class="channel-tab"
+                      class:active={isActive}
+                      onclick={() => activeChannelTab.update((t) => ({ ...t, [$activeChannel]: tab }))}
+                    >{label}</button>
+                  {/each}
+                </div>
+              {/if}
+              {#if isActiveDm || ($activeChannelTab[$activeChannel] || 'messages') === 'messages'}
                 <PendingQuestions />
                 <Channel />
               {:else if ($activeChannelTab[$activeChannel] || 'messages') === 'prs'}

--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { messages, messagesByChannel, activeChannel, channels, coworkers, kanbanData, repoStatus, repoStatuses, daemonStatus, isWideScreen, agentToolItems, threadData } from './store.js'
+  import { messages, messagesByChannel, activeChannel, channels as channelsStore, coworkers, kanbanData, repoStatus, repoStatuses, daemonStatus, isWideScreen, agentToolItems, threadData } from './store.js'
   import { sendMessage, uploadFile, closeThread, openThread, openTaskThread, getApiBase } from './api.js'
   import { AVENUE_COLORS, getSenderColor, isDimSender, formatTime, timeChanged, parseInsightSegments } from './messageUtils.js'
   import { tick, onMount } from 'svelte'
@@ -30,6 +30,11 @@
   let autocompletePosition = $state({ top: 0, left: 0 })
   let autocompleteSelectedIndex = $state(0)
   let autocompleteStartPos = $state(0)
+
+  // DM channel detection: use is_dm field or dm- prefix fallback
+  let activeChannelMeta = $derived($channelsStore.find((ch) => ch.name === $activeChannel) ?? null)
+  let isDm = $derived(activeChannelMeta?.is_dm ?? $activeChannel.startsWith('dm-'))
+  let dmPeerName = $derived($activeChannel.startsWith('dm-') ? $activeChannel.slice(3) : $activeChannel)
 
   // Filter messages by active channel
   let channelMessages = $derived($messagesByChannel[$activeChannel] || [])
@@ -142,7 +147,7 @@
         title: pr.title,
         status: pr.status
       }))
-      const channelList = $channels.map(ch => ({
+      const channelList = $channelsStore.map(ch => ({
         type: 'channel',
         name: ch.name
       }))
@@ -317,7 +322,7 @@
       if (target.classList.contains('channel-link')) {
         e.preventDefault()
         const channelName = target.dataset.channel
-        if ($channels.some((ch) => ch.name === channelName)) {
+        if ($channelsStore.some((ch) => ch.name === channelName)) {
           activeChannel.set(channelName)
         }
       } else if (target.classList.contains('task-link')) {
@@ -636,8 +641,8 @@
   >
       {#if channelMessages.length === 0}
         <div class="text-center text-muted-foreground py-[50px] px-[22px] font-sans">
-          <p>No messages in #{$activeChannel}</p>
-          <p class="text-[0.9rem] mt-[10px]">Messages posted to this channel will appear here</p>
+          <p>No messages {isDm ? `with @${dmPeerName}` : `in #${$activeChannel}`}</p>
+          <p class="text-[0.9rem] mt-[10px]">{isDm ? `Send a message to start a conversation` : `Messages posted to this channel will appear here`}</p>
         </div>
       {:else}
         {#each channelMessages as msg, i}
@@ -758,7 +763,7 @@
           <span class="dot w-[5px] h-[5px] rounded-full" style="background-color: {AVENUE_COLORS.lead}"></span>
         </span>
       {/if}
-      <span class="font-mono font-semibold" style="color: {AVENUE_COLORS.lead}">{$activeChannel}</span>
+      <span class="font-mono font-semibold" style="color: {AVENUE_COLORS.lead}">{isDm ? `@${dmPeerName}` : $activeChannel}</span>
       {#if mostRecentToolCallEntry}
         <span class="text-muted-foreground/60 select-none">{getToolCallStatusIcon(mostRecentToolCallEntry)}</span>
         <span class="font-mono text-muted-foreground truncate">{describeToolCall(mostRecentToolCallEntry)}</span>
@@ -818,7 +823,7 @@
           data-testid="channel-input"
           bind:this={textareaElement}
           bind:value={inputText}
-          placeholder="Message to #{$activeChannel}..."
+          placeholder={isDm ? `Message @${dmPeerName}...` : `Message to #${$activeChannel}...`}
           rows="1"
           class="flex-1 py-[13px] px-[17px] border-2 border-border rounded-[18px] bg-card text-foreground text-[1.02rem] font-inherit outline-none resize-none min-h-[1.6em] max-h-[9em] overflow-y-auto focus:border-primary placeholder:text-muted-foreground"
           onkeydown={handleKeyDown}

--- a/web-app/src/lib/ChannelHeader.svelte
+++ b/web-app/src/lib/ChannelHeader.svelte
@@ -1,10 +1,15 @@
 <script>
   import { onDestroy } from 'svelte'
   import { fade } from 'svelte/transition'
-  import { activeChannel, kanbanData, daemonStatus, repoStatus, repoStatuses } from './store.js'
+  import { activeChannel, channels, kanbanData, daemonStatus, repoStatus, repoStatuses } from './store.js'
   import { formatRelativeTime } from './utils.js'
 
   let isMultiRepo = $derived($repoStatuses.length > 1)
+
+  // DM channel detection: use is_dm field from store, or dm- name prefix as fallback
+  let activeChannelMeta = $derived($channels.find((ch) => ch.name === $activeChannel) ?? null)
+  let isDm = $derived(activeChannelMeta?.is_dm ?? $activeChannel.startsWith('dm-'))
+  let dmPeerName = $derived($activeChannel.startsWith('dm-') ? $activeChannel.slice(3) : $activeChannel)
 
   function ciInfo(status) {
     switch (status) {
@@ -86,8 +91,14 @@
   <div class="flex items-center justify-between px-4 py-2">
     <!-- Left: channel name -->
     <div class="flex items-baseline gap-1 shrink-0">
-      <span class="text-[1.2rem] text-muted-foreground font-bold">#</span>
-      <span class="text-[1.1rem] font-bold font-mono text-foreground">{$activeChannel}</span>
+      {#if isDm}
+        <span class="text-[1.2rem] text-muted-foreground font-bold">@</span>
+        <span class="text-[1.1rem] font-bold font-mono text-foreground">{dmPeerName}</span>
+        <span class="text-[0.7rem] text-muted-foreground font-normal ml-1">Direct Message</span>
+      {:else}
+        <span class="text-[1.2rem] text-muted-foreground font-bold">#</span>
+        <span class="text-[1.1rem] font-bold font-mono text-foreground">{$activeChannel}</span>
+      {/if}
     </div>
 
     <!-- Center: just-merged banner (fades out after 5 min) -->

--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -68,7 +68,7 @@ export async function fetchChannels(includeArchived = false) {
         has_pr: false,
         ci_status: null,
         is_archived: typeof ch === 'object' && ch.is_archived,
-        is_dm: typeof ch === 'object' && !!ch.is_dm,
+        is_dm: typeof ch === 'object' ? ch.is_dm : (typeof ch === 'string' && ch.startsWith('dm-')),
       }))
       // Backend already returns channels sorted with main project channel first
       channels.set(channelList)


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- **ChannelHeader**: shows `@name` + "Direct Message" subtitle for DM channels instead of `#dm-name`
- **Channel**: activity strip, empty state, and input placeholder use `@peer` format for DM channels
- **App**: hides PRs/Notes tab bar entirely for DM channels; forces Messages view
- **App**: mobile header shows `@name` for DM channels
- **api.js**: propagates `is_dm` field from backend channel response

## Implementation notes
DM detection uses the `is_dm` flag (from !1830 backend work) with `dm-` prefix as a fallback. This means the polish is forward-compatible — it works correctly as soon as the DM channel name convention is in use, even before the backend flag lands.

## Dependencies
This is the polish layer for the DM feature. It depends on:
- !1830 (Rust backend — adds `is_dm` to ChannelInfo, message routing)
- !1831 (Frontend channels — adds DM section to sidebar, `selectDm()` helper)

The frontend changes here are self-contained and safe to review/land independently.

## Test plan
- [ ] Navigate to a `dm-<coworker>` channel — header shows `@coworker` with "Direct Message" label
- [ ] Activity strip shows `@coworker is thinking...` (not `#dm-coworker`)
- [ ] Input placeholder says `Message @coworker...`
- [ ] Tab bar is hidden for DM channels; only the messages view is shown
- [ ] Regular channels (`#midtown`, `#web`, etc.) are unaffected

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)