### PR TITLE
feat(daemon): auto-fork topic channel sessions on new user messages [Midtown !1847]

### DIFF
--- a/agents/channel-lead.md
+++ b/agents/channel-lead.md
@@ -72,7 +72,7 @@ The daemon now **automatically forks** your session when a new top-level user me
    midtown session fork <message-id>
    ```
 
-   `session fork` is idempotent — calling it when a fork already exists just returns the existing session ID.
+   `session fork` is idempotent — calling it when a fork already exists returns `{already_exists: true, session_id: ...}`. During the daemon's auto-fork spawn window (~30s), it may return `{pending: true}` instead — this means the daemon is already creating the fork. Retry once after a brief wait.
 
 **After forking (or in an auto-forked session):**
 - All your text output is automatically posted to the thread — no `--thread` flag needed.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -238,22 +238,26 @@ Channel leads can fork themselves into thread-specific sessions via the `session
 
 **Root session as router:** The root session stays lightweight — it handles top-level messages and decides when to fork. Once a fork exists for a thread, subsequent replies in that thread bypass the root session entirely and route directly to the fork.
 
-**Instant ack + fork pattern:** The channel lead prompt (`agents/channel-lead.md`) instructs the root session to always post a brief thread acknowledgment *before* calling `session fork`. This ensures the user sees immediate feedback even though `session fork` blocks for a few seconds while the daemon spawns the new session. For simple questions that don't need a fork, the ack is the complete response. For deeper work, the ack comes first, then the fork takes over.
+**Daemon auto-fork (primary path):** When a user posts a new top-level message to a topic channel, `handle_channel_post` calls `create_fork_session` before sending the nudge. The fork is bound to the message's thread anchor ID so the channel lead receives the nudge already inside the fork session — it just replies directly. `create_fork_session` is a `pub(super)` shared helper in `rpc_session.rs`, callable from both `handle_session_fork` (explicit CLI call) and `handle_channel_post` (auto-fork path). The `channel_hint` parameter lets the auto-fork path supply the known channel name even when session records are stale. `create_fork_session` uses `try_lock()` on `persistent_state` internally to avoid blocking the channel post path when the lock is held.
 
-**Thread routing priority:** When a message arrives with `thread_parent_id` set, `handle_channel_post` checks `topic_sessions[thread_parent_id]` first. If a fork exists, it receives the message. If no fork exists, the message routes to the root channel lead session — spawning it on-demand if it isn't already running (standard channel lead lifecycle).
+**Graceful fallback:** If no channel lead session is registered (first message to a new channel), or if `persistent_state.try_lock()` is contended, auto-fork is skipped and `NudgeChannelLead` spawns the channel lead as before. The next user message will succeed once the lead is running. `session fork` is still documented in `channel-lead.md` as a fallback for when the daemon was not running when the message arrived.
+
+**Thread routing priority:** When a message arrives with `thread_parent_id` set, `handle_channel_post` checks `topic_sessions[thread_parent_id]` first. "pending" entries are filtered out (a concurrent auto-fork is in progress but not yet ready) — the reply falls back to `NudgeChannelLead` rather than producing a nudge with an invalid session ID. Once the fork completes, subsequent replies route to the real fork session.
+
+**`session fork` during auto-fork spawn window:** If the channel lead calls `midtown session fork` while the daemon's auto-fork is still spawning (the "pending" sentinel is set), `handle_session_fork` returns `{pending: true, thread_parent_id: "..."}` instead of an error, so the lead can distinguish "retry shortly" from a hard spawn failure.
 
 **Data flow:**
-- `topic_sessions` (in-memory `Mutex<HashMap<String, String>>`) maps `thread_parent_id → fork_session_id`. Used by `handle_channel_post` to route thread replies to the fork instead of the root channel lead.
+- `topic_sessions` (in-memory `Mutex<HashMap<String, String>>`) maps `thread_parent_id → fork_session_id`. Entries are "pending" (spawn in progress) or a real session ID. Used by both auto-fork and thread-reply routing in `handle_channel_post`.
 - `fork_bound_threads` (in-memory `Mutex<HashMap<String, String>>`) maps `fork_name → thread_parent_id`. Used by the output binding path in `handle_channel_post` to auto-tag forked session posts with their bound thread (avoids the async `persistent_state` lock on the hot path).
 - `DaemonPersistentState.task_thread_id` maps `task_id → thread_parent_id`. When `midtown task create` is called with `--thread-id` (the CLI defaults to `$MIDTOWN_BOUND_THREAD_ID` inside fork sessions), `handle_task_create` stores the binding so `SpawnSession` can attach future coworkers to the same thread.
 - `SessionRecord.bound_thread_id` (persisted) stores the binding on each session so restarts can rebuild the cache.
