### PR TITLE
fix: Match thread header height to channel header and add responsive textarea resizing [Midtown !1946]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -719,6 +719,25 @@
     textareaElement.style.height = textareaElement.scrollHeight + 'px'
   }
 
+  // Re-measure textarea height when its width changes (e.g., thread panel opens/closes,
+  // window resize, sidebar toggle). Track previous width to avoid infinite loops —
+  // without this guard, height changes from resizeTextarea() would re-trigger the observer.
+  $effect(() => {
+    if (!textareaElement) return
+    let prevWidth = textareaElement.getBoundingClientRect().width
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry) return
+      const newWidth = entry.contentRect.width
+      if (newWidth !== prevWidth) {
+        prevWidth = newWidth
+        resizeTextarea()
+      }
+    })
+    ro.observe(textareaElement)
+    return () => ro.disconnect()
+  })
+
   function handleInput() {
     resizeTextarea()
     detectAutocompleteTrigger()
@@ -941,7 +960,7 @@
           bind:value={inputText}
           placeholder={isDm ? `Message @${dmPeerName}...` : `Message to #${$activeChannel}...`}
           rows="1"
-          class="flex-1 py-[13px] px-[17px] border-2 border-border rounded-[18px] bg-card text-foreground text-[1.02rem] font-inherit outline-none resize-none min-h-[1.6em] max-h-[9em] overflow-y-auto focus:border-primary placeholder:text-muted-foreground"
+          class="flex-1 py-[13px] px-[17px] border-2 border-border rounded-[18px] bg-card text-foreground text-[1.02rem] font-inherit outline-none resize-none min-h-[1.6em] max-h-[50vh] overflow-y-auto focus:border-primary placeholder:text-muted-foreground"
           onkeydown={handleKeyDown}
           onpaste={handlePaste}
           oninput={handleInput}

--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -316,6 +316,24 @@
     textareaEl.style.height = textareaEl.scrollHeight + 'px'
   }
 
+  // Re-measure textarea height when its width changes (e.g., thread panel resized,
+  // window resize). Track previous width to avoid infinite loops.
+  $effect(() => {
+    if (!textareaEl) return
+    let prevWidth = textareaEl.getBoundingClientRect().width
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry) return
+      const newWidth = entry.contentRect.width
+      if (newWidth !== prevWidth) {
+        prevWidth = newWidth
+        resizeTextarea()
+      }
+    })
+    ro.observe(textareaEl)
+    return () => ro.disconnect()
+  })
+
   $effect(() => {
     replyText;
     tick().then(() => resizeTextarea())
@@ -345,7 +363,7 @@
     </div>
 
     <!-- Header -->
-    <div class="flex items-center justify-between px-[18px] py-4 bg-card border-b-2 border-border shrink-0">
+    <div class="flex items-center justify-between px-4 py-2 bg-card border-b-2 border-border shrink-0">
       <h2 class="text-[0.85rem] font-bold text-foreground m-0">Thread</h2>
       <button
         class="w-8 h-8 flex items-center justify-center bg-transparent border border-border rounded-md text-muted-foreground text-[1.3rem] cursor-pointer transition-all duration-150 leading-none hover:bg-accent hover:border-destructive hover:text-destructive ml-2 shrink-0"
@@ -518,7 +536,7 @@
         bind:value={replyText}
         placeholder="Reply in thread..."
         rows="1"
-        class="flex-1 py-[10px] px-[14px] border-2 border-input rounded-[14px] bg-background text-foreground text-[0.9rem] font-inherit outline-none resize-none min-h-[1.6em] max-h-[6em] overflow-y-auto focus:border-primary placeholder:text-muted-foreground"
+        class="flex-1 py-[10px] px-[14px] border-2 border-input rounded-[14px] bg-background text-foreground text-[0.9rem] font-inherit outline-none resize-none min-h-[1.6em] max-h-[50vh] overflow-y-auto focus:border-primary placeholder:text-muted-foreground"
         onkeydown={handleTextareaKeyDown}
         oninput={resizeTextarea}
       ></textarea>
@@ -709,7 +727,7 @@
         bind:value={replyText}
         placeholder="Reply in thread..."
         rows="1"
-        class="flex-1 py-[10px] px-[14px] border-2 border-input rounded-[14px] bg-background text-foreground text-[0.9rem] font-inherit outline-none resize-none min-h-[1.6em] max-h-[6em] overflow-y-auto focus:border-primary placeholder:text-muted-foreground"
+        class="flex-1 py-[10px] px-[14px] border-2 border-input rounded-[14px] bg-background text-foreground text-[0.9rem] font-inherit outline-none resize-none min-h-[1.6em] max-h-[50vh] overflow-y-auto focus:border-primary placeholder:text-muted-foreground"
         onkeydown={handleTextareaKeyDown}
         oninput={resizeTextarea}
       ></textarea>


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Aligned thread panel desktop header padding (`px-4 py-2`) to match the channel header, fixing the height mismatch
- Added `ResizeObserver` on textareas in both Channel and ThreadPanel components so height recalculates when container width changes (e.g., thread panel resize, window resize, sidebar toggle)
- Changed textarea `max-height` from fixed values (`9em` / `6em`) to `50vh` so textareas grow up to half the viewport before scrolling

## Details
The thread header used `px-[18px] py-4` (16px vertical padding) while the channel header used `px-4 py-2` (8px). This caused a visible height difference when both panels are visible side-by-side.

The textarea `resizeTextarea()` function only fired on `oninput` and reactive text changes. When the container width changed, word-wrapping would change but the textarea height wasn't recalculated, leaving excess or insufficient space. The `ResizeObserver` tracks previous width to avoid infinite loops from height-only changes.

## Test plan
- [x] Vite build passes
- [x] Pre-commit hooks (clippy + fmt) pass
- [ ] Thread header height visually matches channel header on desktop
- [ ] Textarea resizes when thread panel is dragged wider/narrower
- [ ] Textarea caps at ~50% viewport height with long content

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)