### PR TITLE
fix: Handle edited review_comment webhooks for review detection [Midtown !1956]

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -395,7 +395,7 @@ When a coworker calls `midtown pr merge --pr <N>`, the daemon runs a pre-gate an
 3. **Gate 3 — Feedback addressed**: For each review comment ID in `pr_review_comment_ids`, checks that a subsequent PR comment contains `<!-- addresses-review: {id} -->`. Unaddressed feedback blocks the merge.
 
 **Review comment ID collection**: Review comment database IDs are collected via two paths:
-- **Webhook path** (primary): When `handle_issue_comment` detects a code review (via `is_review_comment()`), the `WebhookEvent.review_comment_id` field carries the comment's database ID. The daemon handler persists it via `add_review_comment_id()`.
+- **Webhook path** (primary): When `handle_issue_comment` or `handle_review_comment` detects a code review (via `is_review_comment()`), the `WebhookEvent.review_comment_id` field carries the comment's database ID. Both handlers also process `"edited"` events to catch the placeholder-then-edit pattern (post a placeholder, then edit it with the final review). Edits to already-posted reviews (e.g. typo fixes) are ignored. The daemon handler persists review comment IDs via `add_review_comment_id()`.
 - **Polling fallback**: When `is_pr_reviewed()` first detects a review via `pr_has_completed_review_uncached()`, it calls `fetch_review_comment_ids()` to retrieve comment IDs from the GitHub REST API.
 
 **State**: `pr_review_comment_ids: HashMap<u64, Vec<u64>>` in `GitHubState` maps PR numbers to lists of review comment database IDs. Persisted in `daemon-state.json`.

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -62,9 +62,10 @@ pub struct WebhookEvent {
     /// marking the PR as reviewed. Prevents bot comments from triggering
     /// premature "reviewed and CI green" alerts.
     pub review_author: Option<String>,
-    /// The database ID of the review comment (issue comment) that triggered `reviewed_pr`.
+    /// The database ID of the comment that triggered `reviewed_pr`.
     /// Used to populate `pr_review_comment_ids` for Gate 3 merge gating.
-    /// Only set for issue comments that are code reviews (not formal GitHub reviews).
+    /// Set by `handle_issue_comment` and `handle_review_comment` when a code
+    /// review signature is detected (not set for formal GitHub reviews).
     pub review_comment_id: Option<u64>,
     /// A formal review state change (approved / changes_requested) — triggers immediate
     /// nudge of the PR owner instead of waiting for the next polling cycle.
@@ -1036,9 +1037,14 @@ fn handle_review_comment(body: &[u8]) -> Result<Option<WebhookEvent>, serde_json
     let clean_body = strip_frontmatter(&event.comment.body);
     let preview = truncate_comment(&clean_body, 50);
 
+    let verb = if is_edited {
+        "posted review (edited) on"
+    } else {
+        "left review comment on"
+    };
     let action_text = format!(
-        "{} left review comment on PR #{}: {}",
-        commenter, event.pull_request.number, preview
+        "{} {} PR #{}: {}",
+        commenter, verb, event.pull_request.number, preview
     );
 
     // Check if this comment is a Claude code review (for review status caching)

--- a/src/webhook_tests.rs
+++ b/src/webhook_tests.rs
@@ -1264,6 +1264,12 @@ fn test_handle_review_comment_edited_placeholder_to_review() {
     let event = handle_review_comment(&payload).unwrap().unwrap();
     assert_eq!(event.reviewed_pr, Some(77));
     assert_eq!(event.review_comment_id, Some(300));
+    // Edited events should say "posted review (edited)" not "left review comment"
+    assert!(
+        event.message.content.contains("posted review (edited) on"),
+        "edited review message should use 'posted review (edited)' wording, got: {}",
+        event.message.content
+    );
     let activity = event.pr_activity.unwrap();
     assert_eq!(activity.pr_number, 77);
     assert_eq!(activity.actor, "park");
@@ -1354,6 +1360,64 @@ fn test_handle_review_comment_edited_no_changes_field() {
     let event = handle_review_comment(&payload).unwrap().unwrap();
     assert_eq!(event.reviewed_pr, Some(77));
     assert_eq!(event.review_comment_id, Some(303));
+}
+
+#[test]
+fn test_handle_review_comment_created_with_review_signature() {
+    // A 'created' review comment with a code review signature should
+    // populate reviewed_pr, review_author, and review_comment_id.
+    let payload = serde_json::json!({
+        "action": "created",
+        "pull_request": {
+            "number": 88,
+            "head": {"ref": "madison/refactor"},
+            "body": "PR body here"
+        },
+        "comment": {
+            "id": 400,
+            "user": {"login": "btucker"},
+            "body": "<!-- midtown: park -->\n\n## Code Review by park\n\nLGTM - ship it!"
+        },
+        "repository": {"full_name": "org/repo"}
+    });
+    let payload = serde_json::to_vec(&payload).unwrap();
+
+    let event = handle_review_comment(&payload).unwrap().unwrap();
+    assert_eq!(event.reviewed_pr, Some(88));
+    assert_eq!(event.review_author.as_deref(), Some("park"));
+    assert_eq!(event.review_comment_id, Some(400));
+    // Created events should use the original "left review comment" wording
+    assert!(
+        event.message.content.contains("left review comment on"),
+        "created review message should use 'left review comment' wording, got: {}",
+        event.message.content
+    );
+}
+
+#[test]
+fn test_handle_review_comment_created_without_review_signature() {
+    // A 'created' review comment without a review signature should NOT
+    // populate reviewed_pr or review_comment_id (it's a regular inline comment).
+    let payload = serde_json::json!({
+        "action": "created",
+        "pull_request": {
+            "number": 88,
+            "head": {"ref": "madison/refactor"},
+            "body": "PR body here"
+        },
+        "comment": {
+            "id": 401,
+            "user": {"login": "reviewer"},
+            "body": "Consider using a match here instead."
+        },
+        "repository": {"full_name": "org/repo"}
+    });
+    let payload = serde_json::to_vec(&payload).unwrap();
+
+    let event = handle_review_comment(&payload).unwrap().unwrap();
+    assert_eq!(event.reviewed_pr, None);
+    assert_eq!(event.review_author, None);
+    assert_eq!(event.review_comment_id, None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Handle `"edited"` action for `pull_request_review_comment` webhooks, matching the existing logic for `issue_comment` (added in !1885)
- When a review comment transitions from non-review to review (placeholder-then-edit pattern), populate `reviewed_pr`, `review_author`, and `review_comment_id`
- Typo-fix edits to existing reviews are still ignored to avoid re-nudging the PR owner
- Rename `IssueCommentChanges` → `CommentChanges` since both event types share the same GitHub `changes.body.from` envelope

## Test plan
- [x] Added 4 unit tests covering: placeholder→review transition, review typo fix (ignored), non-review edit (ignored), missing `changes` field
- [x] All existing tests pass
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)