### PR TITLE
fix: Remove cmake system build dependency from TLS support [Midtown !1922]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,28 +187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,8 +430,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -552,15 +528,6 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
-
-[[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "coarsetime"
@@ -886,12 +853,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,12 +1094,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1755,16 +1710,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,6 +1963,7 @@ dependencies = [
  "ratatui-themes",
  "regex",
  "reqwest",
+ "rustls",
  "selkie-rs",
  "serde",
  "serde_json",
@@ -3065,7 +3011,6 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
- "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3090,7 +3035,6 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,8 @@ once_cell = "1.21"
 
 # Webhook HTTP server
 axum = { version = "0.8", features = ["ws", "multipart"] }
-axum-server = { version = "0.8", features = ["tls-rustls"] }
+axum-server = { version = "0.8", features = ["tls-rustls-no-provider"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 tower-http = { version = "0.6", features = ["trace", "fs", "cors"] }
 
 # Webhook signature verification

--- a/src/webserver.rs
+++ b/src/webserver.rs
@@ -49,13 +49,6 @@ pub struct WebserverConfig {
     pub tls_key: Option<PathBuf>,
 }
 
-impl WebserverConfig {
-    /// Returns true if TLS is configured (both cert and key are set).
-    pub fn tls_enabled(&self) -> bool {
-        self.tls_cert.is_some() && self.tls_key.is_some()
-    }
-}
-
 impl Default for WebserverConfig {
     fn default() -> Self {
         Self {
@@ -536,6 +529,11 @@ pub async fn run(config: WebserverConfig) -> std::result::Result<(), Box<dyn std
     // misconfiguration (and breaks features that require secure origin).
     match (&config.tls_cert, &config.tls_key) {
         (Some(cert_path), Some(key_path)) => {
+            // Install the ring crypto provider for rustls. This avoids the
+            // aws-lc-rs → aws-lc-sys → cmake system build dependency.
+            rustls::crypto::ring::default_provider()
+                .install_default()
+                .map_err(|_| "failed to install ring crypto provider")?;
             info!(
                 "Webserver listening on https://localhost:{} (TLS)",
                 config.port


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Switch `axum-server` from `tls-rustls` to `tls-rustls-no-provider` feature, eliminating the `aws-lc-rs → aws-lc-sys → cmake` dependency chain
- Explicitly install the `ring` crypto provider for rustls TLS operations (ring was already compiled in via reqwest's dependency chain)
- Remove unused `tls_enabled()` helper on `WebserverConfig` (daemon.rs uses the separate `WebserverSection` type from config.rs)

## Context

PR #1655 added TLS support via `axum-server` with `tls-rustls`, which pulled in `rustls → aws-lc-rs → aws-lc-sys → cmake` as a system build dependency. This could break CI and fresh developer setups that don't have `cmake` installed.

The fix is minimal: `axum-server`'s `tls-rustls` feature is just `tls-rustls-no-provider` + `rustls/aws-lc-rs`. By using `tls-rustls-no-provider` directly and installing the `ring` crypto provider instead, we get the same TLS functionality without the cmake dependency. The `ring` crate uses vendored C code that compiles with just a C compiler (cc), which is universally available.

**Dependency removals**: `aws-lc-rs`, `aws-lc-sys`, `cmake`, `dunce`, `fs_extra`, `jobserver` — net reduction of 6 crates.

## Test plan
- [x] `cargo tree -i aws-lc-sys` confirms package no longer in dependency tree
- [x] `cargo tree -i cmake` confirms cmake no longer in dependency tree
- [x] `cargo build` succeeds
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] `cargo test` — all tests pass
- [x] Created follow-up task for silent TLS startup failure detection (separate concern)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)