### PR TITLE
fix(web): fix 3 issues from PR #1581 review [Midtown !1849]

### DIFF
--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -130,6 +130,8 @@ export function switchProject(projectName, webhookPort) {
   })
   repoStatuses.set([])
   usageData.set([])
+  agentClearTimeouts.forEach((t) => clearTimeout(t))
+  agentClearTimeouts.clear()
   agentToolItems.set({})
   threadData.set(null)
   connected.set(false)
@@ -533,7 +535,12 @@ export function handleUpdate(update) {
         //
         // Key by channelName (not msg.from): agentToolItems is channel-keyed, so
         // the correct key to delete is the channel the message was posted to.
-        if (msg.from && msg.from.toLowerCase() !== 'lead' && msg.from.toLowerCase() !== 'midtown') {
+        // Exception: skip when the main lead posts to the main channel — deleting
+        // 'midtown' tool items on every lead response would clear in-progress activity.
+        const fromLower = msg.from ? msg.from.toLowerCase() : ''
+        const isMainLeadOnMainChannel =
+          channelName === 'midtown' && (fromLower === 'lead' || fromLower === 'midtown')
+        if (msg.from && !isMainLeadOnMainChannel) {
           if (agentClearTimeouts.has(channelName)) {
             clearTimeout(agentClearTimeouts.get(channelName))
           }

--- a/web-app/src/lib/api.test.js
+++ b/web-app/src/lib/api.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { get } from 'svelte/store'
 import { messagesByChannel, threadData, channels, activeChannel, agentToolItems } from './store.js'
-import { fetchHistory, handleUpdate, fetchChannels, selectDm } from './api.js'
+import { fetchHistory, handleUpdate, fetchChannels, selectDm, switchProject } from './api.js'
 
 describe('fetchHistory', () => {
   let originalFetch
@@ -473,5 +473,60 @@ describe('handleUpdate — agentToolItems persistence after channel lead message
     // Items cleared after the delay
     vi.advanceTimersByTime(1)
     expect(get(agentToolItems)['midtown']).toBeUndefined()
+  })
+
+  it('clears topic channel tool items when the main lead posts to that channel', () => {
+    // Regression: the original guard blocked the clear when msg.from was 'lead' or
+    // 'midtown', regardless of which channel the message was posted to. A lead
+    // posting to 'web' should still schedule a clear for 'web' tool items.
+    handleUpdate({ type: 'universal_items', data: { channel: 'web', agent_name: 'web', items: [sampleItem] } })
+    expect(get(agentToolItems)['web']).toHaveLength(1)
+
+    handleUpdate({ type: 'channel_message', data: { id: 'msg-3', from: 'lead', content: 'hi', channel: 'web', timestamp: '2026-01-01T00:00:00Z' } })
+
+    // Items present before delay
+    vi.advanceTimersByTime(3999)
+    expect(get(agentToolItems)['web']).toHaveLength(1)
+
+    // Items cleared after delay
+    vi.advanceTimersByTime(1)
+    expect(get(agentToolItems)['web']).toBeUndefined()
+  })
+
+  it('does not clear tool items for an unrelated channel when another channel gets a message', () => {
+    // Channel isolation: clearing 'web' must not affect 'staging'.
+    handleUpdate({ type: 'universal_items', data: { channel: 'web', agent_name: 'web', items: [sampleItem] } })
+    handleUpdate({ type: 'universal_items', data: { channel: 'staging', agent_name: 'staging', items: [sampleItem] } })
+
+    // Message arrives only on 'web'
+    handleUpdate({ type: 'channel_message', data: { id: 'msg-4', from: 'web', content: 'done', channel: 'web', timestamp: '2026-01-01T00:00:00Z' } })
+
+    // Advance past the clear delay
+    vi.advanceTimersByTime(5000)
+
+    // 'web' items cleared, 'staging' items untouched
+    expect(get(agentToolItems)['web']).toBeUndefined()
+    expect(get(agentToolItems)['staging']).toHaveLength(1)
+  })
+
+  it('cancels pending clear timeouts when switching projects', () => {
+    // Regression: pending setTimeout handles in agentClearTimeouts were not
+    // cancelled on switchProject(), so a delayed clear could fire against the
+    // new project's agentToolItems store after the switch.
+    handleUpdate({ type: 'universal_items', data: { channel: 'web', agent_name: 'web', items: [sampleItem] } })
+    handleUpdate({ type: 'channel_message', data: { id: 'msg-5', from: 'web', content: 'done', channel: 'web', timestamp: '2026-01-01T00:00:00Z' } })
+
+    // Switch projects while the 4-second clear is still pending
+    vi.advanceTimersByTime(1000)
+    switchProject('other-project', null)
+
+    // Simulate new tool items arriving in the new project
+    handleUpdate({ type: 'universal_items', data: { channel: 'web', agent_name: 'web', items: [sampleItem] } })
+
+    // Advance past the original delay — the stale timeout must NOT fire
+    vi.advanceTimersByTime(5000)
+
+    // New project's 'web' tool items must not have been cleared by the old timeout
+    expect(get(agentToolItems)['web']).toHaveLength(1)
   })
 })


### PR DESCRIPTION
<!-- midtown: riverside -->

Follow-up to #1581 — addresses all 3 issues from columbus's review.

## Changes

**1. Fix guard condition (semantic mismatch after refactor)**

The `msg.from !== 'lead'` guard was designed for sender-keyed deletion but blocked the delayed clear when the main lead posted to a topic channel (e.g. `from='lead'` → `channel='web'`). The 'web' channel's tool items would never be cleared via this path.

Fix: replace with a channel-keyed guard — only skip when the main lead posts to the main channel (`channelName === 'midtown'`), preserving the lead's own in-progress tool display.

**2. Cancel pending clear timeouts in `switchProject()`**

`agentClearTimeouts` was not cancelled on project switch. A 4-second pending timeout could fire against the new project's `agentToolItems` store, silently deleting a channel key that belonged to the new project.

Fix: `agentClearTimeouts.forEach(t => clearTimeout(t)); agentClearTimeouts.clear()` added to `switchProject()` alongside the existing timer cleanup.

**3. Add 3 new regression tests**

- Lead posting to topic channel schedules a clear (guard condition regression)
- Unrelated channel's tool items unaffected when another channel gets a message (isolation)
- `switchProject()` cancels pending timeouts so stale closures don't corrupt new project state

## Test plan

- [x] All 3 new regression tests pass
- [x] All 147 existing tests still pass
- [x] `cargo clippy` and `cargo fmt` pass (no Rust changes)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)