### PR TITLE
fix: Rebuild topic_sessions on daemon restart to prevent duplicate forks [Midtown !1929]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -694,8 +694,8 @@ pub(crate) struct DaemonState {
     /// reply arrives for a channel with a topic session mapping, the reply is routed
     /// to the forked session instead of the root channel lead.
     ///
-    /// Ephemeral — cleared on daemon restart. Forks don't survive daemon restarts;
-    /// the on-demand channel lead infrastructure handles respawn when needed.
+    /// Rebuilt on daemon startup from persisted `SessionRecord.bound_thread_id` for
+    /// channel-lead sessions, using the same pattern as `fork_bound_threads`.
     pub(crate) topic_sessions: std::sync::Mutex<HashMap<String, String>>,
 
     /// In-memory cache of bound thread IDs for forked sessions.
@@ -1022,6 +1022,12 @@ impl DaemonState {
                 .lock()
                 .unwrap()
                 .retain(|_, sid| sid != &session_id);
+            // Clean up topic_sessions entries pointing to this session
+            // (prevents stale thread routing to dead fork sessions).
+            self.topic_sessions
+                .lock()
+                .unwrap()
+                .retain(|_, sid| sid != &session_id);
             // Mark the SessionRecord as stopped in persistent state.
             // This is the centralized path — all shutdown/cleanup flows converge here,
             // so the SessionRecord is always kept in sync with the actual process state.
@@ -1302,6 +1308,7 @@ impl DaemonState {
         let mut task_to_session: HashMap<String, String> = HashMap::new();
         let mut fork_bound_threads: HashMap<String, String> = HashMap::new();
         let mut fork_bound_channels: HashMap<String, String> = HashMap::new();
+        let mut topic_sessions: HashMap<String, String> = HashMap::new();
         {
             let allocated_names: Vec<String> = persistent_state
                 .sessions
@@ -1320,10 +1327,13 @@ impl DaemonState {
                         // Rebuild inherited channel map only for forked channel leads.
                         // Regular task coworkers also carry `bound_thread_id` but should not
                         // stream their output as lead-like activity.
-                        if record.coworker_type == "channel-lead"
-                            && let Some(ref channel) = record.channel
-                        {
-                            fork_bound_channels.insert(name.clone(), channel.clone());
+                        if record.coworker_type == "channel-lead" {
+                            if let Some(ref channel) = record.channel {
+                                fork_bound_channels.insert(name.clone(), channel.clone());
+                            }
+                            // Rebuild topic_sessions so thread replies route to existing
+                            // forks after a daemon restart (prevents duplicate forks).
+                            topic_sessions.insert(tid.clone(), session_id.clone());
                         }
                     }
                 }
@@ -1387,7 +1397,7 @@ impl DaemonState {
             task_to_session: std::sync::Mutex::new(task_to_session),
             pending_questions: std::sync::Mutex::new(Vec::new()),
             pending_question_id_counter: std::sync::atomic::AtomicU64::new(1),
-            topic_sessions: std::sync::Mutex::new(HashMap::new()),
+            topic_sessions: std::sync::Mutex::new(topic_sessions),
             fork_bound_threads: std::sync::Mutex::new(fork_bound_threads),
             fork_bound_channels: std::sync::Mutex::new(fork_bound_channels),
             session_profile_map: std::sync::Mutex::new(HashMap::new()),

--- a/src/daemon/state_tests.rs
+++ b/src/daemon/state_tests.rs
@@ -654,6 +654,152 @@ fn test_fork_bound_threads_cleaned_up_on_name_reuse() {
     );
 }
 
+// ── topic_sessions rebuild tests ──────────────────────────────────────────────
+//
+// These tests verify the startup reconstruction of the `topic_sessions`
+// in-memory cache (thread_parent_id → session_id) from persisted `SessionRecord`
+// entries with `bound_thread_id` and `coworker_type == "channel-lead"`. This
+// ensures that after a daemon restart, thread replies are routed to existing
+// fork sessions instead of spawning duplicates.
+
+/// Channel-lead sessions with `bound_thread_id` populate `topic_sessions`
+/// during the rebuild loop in `DaemonState::new`.
+#[test]
+fn test_topic_sessions_rebuilt_from_channel_lead_fork_records() {
+    use std::collections::HashMap;
+
+    let mut sessions: HashMap<String, SessionRecord> = HashMap::new();
+    let mut fork_record = make_test_session_record_named("fork-sess-1", true, "fork-riverside");
+    fork_record.coworker_type = "channel-lead".to_string();
+    fork_record.bound_thread_id = Some("thread-msg-abc".to_string());
+    sessions.insert("fork-sess-1".to_string(), fork_record);
+
+    // Simulate the rebuild loop from DaemonState::new
+    let mut topic_sessions: HashMap<String, String> = HashMap::new();
+    for (session_id, record) in &sessions {
+        if record.coworker_type == "channel-lead"
+            && let Some(ref tid) = record.bound_thread_id
+        {
+            topic_sessions.insert(tid.clone(), session_id.clone());
+        }
+    }
+
+    assert_eq!(
+        topic_sessions.get("thread-msg-abc"),
+        Some(&"fork-sess-1".to_string()),
+        "topic_sessions should map thread_parent_id → session_id for channel-lead forks"
+    );
+}
+
+/// Non-channel-lead sessions with `bound_thread_id` (e.g., task coworkers)
+/// must NOT populate `topic_sessions`. Only forked channel leads route
+/// thread replies.
+#[test]
+fn test_topic_sessions_skips_non_channel_lead_sessions() {
+    use std::collections::HashMap;
+
+    let mut sessions: HashMap<String, SessionRecord> = HashMap::new();
+    let mut task_record = make_test_session_record_named("task-sess-1", true, "riverside");
+    task_record.coworker_type = "dev".to_string();
+    task_record.bound_thread_id = Some("thread-task-xyz".to_string());
+    sessions.insert("task-sess-1".to_string(), task_record);
+
+    let mut topic_sessions: HashMap<String, String> = HashMap::new();
+    for (session_id, record) in &sessions {
+        if record.coworker_type == "channel-lead"
+            && let Some(ref tid) = record.bound_thread_id
+        {
+            topic_sessions.insert(tid.clone(), session_id.clone());
+        }
+    }
+
+    assert!(
+        topic_sessions.is_empty(),
+        "Task coworkers with bound_thread_id must not appear in topic_sessions"
+    );
+}
+
+/// Sessions without `bound_thread_id` (root channel leads) must NOT populate
+/// `topic_sessions`.
+#[test]
+fn test_topic_sessions_skips_channel_leads_without_bound_thread() {
+    use std::collections::HashMap;
+
+    let mut sessions: HashMap<String, SessionRecord> = HashMap::new();
+    let mut root_lead = make_test_session_record_named("lead-sess-1", true, "ops-lead");
+    root_lead.coworker_type = "channel-lead".to_string();
+    // bound_thread_id is None — this is a root channel lead, not a fork
+    sessions.insert("lead-sess-1".to_string(), root_lead);
+
+    let mut topic_sessions: HashMap<String, String> = HashMap::new();
+    for (session_id, record) in &sessions {
+        if record.coworker_type == "channel-lead"
+            && let Some(ref tid) = record.bound_thread_id
+        {
+            topic_sessions.insert(tid.clone(), session_id.clone());
+        }
+    }
+
+    assert!(
+        topic_sessions.is_empty(),
+        "Root channel leads (no bound_thread_id) must not appear in topic_sessions"
+    );
+}
+
+/// Mixed sessions: only channel-lead forks with bound_thread_id appear in
+/// `topic_sessions`.
+#[test]
+fn test_topic_sessions_only_includes_channel_lead_forks() {
+    use std::collections::HashMap;
+
+    let mut sessions: HashMap<String, SessionRecord> = HashMap::new();
+
+    // Fork channel lead (should be included)
+    let mut fork = make_test_session_record_named("fork-1", true, "fork-ops");
+    fork.coworker_type = "channel-lead".to_string();
+    fork.bound_thread_id = Some("thread-111".to_string());
+    sessions.insert("fork-1".to_string(), fork);
+
+    // Root channel lead (no bound_thread_id, should be excluded)
+    let mut root_lead = make_test_session_record_named("lead-1", true, "ops-root");
+    root_lead.coworker_type = "channel-lead".to_string();
+    sessions.insert("lead-1".to_string(), root_lead);
+
+    // Task coworker with bound_thread_id (should be excluded)
+    let mut task = make_test_session_record_named("task-1", true, "riverside");
+    task.coworker_type = "dev".to_string();
+    task.bound_thread_id = Some("thread-222".to_string());
+    sessions.insert("task-1".to_string(), task);
+
+    // Regular coworker (no bound_thread_id, should be excluded)
+    let unbound = make_test_session_record_named("reg-1", true, "amsterdam");
+    sessions.insert("reg-1".to_string(), unbound);
+
+    let mut topic_sessions: HashMap<String, String> = HashMap::new();
+    for (session_id, record) in &sessions {
+        if record.coworker_type == "channel-lead"
+            && let Some(ref tid) = record.bound_thread_id
+        {
+            topic_sessions.insert(tid.clone(), session_id.clone());
+        }
+    }
+
+    assert_eq!(
+        topic_sessions.len(),
+        1,
+        "Only the fork channel lead should appear"
+    );
+    assert_eq!(
+        topic_sessions.get("thread-111"),
+        Some(&"fork-1".to_string()),
+        "Fork session should be mapped by its thread_parent_id"
+    );
+    assert!(
+        !topic_sessions.values().any(|v| v == "task-1"),
+        "Task coworker must not appear in topic_sessions"
+    );
+}
+
 #[test]
 fn profile_state_serializes_round_trip() {
     let state = ProfileState {


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Rebuilds `topic_sessions` (thread → fork session map) from persisted `SessionRecord.bound_thread_id` on daemon startup, following the existing `fork_bound_threads` and `fork_bound_channels` reconstruction pattern
- Adds `topic_sessions` cleanup in `cleanup_coworker_state` to remove stale entries when fork sessions shut down
- Only channel-lead sessions with `bound_thread_id` populate `topic_sessions` (task coworkers are excluded)

## Bug
Channel leads were creating duplicate forks for the same thread after daemon restart because `topic_sessions` was initialized empty. The dedup guard in `create_fork_session` worked for in-memory state but not across restarts.

## Test plan
- [x] 4 new unit tests covering rebuild logic (channel-lead forks, non-channel-leads, root leads, mixed sessions)
- [x] All 2161 existing tests pass
- [x] Clippy clean with `-D warnings`

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)