### PR TITLE
feat: Default coworker messages and insights to task announcement thread [Midtown !1862]

### DIFF
--- a/src/daemon/rpc_insight.rs
+++ b/src/daemon/rpc_insight.rs
@@ -69,30 +69,47 @@ pub(super) async fn handle_insight_report(
         }
     }
 
-    // Resolve channel: explicit > coworker's task channel > main.
+    // Resolve channel and thread: explicit > coworker's task channel/thread > main.
     // When a coworker reports an insight without --channel, auto-route to their
     // assigned task's channel so insights don't flood the main channel.
-    let resolved_channel: Option<String> = if channel.is_none() {
-        let ps = state.persistent_state.lock().await;
-        ps.sessions
-            .values()
-            .find(|r| r.current_name.as_deref() == Some(agent))
-            .and_then(|r| r.task_id.as_deref())
-            .and_then(|tid| ps.task_channel.get(tid).cloned())
-    } else {
-        None
-    };
+    // Also resolve the task's thread binding so insights thread under the task
+    // announcement (parallels fork_bound_threads for channel.post).
+    let (resolved_channel, resolved_thread_id): (Option<String>, Option<String>) =
+        if channel.is_none() {
+            let ps = state.persistent_state.lock().await;
+            let task_id = ps
+                .sessions
+                .values()
+                .find(|r| r.current_name.as_deref() == Some(agent))
+                .and_then(|r| r.task_id.as_deref());
+            let ch = task_id.and_then(|tid| ps.task_channel.get(tid).cloned());
+            let thread = task_id.and_then(|tid| ps.task_thread_id.get(tid).cloned());
+            (ch, thread)
+        } else {
+            (None, None)
+        };
 
     // Post insight to specified channel (or main if None)
     let channel_name: &str = channel
         .or(resolved_channel.as_deref())
         .unwrap_or_else(|| state.channel_router.default_channel_name());
