### PR TITLE
fix: Complete no-PR tasks directly instead of nudging for PR [Midtown !1879]

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -388,6 +388,14 @@ When a coworker calls `midtown pr merge --pr <N>`, the daemon runs three gates b
 
 When a coworker is called in, midtown creates a detached git worktree at the current HEAD. The coworker creates a feature branch and works independently. When the coworker shuts down, worktrees with no commits and no uncommitted changes are automatically cleaned up along with their branches. Worktrees with work in progress are preserved.
 
+## Task Completion
+
+Tasks complete through two paths depending on whether they produce a PR:
+
+1. **PR tasks** (most common): The coworker opens a PR and reports `midtown state idle`. The daemon auto-completes the task when the PR merges, via webhook or polling fallback. The task stays `in_progress` until merge — `task_has_open_pr()` in `rpc_coworker.rs` checks both `pr_author_sessions` (in-memory) and the `task.pr` field on disk (survives daemon restarts) to detect this.
+
+2. **No-PR tasks** (ops, release management, investigations): The coworker reports `midtown state completed`. Since no PR exists, the daemon completes the task directly on disk (same as `task.done` RPC), clears `blocked_by` dependencies, and marks the worktree as completed. This avoids the respawn loop that occurs when a task stays `in_progress` with no PR — dispatch would repeatedly recover and respawn the coworker.
+
 ## GitHub Integration
 
 The daemon receives real-time GitHub events via webhooks (PR creation, reviews, check runs) verified with HMAC-SHA256 signatures. PR polling runs as a backstop for missed webhook deliveries and handles time-based concerns like merge conflict detection and stuck PR identification.

