### PR TITLE
fix(web): clicking coworker name in status opens DM channel [Midtown !1848]

### DIFF
--- a/web-app/src/lib/ChannelList.svelte
+++ b/web-app/src/lib/ChannelList.svelte
@@ -21,8 +21,8 @@
     fetchChannels($showArchivedChannels)
   }
 
-  $: regularChannels = $channels.filter((ch) => !ch.is_dm)
-  $: dmChannels = $channels.filter((ch) => ch.is_dm)
+  $: regularChannels = $channels.filter((ch) => !ch.is_dm && !ch.name.startsWith('dm-'))
+  $: dmChannels = $channels.filter((ch) => ch.is_dm || ch.name.startsWith('dm-'))
 
   // Track which channels have their task lists expanded (default: collapsed)
   // Using SvelteSet for reactivity — plain Set mutations don't trigger re-renders in Svelte 5

--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -68,7 +68,10 @@ export async function fetchChannels(includeArchived = false) {
         has_pr: false,
         ci_status: null,
         is_archived: typeof ch === 'object' && ch.is_archived,
-        is_dm: typeof ch === 'object' ? ch.is_dm : (typeof ch === 'string' && ch.startsWith('dm-')),
+        is_dm:
+          typeof ch === 'object'
+            ? ch.is_dm || ch.name.startsWith('dm-')
+            : ch.startsWith('dm-'),
       }))
       // Backend already returns channels sorted with main project channel first
       channels.set(channelList)
@@ -892,6 +895,13 @@ export async function selectDm(coworkerName) {
   const exists = currentChannels.some((ch) => ch.name === channelName)
 
   if (!exists) {
+    // Optimistically add the DM channel so the sidebar shows it immediately,
+    // regardless of whether the backend create or subsequent fetchChannels succeeds.
+    channels.update((list) => [
+      ...list,
+      { name: channelName, unread: 0, has_pr: false, ci_status: null, is_dm: true },
+    ])
+
     try {
       const res = await fetch(`${getApiBase()}/channels/create`, {
         method: 'POST',
@@ -901,13 +911,12 @@ export async function selectDm(coworkerName) {
       if (!res.ok) {
         const errorData = await res.json()
         console.error('Failed to create DM channel:', errorData.error)
-        return
+      } else {
+        // Refresh channel list so the sidebar reflects canonical backend state
+        await fetchChannels(get(showArchivedChannels))
       }
-      // Refresh channel list so the new DM channel appears in the sidebar
-      await fetchChannels(get(showArchivedChannels))
     } catch (err) {
       console.error('Failed to create DM channel:', err)
-      return
     }
   }
 

--- a/web-app/src/lib/api.test.js
+++ b/web-app/src/lib/api.test.js
@@ -402,4 +402,75 @@ describe('selectDm', () => {
     expect(createCall[0]).toContain('/channels/create')
     expect(JSON.parse(createCall[1].body).name).toBe('dm-bob')
   })
+
+  it('still navigates to DM channel when backend creation returns an error', async () => {
+    // Regression: selectDm used to call `return` after a non-ok response, leaving
+    // activeChannel unchanged and giving the user no visible feedback.
+    channels.set([{ name: 'midtown', unread: 0, has_pr: false, ci_status: null, is_dm: false }])
+
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'internal server error' }),
+    })
+
+    await selectDm('carol')
+
+    // Despite the backend failure, the user should land on the DM channel
+    expect(get(activeChannel)).toBe('dm-carol')
+    // The channel should be in the sidebar as a DM
+    const ch = get(channels).find((c) => c.name === 'dm-carol')
+    expect(ch).toBeTruthy()
+    expect(ch.is_dm).toBe(true)
+  })
+
+  it('still navigates to DM channel when fetchChannels fails after creation', async () => {
+    // Regression: selectDm used to call `return` inside the catch block when
+    // fetchChannels threw, leaving activeChannel unchanged.
+    channels.set([{ name: 'midtown', unread: 0, has_pr: false, ci_status: null, is_dm: false }])
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) }) // create succeeds
+      .mockRejectedValueOnce(new Error('network error')) // fetchChannels fails
+
+    await selectDm('dave')
+
+    expect(get(activeChannel)).toBe('dm-dave')
+    const ch = get(channels).find((c) => c.name === 'dm-dave')
+    expect(ch).toBeTruthy()
+    expect(ch.is_dm).toBe(true)
+  })
+})
+
+describe('fetchChannels — is_dm name-prefix fallback', () => {
+  let originalFetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    channels.set([{ name: 'midtown', unread: 0, has_pr: false, ci_status: null }])
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('marks dm- prefixed channels as DMs when is_dm field is absent from API response', async () => {
+    // Regression: if the backend omits is_dm (or sends undefined) for a dm-* channel,
+    // fetchChannels stored is_dm=undefined (falsy), and ChannelList filtered it out
+    // so the DM section never appeared.
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        channels: [
+          { name: 'midtown', is_archived: false, is_dm: false },
+          { name: 'dm-eve', is_archived: false }, // no is_dm field
+        ],
+      }),
+    })
+
+    await fetchChannels()
+
+    const ch = get(channels).find((c) => c.name === 'dm-eve')
+    expect(ch).toBeTruthy()
+    expect(ch.is_dm).toBe(true)
+  })
 })


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- `selectDm()` silently returned early (no navigation, no feedback) when `/channels/create` returned a non-OK response or `fetchChannels` threw a network error — user clicked coworker name and nothing happened
- Added optimistic channel insertion before async network calls so the sidebar updates immediately and `activeChannel` is always set regardless of network outcome
- Added `startsWith('dm-')` fallback in `fetchChannels` and `ChannelList.svelte` so DM channels appear in the Direct Messages section even if the `is_dm` field is absent or false from the API response

## Test plan
- [x] Added 3 regression tests covering the silent-failure paths (non-ok response, network error, missing `is_dm` field)
- [x] All 143 tests pass (`web-app/` vitest suite)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)