### PR TITLE
fix: Route forked lead tool calls to thread panel [Midtown !1928]

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -147,9 +147,13 @@ pub enum Effect {
     ///
     /// `channel` is `None` for the main lead (displayed in the main channel)
     /// or `Some(channel_name)` for a channel lead (displayed only in that topic channel).
+    ///
+    /// `thread_parent_id` is set for fork-bound sessions whose tool calls should appear
+    /// in the thread panel rather than the main channel activity strip.
     BroadcastUniversalItems {
         agent_name: String,
         channel: Option<String>,
+        thread_parent_id: Option<String>,
         items: Vec<crate::universal_events::UniversalItem>,
     },
     /// Record a cooldown entry (category + key).
@@ -1038,6 +1042,7 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
             Effect::BroadcastUniversalItems {
                 agent_name,
                 channel,
+                thread_parent_id,
                 items,
             } => {
                 // Store items in DaemonState for TUI RPC consumers (kanban.data).
@@ -1056,6 +1061,7 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                     crate::web::UniversalItemsData {
                         agent_name,
                         channel,
+                        thread_parent_id,
                         items,
                     },
                 ));

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3603,11 +3603,13 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
                     let coworker_effects =
                         stream::process_coworker_output(&events, &coworker_names);
 
+                    let fork_bound_threads = state.fork_bound_threads.lock().unwrap();
                     let universal_effects = stream::process_universal_events(
                         &events,
                         &ps.channel_lead_sessions,
                         &state.repo_name,
                         &fork_bound_channels,
+                        &fork_bound_threads,
                     );
                     (lead_effects, coworker_effects, universal_effects)
                 };

--- a/src/daemon/stream.rs
+++ b/src/daemon/stream.rs
@@ -156,12 +156,16 @@ pub fn process_coworker_output(
 /// that has an active channel lead, that lead's tool calls are broadcast with the
 /// channel name so the web UI can display them only when viewing that topic channel.
 ///
+/// Forked leads (thread-bound sessions) include `thread_parent_id` so the frontend
+/// routes their tool calls to the thread panel instead of the main channel activity strip.
+///
 /// Coworker tool calls are never shown.
 pub fn process_universal_events(
     events: &HashMap<String, Vec<StreamEvent>>,
     channel_lead_sessions: &HashMap<String, String>,
     main_lead_session_name: &str,
     fork_bound_channels: &HashMap<String, String>,
+    fork_bound_threads: &HashMap<String, String>,
 ) -> Vec<Effect> {
     let timestamp = chrono::Utc::now();
     let mut effects = Vec::new();
@@ -173,6 +177,7 @@ pub fn process_universal_events(
             effects.push(Effect::BroadcastUniversalItems {
                 agent_name: main_lead_session_name.to_string(),
                 channel: None,
+                thread_parent_id: None,
                 items,
             });
         }
@@ -187,21 +192,26 @@ pub fn process_universal_events(
                 effects.push(Effect::BroadcastUniversalItems {
                     agent_name: channel_name.clone(),
                     channel: Some(channel_name.clone()),
+                    thread_parent_id: None,
                     items,
                 });
             }
         }
     }
 
-    // Forked lead tool calls should be visible to only the fork's target channel.
+    // Forked lead tool calls: tagged with thread_parent_id so the frontend routes them
+    // to the thread panel. The channel is still set so the frontend knows which channel
+    // the thread belongs to (used for the thread activity drawer).
     for (fork_name, channel_name) in fork_bound_channels {
         if let Some(fork_events) = events.get(fork_name.as_str()) {
             let items =
                 crate::universal_events::claude::extract_tool_events(fork_events, timestamp);
             if !items.is_empty() {
+                let thread_parent_id = fork_bound_threads.get(fork_name).cloned();
                 effects.push(Effect::BroadcastUniversalItems {
                     agent_name: fork_name.clone(),
                     channel: Some(channel_name.clone()),
+                    thread_parent_id,
                     items,
                 });
             }

--- a/src/daemon/stream_tests.rs
+++ b/src/daemon/stream_tests.rs
@@ -507,7 +507,13 @@ fn test_process_lead_output_forked_session_is_inherited_to_channel() {
 fn test_process_universal_events_no_events() {
     let events = HashMap::new();
     let channel_leads = HashMap::new();
-    let effects = process_universal_events(&events, &channel_leads, "lead", &HashMap::new());
+    let effects = process_universal_events(
+        &events,
+        &channel_leads,
+        "lead",
+        &HashMap::new(),
+        &HashMap::new(),
+    );
     assert!(effects.is_empty());
 }
 
@@ -524,7 +530,13 @@ fn test_process_universal_events_text_only_no_effects() {
             extra: json!(null),
         }],
     );
-    let effects = process_universal_events(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_universal_events(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashMap::new(),
+    );
     assert!(effects.is_empty());
 }
 
@@ -541,16 +553,27 @@ fn test_process_universal_events_lead_tool_use_produces_effect() {
             extra: json!(null),
         }],
     );
