### PR TITLE
fix: Replace interior punctuation in fork name slugs [Midtown !1931]

### DIFF
--- a/src/daemon/rpc_session.rs
+++ b/src/daemon/rpc_session.rs
@@ -1081,14 +1081,40 @@ fn slugify_fork_hint(message: &str, thread_parent_id: &str) -> String {
         "why", "which", "who", "all", "each", "some", "any", "here", "there",
     ];
 
-    let words: Vec<&str> = message
+    // Split on whitespace, skip @mentions, then replace ALL non-alphanumeric chars
+    // with hyphens (not just trim edges). This handles interior punctuation like
+    // "fix/auth" → "fix-auth" and "fix::auth" → "fix-auth".
+    let words: Vec<String> = message
         .split_whitespace()
         // Skip @mentions
         .filter(|w| !w.starts_with('@'))
-        // Strip non-alphanumeric characters and lowercase
-        .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()))
+        // Replace all non-alphanumeric chars with hyphens, collapse consecutive,
+        // and strip leading/trailing hyphens.
+        .map(|w| {
+            let replaced: String = w
+                .chars()
+                .map(|c| if c.is_alphanumeric() { c } else { '-' })
+                .collect();
+            // Collapse consecutive hyphens and trim
+            let mut result = String::new();
+            let mut prev_hyphen = true; // treat start as hyphen to skip leading
+            for c in replaced.chars() {
+                if c == '-' {
+                    if !prev_hyphen {
+                        prev_hyphen = true;
+                    }
+                } else {
+                    if prev_hyphen && !result.is_empty() {
+                        result.push('-');
+                    }
+                    result.push(c);
+                    prev_hyphen = false;
+                }
+            }
+            result.to_lowercase()
+        })
         // Filter empty and stop words
-        .filter(|w| !w.is_empty() && !STOP_WORDS.contains(&w.to_lowercase().as_str()))
+        .filter(|w| !w.is_empty() && !STOP_WORDS.contains(&w.as_str()))
         .take(3)
         .collect();
 
@@ -1098,11 +1124,7 @@ fn slugify_fork_hint(message: &str, thread_parent_id: &str) -> String {
             .unwrap_or(thread_parent_id)
             .to_string()
     } else {
-        words
-            .iter()
-            .map(|w| w.to_lowercase())
-            .collect::<Vec<_>>()
-            .join("-")
+        words.join("-")
     }
 }
 
@@ -1121,8 +1143,11 @@ fn slugify_fork_hint(message: &str, thread_parent_id: &str) -> String {
 /// already knows the channel from the incoming message.
 ///
 /// `fork_name_hint` provides a human-readable description for the fork session name.
-/// When provided, the fork is named `{caller_name}-{hint}` (e.g. `web-push-notifications`).
-/// When `None`, falls back to `fork-{first-8-chars-of-thread-id}`.
+/// When provided, the hint is slugified (non-alphanumeric chars replaced with hyphens,
+/// stop words removed, limited to 3 words) and a short thread ID suffix is appended
+/// for uniqueness: `{caller_name}-{slug}-{tid_prefix}` (e.g. `web-push-notifications-a1b2`).
+/// When `caller_name` is unknown: `fork-{slug}-{tid_prefix}`.
+/// When `None` or empty, falls back to `fork-{first-8-chars-of-thread-id}`.
 ///
 /// Returns `Ok((session_id, already_existed))` where `already_existed` is true when a
 /// fork was found in `topic_sessions` before this call. Returns `Err` if the slot holds

--- a/src/daemon/rpc_session_tests.rs
+++ b/src/daemon/rpc_session_tests.rs
@@ -794,3 +794,23 @@ fn test_slugify_empty_message() {
 fn test_slugify_short_thread_id_fallback() {
     assert_eq!(slugify_fork_hint("", "abc"), "abc");
 }
+
+#[test]
+fn test_slugify_interior_punctuation_replaced() {
+    // Interior slashes, dots, and other punctuation must be replaced with hyphens,
+    // not just edge-trimmed. "fix/auth" is a single whitespace-delimited token
+    // where the slash is interior — trim_matches won't touch it.
+    assert_eq!(
+        slugify_fork_hint("fix/auth bug.report", "abcd1234efgh"),
+        "fix-auth-bug-report"
+    );
+}
+
+#[test]
+fn test_slugify_consecutive_punctuation_collapsed() {
+    // Multiple consecutive non-alphanumeric chars should collapse to a single hyphen.
+    assert_eq!(
+        slugify_fork_hint("fix::auth--endpoint", "abcd1234efgh"),
+        "fix-auth-endpoint"
+    );
+}


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Fixed `slugify_fork_hint` to replace **all** non-alphanumeric characters with hyphens, not just edge characters. The previous `trim_matches` approach left interior punctuation intact (e.g., `fix/auth` → `fix/auth`), which breaks file paths since `fork_name` is used in log filenames like `headless-{name}.jsonl`.
- Added hyphen collapsing so `fix::auth--endpoint` → `fix-auth-endpoint` instead of `fix--auth--endpoint`.
- Updated `create_fork_session` doc comment to accurately describe the current naming format: `{caller_name}-{slug}-{tid_prefix}` (e.g., `web-push-notifications-a1b2`).

Note: Bug 1 from the task (name collision via missing thread ID suffix) was already fixed by madison in the final push of PR #1659 before merge. The `tid_suffix` is already appended on lines 1217-1223. This PR addresses the remaining Bug 2 (interior punctuation) and the doc comment.

## Test plan
- [x] Added `test_slugify_interior_punctuation_replaced` — verifies `fix/auth bug.report` → `fix-auth-bug-report`
- [x] Added `test_slugify_consecutive_punctuation_collapsed` — verifies `fix::auth--endpoint` → `fix-auth-endpoint`
- [x] All 11 existing + new slugify tests pass
- [x] `cargo clippy` clean, `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)