-    let msg = crate::message::Message::for_channel(
-        channel_name,
-        agent,
-        format!("💡 {}", insight),
-        crate::message::MessageType::Text,
-    );
+    let insight_content = format!("💡 {}", insight);
+    let msg = if let Some(ref thread_id) = resolved_thread_id {
+        crate::message::Message::thread_reply(
+            channel_name,
+            agent,
+            insight_content,
+            thread_id,
+            crate::message::MessageType::Text,
+        )
+    } else {
+        crate::message::Message::for_channel(
+            channel_name,
+            agent,
+            insight_content,
+            crate::message::MessageType::Text,
+        )
+    };
     if let Err(e) = state.send_and_broadcast_async(&msg).await {
         warn!("insight.report: failed to post to channel: {}", e);
         return Response::error(

--- a/src/daemon/rpc_insight_tests.rs
+++ b/src/daemon/rpc_insight_tests.rs
@@ -194,6 +194,135 @@ async fn test_insight_routes_to_task_channel_when_no_explicit_channel() {
     );
 }
 
+/// When a coworker reports an insight without specifying a channel and they are
+/// assigned to a task with a task_thread_id, the insight is posted as a thread
+/// reply under the task announcement (not a top-level channel message).
+#[tokio::test]
+async fn test_insight_routes_to_task_thread_when_thread_id_exists() {
+    let (state, temp_dir, _guard) = make_test_state("testrepo");
+
+    let thread_parent_id = "announcement-msg-uuid-42";
+
+    // Assign coworker1 to task 42 with channel "my-feature" and a thread binding
+    {
+        let mut ps = state.persistent_state.lock().await;
+        ps.sessions.insert(
+            "test-session-id".to_string(),
+            super::super::state::SessionRecord {
+                session_id: "test-session-id".to_string(),
+                current_name: Some("coworker1".to_string()),
+                coworker_type: "dev".to_string(),
+                task_id: Some("42".to_string()),
+                purpose: "task !42: some task".to_string(),
+                ..Default::default()
+            },
+        );
+        ps.task_channel
+            .insert("42".to_string(), "my-feature".to_string());
+        ps.task_thread_id
+            .insert("42".to_string(), thread_parent_id.to_string());
+    }
+
+    let response = handle_insight_report(
+        RequestId::Number(1),
+        "coworker1",
+        "A threaded insight",
+        None, // No explicit channel — should auto-route to "my-feature" thread
+        &state,
+    )
+    .await;
+
+    assert_eq!(response.result.expect("should succeed")["posted"], true);
+
+    // Read the channel file and verify the message has thread_parent_id set
+    let task_channel_file = temp_dir
+        .path()
+        .join("channels")
+        .join("my-feature")
+        .join("history")
+        .join("current.jsonl");
+    assert!(
+        task_channel_file.exists(),
+        "insight should be posted to the task channel"
+    );
+    let content = std::fs::read_to_string(&task_channel_file).unwrap();
+    assert!(
+        content.contains("A threaded insight"),
+        "insight text should be in task channel file"
+    );
+    // Verify thread_parent_id is present in the serialized message
+    assert!(
+        content.contains(thread_parent_id),
+        "insight message should contain thread_parent_id pointing to announcement"
+    );
+    // Parse the JSONL line and verify the thread_parent_id field
+    let line = content
+        .lines()
+        .find(|l| l.contains("A threaded insight"))
+        .unwrap();
+    let msg: serde_json::Value = serde_json::from_str(line).unwrap();
+    assert_eq!(
+        msg["thread_parent_id"].as_str(),
+        Some(thread_parent_id),
+        "thread_parent_id should match the task announcement message ID"
+    );
+}
+
+/// When a coworker reports an insight without specifying a channel and their
+/// task has no task_thread_id, the insight is posted as a top-level message.
+#[tokio::test]
+async fn test_insight_no_thread_when_no_thread_id() {
+    let (state, temp_dir, _guard) = make_test_state("testrepo");
+
+    // Assign coworker1 to task 42 with channel "my-feature" but NO thread binding
+    {
+        let mut ps = state.persistent_state.lock().await;
+        ps.sessions.insert(
+            "test-session-id".to_string(),
+            super::super::state::SessionRecord {
+                session_id: "test-session-id".to_string(),
+                current_name: Some("coworker1".to_string()),
+                coworker_type: "dev".to_string(),
+                task_id: Some("42".to_string()),
+                purpose: "task !42: some task".to_string(),
+                ..Default::default()
+            },
+        );
+        ps.task_channel
+            .insert("42".to_string(), "my-feature".to_string());
+        // Deliberately NOT setting task_thread_id
+    }
+
+    let response = handle_insight_report(
+        RequestId::Number(1),
+        "coworker1",
+        "An unthreaded insight",
+        None,
+        &state,
+    )
+    .await;
+
+    assert_eq!(response.result.expect("should succeed")["posted"], true);
+
+    // Read the channel file and verify the message has NO thread_parent_id
+    let task_channel_file = temp_dir
+        .path()
+        .join("channels")
+        .join("my-feature")
+        .join("history")
+        .join("current.jsonl");
+    let content = std::fs::read_to_string(&task_channel_file).unwrap();
+    let line = content
+        .lines()
+        .find(|l| l.contains("An unthreaded insight"))
+        .unwrap();
+    let msg: serde_json::Value = serde_json::from_str(line).unwrap();
+    assert!(
+        msg.get("thread_parent_id").is_none() || msg["thread_parent_id"].is_null(),
+        "message should not have thread_parent_id when task has no thread binding"
+    );
+}
+
 /// When a channel lead session reports an insight, the RPC should return early
 /// with posted=false and reason="channel_lead" — their output already reaches
 /// the channel via the normal auto-posting path.

--- a/src/daemon/rpc_task.rs
+++ b/src/daemon/rpc_task.rs
@@ -330,7 +330,15 @@ pub(super) async fn handle_task_create(
     match state.send_and_broadcast_async(&msg).await {
         Ok(()) => {
             let mut ps = state.persistent_state.lock().await;
-            ps.task_message_id.insert(task_id.clone(), message_id);
+            ps.task_message_id
+                .insert(task_id.clone(), message_id.clone());
+            // Default task_thread_id to the announcement message ID when no
+            // explicit --thread-id was provided. This ensures SpawnSession
+            // picks up a bound_thread_id so coworker messages auto-route to
+            // the task announcement thread.
+            if !ps.task_thread_id.contains_key(&task_id) {
+                ps.task_thread_id.insert(task_id.clone(), message_id);
+            }
             if let Err(e) = ps.save_for_repo(&repo_name) {
                 warn!("Failed to save task message_id mapping: {}", e);
             }

--- a/src/daemon/rpc_task_tests.rs
+++ b/src/daemon/rpc_task_tests.rs
@@ -203,8 +203,8 @@ fn test_task_thread_id_stored_in_persistent_state() {
     );
 }
 
-/// When `thread_id` is `None`, the task_thread_id mapping in
-/// DaemonPersistentState is not modified.
+/// When `thread_id` is `None` and no announcement message ID is available,
+/// the task_thread_id mapping in DaemonPersistentState is not modified.
 #[test]
 fn test_task_thread_id_not_stored_when_none() {
     use crate::daemon::state::DaemonPersistentState;
@@ -213,7 +213,7 @@ fn test_task_thread_id_not_stored_when_none() {
     let task_id = "42";
     let thread_id: Option<&str> = None;
 
-    // Replicate the handle_task_create storage logic
+    // Replicate the handle_task_create storage logic (explicit thread_id path)
     if let Some(tid) = thread_id {
         ps.task_thread_id
             .insert(task_id.to_string(), tid.to_string());
@@ -222,6 +222,82 @@ fn test_task_thread_id_not_stored_when_none() {
     assert!(
         ps.task_thread_id.is_empty(),
         "task_thread_id should remain empty when thread_id is None"
+    );
+}
+
+/// When no explicit `thread_id` is provided, task_thread_id should default
+/// to the announcement message ID after the task-created message is posted.
+/// This ensures SpawnSession picks up a bound_thread_id so coworker messages
+/// auto-route to the task announcement thread.
+#[test]
+fn test_task_thread_id_defaults_to_announcement_message_id() {
+    use crate::daemon::state::DaemonPersistentState;
+
+    let mut ps = DaemonPersistentState::default();
+    let task_id = "42";
+    let announcement_message_id = "msg-uuid-abc-123";
+
+    // No explicit thread_id was provided during task creation
+    let thread_id: Option<&str> = None;
+    if let Some(tid) = thread_id {
+        ps.task_thread_id
+            .insert(task_id.to_string(), tid.to_string());
+    }
+
+    // Replicate the post-announcement defaulting logic: if task_thread_id
+    // was not set by an explicit --thread-id, default to the announcement
+    // message ID.
+    ps.task_message_id
+        .insert(task_id.to_string(), announcement_message_id.to_string());
+    if !ps.task_thread_id.contains_key(task_id) {
+        ps.task_thread_id
+            .insert(task_id.to_string(), announcement_message_id.to_string());
+    }
+
+    assert_eq!(
+        ps.task_thread_id.get("42"),
+        Some(&announcement_message_id.to_string()),
+        "task_thread_id should default to announcement message ID"
+    );
+    assert_eq!(
+        ps.task_thread_id.get("42"),
+        ps.task_message_id.get("42"),
+        "task_thread_id and task_message_id should be equal when no explicit thread_id"
+    );
+}
+
+/// When an explicit `thread_id` is provided, it should NOT be overwritten
+/// by the announcement message ID.
+#[test]
+fn test_task_thread_id_explicit_not_overwritten_by_announcement() {
+    use crate::daemon::state::DaemonPersistentState;
+
+    let mut ps = DaemonPersistentState::default();
+    let task_id = "42";
+    let explicit_thread_id = "explicit-thread-uuid";
+    let announcement_message_id = "msg-uuid-abc-123";
+
+    // Explicit thread_id was provided during task creation
+    ps.task_thread_id
+        .insert(task_id.to_string(), explicit_thread_id.to_string());
+
+    // Replicate the post-announcement defaulting logic
+    ps.task_message_id
+        .insert(task_id.to_string(), announcement_message_id.to_string());
+    if !ps.task_thread_id.contains_key(task_id) {
+        ps.task_thread_id
+            .insert(task_id.to_string(), announcement_message_id.to_string());
+    }
+
+    assert_eq!(
+        ps.task_thread_id.get("42"),
+        Some(&explicit_thread_id.to_string()),
+        "explicit thread_id should not be overwritten by announcement message ID"
+    );
+    assert_ne!(
+        ps.task_thread_id.get("42"),
+        ps.task_message_id.get("42"),
+        "task_thread_id should differ from task_message_id when explicit thread_id was provided"
     );
 }
 


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Wire up `task_thread_id` to default to the announcement message ID when no explicit `--thread-id` is provided during task creation. This ensures `SpawnSession` picks up a `bound_thread_id` so coworker `channel.post` messages auto-route to the task announcement thread via `fork_bound_threads`.
- Update `insight.report` to resolve `task_thread_id` from the coworker's session → task mapping and use `Message::thread_reply()` when a thread binding exists. Previously insights bypassed `fork_bound_threads` entirely since they post via `Message::for_channel()` directly.

## Key changes
- **`rpc_task.rs`**: After storing `task_message_id`, also set `task_thread_id` to the same value when no explicit `--thread-id` was provided
- **`rpc_insight.rs`**: Combined channel and thread resolution into a single lock acquisition; use `Message::thread_reply()` when a task thread binding exists

## Test plan
- [x] Added unit test verifying `task_thread_id` defaults to announcement message ID
- [x] Added unit test verifying explicit `thread_id` is not overwritten
- [x] Added unit test verifying insights route to task thread when `task_thread_id` exists
- [x] Added unit test verifying insights post as top-level messages when no thread binding
- [x] All existing tests pass (2058+ unit tests, 0 failures)
- [x] cargo clippy clean, cargo fmt clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)