### PR TITLE
fix: switch x86_64-apple-darwin build from macos-13 to cross-compilation [Midtown !1884]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -145,7 +145,8 @@ jobs:
             $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
   # ─── Build platform-specific binaries and upload as release assets ─────
-  # Uses native runners for each platform — no cross-compilation needed.
+  # Uses native runners where possible; cross-compiles x86_64-apple-darwin
+  # on arm64 macOS (macos-13 Intel runners were retired by GitHub).
   binaries:
     name: Binary (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
@@ -157,7 +158,7 @@ jobs:
           - runner: macos-latest
             target: aarch64-apple-darwin
             asset: midtown-darwin-arm64
-          - runner: macos-13
+          - runner: macos-latest
             target: x86_64-apple-darwin
             asset: midtown-darwin-amd64
           - runner: ubuntu-latest
@@ -171,6 +172,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -189,12 +192,12 @@ jobs:
           echo "version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Build release binary
-        run: cargo build --release
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package binary
         run: |
           mkdir -p staging
-          cp target/release/midtown staging/
+          cp target/${{ matrix.target }}/release/midtown staging/
           cd staging
           tar czf ../${{ matrix.asset }}-v${{ steps.version.outputs.version }}.tar.gz midtown
 


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- GitHub retired the `macos-13` (Intel x86_64) runner, causing the `x86_64-apple-darwin` binary job to be cancelled during the v0.6.1 publish
- Switched to `macos-latest` (arm64 Apple Silicon) and cross-compile using `--target x86_64-apple-darwin`
- All binary matrix entries now use explicit `--target` for consistent build output paths (`target/<triple>/release/`)
- Added `targets` param to `dtolnay/rust-toolchain` to install cross-compilation targets

## Test plan
- [x] Workflow YAML is valid
- [ ] Next release publish will verify the x86_64-apple-darwin binary builds correctly via cross-compilation

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)