### PR TITLE
chore: bump version to 0.6.2 [Midtown !1886]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "midtown"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "axum",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "midtown"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 description = "Midtown - a multi-Claude Code workspace manager, inspired by Gastown"
 license = "MIT"


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Bumps version from 0.6.1 → 0.6.2 for patch release

Changes since v0.6.1:
- fix: Complete no-PR tasks directly (PR #1613)
- feat: curl | bash install script (PR #1617)
- ci: Fix x86_64-apple-darwin cross-compile (PR #1618)
- fix: Check disk task.pr field in task_has_open_pr (PR #1616)
- fix: Handle edited issue_comment webhooks (PR #1619)

## Test plan
- [x] `cargo check` passes with updated Cargo.lock
- [x] Pre-commit hooks (clippy + fmt) pass
- [ ] CI passes on PR
- [ ] After merge, tag with `gh release create v0.6.2 --target <merge-sha> --generate-notes`
- [ ] Verify publish workflow produces all 4 platform binaries

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)