### PR TITLE
feat(daemon): embed review content in PR feedback nudge [Midtown !1838]

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -306,6 +306,8 @@ Nudge decisions are made in `src/rules.rs` (`decide_interrupt_nudges`, `decide_p
 - **Project Lead nudges**: Delivered through headed intercom queues (`headed.register/poll/ack`) with tmux fallback
 - **Coworker nudges**: JSON streaming via `SessionManager` for headless sessions
 
+**Review content embedding**: PR feedback nudges (GreenWithFeedback, ReviewComplete, ChangesRequested, Approved, ReviewComment) embed the full review body inline via `format_review_content()` in `helpers.rs`. This fetches both formal GitHub reviews and Midtown coworker issue-comment reviews (detected by `text_contains_review_signature()`), so the nudged coworker sees all feedback without running extra `gh` commands. On the polling path (`poll_prs_for_issues`), review content is pre-fetched in bulk before decision functions to keep I/O out of the decision phase. Webhook handlers call `fetch_review_content()` directly since they're already event-driven I/O paths.
+
 ## Mailbox Messaging
 
 In addition to the shared channel, the daemon can deliver targeted messages to individual coworkers via the Claude Code agent teams mailbox protocol. Messages are written as JSON to `~/.claude/teams/{team-name}/inboxes/{agent-name}.json` using atomic file operations with mkdir-based locking for safe concurrent access.

--- a/src/daemon/helpers.rs
+++ b/src/daemon/helpers.rs
@@ -431,8 +431,14 @@ pub fn get_issue_action(issue_type: PrIssueType) -> &'static str {
 /// Check if text contains a coworker review signature.
 ///
 /// Coworker reviews are identified by:
-/// - The "🤖 Reviewed by" or "Reviewed by" signature (legacy formal reviews)
+/// - The "🤖 Reviewed by" signature (legacy formal reviews)
+/// - "Reviewed by" (case-sensitive, capital R) anywhere in the text
 /// - The "# Code Review by" header at any heading level (case-insensitive)
+///
+/// The "Reviewed by" check is case-sensitive (capital R) which avoids false
+/// positives on prose like "This was reviewed by the security team" where
+/// "reviewed" is lowercase. The capital-R form is only used deliberately in
+/// review signatures (e.g., "LGTM! Reviewed by york", "Reviewed by lexington").
 ///
 /// Note: We do NOT check for "<!-- midtown:" frontmatter alone, as ALL coworker
 /// GitHub comments include this frontmatter. Checking for it would cause false

--- a/src/daemon/helpers_tests.rs
+++ b/src/daemon/helpers_tests.rs
@@ -609,6 +609,29 @@ fn review_signature_requires_review_header_with_frontmatter() {
     ));
 }
 
+#[test]
+fn review_signature_rejects_lowercase_reviewed_by() {
+    // Lowercase "reviewed by" in prose should NOT match — the case-sensitive check
+    // for "Reviewed by" (capital R) prevents false positives from natural English.
+    assert!(!text_contains_review_signature(
+        "This change was reviewed by the platform team last week."
+    ));
+    assert!(!text_contains_review_signature(
+        "The code was reviewed by security before release."
+    ));
+}
+
+#[test]
+fn review_signature_matches_capital_reviewed_by_anywhere() {
+    // "Reviewed by" with capital R is a deliberate signature and should match
+    // regardless of position in the text (start of line, mid-line after "!", etc.)
+    assert!(text_contains_review_signature(
+        "Some intro text\nReviewed by lexington\nFooter"
+    ));
+    assert!(text_contains_review_signature("  Reviewed by madison"));
+    assert!(text_contains_review_signature("LGTM! Reviewed by york"));
+}
+
 // -------------------------------------------------------------------------
 // @mention extraction
 // -------------------------------------------------------------------------

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -859,13 +859,24 @@ pub(super) async fn poll_prs_for_issues(
             // with the agent who has full context of the PR and review feedback.
             use crate::rules::decide_pr_issue_action_with_handoff;
 
+            // Embed review content for issue types that involve review feedback.
+            // ChangesRequested/Approved carry a formal review; the coworker needs
+            // to see what was said without running extra `gh` commands.
+            let review_content = match issue_type {
+                PrIssueType::ChangesRequested | PrIssueType::Approved => {
+                    fetch_review_content(pr_number).await
+                }
+                _ => None,
+            };
+
             // Format the nudge message
             let message = format!(
-                "PR #{} ({}) - {}: {}",
+                "PR #{} ({}) - {}: {}{}",
                 pr_number,
                 truncate_str(title, 40),
                 issue_type,
-                get_issue_action(issue_type)
+                get_issue_action(issue_type),
+                review_content.as_deref().unwrap_or("")
             );
 
             // Extract all decision context from persistent state in one lock
@@ -899,10 +910,7 @@ pub(super) async fn poll_prs_for_issues(
             .await,
     );
 
-    // Auto-spawn reviewers for PRs that need review
-    effects.extend(collect_reviewer_effects(snap, state, &prs).await);
-
-    // Pre-collect review status for all PRs before stuck detection (pure decision logic
+    // Pre-collect review status for all PRs before decision functions (pure decision logic
     // should not make async API calls). Coworkers can't submit formal GitHub reviews
     // since they share the same user as PR authors, so we check for comment-based reviews.
     let reviewed_prs: HashSet<u64> = {
@@ -916,6 +924,14 @@ pub(super) async fn poll_prs_for_issues(
         }
         reviewed
     };
+
+    // Pre-fetch review content for all reviewed PRs. This keeps subprocess I/O here
+    // (the polling entry point) instead of inside decision functions — CLAUDE.md:
+    // "Decision functions are pure: must not perform I/O."
+    let pre_fetched_review_content = pre_fetch_review_content_for_prs(&prs, &reviewed_prs).await;
+
+    // Auto-spawn reviewers for PRs that need review
+    effects.extend(collect_reviewer_effects(snap, state, &prs, &pre_fetched_review_content).await);
 
     // Compute prs_needing_review and update cache (must happen here, not in effect
     // collection functions which should be pure). This value is used by task dispatch
@@ -972,6 +988,7 @@ pub(super) async fn poll_prs_for_issues(
             &reviewed_prs,
             &active_coworkers,
             &idle_coworkers,
+            &pre_fetched_review_content,
         )
         .await,
     );
@@ -1007,6 +1024,7 @@ async fn collect_green_with_feedback_effects(
     reviewed_prs: &HashSet<u64>,
     active_coworkers: &[String],
     idle_coworkers: &[String],
+    pre_fetched_review_content: &HashMap<u64, String>,
 ) -> Vec<Effect> {
     let mut effects = Vec::new();
 
@@ -1070,17 +1088,19 @@ async fn collect_green_with_feedback_effects(
             continue;
         }
 
-        // Fetch all review content to embed in the nudge — same rationale as
-        // handle_pr_comment_nudge: coworkers need to see Midtown coworker reviews
-        // (issue comments) as well as formal GitHub reviews.
-        let review_content = fetch_review_content(pr_number).await;
+        // Use pre-fetched review content (fetched at the top of poll_prs_for_issues
+        // to keep this function free of I/O — CLAUDE.md: "Decision functions are pure").
+        let review_suffix = pre_fetched_review_content
+            .get(&pr_number)
+            .map(|s| s.as_str())
+            .unwrap_or("");
         let message = format!(
             "PR #{} ({}) - {}: {}{}",
             pr_number,
             truncate_str(title, 40),
             PrIssueType::GreenWithFeedback,
             get_issue_action(PrIssueType::GreenWithFeedback),
-            review_content.as_deref().unwrap_or("")
+            review_suffix
         );
 
         // Extract all decision context from persistent state in one lock
@@ -1744,6 +1764,31 @@ async fn fetch_review_content(pr_number: u64) -> Option<String> {
     format_review_content(&data)
 }
 
+/// Pre-fetch review content for all reviewed PRs in one batch.
+///
+/// Called at the top of `poll_prs_for_issues` to collect all review content
+/// upfront, keeping subprocess I/O out of inner decision functions.
+/// Returns a map of PR number → formatted review content string.
+async fn pre_fetch_review_content_for_prs(
+    prs: &[serde_json::Value],
+    reviewed_prs: &HashSet<u64>,
+) -> HashMap<u64, String> {
+    let mut result = HashMap::new();
+
+    for pr in prs {
+        let pr_number = match pr.get("number").and_then(|n| n.as_u64()) {
+            Some(n) if reviewed_prs.contains(&n) => n,
+            _ => continue,
+        };
+
+        if let Some(content) = fetch_review_content(pr_number).await {
+            result.insert(pr_number, content);
+        }
+    }
+
+    result
+}
+
 /// Polling fallback for review comment notifications.
 ///
 /// When webhooks are degraded, this detects new review comments by comparing
@@ -1899,10 +1944,13 @@ async fn collect_comment_notification_effects(
             continue;
         }
 
+        // Embed review content so the coworker sees all feedback inline
+        let review_content = fetch_review_content(pr_number).await;
         let nudge_msg = format!(
-            "Your PR #{} ({}) has new review comments — please address feedback.",
+            "Your PR #{} ({}) has new review comments — please address feedback.{}",
             pr_number,
-            truncate_str(title, 40)
+            truncate_str(title, 40),
+            review_content.as_deref().unwrap_or("")
         );
 
         debug!(
@@ -2214,6 +2262,7 @@ async fn collect_reviewer_effects(
     snap: &WorldSnapshot,
     state: &DaemonState,
     prs: &[serde_json::Value],
+    pre_fetched_review_content: &HashMap<u64, String>,
 ) -> Vec<Effect> {
     collect_reviewer_effects_with_source(
         Some(&snap.worktree_branch_owners),
@@ -2222,6 +2271,7 @@ async fn collect_reviewer_effects(
         state,
         prs,
         crate::github_state::AssignmentSource::PollingFallback,
+        pre_fetched_review_content,
     )
     .await
 }
@@ -2233,6 +2283,7 @@ pub(crate) async fn collect_reviewer_effects_with_source(
     state: &DaemonState,
     prs: &[serde_json::Value],
     source: crate::github_state::AssignmentSource,
+    pre_fetched_review_content: &HashMap<u64, String>,
 ) -> Vec<Effect> {
     let mut effects: Vec<Effect> = Vec::new();
     let review_mode = crate::config::get_review_mode_for_repo(&state.repo_name);
@@ -2316,14 +2367,17 @@ pub(crate) async fn collect_reviewer_effects_with_source(
                 };
 
                 if should_nudge {
-                    // Embed review content so the coworker sees all feedback
-                    // (both formal reviews and Midtown coworker issue comments)
-                    let review_content = fetch_review_content(pr_number).await;
+                    // Use pre-fetched review content (fetched at the top of poll_prs_for_issues
+                    // to keep this function free of I/O — CLAUDE.md: "Decision functions are pure").
+                    let review_suffix = pre_fetched_review_content
+                        .get(&pr_number)
+                        .map(|s| s.as_str())
+                        .unwrap_or("");
                     let nudge_msg = format!(
                         "Your PR #{} ({}) has a completed review — please address any feedback and merge if appropriate.{}",
                         pr_number,
                         truncate_str(title, 40),
-                        review_content.as_deref().unwrap_or("")
+                        review_suffix
                     );
 
                     let active_coworkers: Vec<String> = state
@@ -2903,6 +2957,7 @@ pub(super) async fn process_pending_review_spawns(
             state,
             &[pr],
             crate::github_state::AssignmentSource::Webhook,
+            &HashMap::new(), // Webhook path: spawning reviewers, not nudging authors
         )
         .await;
         all_effects.extend(effects);
@@ -3042,6 +3097,7 @@ pub(super) async fn handle_ci_completion_for_review_spawn(
         state,
         &[pr],
         crate::github_state::AssignmentSource::Webhook,
+        &HashMap::new(), // Webhook path: spawning reviewers, not nudging authors
     )
     .await;
 
@@ -3583,11 +3639,15 @@ pub(super) async fn handle_webhook_review_state_change(
         return;
     };
 
+    // Embed review content so the coworker sees the full review body
+    // (both formal reviews and Midtown coworker issue comments).
+    let review_content = fetch_review_content(pr_number).await;
     let nudge_msg = format!(
-        "PR #{} — {}: {}",
+        "PR #{} — {}: {}{}",
         pr_number,
         issue_type,
-        get_issue_action(issue_type)
+        get_issue_action(issue_type),
+        review_content.as_deref().unwrap_or("")
     );
 
     // Get active and idle coworkers for the decision function

--- a/src/daemon/pr_review_feedback_tests.rs
+++ b/src/daemon/pr_review_feedback_tests.rs
@@ -269,4 +269,26 @@ mod tests {
             "should include coworker review"
         );
     }
+
+    /// Test that format_review_content does not embed a comment where "reviewed by"
+    /// appears only as inline prose (false-positive guard for the hardened
+    /// `text_contains_review_signature` check).
+    #[test]
+    fn test_format_review_content_rejects_inline_reviewed_by_prose() {
+        use crate::daemon::helpers::format_review_content;
+
+        let data = serde_json::json!({
+            "reviews": [],
+            "comments": [
+                {
+                    "author": {"login": "btucker"},
+                    "body": "This change was reviewed by the platform team last week."
+                }
+            ]
+        });
+        assert!(
+            format_review_content(&data).is_none(),
+            "inline 'reviewed by' in prose should not be treated as a review"
+        );
+    }
 }

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -514,6 +514,7 @@ async fn test_lead_pr_without_task_id_should_not_be_orphaned() {
         &state,
         &[pr],
         crate::github_state::AssignmentSource::PollingFallback,
+        &std::collections::HashMap::new(),
     )
     .await;
 
@@ -855,6 +856,7 @@ async fn test_reviewer_spawns_when_worktree_exists_but_no_current_coworker() {
         &state,
         &[pr_json],
         crate::github_state::AssignmentSource::PollingFallback,
+        &std::collections::HashMap::new(),
     )
     .await;
 
@@ -916,6 +918,7 @@ async fn test_completed_worktree_with_open_pr_gets_reviewer() {
         &state,
         &[pr_json],
         crate::github_state::AssignmentSource::PollingFallback,
+        &std::collections::HashMap::new(),
     )
     .await;
 
@@ -991,6 +994,7 @@ async fn test_completed_worktree_with_snapshot_data() {
         &state,
         &[pr_json], // Synthetic PR that extracts task ID 1323 from title
         crate::github_state::AssignmentSource::PollingFallback,
+        &std::collections::HashMap::new(),
     )
     .await;
 
@@ -1069,6 +1073,7 @@ async fn test_lead_pr_with_non_standard_branch_gets_reviewer() {
         &state,
         &[pr_json],
         crate::github_state::AssignmentSource::PollingFallback,
+        &std::collections::HashMap::new(),
     )
     .await;
 
@@ -1808,6 +1813,7 @@ async fn test_active_coworker_pr_without_worktree_is_not_orphaned() {
         &state,
         &[pr],
         crate::github_state::AssignmentSource::PollingFallback,
+        &std::collections::HashMap::new(),
     )
     .await;
 
@@ -1870,6 +1876,7 @@ async fn test_headless_only_coworker_pr_is_not_orphaned() {
         &state,
         &[pr],
         crate::github_state::AssignmentSource::PollingFallback,
+        &std::collections::HashMap::new(),
     )
     .await;
 
@@ -2360,6 +2367,7 @@ async fn test_reviewer_not_assigned_to_pr_author() {
         &state,
         &[pr],
         crate::github_state::AssignmentSource::PollingFallback,
+        &std::collections::HashMap::new(),
     )
     .await;
 
@@ -2448,6 +2456,7 @@ async fn test_reviewer_spawn_aborted_on_worktree_collision_with_active_coworker(
         &state,
         &[pr_json],
         crate::github_state::AssignmentSource::PollingFallback,
+        &std::collections::HashMap::new(),
     )
     .await;
 
@@ -2515,6 +2524,7 @@ async fn test_reviewer_spawn_aborted_on_worktree_collision_mixed_case() {
         &state,
         &[pr_json],
         crate::github_state::AssignmentSource::PollingFallback,
+        &std::collections::HashMap::new(),
     )
     .await;
 
@@ -2581,6 +2591,7 @@ async fn test_reviewer_spawn_blocked_by_stale_active_names_retries_next_tick() {
         &state,
         std::slice::from_ref(&pr_json),
         crate::github_state::AssignmentSource::PollingFallback,
+        &std::collections::HashMap::new(),
     )
     .await;
 
@@ -2609,6 +2620,7 @@ async fn test_reviewer_spawn_blocked_by_stale_active_names_retries_next_tick() {
         &state,
         &[pr_json],
         crate::github_state::AssignmentSource::PollingFallback,
+        &std::collections::HashMap::new(),
     )
     .await;
 
@@ -2669,6 +2681,7 @@ async fn test_reviewer_spawn_proceeds_when_previous_reviewer_is_dead() {
         &state,
         &[pr_json],
         crate::github_state::AssignmentSource::PollingFallback,
+        &std::collections::HashMap::new(),
     )
     .await;
 
@@ -2717,6 +2730,7 @@ async fn test_review_mode_github_app_disables_local_reviewer_spawn() {
         &state,
         &[pr_json],
         crate::github_state::AssignmentSource::PollingFallback,
+        &std::collections::HashMap::new(),
     )
     .await;
 
@@ -2763,6 +2777,7 @@ async fn test_review_mode_both_allows_local_reviewer_spawn() {
         &state,
         &[pr_json],
         crate::github_state::AssignmentSource::PollingFallback,
+        &std::collections::HashMap::new(),
     )
     .await;
 
@@ -2816,6 +2831,7 @@ async fn test_reviewer_spawn_warns_pr_author_via_mailbox() {
         &state,
         &[pr_json],
         crate::github_state::AssignmentSource::PollingFallback,
+        &std::collections::HashMap::new(),
     )
     .await;
 

--- a/src/daemon/rpc_prs.rs
+++ b/src/daemon/rpc_prs.rs
@@ -608,6 +608,7 @@ pub(super) async fn handle_pr_review(
         state,
         &[pr_json],
         crate::github_state::AssignmentSource::Manual,
+        &std::collections::HashMap::new(), // RPC path: spawning reviewers, not nudging authors
     )
     .await;
 


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary

- Add `format_review_content()` pure helper (helpers.rs) and `fetch_review_content()` async wrapper (pr.rs) that fetch and format both formal GitHub reviews and Midtown coworker issue-comment reviews for a given PR
- Update `handle_pr_comment_nudge` (webhook path), `collect_green_with_feedback_effects` (CI-green path), and `collect_reviewer_effects` review-complete path to embed the actual review content in nudge messages
- Add 6 unit tests covering: empty PR, formal-review-only, coworker-issue-comment-only, both types together, skipping empty review bodies, and skipping non-review issue comments

## Problem

When a coworker was nudged to address PR feedback, the message was generic:
> "Your PR #42 has review feedback from park. Please address it."

The coworker would then run `gh pr view --json reviews` which only returns formal GitHub reviews (e.g., Codex inline reviews). Midtown coworker reviews are posted as issue comments with `<!-- midtown: -->` frontmatter — they don't appear in the `reviews` JSON field. The coworker would address only the Codex findings and miss the coworker review entirely.

## Solution

At nudge time, the daemon now fetches `gh pr view --json reviews,comments`, formats all review content (formal reviews with non-empty bodies + issue comments containing a Code Review signature), and embeds it directly in the nudge message. The coworker sees everything inline without needing to run extra commands.

## Test Plan

- [x] Unit tests pass (`cargo test format_review` → 6/6 pass)
- [x] Clippy clean (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] `cargo fmt --all -- --check` passes

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)