### PR TITLE
fix: Add push notification bell icon to sidebar and mobile headers [Midtown !1964]

### DIFF
--- a/web-app/src/App.svelte
+++ b/web-app/src/App.svelte
@@ -22,6 +22,9 @@
   import { theme, toggleTheme } from '$lib/theme.js'
   import { Sun, Moon } from 'lucide-svelte'
   import SearchIcon from '@lucide/svelte/icons/search'
+  import Bell from '@lucide/svelte/icons/bell'
+  import BellOff from '@lucide/svelte/icons/bell-off'
+  import { pushSupported, pushPermission, pushSubscribed, subscribePush, unsubscribePush, checkPushSubscription } from '$lib/push.js'
 
   $effect(() => {
     if ($theme === 'dark') {
@@ -65,7 +68,18 @@
     }
   })
 
+  async function togglePush() {
+    if ($pushSubscribed) {
+      await unsubscribePush()
+    } else {
+      await subscribePush()
+    }
+  }
+
   onMount(async () => {
+    // Initialize push notification support check
+    checkPushSubscription()
+
     // Always in multi-project mode — served from shared gateway on port 47022
     const projectList = await fetchProjects()
 
@@ -199,6 +213,25 @@
               <SearchIcon size={16} />
             </button>
             <button
+              class="theme-toggle"
+              class:push-subscribed={$pushSubscribed}
+              onclick={togglePush}
+              disabled={!$pushSupported || $pushPermission === 'denied'}
+              title={!$pushSupported
+                ? 'Push notifications not supported in this browser'
+                : $pushPermission === 'denied'
+                  ? 'Notifications blocked in browser settings'
+                  : $pushSubscribed
+                    ? 'Disable push notifications'
+                    : 'Enable push notifications'}
+            >
+              {#if $pushSubscribed}
+                <Bell size={16} />
+              {:else}
+                <BellOff size={16} />
+              {/if}
+            </button>
+            <button
               data-testid="theme-toggle"
               class="theme-toggle"
               onclick={toggleTheme}
@@ -248,6 +281,24 @@
           <MiniRepoStatus />
           <button
             class="mobile-search-btn ml-auto p-1.5 text-muted-foreground hover:text-foreground"
+            onclick={togglePush}
+            disabled={!$pushSupported || $pushPermission === 'denied'}
+            title={!$pushSupported
+              ? 'Push notifications not supported'
+              : $pushPermission === 'denied'
+                ? 'Notifications blocked'
+                : $pushSubscribed
+                  ? 'Disable push notifications'
+                  : 'Enable push notifications'}
+          >
+            {#if $pushSubscribed}
+              <Bell size={16} />
+            {:else}
+              <BellOff size={16} />
+            {/if}
+          </button>
+          <button
+            class="mobile-search-btn p-1.5 text-muted-foreground hover:text-foreground"
             onclick={() => searchOpen = true}
             title="Search messages"
           >
@@ -452,9 +503,18 @@
     transition: color 0.2s, background 0.2s;
   }
 
-  .theme-toggle:hover {
+  .theme-toggle:hover:not(:disabled) {
     color: hsl(var(--foreground));
     background: hsl(var(--accent));
+  }
+
+  .theme-toggle:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+  }
+
+  .theme-toggle.push-subscribed {
+    color: hsl(var(--primary));
   }
 
   /* Sidebar content */


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Added Lucide `Bell`/`BellOff` icon to the desktop sidebar header (between search and theme toggle) and the mobile header
- Initialized `checkPushSubscription()` on mount so `pushSupported` is properly detected
- The bell icon is **always visible** — when push notifications aren't supported, it shows as disabled (30% opacity) with a tooltip explaining why, rather than being hidden entirely
- When subscribed, the bell icon highlights with the primary color

## Root cause
The old `Sidebar.svelte` component had the push toggle with correct Lucide icons, but it's **no longer rendered** after the layout migrated to shadcn's `<Sidebar>` UI component in `App.svelte`. The push toggle was never re-added to the new layout, and `checkPushSubscription()` was never called — so `pushSupported` stayed `false` forever.

## Test plan
- [x] Web app builds successfully (`vite build`)
- [ ] Verify bell icon appears in desktop sidebar header next to search and theme toggle
- [ ] Verify bell icon appears in mobile header
- [ ] Verify bell shows as disabled with tooltip on browsers without push support
- [ ] Verify clicking bell toggles push subscription on supported browsers
- [ ] Verify subscribed state shows primary color highlight on bell icon

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)