### PR TITLE
feat: Gate PrApproved workflow event on reviewer completion [Midtown !1902]

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -384,6 +384,10 @@ When a coworker calls `midtown pr merge --pr <N>`, the daemon runs three gates b
 
 **Effect**: On success, `Effect::MergePr` calls `gh pr merge --squash --auto` with `current_dir` set to the repo path.
 
+**Pre-gate — Reviewer active**: Before the three gates, the RPC handler checks `get_reviewer(pr_number)`. If a reviewer coworker is still assigned, the merge is hard-blocked. This prevents the PR #1624 incident where a merge happened while the reviewer was still working.
+
+**Workflow event gate** (`pr.approved`): The `PrApproved` workflow event is gated on the same reviewer check in `pr_action_to_effects`. When `PrContext.has_active_reviewer` is true (reviewer assigned AND review not yet cached), `PrApproved` is suppressed so workflow scripts don't prematurely nudge the author to merge. The `Approved` nudge cooldown is cleared when the reviewer finishes (in `collect_reviewer_effects`) so PrApproved fires promptly on the next tick.
+
 ## Worktree Lifecycle
 
 When a coworker is called in, midtown creates a detached git worktree at the current HEAD. The coworker creates a feature branch and works independently. When the coworker shuts down, worktrees with no commits and no uncommitted changes are automatically cleaned up along with their branches. Worktrees with work in progress are preserved.

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -185,7 +185,12 @@ impl PrContext {
         // Gate check: reviewer assigned in github-state (raw presence, no timeout).
         // Uses get_reviewer() like the RPC merge gate (!1896) so the workflow event
         // layer stays consistent with the merge enforcement layer.
-        let has_active_reviewer = ps.github.get_reviewer(pr_number).is_some();
+        //
+        // Bypass: if the review is already cached (complete), don't suppress
+        // PrApproved even if the assignment hasn't been cleared yet. This handles
+        // the race between webhook review completion and poll-tick assignment removal.
+        let has_active_reviewer =
+            ps.github.get_reviewer(pr_number).is_some() && !ps.github.has_cached_review(pr_number);
 
         Self {
             pr_task_associations,
@@ -197,6 +202,10 @@ impl PrContext {
     }
 
     /// Extract only channel routing data (when session context isn't needed).
+    ///
+    /// Note: `has_active_reviewer` defaults to `false` because this constructor
+    /// is only used for `ReviewComplete` contexts where the reviewer has already
+    /// finished. Do NOT use this for `PrIssueType::Approved` code paths.
     fn routing_only(ps: &super::state::DaemonPersistentState) -> Self {
         Self {
             pr_task_associations: ps.github.pr_to_task_map(),
@@ -213,11 +222,12 @@ impl PrContext {
         self.task_channel.get(task_id).cloned()
     }
 
-    /// Defense-in-depth: check if any coworker in `reviewing_phase_coworkers`
-    /// (from the snapshot) is assigned to review this PR.
+    /// Defense-in-depth: cross-check `reviewing_phase_coworkers` from the
+    /// snapshot against `reviewer_pr_assignments` for this specific PR.
     ///
-    /// Catches the edge case where the reviewer assignment has been cleared
-    /// but the coworker session is still in Reviewing workflow phase.
+    /// Confirms that the reviewer detected by `get_reviewer()` is still in
+    /// Reviewing workflow phase. This is a secondary signal from the coworker
+    /// session, complementing the persistent-state assignment check.
     fn augment_reviewer_from_snapshot(
         &mut self,
         pr_number: u64,
@@ -230,42 +240,6 @@ impl PrContext {
             .reviewing_phase_coworkers
             .iter()
             .any(|name| snap.reviewer_pr_assignments.get(name).copied() == Some(pr_number));
-    }
-
-    /// Async version of the reviewing-phase check, reading coworker records
-    /// and reviewer assignments directly from state. Used by webhook handlers
-    /// that don't have a snapshot available.
-    async fn augment_reviewer_from_coworker_records(
-        &mut self,
-        pr_number: u64,
-        state: &DaemonState,
-    ) {
-        if self.has_active_reviewer {
-            return; // Already flagged via get_reviewer()
-        }
-        let reviewing_names: std::collections::HashSet<String> = {
-            let records = state.coworker_records.read().await;
-            records
-                .iter()
-                .filter(|(_, rec)| {
-                    matches!(
-                        rec.workflow_phase,
-                        Some(crate::coworker_state::WorkflowPhase::Reviewing)
-                    )
-                })
-                .map(|(name, _)| name.to_lowercase())
-                .collect()
-        };
-        if reviewing_names.is_empty() {
-            return;
-        }
-        let ps = state.persistent_state.lock().await;
-        self.has_active_reviewer = reviewing_names.iter().any(|name| {
-            ps.github
-                .pr_for_reviewer(name)
-                .map(|assigned_pr| assigned_pr == pr_number)
-                .unwrap_or(false)
-        });
     }
 }
 
@@ -1235,6 +1209,10 @@ async fn collect_green_with_feedback_effects(
 /// into concrete effects. Uses `SpawnCoworkerWithCallbacks` for spawn actions so
 /// that follow-up effects (broadcast update, channel message, session cleanup)
 /// only happen on success, with a fallback message on failure.
+///
+/// Also gates `PrApproved` workflow events: when `ctx.has_active_reviewer` is true,
+/// the `PrApproved` event is suppressed to keep the workflow script contract clean
+/// ("pr.approved = safe to merge"). See !1902.
 fn pr_action_to_effects(
     action: crate::rules::PrAction,
     pr_number: u64,
@@ -3856,19 +3834,40 @@ pub(super) async fn handle_webhook_review_state_change(
         .cloned()
         .collect();
 
-    // Extract all decision context from persistent state in one lock
-    let (mut pr_ctx, channel_lead_names) = {
-        let ps = state.persistent_state.lock().await;
-        (
-            PrContext::from_persistent_state(&ps, pr_number),
-            ps.channel_lead_names(),
-        )
+    // Pre-collect reviewing-phase coworker names (read lock, then release)
+    // so we can augment the reviewer check without holding two locks.
+    let reviewing_names: std::collections::HashSet<String> = {
+        let records = state.coworker_records.read().await;
+        records
+            .iter()
+            .filter(|(_, rec)| {
+                matches!(
+                    rec.workflow_phase,
+                    Some(crate::coworker_state::WorkflowPhase::Reviewing)
+                )
+            })
+            .map(|(name, _)| name.to_lowercase())
+            .collect()
     };
 
-    // Defense-in-depth: also check reviewing_phase_coworkers from coworker records.
-    pr_ctx
-        .augment_reviewer_from_coworker_records(pr_number, state)
-        .await;
+    // Extract all decision context from persistent state in one lock
+    let (pr_ctx, channel_lead_names) = {
+        let ps = state.persistent_state.lock().await;
+        let mut ctx = PrContext::from_persistent_state(&ps, pr_number);
+
+        // Defense-in-depth: cross-check reviewing_phase_coworkers against
+        // reviewer assignments for this PR (same logic as snapshot path).
+        if !ctx.has_active_reviewer && !reviewing_names.is_empty() {
+            ctx.has_active_reviewer = reviewing_names.iter().any(|name| {
+                ps.github
+                    .pr_for_reviewer(name)
+                    .map(|assigned_pr| assigned_pr == pr_number)
+                    .unwrap_or(false)
+            });
+        }
+
+        (ctx, ps.channel_lead_names())
+    };
 
     let action = crate::rules::decide_pr_issue_action_with_handoff(
         &owner,

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -3370,3 +3370,36 @@ fn pr_approved_re_emitted_after_reviewer_clears() {
         "Event should be PrApproved for PR #42"
     );
 }
+
+/// Gate !1902: has_cached_review bypass — PrApproved is NOT suppressed when the
+/// review is already cached, even if get_reviewer() still returns Some.
+///
+/// This handles the race between webhook review completion (which caches the
+/// review) and the poll tick that clears the reviewer assignment.
+#[tokio::test]
+async fn pr_approved_not_suppressed_when_review_cached() {
+    let (state, _tmp, _guard) = make_test_state("test-repo");
+    let pr_number = 42;
+
+    // Simulate: reviewer is assigned BUT review is already cached (complete)
+    {
+        let mut ps = state.persistent_state.lock().await;
+        ps.github.assign_reviewer(
+            pr_number,
+            "lexington",
+            crate::github_state::AssignmentSource::PollingFallback,
+        );
+        ps.github.mark_reviewed_pr(pr_number);
+    }
+
+    // Build PrContext — should detect cached review and NOT flag active reviewer
+    let ctx = {
+        let ps = state.persistent_state.lock().await;
+        PrContext::from_persistent_state(&ps, pr_number)
+    };
+
+    assert!(
+        !ctx.has_active_reviewer,
+        "has_active_reviewer should be false when review is cached (race bypass)"
+    );
+}


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Suppress `PrApproved` workflow event while a reviewer coworker is still actively working on the PR
- Two-layer check: `get_reviewer()` from persistent state (raw assignment) + `reviewing_phase_coworkers` defense-in-depth from snapshot/coworker records
- Complements the RPC merge gate from !1896 — that blocks the merge RPC call, this blocks the workflow event that triggers merge nudges
- Keeps the workflow script contract clean: `pr.approved` = safe to merge

## Changes
- Added `has_active_reviewer` field to `PrContext` — set from `get_reviewer()` during construction, augmented with `reviewing_phase_coworkers` at call sites
- Added `augment_reviewer_from_snapshot()` (polling path) and `augment_reviewer_from_coworker_records()` (webhook path) methods
- Gated `PrApproved` emission in `pr_action_to_effects` — suppresses event when `has_active_reviewer` is true
- 3 new tests covering suppression, normal emission, and non-interference with other event types

## Test plan
- [x] `pr_approved_suppressed_while_reviewer_active` — PrApproved NOT emitted when reviewer is active
- [x] `pr_approved_emitted_when_no_reviewer_active` — PrApproved emitted normally when no reviewer
- [x] `non_approved_events_unaffected_by_reviewer_gate` — CiFailed still emitted with active reviewer
- [x] All 2117 lib tests pass
- [x] Clippy clean (`-D warnings`)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)