### PR TITLE
feat(code-review): fetch existing reviews before starting review passes [Midtown !1837]

### DIFF
--- a/.codex/skills/code-review/SKILL.md
+++ b/.codex/skills/code-review/SKILL.md
@@ -95,7 +95,7 @@ Before reviewing, fetch all existing review comments so you don't duplicate find
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 
 # Inline review comments (line-level, from Codex or other reviewers)
-gh api "repos/$REPO/pulls/<PR_NUMBER>/comments" \
+gh api --paginate "repos/$REPO/pulls/<PR_NUMBER>/comments" \
   --jq '.[] | "[\(.user.login) on \(.path):\(.line // .original_line)]: \(.body)"'
 
 # Top-level review bodies (summary reviews with optional state)
@@ -103,7 +103,7 @@ gh pr view <PR_NUMBER> --json reviews \
   --jq '.reviews[] | select(.body != "") | "[\(.author.login) (\(.state))]: \(.body)"'
 
 # Issue comments (coworker reviews posted as PR comments with <!-- midtown: --> frontmatter)
-gh api "repos/$REPO/issues/<PR_NUMBER>/comments" \
+gh api --paginate "repos/$REPO/issues/<PR_NUMBER>/comments" \
   --jq '.[] | select(.body | contains("<!-- midtown:") or startswith("## Code Review")) | "[\(.user.login)]: \(.body[:500])"'
 ```
 


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Adds Step 3b to the code-review skill to fetch existing inline comments, top-level review bodies, and coworker PR comments before review passes begin
- Inline comments are fetched via the GitHub REST API (`pulls/<PR>/comments`)
- Top-level review summaries are fetched via `gh pr view --json reviews`
- Coworker comment-based reviews (containing `<!-- midtown:` or starting with `## Code Review`) are fetched via the issues comments API
- Step 4 now opens with a note to acknowledge existing findings rather than duplicating them

## Motivation
Reviewers were blind to Codex inline comments and prior reviewer findings. For example, on PR #1566 Codex posted a P2 inline comment about the grace period on page reload, but the subsequent reviewer didn't reference it at all.

## Test plan
- [ ] Review a PR that has existing Codex inline comments — verify the new step surfaces them before the review passes run
- [ ] Review a PR that has coworker comment-based reviews — verify they are fetched and acknowledged

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)