### PR TITLE
feat: collapse DM sidebar section by default, show only unread [Midtown !1895]

### DIFF
--- a/web-app/src/lib/ChannelList.svelte
+++ b/web-app/src/lib/ChannelList.svelte
@@ -36,7 +36,7 @@
   $: visibleDmChannels = dmSectionExpanded
     ? showAllDms
       ? dmChannels
-      : dmChannels.filter((ch) => ch.unread > 0)
+      : dmChannels.filter((ch) => ch.unread > 0 || ch.name === $activeChannel)
     : []
 
   function selectChannel(channelName) {


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- DM section in sidebar is now **collapsed by default** — users primarily reach DMs via the CoworkerStatus box, so the sidebar DM list was redundant
- When expanded, only shows DMs with **unread messages** (acts as an inbox)
- "**show all**" toggle at the bottom reveals the full DM list; "show less" returns to unread-only
- **Unread count badge** appears on the collapsed header when there are unreads (e.g., "Direct Messages ●2")

## Changes
- `web-app/src/lib/ChannelList.svelte` — single file change (57 insertions, 19 deletions)

## Test plan
- [x] DM section collapsed by default on page load
- [x] Clicking header toggles expand/collapse with ▶/▼ indicator
- [x] When expanded, only DMs with unread messages appear
- [x] "show all (N)" link appears when there are hidden DMs
- [x] Clicking "show all" reveals all DMs; "show less" hides read ones
- [x] Unread count badge visible on collapsed header when unreads exist
- [x] Badge hidden when no unreads or when section is expanded
- [x] Collapsing resets "show all" state
- [x] Web app builds successfully (`npm run build`)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)