### PR TITLE
fix(web): delay tool call display clear for 4s after message [Midtown !1849]

### DIFF
--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -531,22 +531,21 @@ export function handleUpdate(update) {
         // activity strip resets. Only applies to top-level messages; a thread
         // reply mid-task should not clear the coworker's tool activity.
         //
-        // agentToolItems is keyed by channel name. For a channel lead named 'web'
-        // posting to channel 'web', msg.from.toLowerCase() === 'web' === channel key.
+        // Key by channelName (not msg.from): agentToolItems is channel-keyed, so
+        // the correct key to delete is the channel the message was posted to.
         if (msg.from && msg.from.toLowerCase() !== 'lead' && msg.from.toLowerCase() !== 'midtown') {
-          const senderKey = msg.from.toLowerCase()
-          if (agentClearTimeouts.has(senderKey)) {
-            clearTimeout(agentClearTimeouts.get(senderKey))
+          if (agentClearTimeouts.has(channelName)) {
+            clearTimeout(agentClearTimeouts.get(channelName))
           }
           const timeout = setTimeout(() => {
-            agentClearTimeouts.delete(senderKey)
+            agentClearTimeouts.delete(channelName)
             agentToolItems.update((byAgent) => {
               const updated = { ...byAgent }
-              delete updated[senderKey]
+              delete updated[channelName]
               return updated
             })
           }, TOOL_ITEMS_CLEAR_DELAY_MS)
-          agentClearTimeouts.set(senderKey, timeout)
+          agentClearTimeouts.set(channelName, timeout)
           // Note: pending questions are NOT cleared on channel messages. A coworker
           // posting a /me status update does not mean their question was answered.
           // Questions are cleared by: (1) the daemon via nudge delivery, (2) optimistic

--- a/web-app/src/lib/api.test.js
+++ b/web-app/src/lib/api.test.js
@@ -458,17 +458,20 @@ describe('handleUpdate — agentToolItems persistence after channel lead message
     expect(get(agentToolItems)['web'].length).toBeGreaterThan(0)
   })
 
-  it('still immediately clears tool items for non-channel-lead coworkers (keyed by channel)', () => {
-    // Coworker 'manhattan' posts to 'midtown' — their items are NOT stored under 'manhattan'
-    // so the delete('manhattan') call is a no-op, but the 'midtown' key is unaffected
+  it('clears midtown tool items after delay when a coworker posts to midtown', () => {
+    // agentToolItems is channel-keyed: a coworker posting to 'midtown' schedules
+    // a delayed clear for the 'midtown' key, not a no-op on their sender name.
     handleUpdate({ type: 'universal_items', data: { channel: null, agent_name: 'lead', items: [sampleItem] } })
     expect(get(agentToolItems)['midtown']).toHaveLength(1)
 
-    // A non-lead, non-midtown sender posting to midtown schedules a delayed clear for 'manhattan'
-    // (which doesn't exist), so midtown items are unaffected
     handleUpdate({ type: 'channel_message', data: { id: 'msg-2', from: 'manhattan', content: 'hi', channel: 'midtown', timestamp: '2026-01-01T00:00:00Z' } })
-    vi.advanceTimersByTime(5000)
-    // midtown items were not deleted — 'manhattan' key didn't exist in the store
+
+    // Items still present before the delay
+    vi.advanceTimersByTime(3999)
     expect(get(agentToolItems)['midtown']).toHaveLength(1)
+
+    // Items cleared after the delay
+    vi.advanceTimersByTime(1)
+    expect(get(agentToolItems)['midtown']).toBeUndefined()
   })
 })


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

- Tool call items in the activity strip disappeared instantly when a channel lead posted a response, making it impossible to read tool call summaries if the agent responded quickly
- Added a 4-second persistence delay: `agentToolItems` entries are cleared 4s after a sender's channel message arrives, not immediately
- If new `universal_items` events arrive within the delay window (agent is still working), the pending clear is cancelled — keeping the strip live

## Root Cause

In `api.js handleUpdate('channel_message')`, tool items were deleted immediately for any non-lead sender:

```js
delete updated[msg.from.toLowerCase()]
```

Channel leads (e.g., `'web'`) post with their channel name, which coincidentally matches the `agentToolItems` channel key — so their activity strip was cleared the moment their first message arrived.

## Fix

Replaced the immediate delete with a `setTimeout`-based delayed clear (4 seconds). A `Map` tracks pending timeouts per channel key, allowing the `universal_items` handler to cancel any pending clear if the agent continues working.

## Test plan

- [x] New tests cover: (1) items not cleared immediately, (2) items cleared after delay, (3) clear cancelled by new tool activity, (4) unrelated channels unaffected
- [x] All 144 existing + new tests pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)