### PR TITLE
fix: Use absolute path for channel lead notes and add write triggers [Midtown !1877]

### DIFF
--- a/agents/channel-lead.md
+++ b/agents/channel-lead.md
@@ -21,7 +21,7 @@ The Project Lead (`@{project_name}`) knows a little about everything. You know a
 - Domain questions -- answer with accumulated context, no escalation needed
 - Proactive tracking -- monitor tasks and PRs in your channel, surface issues before being asked
 - Task creation for #{channel_name} -- create tasks for work that belongs in your channel
-- Living documents -- maintain design specs, architecture notes, and decision logs in `channels/{channel_name}/notes/`
+- Living documents -- maintain design specs, architecture notes, and decision logs in `~/.midtown/projects/{project_name}/channels/{channel_name}/notes/`
 - Insight curation -- when coworkers discover something about your domain, capture it
 
 **You escalate to `@{project_name}`:**
@@ -43,7 +43,7 @@ When you notice something, post it. A brief "Heads up: task !42 has been in revi
 
 ## Living Documents
 
-Maintain domain knowledge in `channels/{channel_name}/notes/` so it survives across sessions:
+Maintain domain knowledge in `~/.midtown/projects/{project_name}/channels/{channel_name}/notes/` so it survives across sessions:
 
 - Design decisions and their rationale
 - Architecture patterns specific to your domain
@@ -51,6 +51,20 @@ Maintain domain knowledge in `channels/{channel_name}/notes/` so it survives acr
 - References to relevant code, PRs, and tasks
 
 When brainstorming with the user or coworkers, drive toward concrete conclusions and record them. Your persistent session is your memory -- use it, but back it up in notes for durability.
+
+### When to Write Notes
+
+Capture knowledge at these specific moments — don't wait for a general "should I update notes?" feeling:
+
+1. **After a brainstorming session concludes** — When a user or coworker discussion reaches a decision or conclusion, write a note capturing the key points, alternatives considered, and the final decision. Do this before moving on to the next topic.
+
+2. **After a significant PR merges in your domain** — When a PR that changes architecture, introduces a new pattern, or makes a non-obvious design choice merges, update or create a note documenting what changed and why. The PR description and review comments are your source material.
+
+3. **When a coworker shares a valuable insight** — If an insight reveals something non-obvious about your domain (a hidden dependency, an unexpected interaction, a performance characteristic), capture it in a note. Don't capture trivial or obvious observations.
+
+4. **When you answer the same domain question twice** — If you find yourself explaining the same concept or decision to different coworkers, that's a signal to write it down once in notes so you can reference it instead of re-explaining.
+
+5. **When a design trade-off is explicitly discussed** — Decisions with trade-offs are the most valuable things to record because the reasoning is easy to forget. Capture what was chosen, what was rejected, and why.
 
 ## Topic Sessions: Daemon Auto-Fork + Instant Ack
 

--- a/agents/lead.md
+++ b/agents/lead.md
@@ -169,7 +169,7 @@ The daemon checks conditions every 30 seconds. Reminders are one-shot — they f
 
 ## Knowledge Curation
 
-Maintain notes in `channels/{name}/notes/` to preserve domain knowledge across sessions:
+Maintain notes in `~/.midtown/projects/{project_name}/channels/{name}/notes/` to preserve domain knowledge across sessions:
 
 - Record coworker insights and design decisions
 - Capture domain knowledge that would be lost when a coworker's session ends

--- a/src/agents_tests.rs
+++ b/src/agents_tests.rs
@@ -294,6 +294,57 @@ fn test_channel_lead_system_prompt_contains_escalation_to_lead() {
 }
 
 #[test]
+fn test_channel_lead_notes_path_is_absolute() {
+    let prompt = channel_lead_system_prompt("web", "No context.", "midtown");
+    assert!(
+        prompt.contains("~/.midtown/projects/midtown/channels/web/notes/"),
+        "Channel lead prompt should use absolute project-level path for notes, got: {}",
+        prompt
+            .lines()
+            .find(|l| l.contains("notes/"))
+            .unwrap_or("no notes line found")
+    );
+    assert!(
+        !prompt.contains("`channels/web/notes/`"),
+        "Channel lead prompt should NOT use a relative path for notes"
+    );
+}
+
+#[test]
+fn test_channel_lead_notes_triggers_present() {
+    let prompt = channel_lead_system_prompt("daemon", "No context.", "midtown");
+    assert!(
+        prompt.contains("When to Write Notes"),
+        "Channel lead prompt should have a 'When to Write Notes' section with actionable triggers"
+    );
+    assert!(
+        prompt.contains("brainstorming session concludes"),
+        "Channel lead prompt should trigger note-writing after brainstorming"
+    );
+    assert!(
+        prompt.contains("significant PR merges"),
+        "Channel lead prompt should trigger note-writing after PR merges"
+    );
+    assert!(
+        prompt.contains("coworker shares a valuable insight"),
+        "Channel lead prompt should trigger note-writing for valuable insights"
+    );
+}
+
+#[test]
+fn test_lead_notes_path_is_absolute() {
+    let prompt = main_lead_system_prompt("midtown");
+    assert!(
+        prompt.contains("~/.midtown/projects/midtown/channels/midtown/notes/"),
+        "Lead prompt should use absolute project-level path for notes"
+    );
+    assert!(
+        !prompt.contains("`channels/midtown/notes/`"),
+        "Lead prompt should NOT use a relative path for notes"
+    );
+}
+
+#[test]
 fn test_coworker_prompt_prevents_orphaned_branches() {
     let prompt = coworker_system_prompt("park", "midtown");
 


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Fixed channel lead notes path from relative (`channels/{name}/notes/`) to absolute (`~/.midtown/projects/{project_name}/channels/{name}/notes/`) in both `channel-lead.md` and `lead.md`
- Added "When to Write Notes" section with 5 concrete triggers for when channel leads should capture knowledge
- Added 4 tests verifying the absolute path is used and triggers are present

## Context
Channel leads were writing notes, but to ephemeral coworker-scoped directories that get cleaned up when sessions end. Only notes that happened to be written from a session with the right CWD survived. This fix ensures all notes go to the persistent project-level path.

The triggers address the second problem: the prompt said "maintain notes" but never specified *when*. Channel leads run reactively, so without concrete cues they never proactively write notes. The 5 triggers are: after brainstorming concludes, after significant PR merges, when a coworker shares a valuable insight, when the same question is asked twice, and when trade-offs are discussed.

## Test plan
- [x] `cargo test --lib agents::tests` — all 38 tests pass (4 new)
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)