### PR TITLE
fix: Resolve --task thread parent from task_thread_id, not task_message_id [Midtown !1920]

### DIFF
--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -199,12 +199,15 @@ impl DaemonClient {
         self.channel_post_as(message, &from, channel, None)
     }
 
-    /// Post a message threaded to a task's announcement message.
+    /// Post a message threaded to a task's thread.
     ///
-    /// Resolves the task's announcement message ID via `task.metadata`, then
-    /// posts as a thread reply. Returns an error if the task is not found
-    /// (daemon returns RPC error) or if the task has no announcement message
-    /// (e.g. created before threading was added).
+    /// Resolves the task's thread parent via `task.metadata`, preferring
+    /// `thread_id` (the conversation thread root) over `message_id` (the
+    /// announcement message). When a task was created with `--thread-id`,
+    /// the announcement is a reply within that thread, so using `message_id`
+    /// would create nested replies instead of siblings. Falls back to
+    /// `message_id` for tasks created without `--thread-id` (where both
+    /// are equal). Returns an error if neither is available.
     pub fn channel_post_for_task(
         &self,
         message: &str,
@@ -212,12 +215,16 @@ impl DaemonClient {
         task_id: &str,
     ) -> Result<Response, String> {
         let metadata = self.task_metadata(task_id)?;
+        // Prefer thread_id (conversation root) over message_id (announcement).
+        // When --thread-id was used, message_id points to a reply within the
+        // thread, so using it as thread_parent_id would nest replies incorrectly.
         let thread_parent_id = metadata
-            .get("message_id")
+            .get("thread_id")
             .and_then(|v| v.as_str())
+            .or_else(|| metadata.get("message_id").and_then(|v| v.as_str()))
             .ok_or_else(|| {
                 format!(
-                    "Task !{} has no announcement message (may have been created before threading was added)",
+                    "Task !{} has no thread or announcement message (may have been created before threading was added)",
                     task_id
                 )
             })?

--- a/src/daemon/rpc_task.rs
+++ b/src/daemon/rpc_task.rs
@@ -605,6 +605,7 @@ pub(super) async fn handle_task_metadata(
     let plan = ps.task_plan.get(task_id).cloned();
     let execution_skill = ps.task_execution_skill.get(task_id).cloned();
     let message_id = ps.task_message_id.get(task_id).cloned();
+    let thread_id = ps.task_thread_id.get(task_id).cloned();
 
     Response::success(
         id,
@@ -614,6 +615,7 @@ pub(super) async fn handle_task_metadata(
             "plan": plan,
             "execution_skill": execution_skill,
             "message_id": message_id,
+            "thread_id": thread_id,
         }),
     )
 }

--- a/src/daemon/rpc_task_tests.rs
+++ b/src/daemon/rpc_task_tests.rs
@@ -337,6 +337,106 @@ fn test_task_thread_id_defaults_to_empty_on_old_state() {
     );
 }
 
