### PR TITLE
feat: Add curl | bash install script and document in README [Midtown !1883]

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The quickest way to install:
 curl -fsSL https://raw.githubusercontent.com/btucker/midtown/main/install.sh | sh
 ```
 
-This detects your OS and architecture, downloads the latest release binary, and installs it to `~/.cargo/bin`. Set `MIDTOWN_INSTALL_DIR` to change the install location.
+This detects your OS and architecture, downloads the latest release binary, and installs it to `~/.cargo/bin`. Set `MIDTOWN_INSTALL_DIR` to change the install location. If `~/.cargo/bin` is not already in your PATH, the script will print instructions to add it.
 
 Or install from [crates.io](https://crates.io/crates/midtown):
 

--- a/install.sh
+++ b/install.sh
@@ -53,19 +53,23 @@ echo "Latest version: ${VERSION}"
 
 # ── Download and install ─────────────────────────────────────────────────────
 
-ASSET="midtown-${OS}-${ARCH}-${VERSION}.tar.gz"
+# Normalize version: strip leading "v" to get the bare version number.
+# Asset naming must match .github/workflows/publish.yml which produces
+# midtown-<os>-<arch>-v<bare_version>.tar.gz
+BARE_VERSION="${VERSION#v}"
+ASSET="midtown-${OS}-${ARCH}-v${BARE_VERSION}.tar.gz"
 URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
 
 echo "Downloading ${ASSET}..."
 
-TMPDIR="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR"' EXIT
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
-curl -fsSL "$URL" -o "${TMPDIR}/${ASSET}"
-tar xzf "${TMPDIR}/${ASSET}" -C "$TMPDIR"
+curl -fsSL "$URL" -o "${TMP_DIR}/${ASSET}"
+tar xzf "${TMP_DIR}/${ASSET}" -C "$TMP_DIR"
 
 mkdir -p "$INSTALL_DIR"
-mv "${TMPDIR}/midtown" "${INSTALL_DIR}/midtown"
+mv "${TMP_DIR}/midtown" "${INSTALL_DIR}/midtown"
 chmod +x "${INSTALL_DIR}/midtown"
 
 echo ""


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Add `install.sh` to the repo root — a POSIX-compatible shell script that detects OS/arch, downloads the latest release binary from GitHub, and installs it to `~/.cargo/bin` (configurable via `MIDTOWN_INSTALL_DIR`)
- Update README.md to show `curl | sh` as the primary (quickest) install method, keeping `cargo install` and source build as alternatives

## Test plan
- [x] Tested locally on macOS arm64 — script downloads v0.6.1 binary and installs correctly
- [x] Verified installed binary runs (`midtown --help`)
- [x] Script handles missing PATH gracefully with a helpful message

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)