### PR TITLE
docs: Update slugify_fork_hint doc comment [Midtown !1931]

### DIFF
--- a/src/daemon/rpc_session.rs
+++ b/src/daemon/rpc_session.rs
@@ -1067,8 +1067,9 @@ pub(super) async fn handle_session_clear(
 /// Derive a short, human-readable slug from message content for fork session names.
 ///
 /// Extracts the first 1-3 meaningful words from a message, lowercased and joined with
-/// hyphens. Strips @mentions, punctuation, and common filler words. Falls back to the
-/// first 8 characters of `thread_parent_id` if no meaningful words are found.
+/// hyphens. Strips @mentions, replaces all non-alphanumeric characters with hyphens
+/// (collapsing consecutive hyphens), and filters common filler words. Falls back to
+/// the first 8 characters of `thread_parent_id` if no meaningful words are found.
 fn slugify_fork_hint(message: &str, thread_parent_id: &str) -> String {
     // Words to skip when building the slug
     static STOP_WORDS: &[&str] = &[


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Follow-up from amsterdam's review of PR #1665: updated `slugify_fork_hint` doc comment to say "replaces all non-alphanumeric characters with hyphens (collapsing consecutive hyphens)" instead of "strips punctuation", matching the actual behavior after the Bug 2 fix.

## Test plan
- Doc-only change, no behavior change
- [x] `cargo clippy` clean, `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)