### PR TITLE
fix: Draft persistence improvements — clear on send, resize on restore, survive unmount [Midtown !1910]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -80,6 +80,7 @@
       pendingFile = draft?.file ?? null
     }
     prevChannel = ch
+    tick().then(() => resizeTextarea())
   })
 
   function isNewMessage(channelName, index) {
@@ -536,6 +537,7 @@
         inputText = ''
         if (textareaElement) textareaElement.value = ''
         pendingFile = null
+        channelDrafts.delete($activeChannel)
       } else {
         alert(`Upload failed: ${result.error}`)
         return
@@ -551,6 +553,7 @@
         }, 30000)
       }
       inputText = ''
+      channelDrafts.delete($activeChannel)
       clearMobileTextarea(textareaElement, () => { inputText = '' })
     }
   }

--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -1,3 +1,11 @@
+<script module>
+  // Module-level draft storage persists across mount/unmount cycles.
+  // ThreadPanel is conditionally rendered ({#if $threadData}), so instance-level
+  // state would be lost when the thread panel closes and reopens.
+  const threadDrafts = new Map()
+  let prevThreadId = null
+</script>
+
 <script>
   import { threadData, agentToolItems } from './store.js'
   import { sendMessage, closeThread, getApiBase } from './api.js'
@@ -86,9 +94,6 @@
   }
 
   let replyText = $state('')
-  // Per-thread draft storage: saves replyText when switching between threads
-  let threadDrafts = new Map()
-  let prevThreadId = null
   let desktopScrollArea = $state(null)
   let mobileScrollArea = $state(null)
   let desktopTextareaEl = $state(null)
@@ -135,6 +140,7 @@
       replyText = tid !== null ? (threadDrafts.get(tid) ?? '') : ''
     }
     prevThreadId = tid
+    tick().then(() => resizeTextarea())
   })
 
   // Clear thinking when real InProgress tool items arrive for this thread's channel.
@@ -151,6 +157,11 @@
   })
 
   onDestroy(() => {
+    // Save current draft before component unmounts (thread panel closes)
+    if (prevThreadId !== null && replyText.trim()) {
+      threadDrafts.set(prevThreadId, replyText)
+    }
+    prevThreadId = null  // Reset so the next mount triggers a restore
     if (thinkingTimeout) {
       clearTimeout(thinkingTimeout)
       thinkingTimeout = null
@@ -258,6 +269,7 @@
     const parentId = $threadData.parentMessage?.id ?? null
     sendMessage(replyText.trim(), $threadData.channelName, parentId)
     replyText = ''
+    if (currentThreadId) threadDrafts.delete(currentThreadId)
     clearMobileTextarea(textareaEl, () => { replyText = '' })
     // Optimistic: show the drawer immediately while waiting for tool calls to arrive
     thinking = true


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
Incremental fixes on top of the base draft feature (PR #1641):

- **Clear drafts on send** — `channelDrafts.delete()` in both file-upload and text-only send paths prevents stale drafts from restoring after a message is sent
- **Resize textarea on restore** — `tick().then(() => resizeTextarea())` adjusts textarea height for multi-line restored drafts (both channel and thread inputs)
- **Persist thread drafts across unmount** — `threadDrafts` Map moved to `<script module>` so it survives `ThreadPanel` conditional rendering (`{#if $threadData}`)
- **Save draft before unmount** — `onDestroy` saves the current reply before the panel tears down
- **Fix delete key for task threads** — Use `currentThreadId` (includes `task-${id}` fallback) instead of `parentId` which is null for task-only threads

## Test plan
- [ ] Type in #web, switch to #daemon, switch back — draft restored with correct textarea height
- [ ] Send a message — draft cleared, switching away and back shows empty input
- [ ] Open thread, type reply, close thread, reopen same thread — reply text restored
- [ ] Open task thread (no parent message), type reply, close, reopen — reply text restored
- [ ] Send in task thread — draft cleared

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)