### PR TITLE
chore: bump version to 0.6.3 for patch release [Midtown !1889]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "midtown"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "axum",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "midtown"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 description = "Midtown - a multi-Claude Code workspace manager, inspired by Gastown"
 license = "MIT"


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Bumps version from 0.6.2 → 0.6.3 in Cargo.toml and Cargo.lock
- PR #1621 landed web-app bundling in release tarballs — this version bump enables cutting a release that includes the web UI

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` passes (pre-commit hook)
- [x] `cargo fmt` passes (pre-commit hook)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)