### PR TITLE
fix: Thread task announcements under --thread-id parent [Midtown !1917]

### DIFF
--- a/src/daemon/rpc_task.rs
+++ b/src/daemon/rpc_task.rs
@@ -181,6 +181,22 @@ pub(crate) fn task_created_message_author(task_channel: &str, main_channel: &str
     }
 }
 
+/// Build the "created task:" announcement message, threading it under `thread_id`
+/// when present.
+pub(crate) fn task_announcement_message(
+    channel: &str,
+    author: &str,
+    subject: &str,
+    thread_id: Option<&str>,
+) -> Message {
+    let content = format!("created task: {}", subject);
+    if let Some(tid) = thread_id {
+        Message::thread_reply(channel, author, content, tid, MessageType::Text)
+    } else {
+        Message::for_channel(channel, author, content, MessageType::Text)
+    }
+}
+
 /// Resolve the effective channel for task routing, announcement, and nudge.
 ///
 /// When a task is created with `--channel <name>` pointing to an archived
@@ -381,12 +397,7 @@ pub(super) async fn handle_task_create(
     // Only store the mapping if the write succeeds — a failed write means no channel
     // message exists, so storing the ID would create an orphan thread root.
     let author = task_created_message_author(effective_channel, state.default_channel_name());
-    let msg = Message::for_channel(
-        effective_channel,
-        author,
-        format!("created task: {}", subject),
-        MessageType::Text,
-    );
+    let msg = task_announcement_message(effective_channel, &author, subject, thread_id);
     let message_id = msg.id.clone();
     match state.send_and_broadcast_async(&msg).await {
         Ok(()) => {

--- a/src/daemon/rpc_task_tests.rs
+++ b/src/daemon/rpc_task_tests.rs
@@ -424,6 +424,31 @@ fn test_task_created_message_sub_channel_routing() {
     );
 }
 
+// ── task_announcement_message tests ──────────────────────────────────────────
+
+/// When thread_id is Some, the announcement should be a thread reply.
+#[test]
+fn test_task_announcement_message_with_thread_id_is_threaded() {
+    let msg = task_announcement_message("ops", "ops", "Fix the bug", Some("parent-thread-id"));
+    assert_eq!(
+        msg.thread_parent_id,
+        Some("parent-thread-id".to_string()),
+        "announcement should be a thread reply when thread_id is provided"
+    );
+    assert_eq!(msg.channel_name(), "ops");
+}
+
+/// When thread_id is None, the announcement should be top-level.
+#[test]
+fn test_task_announcement_message_without_thread_id_is_top_level() {
+    let msg = task_announcement_message("ops", "ops", "Fix the bug", None);
+    assert!(
+        msg.thread_parent_id.is_none(),
+        "announcement should be top-level when no thread_id"
+    );
+    assert_eq!(msg.channel_name(), "ops");
+}
+
 // ── apply_task_channel_mapping clears task_thread_id tests ───────────────────
 
 /// When channel is changed via apply_task_channel_mapping, any existing


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- When tasks are created with `--thread-id`, the announcement message (`created task: ...`) was always posted as a top-level channel message, ignoring the thread_id
- Extracted a `task_announcement_message()` helper that uses `Message::thread_reply()` when `thread_id` is present, matching the existing pattern in `effects.rs` and `rpc_channel.rs`
- Added unit tests for the new helper function

## Root Cause
In `rpc_task.rs:handle_task_create()`, the `thread_id` was stored in `ps.task_thread_id` for coworker routing but the announcement message construction at lines 383-390 unconditionally used `Message::for_channel()` (top-level).

## Test plan
- [x] New tests verify threaded vs top-level announcement messages
- [x] All 42 rpc_task unit tests pass
- [x] Full test suite passes (2146 passed, 1 pre-existing failure in unrelated rpc_channel test)
- [x] Clippy clean with `-D warnings`

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)