### PR TITLE
chore: bump version to 0.6.1 [Midtown !1881]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "midtown"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "axum",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "midtown"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "Midtown - a multi-Claude Code workspace manager, inspired by Gastown"
 license = "MIT"


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Bumps version from 0.6.0 to 0.6.1 in Cargo.toml and Cargo.lock
- This will be the first release with binary assets attached (darwin-arm64, darwin-amd64, linux-amd64, linux-arm64) thanks to the publish workflow added in #1614

## Test plan
- [x] `cargo check` passes with updated version
- [x] Pre-commit hooks (fmt + clippy) pass
- [ ] After merge: tag v0.6.1, create release, verify binary assets are uploaded

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)