-- `name_to_session` / `session_to_name` reverse maps are backfilled in `handle_session_fork` since `spawn_fork` consumes the init event before the event loop sees it.
+- `name_to_session` / `session_to_name` reverse maps are backfilled in `create_fork_session` since `spawn_fork` consumes the init event before the event loop sees it.
 
 **Architectural invariants:**
 - Fork sessions are NOT registered in `CoworkerManager`. They bypass `spawn_coworker()` entirely, which means they are excluded from idle-shutdown evaluation, orphan recovery, and coworker status tracking.
-- The `topic_sessions` guard uses an atomic check-and-reserve pattern (inserting a "pending" sentinel) to prevent duplicate forks for the same thread.
+- The `topic_sessions` guard uses an atomic check-and-reserve pattern (inserting a "pending" sentinel) to prevent duplicate forks for the same thread. On spawn failure, the sentinel is removed so the slot is available for retry.
 - `topic_sessions` is cleared on daemon restart, so fork sessions themselves do not survive across daemon lifetimes.
-- `fork_bound_threads` is rebuilt on startup from persisted `SessionRecord.bound_thread_id` entries, which keeps thread-bound coworkers routed correctly across restarts (including auto-binding spawned tasks via `task_thread_id`). Entries created directly by `handle_session_fork` remain ephemeral.
+- `fork_bound_threads` is rebuilt on startup from persisted `SessionRecord.bound_thread_id` entries, which keeps thread-bound coworkers routed correctly across restarts (including auto-binding spawned tasks via `task_thread_id`). Entries created directly by `create_fork_session` remain ephemeral.
 
 ## Channel Storage Layout
 

--- a/src/daemon/rpc_channel.rs
+++ b/src/daemon/rpc_channel.rs
@@ -83,9 +83,12 @@ fn parse_duration(s: &str) -> Option<Duration> {
 /// For coworkers, the action text is also reflected in the web UI status.
 ///
 /// Also detects feedback requests from coworkers and nudges the Lead.
-/// For topic channels, nudges the active channel lead session (if any)
-/// instead of the main Lead. @mentions are not routed in topic channels
-/// since the channel lead owns all routing in its domain.
+/// For topic channels, auto-forks the channel lead session when a new top-level
+/// user message arrives — the fork is bound to the message thread so replies
+/// stay in context. Thread replies route to the existing fork session (if any).
+/// Falls back to nudging the channel lead directly when no lead session is
+/// registered. @mentions are not routed in topic channels since the channel
+/// lead owns all routing in its domain.
 ///
 /// Accepts an optional `channel` parameter to post to topic channels.
 /// If not provided, defaults to the main channel.
@@ -165,7 +168,7 @@ pub(super) async fn handle_channel_post(
         }
     }
 
-    // Task 3: Output binding — if the sender is a forked topic session with a bound
+    // Output binding — if the sender is a forked topic session with a bound
     // thread, auto-apply the bound thread_parent_id so their posts appear in the
     // correct thread without the session needing to pass it explicitly.
     // Uses the in-memory fork_bound_threads cache (sync Mutex) instead of the async
