### PR TITLE
ci: add binary release assets to publish workflow [Midtown !1880]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,14 +176,20 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
-      - name: Build release binary
-        run: cargo build --release
-
-      - name: Get version
+      - name: Verify version matches release tag
         id: version
         run: |
+          CARGO_VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)"/\1/')
           RELEASE_TAG="${{ github.event.release.tag_name }}"
-          echo "version=${RELEASE_TAG#v}" >> $GITHUB_OUTPUT
+          RELEASE_VERSION="${RELEASE_TAG#v}"
+          if [ "$CARGO_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "Error: Cargo.toml version ($CARGO_VERSION) does not match release tag ($RELEASE_VERSION)"
+            exit 1
+          fi
+          echo "version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Build release binary
+        run: cargo build --release
 
       - name: Package binary
         run: |


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Adds a `binaries` job to the publish workflow that builds platform-specific release binaries
- Covers 4 targets: darwin-arm64, darwin-amd64, linux-amd64, linux-arm64
- Uses native GitHub runners (no cross-compilation) for each platform
- Packages binaries as tarballs (e.g., `midtown-darwin-arm64-v0.6.0.tar.gz`) and uploads them as release assets via `gh release upload`
- Runs in parallel with existing `crates` and `docker-build` jobs

## Design decisions
- **Native runners over cross-compilation**: Uses `macos-latest` (ARM64), `macos-13` (x86_64), `ubuntu-latest` (amd64), and `ubuntu-24.04-arm` (arm64) — matching the pattern already used by the `docker-build` job
- **`gh release upload` over deprecated action**: The `actions/upload-release-asset` action is archived; `gh` CLI is pre-installed on all runners and `--clobber` handles re-runs gracefully
- **`contents: write` permission**: Required to upload assets to the release object

## Test plan
- [x] YAML validates correctly (no tabs, consistent indentation)
- [x] Pre-commit hooks pass (clippy + fmt)
- [ ] Workflow runs on next release publish (can verify structure in CI dry-run)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)