### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "midtown"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "axum",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "midtown"
-version = "0.5.4"
+version = "0.6.0"
 edition = "2024"
 description = "Midtown - a multi-Claude Code workspace manager, inspired by Gastown"
 license = "MIT"


### PR DESCRIPTION
<!-- midtown: midtown -->

## Summary
- Bump Cargo.toml version from 0.5.4 to 0.6.0 for release

## Test plan
- [x] `cargo check` passes
- [ ] CI passes

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)