@@ -251,22 +254,33 @@ pub(super) async fn handle_channel_post(
             //   and context isolation reliable without relying on the lead to fork manually.
             let topic_session_id = if let Some(parent_id) = thread_parent_id {
                 // Thread reply: route to existing fork session (if any).
-                state.topic_sessions.lock().unwrap().get(parent_id).cloned()
+                // Filter out "pending" — a concurrent auto-fork is in progress but not yet
+                // ready. Treating "pending" as None falls back to NudgeChannelLead rather
+                // than producing a NudgeSession with an invalid "pending" session_id.
+                state
+                    .topic_sessions
+                    .lock()
+                    .unwrap()
+                    .get(parent_id)
+                    .filter(|s| s.as_str() != "pending")
+                    .cloned()
             } else {
                 // New top-level message: auto-fork from the channel lead session.
                 // Look up the channel lead's session ID from persistent state.
-                let lead_session_id = {
-                    let ps = state.persistent_state.lock().await;
+                // Use try_lock to avoid blocking the channel post path — if persistent_state
+                // is momentarily held, fall through to NudgeChannelLead rather than queuing.
+                let lead_session_id = state.persistent_state.try_lock().ok().and_then(|ps| {
                     ps.channel_lead_sessions
                         .get(channel_name)
                         .filter(|s| !s.is_empty())
                         .cloned()
-                };
+                });
                 if let Some(lead_sid) = lead_session_id {
                     match super::rpc_session::create_fork_session(
                         &wake_msg_id,
                         &lead_sid,
                         Some(channel_name),
+                        "channel.post",
                         state,
                     )
                     .await

--- a/src/daemon/rpc_channel_tests.rs
+++ b/src/daemon/rpc_channel_tests.rs
@@ -1883,6 +1883,47 @@ async fn test_user_message_to_topic_channel_without_lead_skips_fork() {
     );
 }
 
+/// When a thread reply arrives while the auto-fork is still spawning ("pending"
+/// sentinel in topic_sessions), the reply must NOT produce a NudgeSession with
+/// session_id="pending" — that would silently drop the message. The handler
+/// should filter out "pending" and fall back to NudgeChannelLead instead.
+#[tokio::test]
+async fn test_thread_reply_during_pending_fork_does_not_route_to_pending_session() {
+    let (state, _tmp, _guard) = make_test_state("midtown-test-pending-thread-reply");
+
+    let thread_parent_id = "top-level-msg-pending-fork";
+    // Simulate auto-fork in progress: sentinel is "pending", not a real session
+    state
+        .topic_sessions
+        .lock()
+        .unwrap()
+        .insert(thread_parent_id.to_string(), "pending".to_string());
+
+    // Thread reply arrives during the spawn window
+    let response = handle_channel_post(
+        1_i64.into(),
+        "user",
+        "follow-up reply while fork is spawning",
+        Some("web"),
+        Some(thread_parent_id),
+        &state,
+    )
+    .await;
+    assert!(
+        response.error.is_none(),
+        "thread reply should succeed even with pending fork"
+    );
+
+    // The "pending" sentinel must not have been removed or changed — it belongs to
+    // the spawning fork, not this thread reply.
+    let topic = state.topic_sessions.lock().unwrap();
+    assert_eq!(
+        topic.get(thread_parent_id).map(String::as_str),
+        Some("pending"),
+        "pending sentinel should be untouched by a thread reply"
+    );
+}
+
 /// Verify the DmFromUser wake reason encodes the correct reply instruction
 /// for a channel.post to a dm- channel.
 #[test]

--- a/src/daemon/rpc_session.rs
+++ b/src/daemon/rpc_session.rs
@@ -1086,6 +1086,7 @@ pub(super) async fn create_fork_session(
     thread_parent_id: &str,
     calling_session_id: &str,
     channel_hint: Option<&str>,
+    caller: &str,
     state: &DaemonState,
 ) -> Result<(String, bool), String> {
     // Atomic guard: check-and-reserve the topic_sessions slot in a single lock
@@ -1137,8 +1138,8 @@ pub(super) async fn create_fork_session(
             }
             None => {
                 warn!(
-                    "session.fork: could not find session info for calling_session_id={}",
-                    calling_session_id
+                    "{}: could not find session info for calling_session_id={}",
+                    caller, calling_session_id
                 );
                 // Fall back to repo root and no channel
                 (None, None, crate::auth::AuthProvider::Claude)
@@ -1221,7 +1222,7 @@ pub(super) async fn create_fork_session(
                 .lock()
                 .unwrap()
                 .remove(thread_parent_id);
-            warn!("session.fork: failed to spawn fork session: {}", e);
+            warn!("{}: failed to spawn fork session: {}", caller, e);
             return Err(format!("Failed to fork session: {}", e));
         }
     };
@@ -1286,7 +1287,7 @@ pub(super) async fn create_fork_session(
             },
         );
         if let Err(e) = ps.save_for_repo(repo_name) {
-            warn!("session.fork: failed to persist session record: {}", e);
+            warn!("{}: failed to persist session record: {}", caller, e);
         }
     }
 
@@ -1318,7 +1319,8 @@ pub(super) async fn create_fork_session(
     }
 
     info!(
-        "session.fork: forked {} (parent={}) → thread={}, new_session={}",
+        "{}: forked {} (parent={}) → thread={}, new_session={}",
+        caller,
         calling_session_id,
         caller_name.as_deref().unwrap_or("?"),
         thread_parent_id,
@@ -1350,7 +1352,15 @@ pub(super) async fn handle_session_fork(
     calling_session_id: &str,
     state: &DaemonState,
 ) -> crate::rpc::Response {
-    match create_fork_session(thread_parent_id, calling_session_id, None, state).await {
+    match create_fork_session(
+        thread_parent_id,
+        calling_session_id,
+        None,
+        "session.fork",
+        state,
+    )
+    .await
+    {
         Ok((sid, true)) => crate::rpc::Response::success(
             id,
             serde_json::json!({
@@ -1365,6 +1375,19 @@ pub(super) async fn handle_session_fork(
                 "thread_parent_id": thread_parent_id,
             }),
         ),
+        Err(ref e) if e.starts_with("fork in progress") => {
+            // The daemon's auto-fork path already reserved this slot.
+            // Return a distinct pending response so the channel lead can
+            // distinguish "retry shortly" from a hard spawn failure.
+            crate::rpc::Response::success(
+                id,
+                serde_json::json!({
+                    "pending": true,
+                    "thread_parent_id": thread_parent_id,
+                    "message": "fork in progress — retry shortly",
+                }),
+            )
+        }
         Err(e) => crate::rpc::Response::error(id, crate::rpc::RpcError::new(-32603, e)),
     }
 }

--- a/src/daemon/rpc_session_tests.rs
+++ b/src/daemon/rpc_session_tests.rs
@@ -535,7 +535,7 @@ async fn test_create_fork_session_returns_existing_when_already_present() {
         .unwrap()
         .insert(thread_id.to_string(), existing_sid.clone());
 
-    let result = create_fork_session(thread_id, "any-calling-session", None, &state).await;
+    let result = create_fork_session(thread_id, "any-calling-session", None, "test", &state).await;
 
     assert!(result.is_ok(), "should succeed when fork already exists");
     let (returned_sid, already_existed) = result.unwrap();
@@ -564,7 +564,7 @@ async fn test_create_fork_session_returns_err_when_pending() {
         .unwrap()
         .insert(thread_id.to_string(), "pending".to_string());
 
-    let result = create_fork_session(thread_id, "any-calling-session", None, &state).await;
+    let result = create_fork_session(thread_id, "any-calling-session", None, "test", &state).await;
 
     assert!(
         result.is_err(),
@@ -617,7 +617,8 @@ async fn test_create_fork_session_cleans_up_sentinel_on_spawn_failure() {
         .insert(calling_session_id.to_string(), "web".to_string());
 
     // spawn_fork will fail since there's no real claude process
-    let result = create_fork_session(thread_id, calling_session_id, Some("web"), &state).await;
+    let result =
+        create_fork_session(thread_id, calling_session_id, Some("web"), "test", &state).await;
 
     assert!(result.is_err(), "should fail when spawn_fork fails");
 
@@ -655,5 +656,38 @@ async fn test_handle_session_fork_already_exists_response() {
     assert!(
         result["already_exists"].as_bool().unwrap(),
         "already_exists should be true"
+    );
+}
+
+/// When the daemon auto-fork has reserved the slot with "pending", calling
+/// `handle_session_fork` should return `{pending: true}` instead of an error,
+/// so the channel lead can distinguish "retry shortly" from a hard spawn failure.
+#[tokio::test]
+async fn test_handle_session_fork_returns_pending_during_spawn_window() {
+    let (state, _tmp, _guard) = make_test_state();
+
+    let thread_id = "thread-rpc-pending-fork";
+    state
+        .topic_sessions
+        .lock()
+        .unwrap()
+        .insert(thread_id.to_string(), "pending".to_string());
+
+    let resp = handle_session_fork(RequestId::Number(2), thread_id, "any-caller", &state).await;
+    let json = serde_json::to_value(&resp).unwrap();
+
+    assert!(
+        json.get("error").is_none(),
+        "should not return an error when fork is in progress"
+    );
+    let result = json["result"].as_object().unwrap();
+    assert!(
+        result["pending"].as_bool().unwrap_or(false),
+        "result should have pending: true"
+    );
+    assert_eq!(
+        result["thread_parent_id"].as_str().unwrap(),
+        thread_id,
+        "result should echo thread_parent_id"
     );
 }


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary

- **Daemon auto-fork**: When a user posts a new top-level message to a topic channel, `handle_channel_post` now automatically creates a fork session (bound to the message ID) before nudging the channel lead. The nudge goes directly to the fork, so the fork session exists and handles the conversation from the start.

- **Shared fork helper**: Extracted `create_fork_session` from `handle_session_fork` as a `pub(super)` helper in `rpc_session.rs`. Adds a `channel_hint` parameter so the auto-fork path can provide the known channel name even when session records are stale.

- **Graceful fallback**: If no channel lead session is registered (first message to a new channel), auto-fork is skipped and `NudgeChannelLead` spawns one as before. If spawn fails (e.g., during tests), the "pending" sentinel is cleaned up and the call succeeds.

- **Channel lead instructions updated**: `agents/channel-lead.md` now explains that the daemon auto-forks — leads receive the nudge already in the fork session and just need to respond directly. Manual `session fork` is still documented as a fallback.

## Test plan

- [x] `create_fork_session` returns `Ok((sid, true))` when fork already exists — no spawn triggered
- [x] `create_fork_session` returns `Err` when slot is "pending" (concurrent fork guard)
- [x] `create_fork_session` cleans up "pending" sentinel on spawn failure
- [x] `handle_session_fork` preserves `already_exists: true` RPC response format
- [x] `handle_channel_post` auto-fork: sentinel cleaned up when spawn fails
- [x] `handle_channel_post` auto-fork: skipped gracefully when no channel lead exists
- [x] Thread replies still route to existing fork sessions (existing behavior preserved)
- [x] All 2031+ unit tests pass, clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)