--- a/src/daemon/rpc_coworker.rs
+++ b/src/daemon/rpc_coworker.rs
@@ -688,23 +688,47 @@ pub(super) async fn handle_coworker_questions(id: RequestId, state: &DaemonState
 
 /// Check if a task has an associated open PR.
 ///
-/// Returns true if any open PR has this task_id stored in its PrAuthorSession.
-/// This mapping is established when a coworker opens a PR - the daemon extracts
-/// the task ID from the PR title's "[Midtown !XXX]" marker and stores it in
-/// persistent state.
+/// Returns true if the task has an associated open PR, checking two sources:
 ///
-/// Presence in `pr_author_sessions` implies the PR is still open — closed PRs
-/// are cleaned up by `cleanup_closed_pr_state`.
+/// 1. **`pr_author_sessions` (in-memory persistent state)**: Presence implies
+///    the PR is still open — closed PRs are cleaned up by `cleanup_closed_pr_state`.
+///    This mapping is established when a coworker opens a PR and the daemon
+///    extracts the task ID from the PR title's `[Midtown !XXX]` marker.
 ///
-/// Used to decide whether to auto-complete a task when a coworker reports
-/// WorkflowPhase::Completed. Tasks with open PRs should complete on merge,
-/// not on phase transition.
+/// 2. **`task.pr` field on disk**: The task file may have an explicit PR number
+///    set via `--pr` or auto-detected. This survives daemon restarts (unlike
+///    `pr_author_sessions` which is rebuilt over time). If set, we treat it as
+///    an open PR to err on the side of deferring to the merge path.
+///
+/// Used to decide completion strategy when a coworker reports
+/// `WorkflowPhase::Completed`:
+/// - Tasks WITH open PRs defer completion to the merge path (auto-complete on merge).
+/// - Tasks WITHOUT open PRs are completed directly to avoid the respawn loop (!1879).
 async fn task_has_open_pr(task_id: &str, state: &DaemonState) -> bool {
-    let ps = state.persistent_state.lock().await;
-    ps.github
-        .pr_author_sessions
-        .values()
-        .any(|session| session.task_id.as_deref() == Some(task_id))
+    // Source 1: in-memory pr_author_sessions
+    let in_memory = {
+        let ps = state.persistent_state.lock().await;
+        ps.github
+            .pr_author_sessions
+            .values()
+            .any(|session| session.task_id.as_deref() == Some(task_id))
+    };
+    if in_memory {
+        return true;
+    }
+
+    // Source 2: task.pr field on disk (survives daemon restarts)
+    if let Some(task) = crate::tasks::read_task_for_repo(task_id, &state.repo_name)
+        && let Some(pr_num) = task.pr
+    {
+        debug!(
+            "Task !{} has pr={} on disk — treating as having an open PR",
+            task_id, pr_num
+        );
+        return true;
+    }
+
+    false
 }
 
 // ============================================================================

--- a/src/daemon/rpc_coworker_tests.rs
+++ b/src/daemon/rpc_coworker_tests.rs
@@ -724,6 +724,74 @@ async fn test_completed_without_pr_marks_task_done() {
 }
 
 #[tokio::test]
+async fn test_completed_with_pr_on_disk_defers_to_merge_path() {
+    // Review feedback (!1879): After a daemon restart, pr_author_sessions is
+    // empty but the task's `pr` field on disk still has the PR number.
+    // task_has_open_pr must check the disk field to avoid orphaning the PR.
+    let (state, _tmp, _guard) = make_test_state();
+
+    // Create a task file on disk WITH a pr field set (simulating post-restart state)
+    let home = dirs::home_dir().expect("home dir");
+    let task_list_id = crate::paths::task_list_id_for_repo(&state.repo_name);
+    let tasks_dir = home.join(".claude").join("tasks").join(&task_list_id);
+    std::fs::create_dir_all(&tasks_dir).expect("create tasks dir");
+    let task_id = "9952";
+    let task_file = tasks_dir.join(format!("{}.json", task_id));
+    std::fs::write(
+        &task_file,
+        serde_json::to_string(&serde_json::json!({
+            "id": task_id,
+            "subject": "Add new endpoint",
+            "status": "in_progress",
+            "owner": "riverside",
+            "pr": 99
+        }))
+        .unwrap(),
+    )
+    .expect("write task file");
+
+    // Set up in-memory task assignment
+    {
+        let mut assignments = state.coworker_task_assignments.lock().unwrap();
+        assignments.insert(
+            "riverside".to_string(),
+            super::super::TaskAssignment {
+                task_id: task_id.to_string(),
+            },
+        );
+    }
+
+    // NOTE: pr_author_sessions is empty — simulates daemon restart.
+    // The task has pr=99 on disk but no in-memory PR tracking.
+
+    // Report completed — task.pr is set on disk
+    let response = handle_coworker_report_state(
+        RequestId::Number(1),
+        "riverside",
+        "completed",
+        Some(9952u32),
+        None,
+        None,
+        &state,
+    )
+    .await;
+
+    assert!(!response.is_error(), "completed report should succeed");
+
+    // Task should remain in_progress (deferred to merge path via disk pr field)
+    let content = std::fs::read_to_string(&task_file).expect("read task file");
+    let parsed: serde_json::Value = serde_json::from_str(&content).expect("parse task json");
+    assert_eq!(
+        parsed["status"].as_str().unwrap(),
+        "in_progress",
+        "task with pr field on disk should remain in_progress (deferred to merge path)"
+    );
+
+    // Cleanup
+    let _ = std::fs::remove_file(&task_file);
+}
+
+#[tokio::test]
 async fn test_completed_with_open_pr_defers_to_merge_path() {
     // When a task HAS an open PR, reporting completed should NOT complete
     // the task on disk — it defers to the PR merge auto-completion path.

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -79,7 +79,14 @@ pub fn read_tasks_for_session(session_id: &str) -> Vec<Task> {
 /// Returns None if the task doesn't exist or can't be parsed.
 pub fn read_task(task_id: &str) -> Option<Task> {
     let repo = crate::paths::detect_repo_name().unwrap_or_else(|| "default".to_string());
-    let task_list_id = crate::paths::task_list_id_for_repo(&repo);
+    read_task_for_repo(task_id, &repo)
+}
+
+/// Read a single task by ID for a specific repository.
+///
+/// Returns None if the task doesn't exist or can't be parsed.
+pub fn read_task_for_repo(task_id: &str, repo_name: &str) -> Option<Task> {
+    let task_list_id = crate::paths::task_list_id_for_repo(repo_name);
 
     let home = dirs::home_dir()?;
 


### PR DESCRIPTION
<!-- midtown: park -->

## Summary

- When a coworker reported `midtown state completed` on a task without an open PR, the daemon nudged "please open a PR" but left the task `in_progress`. This caused `dispatch_via_sessions` to respawn the coworker repeatedly (riverside hit 7+ sessions on task !1878 for v0.6.0 release)
- Now the daemon completes the task on disk when the coworker reports completed, even without a PR. This handles legitimate no-PR tasks (release management, ops, investigations)
- Tasks with open PRs still defer to the merge auto-completion path (existing behavior preserved)

## Test plan

- [x] `test_completed_without_pr_marks_task_done` — verifies task is marked completed on disk when reported completed without PR
- [x] `test_completed_with_open_pr_defers_to_merge_path` — verifies task with open PR stays `in_progress` (deferred to merge path)
- [x] Full test suite passes (`cargo test`)
- [x] `cargo clippy` and `cargo fmt` pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)