-    let effects = process_universal_events(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_universal_events(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashMap::new(),
+    );
     assert_eq!(effects.len(), 1);
     match &effects[0] {
         Effect::BroadcastUniversalItems {
             agent_name,
             channel,
+            thread_parent_id,
             items,
         } => {
             assert_eq!(agent_name, "lead");
             assert!(channel.is_none(), "Main lead should have no channel");
+            assert!(
+                thread_parent_id.is_none(),
+                "Main lead should have no thread_parent_id"
+            );
             assert_eq!(items.len(), 1);
         }
         _ => panic!("Expected BroadcastUniversalItems effect"),
@@ -571,7 +594,13 @@ fn test_process_universal_events_coworker_tool_use_ignored() {
         }],
     );
     // Coworker tool calls are not shown to the user — only lead and channel lead tool calls are.
-    let effects = process_universal_events(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_universal_events(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashMap::new(),
+    );
     assert!(effects.is_empty());
 }
 
@@ -599,7 +628,13 @@ fn test_process_universal_events_only_lead_when_multiple_agents() {
         }],
     );
     // Only the lead's tool calls produce an effect; coworker events are ignored.
-    let effects = process_universal_events(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_universal_events(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashMap::new(),
+    );
     assert_eq!(effects.len(), 1);
     match &effects[0] {
         Effect::BroadcastUniversalItems {
@@ -630,12 +665,19 @@ fn test_process_universal_events_channel_lead_tool_use_produces_channel_scoped_e
     let mut channel_leads = HashMap::new();
     channel_leads.insert("web".to_string(), "some-session-id".to_string());
 
-    let effects = process_universal_events(&events, &channel_leads, "lead", &HashMap::new());
+    let effects = process_universal_events(
+        &events,
+        &channel_leads,
+        "lead",
+        &HashMap::new(),
+        &HashMap::new(),
+    );
     assert_eq!(effects.len(), 1);
     match &effects[0] {
         Effect::BroadcastUniversalItems {
             agent_name,
             channel,
+            thread_parent_id,
             items,
         } => {
             assert_eq!(agent_name, "web");
@@ -643,6 +685,10 @@ fn test_process_universal_events_channel_lead_tool_use_produces_channel_scoped_e
                 channel.as_deref(),
                 Some("web"),
                 "Channel lead should be tagged with its channel"
+            );
+            assert!(
+                thread_parent_id.is_none(),
+                "Channel lead should have no thread_parent_id"
             );
             assert_eq!(items.len(), 1);
         }
@@ -665,7 +711,13 @@ fn test_process_universal_events_channel_lead_not_in_sessions_is_ignored() {
         }],
     );
     // No channel leads registered → "web" session is treated as a regular coworker.
-    let effects = process_universal_events(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_universal_events(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashMap::new(),
+    );
     assert!(effects.is_empty());
 }
 
@@ -695,7 +747,13 @@ fn test_process_universal_events_lead_and_channel_lead_produce_separate_effects(
     let mut channel_leads = HashMap::new();
     channel_leads.insert("features".to_string(), "cl-session-id".to_string());
 
-    let effects = process_universal_events(&events, &channel_leads, "lead", &HashMap::new());
+    let effects = process_universal_events(
+        &events,
+        &channel_leads,
+        "lead",
+        &HashMap::new(),
+        &HashMap::new(),
+    );
     assert_eq!(effects.len(), 2);
 
     // Verify both effects are present with correct scoping.
@@ -727,7 +785,13 @@ fn test_process_universal_events_channel_lead_registered_but_no_events_produces_
     let mut channel_leads = HashMap::new();
     channel_leads.insert("web".to_string(), "some-session-id".to_string());
 
-    let effects = process_universal_events(&events, &channel_leads, "lead", &HashMap::new());
+    let effects = process_universal_events(
+        &events,
+        &channel_leads,
+        "lead",
+        &HashMap::new(),
+        &HashMap::new(),
+    );
     assert!(
         effects.is_empty(),
         "No effect when channel lead has no events this tick"
@@ -750,16 +814,73 @@ fn test_process_universal_events_forked_session_tool_use_is_scoped_to_channel() 
     let mut fork_bound_channels = HashMap::new();
     fork_bound_channels.insert("fork-1234".to_string(), "topic-omega".to_string());
 
-    let effects = process_universal_events(&events, &HashMap::new(), "lead", &fork_bound_channels);
+    let effects = process_universal_events(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &fork_bound_channels,
+        &HashMap::new(),
+    );
     assert_eq!(effects.len(), 1);
     match &effects[0] {
         Effect::BroadcastUniversalItems {
             agent_name,
             channel,
+            thread_parent_id,
             items,
         } => {
             assert_eq!(agent_name, "fork-1234");
             assert_eq!(channel.as_deref(), Some("topic-omega"));
+            assert!(
+                thread_parent_id.is_none(),
+                "Fork without thread binding should have no thread_parent_id"
+            );
+            assert_eq!(items.len(), 1);
+        }
+        _ => panic!("Expected BroadcastUniversalItems effect"),
+    }
+}
+
+#[test]
+fn test_process_universal_events_forked_session_with_thread_binding_includes_thread_parent_id() {
+    let mut events = HashMap::new();
+    events.insert(
+        "fork-abcd".to_string(),
+        vec![StreamEvent::Assistant {
+            message: json!({
+                "content": [{"type": "tool_use", "id": "tc_1", "name": "Read", "input": {}}]
+            }),
+            session_id: None,
+            extra: json!(null),
+        }],
+    );
+    let mut fork_bound_channels = HashMap::new();
+    fork_bound_channels.insert("fork-abcd".to_string(), "web".to_string());
+    let mut fork_bound_threads = HashMap::new();
+    fork_bound_threads.insert("fork-abcd".to_string(), "msg-9999".to_string());
+
+    let effects = process_universal_events(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &fork_bound_channels,
+        &fork_bound_threads,
+    );
+    assert_eq!(effects.len(), 1);
+    match &effects[0] {
+        Effect::BroadcastUniversalItems {
+            agent_name,
+            channel,
+            thread_parent_id,
+            items,
+        } => {
+            assert_eq!(agent_name, "fork-abcd");
+            assert_eq!(channel.as_deref(), Some("web"));
+            assert_eq!(
+                thread_parent_id.as_deref(),
+                Some("msg-9999"),
+                "Fork with thread binding should include thread_parent_id"
+            );
             assert_eq!(items.len(), 1);
         }
         _ => panic!("Expected BroadcastUniversalItems effect"),

--- a/src/web.rs
+++ b/src/web.rs
@@ -300,6 +300,10 @@ pub struct UniversalItemsData {
     /// The channel this agent's tool calls belong to. `None` for the main lead (main channel),
     /// `Some(channel_name)` for a channel lead (displayed only in that topic channel).
     pub channel: Option<String>,
+    /// When set, this agent's tool calls should appear in the thread panel for this
+    /// thread parent ID rather than in the main channel activity strip.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_parent_id: Option<String>,
     pub items: Vec<crate::universal_events::UniversalItem>,
 }
 

--- a/web-app/src/lib/ThreadActivityDrawer.svelte
+++ b/web-app/src/lib/ThreadActivityDrawer.svelte
@@ -3,14 +3,15 @@
    * ThreadActivityDrawer — terminal-styled slide-up drawer above the thread reply input.
    *
    * Props:
-   *   channelName — the channel whose tool items to display (e.g. "web")
-   *   thinking    — true when the user just sent a message and we're waiting for tool calls
+   *   channelName    — the channel whose tool items to display (e.g. "web")
+   *   threadParentId — when set, reads from threadToolItems[id] instead of agentToolItems[channel]
+   *   thinking       — true when the user just sent a message and we're waiting for tool calls
    */
-  import { agentToolItems } from './store.js'
+  import { agentToolItems, threadToolItems } from './store.js'
   import { onDestroy } from 'svelte'
   import { slide } from 'svelte/transition'
 
-  let { channelName, thinking = false } = $props()
+  let { channelName, threadParentId = null, thinking = false } = $props()
 
   const AGE_OUT_MS = 3000
   const MAX_VISIBLE = 10
@@ -24,16 +25,21 @@
   let completedAt = $state(new Map())
   let expired = $state(new Set())
 
-  // Reset both maps when channelName changes (switching threads clears stale state)
+  // Reset both maps when the thread changes (switching threads clears stale state)
   $effect(() => {
     channelName // track dependency
+    threadParentId // track dependency
     completedAt = new Map()
     expired = new Set()
   })
 
-  // Build merged view: fold ToolResults into their ToolCalls
+  // Build merged view: fold ToolResults into their ToolCalls.
+  // When threadParentId is set, read from the thread-scoped store; otherwise fall back
+  // to the channel-scoped store (for non-fork threads like DM channels).
   let merged = $derived.by(() => {
-    const items = $agentToolItems[channelName ?? 'midtown'] || []
+    const items = threadParentId
+      ? ($threadToolItems[threadParentId] || [])
+      : ($agentToolItems[channelName ?? 'midtown'] || [])
     const resultStatus = {}
     for (const item of items) {
       for (const part of item.content) {

--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <script>
-  import { threadData, agentToolItems } from './store.js'
+  import { threadData, agentToolItems, threadToolItems } from './store.js'
   import { sendMessage, closeThread, getApiBase } from './api.js'
   import { tick, onMount, onDestroy, untrack } from 'svelte'
   import { getSenderColor, isDimSender, parseInsightSegments } from './messageUtils.js'
@@ -143,11 +143,16 @@
     tick().then(() => resizeTextarea())
   })
 
-  // Clear thinking when real InProgress tool items arrive for this thread's channel.
+  // Clear thinking when real InProgress tool items arrive — check both thread-scoped
+  // items (for forked leads) and channel-scoped items (for channel leads / DM channels).
   $effect(() => {
+    const parentId = $threadData?.parentMessage?.id
     const channelName = $threadData?.channelName ?? 'midtown'
-    const items = $agentToolItems[channelName] || []
-    if (items.some((item) => item.status === 'InProgress')) {
+    const threadItems = parentId ? ($threadToolItems[parentId] || []) : []
+    const channelItems = $agentToolItems[channelName] || []
+    const hasInProgress = threadItems.some((item) => item.status === 'InProgress')
+      || channelItems.some((item) => item.status === 'InProgress')
+    if (hasInProgress) {
       thinking = false
       if (thinkingTimeout) {
         clearTimeout(thinkingTimeout)
@@ -505,7 +510,7 @@
     </div>
 
     <!-- Activity drawer: slides up from the input when lead is working -->
-    <ThreadActivityDrawer channelName={$threadData?.channelName} {thinking} />
+    <ThreadActivityDrawer channelName={$threadData?.channelName} threadParentId={$threadData?.parentMessage?.id} {thinking} />
 
     <!-- Input -->
     <form class="flex gap-2 px-3 pt-2 pb-2 bg-card border-t border-border shrink-0" onsubmit={handleSubmit}>
@@ -700,7 +705,7 @@
     </div>
 
     <!-- Activity drawer: slides up from the input when lead is working -->
-    <ThreadActivityDrawer channelName={$threadData?.channelName} {thinking} />
+    <ThreadActivityDrawer channelName={$threadData?.channelName} threadParentId={$threadData?.parentMessage?.id} {thinking} />
 
     <!-- Mobile input -->
     <form class="flex gap-2 px-3 pt-2 pb-safe-offset-2 bg-card border-t border-border shrink-0" onsubmit={handleSubmit}>

--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -19,6 +19,7 @@ import {
   authSwitching,
   usageData,
   agentToolItems,
+  threadToolItems,
   pendingQuestions,
   threadData,
   showArchivedChannels,
@@ -136,6 +137,7 @@ export function switchProject(projectName, webhookPort) {
   agentClearTimeouts.forEach((t) => clearTimeout(t))
   agentClearTimeouts.clear()
   agentToolItems.set({})
+  threadToolItems.set({})
   threadData.set(null)
   connected.set(false)
 
@@ -474,6 +476,24 @@ export function handleUpdate(update) {
           return td
         })
 
+        // Schedule a delayed clear of thread tool activity when the fork posts a reply.
+        // Mirrors the channel-scoped clear logic below for top-level messages.
+        if (msg.from && msg.from !== 'user') {
+          const threadClearKey = `thread:${msg.thread_parent_id}`
+          if (agentClearTimeouts.has(threadClearKey)) {
+            clearTimeout(agentClearTimeouts.get(threadClearKey))
+          }
+          const timeout = setTimeout(() => {
+            agentClearTimeouts.delete(threadClearKey)
+            threadToolItems.update((byThread) => {
+              const updated = { ...byThread }
+              delete updated[msg.thread_parent_id]
+              return updated
+            })
+          }, TOOL_ITEMS_CLEAR_DELAY_MS)
+          agentClearTimeouts.set(threadClearKey, timeout)
+        }
+
         // Increment reply_count on the parent message in messagesByChannel
         messagesByChannel.update((byChannel) => {
           const channelMsgs = byChannel[channelName]
@@ -589,22 +609,35 @@ export function handleUpdate(update) {
       break
     }
     case 'universal_items': {
-      // Tool call activity keyed by channel.
-      // data: { agent_name: string, channel: string|null, items: UniversalItem[] }
-      // channel is null for the main lead (store under the active project name), or a topic
-      // channel name for channel leads (store under that channel name).
-      const channelKey = update.data.channel ?? get(activeProject)
-      // If a delayed clear is pending for this channel, cancel it — new tool activity
-      // means the agent is still working and the strip should not reset yet.
-      if (agentClearTimeouts.has(channelKey)) {
-        clearTimeout(agentClearTimeouts.get(channelKey))
-        agentClearTimeouts.delete(channelKey)
+      // Tool call activity keyed by channel or thread.
+      // data: { agent_name, channel, thread_parent_id?, items }
+      // When thread_parent_id is present, the items belong to a forked lead working
+      // in a thread — route them to threadToolItems so they appear in the thread panel
+      // instead of the main channel activity strip.
+      const threadId = update.data.thread_parent_id
+      if (threadId) {
+        if (agentClearTimeouts.has(`thread:${threadId}`)) {
+          clearTimeout(agentClearTimeouts.get(`thread:${threadId}`))
+          agentClearTimeouts.delete(`thread:${threadId}`)
+        }
+        threadToolItems.update((byThread) => {
+          const existing = byThread[threadId] || []
+          const merged = [...existing, ...update.data.items].slice(-MAX_TOOL_ITEMS_PER_AGENT)
+          return { ...byThread, [threadId]: merged }
+        })
+      } else {
+        // Channel-scoped: main lead or channel lead tool calls.
+        const channelKey = update.data.channel ?? get(activeProject)
+        if (agentClearTimeouts.has(channelKey)) {
+          clearTimeout(agentClearTimeouts.get(channelKey))
+          agentClearTimeouts.delete(channelKey)
+        }
+        agentToolItems.update((byChannel) => {
+          const existing = byChannel[channelKey] || []
+          const merged = [...existing, ...update.data.items].slice(-MAX_TOOL_ITEMS_PER_AGENT)
+          return { ...byChannel, [channelKey]: merged }
+        })
       }
-      agentToolItems.update((byChannel) => {
-        const existing = byChannel[channelKey] || []
-        const merged = [...existing, ...update.data.items].slice(-MAX_TOOL_ITEMS_PER_AGENT)
-        return { ...byChannel, [channelKey]: merged }
-      })
       break
     }
     case 'coworker_question':

--- a/web-app/src/lib/api.test.js
+++ b/web-app/src/lib/api.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { get } from 'svelte/store'
-import { messagesByChannel, threadData, channels, activeChannel, activeProject, agentToolItems } from './store.js'
+import { messagesByChannel, threadData, channels, activeChannel, activeProject, agentToolItems, threadToolItems } from './store.js'
 import { fetchHistory, handleUpdate, fetchChannels, selectDm, switchProject } from './api.js'
 
 describe('fetchHistory', () => {
@@ -710,5 +710,92 @@ describe('handleUpdate universal_items — null channel uses activeProject, not 
     const items = get(agentToolItems)
     expect(items['my-project']).toHaveLength(1)
     expect(items['midtown']).toBeUndefined()
+  })
+})
+
+describe('handleUpdate universal_items — thread_parent_id routes to threadToolItems', () => {
+  const sampleItem = {
+    status: 'InProgress',
+    content: [{ ToolCall: { call_id: 'tc-1', name: 'Read', semantic_header: 'Read file.txt' } }],
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    agentToolItems.set({})
+    threadToolItems.set({})
+    activeProject.set('midtown')
+    messagesByChannel.set({ midtown: [], web: [] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    activeProject.set(null)
+  })
+
+  it('stores items in threadToolItems when thread_parent_id is present', () => {
+    handleUpdate({
+      type: 'universal_items',
+      data: { channel: 'web', agent_name: 'fork-abcd', thread_parent_id: 'msg-9999', items: [sampleItem] },
+    })
+
+    // Should be in threadToolItems, NOT agentToolItems
+    expect(get(threadToolItems)['msg-9999']).toHaveLength(1)
+    expect(get(agentToolItems)['web']).toBeUndefined()
+  })
+
+  it('stores items in agentToolItems when thread_parent_id is absent', () => {
+    handleUpdate({
+      type: 'universal_items',
+      data: { channel: 'web', agent_name: 'web', items: [sampleItem] },
+    })
+
+    expect(get(agentToolItems)['web']).toHaveLength(1)
+    expect(get(threadToolItems)).toEqual({})
+  })
+
+  it('clears thread tool items after delay when a thread reply arrives', () => {
+    handleUpdate({
+      type: 'universal_items',
+      data: { channel: 'web', agent_name: 'fork-abcd', thread_parent_id: 'msg-9999', items: [sampleItem] },
+    })
+    expect(get(threadToolItems)['msg-9999']).toHaveLength(1)
+
+    // Fork posts a reply in the thread
+    handleUpdate({
+      type: 'channel_message',
+      data: { id: 'reply-1', from: 'fork-abcd', content: 'Done!', channel: 'web', thread_parent_id: 'msg-9999', timestamp: '2026-01-01T00:00:00Z' },
+    })
+
+    // Items still present before delay
+    expect(get(threadToolItems)['msg-9999']).toHaveLength(1)
+
+    // After delay, items are cleared
+    vi.advanceTimersByTime(5000)
+    expect(get(threadToolItems)['msg-9999']).toBeUndefined()
+  })
+
+  it('cancels thread clear timeout when new thread tool activity arrives', () => {
+    handleUpdate({
+      type: 'universal_items',
+      data: { channel: 'web', agent_name: 'fork-abcd', thread_parent_id: 'msg-9999', items: [sampleItem] },
+    })
+
+    // Fork posts a reply — schedules delayed clear
+    handleUpdate({
+      type: 'channel_message',
+      data: { id: 'reply-1', from: 'fork-abcd', content: 'status', channel: 'web', thread_parent_id: 'msg-9999', timestamp: '2026-01-01T00:00:00Z' },
+    })
+
+    // New tool activity arrives before delay — cancels the pending clear
+    vi.advanceTimersByTime(2000)
+    const newItem = { ...sampleItem, content: [{ ToolCall: { call_id: 'tc-2', name: 'Edit', semantic_header: 'Edit app.js' } }] }
+    handleUpdate({
+      type: 'universal_items',
+      data: { channel: 'web', agent_name: 'fork-abcd', thread_parent_id: 'msg-9999', items: [newItem] },
+    })
+
+    // Advance past original delay — items should still be present
+    vi.advanceTimersByTime(3000)
+    expect(get(threadToolItems)['msg-9999']).toHaveLength(2)
   })
 })

--- a/web-app/src/lib/store.js
+++ b/web-app/src/lib/store.js
@@ -133,6 +133,11 @@ export const activeChannelTab = writable({})
 // Each array holds the most recent items (capped at MAX_TOOL_ITEMS_PER_AGENT) for display.
 export const agentToolItems = writable({})
 
+// Thread-scoped tool call activity keyed by thread parent message ID.
+// When a forked lead works in a thread, its tool calls are stored here instead of agentToolItems.
+// Format: { 'msg-1234': [{ item_id, kind, content, status, timestamp }, ...], ... }
+export const threadToolItems = writable({})
+
 // Pending questions from coworkers waiting for user input
 // Format: [{ id, coworker_name, question, timestamp }, ...]
 export const pendingQuestions = writable([])


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- When a session forks in a thread context, its tool call activity was incorrectly appearing in the main channel activity strip alongside the channel lead
- **Backend**: Added `thread_parent_id` field to `BroadcastUniversalItems` effect and `UniversalItemsData` WebSocket payload. Passed `fork_bound_threads` into `process_universal_events()` so fork sessions include their thread parent ID
- **Frontend**: Added `threadToolItems` store keyed by thread parent message ID. Routes `universal_items` with `thread_parent_id` to this store instead of `agentToolItems`. Updated `ThreadActivityDrawer` to read from thread-scoped store when `threadParentId` prop is set

## Test plan
- [x] New Rust test: `test_process_universal_events_forked_session_with_thread_binding_includes_thread_parent_id`
- [x] Updated existing tests to verify `thread_parent_id` is `None` for non-fork sessions
- [x] 4 new vitest tests for thread routing, clearing, and timeout cancellation
- [x] All 168 vitest tests pass
- [x] All Rust tests pass (3000+ across all crates)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Web app builds successfully

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)