+// ── --task thread resolution tests ───────────────────────────────────────────
+//
+// These tests verify the semantics that `--task <id>` should resolve to
+// `task_thread_id` (the conversation thread root) rather than `task_message_id`
+// (the announcement message). When a task is created with `--thread-id <parent>`,
+// the announcement becomes a reply within that thread, so using `task_message_id`
+// as the thread parent would nest replies incorrectly.
+
+/// When a task is created with `--thread-id`, the `--task` resolution should
+/// prefer `task_thread_id` (the parent thread) over `task_message_id` (the
+/// announcement reply). This mirrors the logic in `channel_post_for_task`.
+#[test]
+fn test_task_thread_resolution_prefers_thread_id_over_message_id() {
+    use crate::daemon::state::DaemonPersistentState;
+
+    let mut ps = DaemonPersistentState::default();
+    let task_id = "42";
+    let parent_thread = "user-original-message-uuid";
+    let announcement_reply = "announcement-reply-uuid";
+
+    // Task created with --thread-id: announcement is a reply in the parent thread
+    ps.task_thread_id
+        .insert(task_id.to_string(), parent_thread.to_string());
+    ps.task_message_id
+        .insert(task_id.to_string(), announcement_reply.to_string());
+
+    // Simulate the --task resolution logic from channel_post_for_task:
+    // prefer thread_id, fall back to message_id
+    let resolved = ps
+        .task_thread_id
+        .get(task_id)
+        .or_else(|| ps.task_message_id.get(task_id));
+
+    assert_eq!(
+        resolved,
+        Some(&parent_thread.to_string()),
+        "--task should resolve to the parent thread, not the announcement reply"
+    );
+    assert_ne!(
+        resolved,
+        Some(&announcement_reply.to_string()),
+        "using task_message_id would create nested replies instead of siblings"
+    );
+}
+
+/// When a task is created without `--thread-id`, `task_thread_id` equals
+/// `task_message_id`, so `--task` resolution produces the same result
+/// regardless of which field is used.
+#[test]
+fn test_task_thread_resolution_equivalent_without_explicit_thread_id() {
+    use crate::daemon::state::DaemonPersistentState;
+
+    let mut ps = DaemonPersistentState::default();
+    let task_id = "42";
+    let announcement_id = "announcement-uuid";
+
+    // Task created without --thread-id: both point to the announcement
+    ps.task_message_id
+        .insert(task_id.to_string(), announcement_id.to_string());
+    ps.task_thread_id
+        .insert(task_id.to_string(), announcement_id.to_string());
+
+    let resolved = ps
+        .task_thread_id
+        .get(task_id)
+        .or_else(|| ps.task_message_id.get(task_id));
+
+    assert_eq!(
+        resolved,
+        Some(&announcement_id.to_string()),
+        "--task should resolve to the announcement message (same as thread_id)"
+    );
+}
+
+/// Backward compatibility: tasks created before `task_thread_id` was introduced
+/// only have `task_message_id`. The resolution should fall back to `message_id`.
+#[test]
+fn test_task_thread_resolution_falls_back_to_message_id() {
+    use crate::daemon::state::DaemonPersistentState;
+
+    let mut ps = DaemonPersistentState::default();
+    let task_id = "42";
+    let announcement_id = "old-announcement-uuid";
+
+    // Legacy task: only has task_message_id, no task_thread_id
+    ps.task_message_id
+        .insert(task_id.to_string(), announcement_id.to_string());
+
+    let resolved = ps
+        .task_thread_id
+        .get(task_id)
+        .or_else(|| ps.task_message_id.get(task_id));
+
+    assert_eq!(
+        resolved,
+        Some(&announcement_id.to_string()),
+        "should fall back to message_id when thread_id is not available"
+    );
+}
+
 // ── task_created_message_author tests ────────────────────────────────────────
 
 /// For the main channel, the task-created message should be attributed to "lead".


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Fixed `--task <id>` resolution in `midtown channel post` to use `task_thread_id` (conversation root) instead of `task_message_id` (announcement reply) when threading posts
- Added `thread_id` to the `task.metadata` RPC response so the CLI can access it
- When a task is created with `--thread-id <parent>`, the announcement is a reply within that thread — using `message_id` as the thread parent would nest replies incorrectly instead of creating siblings
- Falls back to `message_id` for backward compatibility with tasks created before `task_thread_id` was introduced

### Root cause
PR #1651 correctly threaded task announcements under `--thread-id`, but the CLI's `channel_post_for_task` still resolved thread parent from `message_id` (the announcement reply) rather than `thread_id` (the parent thread). This would cause coworker `--task` posts to create nested replies-to-a-reply instead of sibling replies in the conversation thread.

### Web UI already handled this
The web UI's `openTaskThread()` already walks up `thread_parent_id` to find the root, so it was unaffected.

## Test plan
- [x] Added 3 unit tests documenting `--task` thread resolution semantics (prefer `thread_id`, equivalence without `--thread-id`, fallback to `message_id`)
- [x] All existing tests pass (`cargo test` — 49 suites)
- [x] `cargo clippy` passes with no warnings

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)