### PR TITLE
docs: Remove stale 'nudge all thread participants' claims [Midtown !1916]

### DIFF
--- a/agents/common.md
+++ b/agents/common.md
@@ -65,7 +65,7 @@ midtown channel post "found the root cause in auth.rs" --task 42
 
 In the TUI, use `/thread` to pick a message and open the thread panel.
 
-**Thread notifications:** When a new reply is added to a thread, all thread participants (original message author and authors of existing replies) are automatically notified via nudge. You do not need to @mention them manually.
+**Thread notifications:** Thread replies are routed to the forked lead session that owns the thread. The fork decides when to loop in other participants via @mentions — there is no automatic broadcast to all thread participants.
 
 ## Useful Commands
 
@@ -109,7 +109,7 @@ or add the HTML comment anywhere in your comment:
 
 ## Insights
 
-Insights are auto-posted to the task's channel and nudge the channel lead. Channel leads reply in a thread ONLY if they can add genuine value (the daemon already nudges thread participants on new replies). No "thanks for sharing" replies.
+Insights are auto-posted to the task's channel and nudge the channel lead. Channel leads reply in a thread ONLY if they can add genuine value. No "thanks for sharing" replies.
 
 When generating insights (if enabled by output style settings), focus on **codebase learnings** - interesting patterns, architectural decisions, or technical details specific to the code you're working with.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -422,7 +422,7 @@ The `/api/channels/history` endpoint accepts an optional `thread_parent_id` quer
 - Absent: returns only top-level messages (where `thread_parent_id` is `None`), with `reply_count` and `last_reply` metadata when replies exist
 - Present: returns only thread replies matching the given parent ID
 
-When a thread reply is posted via `midtown channel post --thread <id>`, the daemon automatically nudges all thread participants (the original message author and all authors of existing replies in that thread), ensuring no reply goes unnoticed.
+When a thread reply is posted via `midtown channel post --thread <id>`, the daemon routes the nudge to the forked lead session that owns the thread (looked up via `topic_sessions`). The fork session has full thread context and decides when to loop in other participants via @mentions — there is no automatic broadcast to all thread participants.
 
 ## Chat TUI
 


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Removed three stale documentation claims that the daemon nudges all thread participants on every reply
- Updated `agents/common.md` (two places) and `docs/architecture.md` (one place) to reflect the actual fork-owns-the-thread model
- The daemon routes thread replies to a single forked lead session via `topic_sessions`, and the fork decides when to loop in other participants

## Changes
1. **`agents/common.md:68`** — Thread notifications section now explains the fork-based routing instead of claiming all-participant broadcast
2. **`agents/common.md:112`** — Insights section removed parenthetical about daemon nudging thread participants  
3. **`docs/architecture.md:425`** — Thread Storage section now documents the actual `build_topic_thread_nudge_effect` behavior (single `NudgeSession` to fork)

## Test plan
- [x] Verified `build_topic_thread_nudge_effect` in `rpc_channel.rs` returns single `NudgeSession` (not broadcast)
- [x] Searched for any other references to the old behavior — only test fixture snapshots remain (expected, not docs)
- [x] No code changes, docs-only

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)