### PR TITLE
Add worktree clean helper script and AGENTS update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,8 @@ midtown e2e run coordination    # run while CI is in progress
 
 This catches failures faster than waiting for GitHub Actions and keeps you productive. The container environment matches CI, so local passes should match remote passes.
 
+**End-of-work cleanup**: run `cargo clean` after completing work to reclaim disk space from build artifacts.
+
 ## Conventions
 
 **Decision functions are pure**: Functions in `rules.rs` (and all functions called from `evaluate_tick()`) must not perform I/O, mutation, or async operations. Return `Vec<Effect>` instead. If data is needed for a decision, add it to `WorldSnapshot` during `collect_world_snapshot()`. See [docs/architecture.md](docs/architecture.md) for the full pipeline.

--- a/scripts/clean-midtown-worktrees.sh
+++ b/scripts/clean-midtown-worktrees.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Clean Cargo build artifacts from all midtown worktrees.
+#
+# Usage:
+#   ./scripts/clean-midtown-worktrees.sh [WORKTREES_DIR]
+#
+# Defaults to ~/.midtown/worktrees/midtown when no directory is provided.
+
+set -euo pipefail
+
+WORKTREES_DIR="${1:-${HOME}/.midtown/worktrees/midtown}"
+
+if [ ! -d "${WORKTREES_DIR}" ]; then
+  echo "ERROR: Directory not found: ${WORKTREES_DIR}"
+  exit 1
+fi
+
+for worktree in "${WORKTREES_DIR}"/*; do
+  if [ -d "${worktree}" ] && [ -f "${worktree}/Cargo.toml" ]; then
+    echo "cargo clean: ${worktree}"
+    (cd "${worktree}" && cargo clean)
+  fi
+done


### PR DESCRIPTION
## Summary
- Adds scripts/clean-midtown-worktrees.sh to run cargo clean across midtown worktrees.
- Updates AGENTS.md end-of-work guidance to run cargo clean.

## Testing
- Pre-commit hooks (fmt/clippy) pass during commit.
