### PR TITLE
fix: skip DM separators and streaming for reviewer sessions [Midtown !1865]

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -2369,7 +2369,8 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                                 }
                             }
                             // Look up task_thread_id so coworker posts route to the
-                            // fork session's thread (if the task was created with --thread-id).
+                            // task's thread. This is set either explicitly via --thread-id
+                            // or auto-defaulted to the task announcement message ID.
                             let bound_thread_id = ps.task_thread_id.get(&task_id).cloned();
                             // Populate in-memory cache so handle_channel_post can auto-tag
                             // the coworker's posts without touching persistent state.
@@ -2434,22 +2435,26 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                         record_session_recovery_cooldown(&state.cooldowns, &session_id, resume);
 
                         // Post session separator to the coworker's DM channel.
-                        let task_subject =
-                            crate::tasks::read_tasks_for_repo(Some(&state.repo_name))
-                                .into_iter()
-                                .find(|t| t.id == task_id)
-                                .map(|t| t.subject);
-                        let separator = match task_subject {
-                            Some(subject) => {
-                                format!("─── Task !{}: {} ───", task_id, subject)
-                            }
-                            None => format!("─── Task !{} ───", task_id),
-                        };
-                        let separator_effect = Effect::PostSystemMessage {
-                            message: separator,
-                            channel: Some(format!("dm-{}", name)),
-                        };
-                        Box::pin(execute_effects(vec![separator_effect], state)).await;
+                        // Reviewers are ephemeral PR-scoped sessions — skip DM
+                        // separators since they don't have DM channels.
+                        if !is_reviewer {
+                            let task_subject =
+                                crate::tasks::read_tasks_for_repo(Some(&state.repo_name))
+                                    .into_iter()
+                                    .find(|t| t.id == task_id)
+                                    .map(|t| t.subject);
+                            let separator = match task_subject {
+                                Some(subject) => {
+                                    format!("─── Task !{}: {} ───", task_id, subject)
+                                }
+                                None => format!("─── Task !{} ───", task_id),
+                            };
+                            let separator_effect = Effect::PostSystemMessage {
+                                message: separator,
+                                channel: Some(format!("dm-{}", name)),
+                            };
+                            Box::pin(execute_effects(vec![separator_effect], state)).await;
+                        }
 
                         state.broadcast_coworker_update(&name, "running", None);
                     }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3527,7 +3527,15 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
                     );
 
                     // Build coworker name set: all active session names minus lead,
-                    // channel leads, and fork-bound sessions.
+                    // channel leads, fork-bound sessions, and reviewers.
+                    // Reviewers are ephemeral PR-scoped sessions that shouldn't
+                    // have DM channels or streaming output.
+                    let reviewer_names: std::collections::HashSet<&str> = ps
+                        .sessions
+                        .values()
+                        .filter(|r| r.is_reviewer && r.is_running)
+                        .filter_map(|r| r.current_name.as_deref())
+                        .collect();
                     let coworker_names: std::collections::HashSet<String> = state
                         .name_to_session
                         .lock()
@@ -3537,6 +3545,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
                             *name != &state.repo_name
                                 && !ps.channel_lead_sessions.contains_key(*name)
                                 && !fork_bound_channels.contains_key(*name)
+                                && !reviewer_names.contains(name.as_str())
                         })
                         .cloned()
                         .collect();


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Filter reviewer sessions from the `coworker_names` set in the stream processing loop (`mod.rs`) so their output isn't streamed to `dm-<name>` channels
- Guard DM separator posting in SpawnSession (`effects.rs`) with `!is_reviewer` so "─── Task !N: ... ───" messages aren't posted for reviewer sessions
- Update stale comment about `task_thread_id` to reflect auto-defaulting from task announcement message ID (added in PR #1597)

## Test plan
- [x] All 2066 unit tests pass
- [x] All 688 integration tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] `cargo fmt --all -- --check` passes

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)