### PR TITLE
fix: Update VAPID mailto contact to info@midtown.sh [Midtown !1919]

### DIFF
--- a/src/push.rs
+++ b/src/push.rs
@@ -230,7 +230,7 @@ impl PushManager {
         let builder = WebPushBuilder::new(endpoint, ua_public, ua_auth)
             .with_valid_duration(std::time::Duration::from_secs(12 * 3600));
 
-        let signed_builder = builder.with_vapid(kp, "mailto:push@midtown.dev");
+        let signed_builder = builder.with_vapid(kp, "mailto:info@midtown.sh");
 
         let request = signed_builder
             .build(json_payload.as_bytes())


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Changed VAPID contact email from `mailto:push@midtown.dev` to `mailto:info@midtown.sh` per user request
- One-line fix in `src/push.rs:233`

## Test plan
- [x] Build passes
- [x] Clippy + fmt pass
- [x] Verified no other occurrences of old email in codebase

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)