### PR TITLE
feat: DM channel backend — is_dm, routing, WakeReason::DmFromUser [Midtown !1830]

### DIFF
--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -4774,10 +4774,12 @@ pub(super) mod tests {
                 midtown::ChannelInfo {
                     name: "features".to_string(),
                     is_archived: false,
+                    is_dm: false,
                 },
                 midtown::ChannelInfo {
                     name: "midtown".to_string(),
                     is_archived: false,
+                    is_dm: false,
                 },
             ],
             ..test_app()

--- a/src/bin/midtown/cli/chat/mod.rs
+++ b/src/bin/midtown/cli/chat/mod.rs
@@ -2344,10 +2344,12 @@ mod tests {
             ChannelInfo {
                 name: "midtown".to_string(),
                 is_archived: false,
+                is_dm: false,
             },
             ChannelInfo {
                 name: "feature-x".to_string(),
                 is_archived: false,
+                is_dm: false,
             },
         ];
         app.tasks = vec![
@@ -2441,6 +2443,7 @@ mod tests {
         app.available_channels = vec![ChannelInfo {
             name: "midtown".to_string(),
             is_archived: false,
+            is_dm: false,
         }];
         app.tasks = vec![KanbanTask {
             id: "1".to_string(),
@@ -2675,6 +2678,7 @@ mod tests {
         app.available_channels = vec![ChannelInfo {
             name: "midtown".to_string(),
             is_archived: false,
+            is_dm: false,
         }];
         app.tasks = vec![KanbanTask {
             id: "1".to_string(),

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -21,6 +21,8 @@ pub struct ChannelInfo {
     pub name: String,
     /// Whether this channel is archived
     pub is_archived: bool,
+    /// Whether this is a direct-message channel (name starts with "dm-")
+    pub is_dm: bool,
 }
 
 /// A channel for agent communication.
@@ -476,6 +478,7 @@ impl Channel {
                     .or_insert(ChannelInfo {
                         name: channel_name.clone(),
                         is_archived,
+                        is_dm: channel_name.starts_with("dm-"),
                     });
                 if is_archived {
                     entry.is_archived = true;

--- a/src/channel_tests.rs
+++ b/src/channel_tests.rs
@@ -1682,3 +1682,36 @@ fn test_rename_channel_rejects_avenue_name() {
         err
     );
 }
+
+#[test]
+fn test_channel_info_is_dm_true_for_dm_prefix() {
+    let temp_dir = TempDir::new().unwrap();
+
+    // Create a DM channel and a regular channel
+    Channel::new(temp_dir.path(), "dm-madison").unwrap();
+    Channel::new(temp_dir.path(), "midtown").unwrap();
+    Channel::new(temp_dir.path(), "feature-x").unwrap();
+
+    let channels = Channel::list(temp_dir.path(), false, None).unwrap();
+
+    let dm_channel = channels.iter().find(|c| c.name == "dm-madison").unwrap();
+    assert!(dm_channel.is_dm, "dm-madison should have is_dm=true");
+
+    let midtown = channels.iter().find(|c| c.name == "midtown").unwrap();
+    assert!(!midtown.is_dm, "midtown should have is_dm=false");
+
+    let feature = channels.iter().find(|c| c.name == "feature-x").unwrap();
+    assert!(!feature.is_dm, "feature-x should have is_dm=false");
+}
+
+#[test]
+fn test_channel_info_is_dm_only_with_dm_prefix() {
+    let temp_dir = TempDir::new().unwrap();
+
+    // Create a channel that starts with "dm" but without the dash — should NOT be is_dm
+    Channel::new(temp_dir.path(), "dmz").unwrap();
+
+    let channels = Channel::list(temp_dir.path(), false, None).unwrap();
+    let dmz = channels.iter().find(|c| c.name == "dmz").unwrap();
+    assert!(!dmz.is_dm, "channel 'dmz' (no dash) should not be is_dm");
+}

--- a/src/daemon/rpc_channel.rs
+++ b/src/daemon/rpc_channel.rs
@@ -141,6 +141,30 @@ pub(super) async fn handle_channel_post(
     // Use provided channel or default to main channel
     let channel_name = channel.unwrap_or_else(|| state.channel_router.default_channel_name());
 
+    // Validate DM channels: ensure the target coworker is an active session.
+    // This prevents posting to dm-<unknown> channels that have no one to receive the message.
+    if state.is_user_sender(from)
+        && let Some(coworker_name) = channel_name.strip_prefix("dm-")
+    {
+        let is_active = state
+            .name_to_session
+            .lock()
+            .unwrap()
+            .contains_key(coworker_name);
+        if !is_active {
+            return Response::error(
+                id,
+                RpcError::new(
+                    -32602,
+                    format!(
+                        "Cannot send DM to '{}': no active session found for this coworker",
+                        coworker_name
+                    ),
+                ),
+            );
+        }
+    }
+
     // Task 3: Output binding — if the sender is a forked topic session with a bound
     // thread, auto-apply the bound thread_parent_id so their posts appear in the
     // correct thread without the session needing to pass it explicitly.
@@ -187,11 +211,38 @@ pub(super) async fn handle_channel_post(
     // Nudge lead when user messages arrive (from web UI or TUI input)
     if state.is_user_sender(from) {
         let default_channel = state.channel_router.default_channel_name();
+        let is_dm_channel = channel_name.starts_with("dm-");
         let is_topic_channel = channel_name != default_channel;
 
         let wake_msg_id = msg.thread_anchor_id().to_string();
 
-        if is_topic_channel {
+        if is_dm_channel {
+            // DM channel: nudge the specific coworker directly instead of the channel lead.
+            // We already validated the coworker is active above, so this lookup should succeed.
+            let coworker_name = &channel_name["dm-".len()..];
+            let session_id = state
+                .name_to_session
+                .lock()
+                .unwrap()
+                .get(coworker_name)
+                .cloned();
+            if let Some(session_id) = session_id {
+                let nudge_effect = crate::daemon::effects::Effect::NudgeSession {
+                    session_id,
+                    reason: crate::daemon::wake_reason::WakeReason::DmFromUser {
+                        content: content.clone(),
+                        msg_id: wake_msg_id,
+                        coworker_name: coworker_name.to_string(),
+                    },
+                };
+                crate::daemon::effects::execute_effects(vec![nudge_effect], state).await;
+            } else {
+                warn!(
+                    "channel.post: DM to dm-{} but session lookup failed after validation passed",
+                    coworker_name
+                );
+            }
+        } else if is_topic_channel {
             // Task 2: Thread-aware routing — if there's a forked topic session for
             // this thread, route directly to it instead of the channel lead.
             // This lets thread-specific forks handle their own conversation slice

--- a/src/daemon/rpc_channel_tests.rs
+++ b/src/daemon/rpc_channel_tests.rs
@@ -1647,3 +1647,147 @@ async fn test_channel_rename_reserved_avenue_name() {
         "renaming to a reserved avenue name should return an error"
     );
 }
+
+// ── DM channel routing tests ──────────────────────────────────────────────────
+
+/// Posting to dm-<coworker> when no active session exists returns an error.
+/// The channel directory is NOT created when validation fails.
+#[tokio::test]
+async fn test_dm_post_unknown_coworker_returns_error() {
+    let (state, _tmp, _guard) = make_test_state("midtown-test-dm-unknown-coworker");
+
+    // "york" has no entry in name_to_session — it's not an active coworker
+    let response = handle_channel_post(
+        1_i64.into(),
+        "user",
+        "Are you there?",
+        Some("dm-york"),
+        None,
+        &state,
+    )
+    .await;
+
+    assert!(
+        response.error.is_some(),
+        "posting to dm- channel with unknown coworker should return an error"
+    );
+    let err_msg = response.error.unwrap().message;
+    assert!(
+        err_msg.contains("york"),
+        "error should mention the unknown coworker name, got: {}",
+        err_msg
+    );
+}
+
+/// Posting to dm-<coworker> when a session is active routes via NudgeSession
+/// (not NudgeChannelLead), so the lead is NOT nudged.
+///
+/// Since `NudgeSession` fails gracefully when the headless session isn't live
+/// in tests, we verify the lead adapter receives NO messages (DM path was taken).
+#[tokio::test]
+async fn test_dm_post_active_coworker_does_not_nudge_lead() {
+    let (state, _tmp, _guard) = make_test_state("midtown-test-dm-active-coworker");
+
+    // Register the lead's headed adapter so we can verify it gets no nudge
+    let adapter_id = "test-dm-adapter";
+    state
+        .headed_register(
+            &state.repo_name,
+            adapter_id,
+            crate::auth::AuthProvider::Claude,
+        )
+        .await
+        .expect("register headed adapter");
+
+    // Register "amsterdam" as an active coworker in name_to_session
+    let coworker_session_id = "session-amsterdam-xyz";
+    state
+        .name_to_session
+        .lock()
+        .unwrap()
+        .insert("amsterdam".to_string(), coworker_session_id.to_string());
+
+    // User posts a DM to amsterdam
+    let response = handle_channel_post(
+        1_i64.into(),
+        "user",
+        "Hey amsterdam, can you help?",
+        Some("dm-amsterdam"),
+        None,
+        &state,
+    )
+    .await;
+    assert!(
+        response.error.is_none(),
+        "DM to active coworker should succeed"
+    );
+
+    // Lead should NOT be nudged — the DM was routed to the coworker's session
+    let (messages, _capture) = state
+        .headed_poll(&state.repo_name, adapter_id, 0, 10)
+        .await
+        .expect("poll headed queue");
+    assert!(
+        messages.is_empty(),
+        "Lead should not receive nudge when user sends DM to an active coworker"
+    );
+}
+
+/// A non-user sender posting to a dm- channel goes through normally
+/// without validation (DM validation only applies to user senders).
+#[tokio::test]
+async fn test_dm_post_from_coworker_is_not_blocked() {
+    let (state, _tmp, _guard) = make_test_state("midtown-test-dm-coworker-sender");
+
+    // Register the lead's headed adapter
+    let adapter_id = "test-dm-coworker-adapter";
+    state
+        .headed_register(
+            &state.repo_name,
+            adapter_id,
+            crate::auth::AuthProvider::Claude,
+        )
+        .await
+        .expect("register headed adapter");
+
+    // "amsterdam" posts to their own DM channel (replying to user)
+    // No session registered — but coworker senders skip DM validation
+    let response = handle_channel_post(
+        1_i64.into(),
+        "amsterdam",
+        "Sure, I can help with that!",
+        Some("dm-amsterdam"),
+        None,
+        &state,
+    )
+    .await;
+    assert!(
+        response.error.is_none(),
+        "Coworker posting to their own dm- channel should not be blocked"
+    );
+}
+
+/// Verify the DmFromUser wake reason encodes the correct reply instruction
+/// for a channel.post to a dm- channel.
+#[test]
+fn test_dm_from_user_wake_reason_reply_instruction() {
+    let reason = crate::daemon::wake_reason::WakeReason::DmFromUser {
+        content: "Can you look at the tests?".to_string(),
+        msg_id: "msg-dm-xyz".to_string(),
+        coworker_name: "amsterdam".to_string(),
+    };
+    let msg = reason.to_nudge_message();
+    assert!(msg.contains("msg-dm-xyz"), "should include msg_id");
+    assert!(
+        msg.contains("Can you look at the tests?"),
+        "should include message content"
+    );
+    assert!(
+        msg.contains("--channel dm-amsterdam"),
+        "reply instruction should reference the coworker's DM channel"
+    );
+    assert!(
+        msg.contains("midtown channel post"),
+        "reply instruction should include the midtown command"
+    );
+}

--- a/src/daemon/wake_reason.rs
+++ b/src/daemon/wake_reason.rs
@@ -40,6 +40,15 @@ pub enum WakeReason {
     },
     /// Generic nudge (freeform message).
     Nudge { message: String },
+
+    // ── DM triggers ────────────────────────────────────────────────────
+    /// A direct message was sent to this coworker via their dm-<name> channel.
+    DmFromUser {
+        content: String,
+        msg_id: String,
+        /// The coworker's own name, used to format the reply instruction.
+        coworker_name: String,
+    },
 }
 
 impl WakeReason {
@@ -107,6 +116,16 @@ impl WakeReason {
                 format!("{from} mentioned you ({msg_id}): {content}")
             }
             Self::Nudge { message } => message.clone(),
+            Self::DmFromUser {
+                content,
+                msg_id,
+                coworker_name,
+            } => {
+                format!(
+                    "user ({msg_id}): {content}\n\n\
+                     Reply with: midtown channel post \"...\" --channel dm-{coworker_name}"
+                )
+            }
         }
     }
 

--- a/src/daemon/wake_reason_tests.rs
+++ b/src/daemon/wake_reason_tests.rs
@@ -124,3 +124,36 @@ fn nudge_passthrough() {
     let msg = reason.to_nudge_message();
     assert!(msg.contains("Check PR #99"));
 }
+
+#[test]
+fn dm_from_user_nudge_message_contains_content_and_reply_instruction() {
+    let reason = WakeReason::DmFromUser {
+        content: "Hey, can you check the auth module?".to_string(),
+        msg_id: "msg-dm-001".to_string(),
+        coworker_name: "madison".to_string(),
+    };
+    let msg = reason.to_nudge_message();
+    assert!(msg.contains("msg-dm-001"), "should contain msg_id");
+    assert!(
+        msg.contains("Hey, can you check the auth module?"),
+        "should contain message content"
+    );
+    assert!(
+        msg.contains("--channel dm-madison"),
+        "should include reply channel instruction"
+    );
+}
+
+#[test]
+fn dm_from_user_nudge_message_reply_instruction_uses_coworker_name() {
+    let reason = WakeReason::DmFromUser {
+        content: "quick question".to_string(),
+        msg_id: "msg-dm-002".to_string(),
+        coworker_name: "amsterdam".to_string(),
+    };
+    let msg = reason.to_nudge_message();
+    assert!(
+        msg.contains("dm-amsterdam"),
+        "reply instruction should reference the coworker's DM channel"
+    );
+}

--- a/src/web.rs
+++ b/src/web.rs
@@ -449,8 +449,24 @@ fn validate_channel_name_for_history(
 /// - Be non-empty
 /// - Contain only alphanumeric characters, hyphens, and underscores
 /// - Not be "midtown" (reserved for the main channel)
+///
+/// DM channels (`dm-<coworker>`) are explicitly allowed. The coworker suffix must
+/// be non-empty and contain only alphanumeric characters and hyphens.
 fn validate_channel_name(name: &str) -> Result<(), (StatusCode, axum::Json<serde_json::Value>)> {
     validate_channel_name_for_history(name)?;
+
+    // DM channels (dm-<coworker>) are allowed — validate the coworker suffix.
+    if let Some(coworker) = name.strip_prefix("dm-") {
+        if coworker.is_empty() || !coworker.chars().all(|c| c.is_alphanumeric() || c == '-') {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                axum::Json(serde_json::json!({
+                    "error": "DM channel name must be 'dm-<coworker>' where coworker contains only alphanumeric characters and hyphens"
+                })),
+            ));
+        }
+        return Ok(());
+    }
 
     if name == "midtown" {
         return Err((

--- a/src/web_tests.rs
+++ b/src/web_tests.rs
@@ -847,3 +847,42 @@ fn test_validate_channel_name_for_history_allows_valid_names() {
     assert!(validate_channel_name_for_history("auth_refactor").is_ok());
     assert!(validate_channel_name_for_history("midtown").is_ok());
 }
+
+#[test]
+fn test_validate_channel_name_allows_dm_channels() {
+    // DM channels with valid coworker names should pass
+    assert!(
+        validate_channel_name("dm-madison").is_ok(),
+        "dm-madison should be a valid channel name"
+    );
+    assert!(
+        validate_channel_name("dm-amsterdam").is_ok(),
+        "dm-amsterdam should be valid"
+    );
+    assert!(
+        validate_channel_name("dm-channel-lead").is_ok(),
+        "dm-channel-lead (hyphenated coworker name) should be valid"
+    );
+}
+
+#[test]
+fn test_validate_channel_name_rejects_invalid_dm_channels() {
+    // dm- with empty suffix is invalid
+    assert!(
+        validate_channel_name("dm-").is_err(),
+        "dm- with empty coworker suffix should be invalid"
+    );
+    // dm- with underscore in coworker name is invalid (coworker names are alphanumeric/hyphens only)
+    assert!(
+        validate_channel_name("dm-foo_bar").is_err(),
+        "dm-foo_bar with underscore in suffix should be invalid"
+    );
+}
+
+#[test]
+fn test_validate_channel_name_still_rejects_midtown() {
+    assert!(
+        validate_channel_name("midtown").is_err(),
+        "midtown should still be rejected as a reserved channel name"
+    );
+}


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary

Adds backend support for DM channels with coworkers:

- **`ChannelInfo.is_dm`**: New boolean field (derived from `name.starts_with("dm-")`) included in `GET /api/channels` so the frontend can identify DM channels without string matching
- **`WakeReason::DmFromUser`**: New variant that formats a reply instruction pointing to `--channel dm-{coworker_name}` so the coworker knows where to reply
- **Validation carve-out**: `validate_channel_name` now explicitly allows `dm-<coworker>` write operations while rejecting malformed suffixes (empty, underscore)
- **DM routing in `handle_channel_post`**: When a user posts to `dm-*`, the handler:
  1. Validates the coworker has an active session (returns useful error if not)
  2. Uses `NudgeSession` + `WakeReason::DmFromUser` to route directly to that coworker's session instead of `NudgeChannelLead`
- **Auto-create**: DM channel directories are created on first message via the existing `Channel::new()` behavior (no special handling needed)

## Test plan

- [x] `test_channel_info_is_dm_true_for_dm_prefix` — `dm-*` channels have `is_dm=true`
- [x] `test_channel_info_is_dm_only_with_dm_prefix` — `dmz` (no dash) is not a DM
- [x] `test_validate_channel_name_allows_dm_channels` — valid DM names pass write validation
- [x] `test_validate_channel_name_rejects_invalid_dm_channels` — `dm-` and `dm-foo_bar` rejected
- [x] `test_validate_channel_name_still_rejects_midtown` — reserved names unchanged
- [x] `test_dm_from_user_nudge_message_*` — `WakeReason::DmFromUser` formats correct reply instruction
- [x] `test_dm_post_unknown_coworker_returns_error` — inactive coworker returns 400-style error
- [x] `test_dm_post_active_coworker_does_not_nudge_lead` — lead NOT nudged when routing to DM
- [x] `test_dm_post_from_coworker_is_not_blocked` — coworkers can post to their own DM channel

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)