### PR TITLE
fix: restore list markers stripped by Tailwind Preflight [Midtown !1897]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -953,13 +953,19 @@
     margin: 5px 0 3px;
   }
 
-  /* Lists */
+  /* Lists — restore list-style-type stripped by Tailwind Preflight */
   :global(.message-text ul),
+  :global(.action-text ul) {
+    margin: 3px 0;
+    padding-left: 1.6em;
+    list-style-type: disc;
+  }
+
   :global(.message-text ol),
-  :global(.action-text ul),
   :global(.action-text ol) {
     margin: 3px 0;
     padding-left: 1.6em;
+    list-style-type: decimal;
   }
 
   /* Blockquotes */

--- a/web-app/src/lib/markdown.test.js
+++ b/web-app/src/lib/markdown.test.js
@@ -146,6 +146,14 @@ describe('renderContent', () => {
     expect(result).toContain('<li>item2</li>')
   })
 
+  it('renders ordered lists', () => {
+    const result = renderContent('1. first\n2. second\n3. third')
+    expect(result).toContain('<ol>')
+    expect(result).toContain('<li>first</li>')
+    expect(result).toContain('<li>second</li>')
+    expect(result).toContain('<li>third</li>')
+  })
+
   // Headings
   it('renders headings', () => {
     expect(renderContent('# Title')).toContain('<h1>Title</h1>')


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Tailwind's Preflight CSS reset sets `list-style: none` on all `<ol>` and `<ul>` elements globally
- The message content styles in Channel.svelte restored `padding-left` (for indentation) but never restored `list-style-type`, leaving numbered and bulleted lists without their markers
- Split the combined `ul, ol` CSS rule and added `list-style-type: disc` for `<ul>` and `list-style-type: decimal` for `<ol>` within `.message-text` and `.action-text` containers
- Added ordered list test to markdown.test.js

## Test plan
- [x] All 157 web-app tests pass (6 test files)
- [x] New ordered list test verifies `<ol>` HTML output
- [ ] Visual verification: send a message with `1. First\n2. Second\n3. Third` — numbers should appear
- [ ] Visual verification: send a message with `- item\n- item` — bullets should appear

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)