### PR TITLE
fix(web): use SvelteMap so lastSeenActive initialization triggers immediate UI update [Midtown !1836]

### DIFF
--- a/web-app/src/lib/CoworkerStatus.svelte
+++ b/web-app/src/lib/CoworkerStatus.svelte
@@ -1,5 +1,6 @@
 <script>
-  import { onMount, onDestroy } from 'svelte'
+  import { onMount, onDestroy, untrack } from 'svelte'
+  import { SvelteMap } from 'svelte/reactivity'
   import { coworkers, maxCoworkers, repoStatus, kanbanData } from './store.js'
   import { openTaskThread, selectDm } from './api.js'
   import { getSenderColor } from './messageUtils.js'
@@ -7,8 +8,10 @@
 
   const OFFLINE_GRACE_MS = 10 * 60 * 1000
 
-  // Map of coworker name → timestamp of last seen active (not $state; read via `now` tick)
-  let lastSeenActive = new Map()
+  // Map of coworker name → timestamp of last seen active.
+  // SvelteMap so that .set() invalidates $derived(activeCoworkers) immediately,
+  // rather than waiting up to 30s for the `now` tick.
+  let lastSeenActive = new SvelteMap()
   let now = $state(Date.now())
   let interval
 
@@ -32,9 +35,11 @@
   // Record last-active timestamp whenever a coworker is in a non-idle state.
   // On first sight of an idle coworker (e.g. after page reload), initialize to now
   // so they get the full 10-minute grace window instead of disappearing immediately.
+  // untrack() prevents reading lastSeenActive.has() from making the map a $effect
+  // dependency (which would re-trigger the effect on every map mutation).
   $effect(() => {
     for (const cw of $coworkers) {
-      if (!isIdleOrStopped(cw) || !lastSeenActive.has(cw.name)) {
+      if (!isIdleOrStopped(cw) || untrack(() => !lastSeenActive.has(cw.name))) {
         lastSeenActive.set(cw.name, Date.now())
       }
     }


### PR DESCRIPTION
## Summary

Follow-up to PR #1570 (merged). Addresses the Codex P2 review comment: plain `Map` mutations in `$effect` don't invalidate `$derived`, so idle coworkers would stay hidden for up to 30s after page reload (until the `now` tick fired).

**Changes:**
- Switch `lastSeenActive` from plain `Map` to `SvelteMap` (`svelte/reactivity`) so `.set()` immediately invalidates `$derived(activeCoworkers)` — idle coworkers appear instantly on reload rather than after a 30s delay
- Use `untrack()` when reading `.has()` inside `$effect` to prevent the map from becoming an effect dependency (which would re-trigger the effect on every map mutation)

`SvelteMap` is already used in `ChannelList.svelte` for the same reason — plain `Set`/`Map` mutations don't trigger re-renders in Svelte 5.

## Test plan
- [ ] Page reload with idle coworkers: they appear immediately (not after 30s delay)
- [ ] No infinite reactive loops (effect only re-runs when `$coworkers` changes, not on every map write)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)