### PR TITLE
feat: Render DM channels with friendly @name in TUI [Midtown !1891]

### DIFF
--- a/src/bin/midtown/cli/chat/ui/board.rs
+++ b/src/bin/midtown/cli/chat/ui/board.rs
@@ -223,12 +223,13 @@ pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> (Vec<Hyperl
     (hyperlinks, tasks_area)
 }
 
-/// Render a channel header line: `#channel-name` with optional `(X)` unread count.
+/// Render a channel header line: `#channel-name` or `@peer` (for DMs) with optional `(X)` unread count.
 fn render_channel_header(app: &App, channel_name: &str, lines: &mut Vec<Line<'static>>) {
+    let display_name = super::format_channel_display_name(channel_name);
     let channel_header = if let Some(&unread_count) = app.channel_unread_counts.get(channel_name) {
-        format!("#{} ({})", channel_name, unread_count)
+        format!("{} ({})", display_name, unread_count)
     } else {
-        format!("#{}", channel_name)
+        display_name
     };
 
     let is_selected = app.board_selection.as_ref().is_some_and(|sel| match sel {

--- a/src/bin/midtown/cli/chat/ui/chat.rs
+++ b/src/bin/midtown/cli/chat/ui/chat.rs
@@ -229,10 +229,11 @@ fn draw_pending_questions(
 
 /// Draw the chat messages area (top of chat panel)
 fn draw_chat_messages(f: &mut Frame, app: &mut App, area: Rect) {
+    let display_name = super::format_channel_display_name(&app.selected_channel);
     let title = if app.selection_mode {
-        format!(" #{} [SELECT] ", app.selected_channel)
+        format!(" {} [SELECT] ", display_name)
     } else {
-        format!(" #{} ", app.selected_channel)
+        format!(" {} ", display_name)
     };
     let palette = app.theme.palette();
     let is_focused = app.focused_pane == FocusedPane::Chat;
@@ -720,7 +721,8 @@ pub fn draw_channel_switcher_overlay(f: &mut Frame, app: &App, area: Rect) {
             } else {
                 String::new()
             };
-            let channel_text = format!(" #{}{}", channel.name, unread_suffix);
+            let display_name = super::format_channel_display_name(&channel.name);
+            let channel_text = format!(" {}{}", display_name, unread_suffix);
 
             let style = if is_selected {
                 Style::default()

--- a/src/bin/midtown/cli/chat/ui/mod.rs
+++ b/src/bin/midtown/cli/chat/ui/mod.rs
@@ -51,6 +51,18 @@ pub struct Hyperlink {
 /// Gutter width for timestamp: " HH:MM " = 7 chars
 const TIMESTAMP_GUTTER_WIDTH: usize = 7;
 
+/// Format a channel name for display.
+///
+/// DM channels (`dm-<name>`) are rendered as `@<name>` to match the web UI.
+/// Regular channels keep the `#<name>` prefix.
+pub(super) fn format_channel_display_name(channel_name: &str) -> String {
+    if let Some(peer) = channel_name.strip_prefix("dm-") {
+        format!("@{}", peer)
+    } else {
+        format!("#{}", channel_name)
+    }
+}
+
 /// Maximum sidebar width in terminal columns (including left and right borders)
 const MAX_SIDEBAR_WIDTH: u16 = 40;
 
@@ -340,5 +352,30 @@ mod tests {
 
         assert_eq!(format_relative_time(now - Duration::days(1)), "1 day ago");
         assert_eq!(format_relative_time(now - Duration::days(7)), "7 days ago");
+    }
+
+    #[test]
+    fn test_format_channel_display_name_regular() {
+        assert_eq!(format_channel_display_name("midtown"), "#midtown");
+        assert_eq!(format_channel_display_name("tui"), "#tui");
+        assert_eq!(format_channel_display_name("ops"), "#ops");
+    }
+
+    #[test]
+    fn test_format_channel_display_name_dm() {
+        assert_eq!(format_channel_display_name("dm-park"), "@park");
+        assert_eq!(format_channel_display_name("dm-vernon"), "@vernon");
+        assert_eq!(format_channel_display_name("dm-riverside"), "@riverside");
+    }
+
+    #[test]
+    fn test_format_channel_display_name_dm_edge_cases() {
+        // Channel that contains "dm-" but doesn't start with it
+        assert_eq!(
+            format_channel_display_name("my-dm-channel"),
+            "#my-dm-channel"
+        );
+        // Bare "dm-" prefix with empty peer name
+        assert_eq!(format_channel_display_name("dm-"), "@");
     }
 }


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- DM channels (`dm-<peer>`) now display as `@<peer>` instead of `#dm-<peer>` in the TUI, matching the web UI pattern
- Added `format_channel_display_name()` helper in `ui/mod.rs` that detects the `dm-` prefix and renders `@peer` for DMs, `#name` for regular channels
- Updated all three render sites: board sidebar header, chat panel title bar, and Ctrl+K channel switcher

## Test plan
- [x] Unit tests for `format_channel_display_name()` covering regular channels, DM channels, and edge cases
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` passes
- [x] `cargo build` succeeds

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)