### PR TITLE
fix(web): initialize lastSeenActive on first-seen-idle for page reload grace period [Midtown !1836]

### DIFF
--- a/web-app/src/lib/CoworkerStatus.svelte
+++ b/web-app/src/lib/CoworkerStatus.svelte
@@ -30,9 +30,11 @@
   }
 
   // Record last-active timestamp whenever a coworker is in a non-idle state.
+  // On first sight of an idle coworker (e.g. after page reload), initialize to now
+  // so they get the full 10-minute grace window instead of disappearing immediately.
   $effect(() => {
     for (const cw of $coworkers) {
-      if (!isIdleOrStopped(cw)) {
+      if (!isIdleOrStopped(cw) || !lastSeenActive.has(cw.name)) {
         lastSeenActive.set(cw.name, Date.now())
       }
     }


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary

Follow-up to PR #1566 (merged). Fixes a P2 bug flagged by park in code review: idle coworkers disappear immediately after page reload because `lastSeenActive` starts as an empty Map.

**Root cause:** The `$effect` only recorded timestamps for non-idle coworkers. On first load, idle coworkers had no map entry → `seen === undefined` → grace-period filter returned `false` → immediate disappearance.

**Fix:** Changed the condition to also initialize idle coworkers when first encountered (no existing entry). The `||` short-circuit preserves existing behavior — once an entry exists, subsequent idle states don't overwrite it, so the 10-min countdown runs from the actual last-active time.

```diff
- if (!isIdleOrStopped(cw)) {
+ if (!isIdleOrStopped(cw) || !lastSeenActive.has(cw.name)) {
```

## Test plan
- [ ] Page reload: idle coworkers remain visible for up to 10 minutes after reload
- [ ] Coworker that goes idle after being active: grace period counts from actual last-active time, not from reload
- [ ] Coworker that was idle before the 10-min window: disappears correctly after window expires

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)