### PR TITLE
fix: limit channel history API response to prevent iOS Safari crash

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -533,6 +533,9 @@ struct ChannelHistoryQuery {
     /// Optional thread parent ID to filter by. If provided, return the parent
     /// message itself plus all replies to it.
     thread_parent_id: Option<String>,
+    /// Maximum number of messages to return (default: 500). Only applies to
+    /// non-thread queries; thread queries always return all replies.
+    limit: Option<usize>,
 }
 
 /// Get channel message history
@@ -562,35 +565,46 @@ async fn api_channel_history(
         })?
     };
 
-    let messages = channel.read_all_async().await.map_err(|e| {
-        error!("Failed to read channel: {}", e);
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
     let response: Vec<ChannelMessageData> = match params.thread_parent_id {
-        // Thread history query: return the parent message + its replies.
-        // Including the parent makes the response self-contained so the frontend
-        // doesn't need to hope the parent is in the local message store.
-        Some(parent_id) => messages
-            .into_iter()
-            .filter(|m| is_in_thread(m, &parent_id))
-            .map(|m| {
-                let channel = m.channel_name().to_string();
-                ChannelMessageData {
-                    id: m.id.clone(),
-                    from: m.from,
-                    content: m.content,
-                    timestamp: m.timestamp.to_rfc3339(),
-                    msg_type: format!("{:?}", m.message_type).to_lowercase(),
-                    channel,
-                    thread_parent_id: m.thread_parent_id,
-                    reply_count: None,
-                    last_reply: None,
-                }
-            })
-            .collect(),
-        // Default history query: top-level only, annotated with thread reply metadata.
+        // Thread history query: read ALL messages so we find every reply regardless
+        // of how far back it was posted. Thread responses are small, so this is safe.
+        Some(parent_id) => {
+            let messages = channel.read_all_async().await.map_err(|e| {
+                error!("Failed to read channel: {}", e);
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+            messages
+                .into_iter()
+                .filter(|m| is_in_thread(m, &parent_id))
+                .map(|m| {
+                    let channel = m.channel_name().to_string();
+                    ChannelMessageData {
+                        id: m.id.clone(),
+                        from: m.from,
+                        content: m.content,
+                        timestamp: m.timestamp.to_rfc3339(),
+                        msg_type: format!("{:?}", m.message_type).to_lowercase(),
+                        channel,
+                        thread_parent_id: m.thread_parent_id,
+                        reply_count: None,
+                        last_reply: None,
+                    }
+                })
+                .collect()
+        }
+        // Default history query: load only the most recent N messages, then
+        // return top-level messages annotated with thread reply metadata.
         None => {
+            let limit = params.limit.unwrap_or(500);
+            let (messages, _count) =
+                channel
+                    .read_last_n_messages_async(limit)
+                    .await
+                    .map_err(|e| {
+                        error!("Failed to read channel: {}", e);
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    })?;
+
             let mut reply_meta: std::collections::HashMap<String, (usize, ThreadReplySummary)> =
                 std::collections::HashMap::new();
             for msg in &messages {


### PR DESCRIPTION
## Summary
- The `/api/channels/history` endpoint was returning ALL messages from ALL archived history files (105K messages / 27MB for the midtown channel), causing iOS Safari to crash with "A problem repeatedly occurred"
- Switched non-thread queries from `read_all_async()` to `read_last_n_messages_async(limit)` with a default limit of 500 messages
- Added optional `?limit=N` query parameter for clients to request a specific number of messages
- Thread queries (with `thread_parent_id`) still use `read_all_async()` since thread replies are small and may span archives

## Test plan
- [x] `cargo build` compiles successfully
- [x] `cargo test` — all 2085+ tests pass, 0 failures
- [x] `cargo clippy` and `cargo fmt` pass (pre-commit hooks)
- [ ] `curl http://localhost:47024/api/channels/history | python3 -c "import sys,json; data=json.load(sys.stdin); print(len(data))"` — should return ~500 (not 105K)
- [ ] `curl "http://localhost:47024/api/channels/history?limit=10"` — should return 10 messages
- [ ] Load web app on iOS Safari — should show recent messages without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)