### PR TITLE
feat: Make all timestamps clickable permalinks across web UI [Midtown !1963]

### DIFF
--- a/web-app/src/lib/OpsChannel.svelte
+++ b/web-app/src/lib/OpsChannel.svelte
@@ -1,8 +1,8 @@
 <script>
-  import { messagesByChannel } from './store.js'
+  import { messagesByChannel, activeProject } from './store.js'
   import { tick } from 'svelte'
-  import { fetchHistory } from './api.js'
-  import { getSenderColor, formatTime } from './messageUtils.js'
+  import { fetchHistory, openThread } from './api.js'
+  import { getSenderColor, formatTime, getPermalinkUrl } from './messageUtils.js'
 
   const OPS_SENDER_OVERRIDES = {
     midtown: '#585858',
@@ -69,8 +69,13 @@
         <div class="text-muted-foreground text-center py-4">No ops messages</div>
       {:else}
         {#each opsMessages as msg}
+          {@const opsUrl = getPermalinkUrl($activeProject, 'ops', msg.thread_parent_id || msg.id)}
           <div class="flex gap-1 break-words min-w-0">
-            <span class="text-muted-foreground/60 flex-shrink-0 w-[5.2em] text-right">{formatTime(msg.timestamp)}</span>
+            {#if opsUrl}
+              <a href={opsUrl} class="text-muted-foreground/60 flex-shrink-0 w-[5.2em] text-right no-underline hover:underline" onclick={(e) => { if (!msg.thread_parent_id) { e.preventDefault(); e.stopPropagation(); openThread(msg, 'ops') } }}>{formatTime(msg.timestamp)}</a>
+            {:else}
+              <span class="text-muted-foreground/60 flex-shrink-0 w-[5.2em] text-right">{formatTime(msg.timestamp)}</span>
+            {/if}
             {#if msg.msg_type === 'action' || msg.content?.startsWith('/me ')}
               <!-- Action: "* name content" -->
               <span class="flex-shrink-0" style="color: {getSenderColor(msg.from, OPS_SENDER_OVERRIDES)}">*</span>


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Make OpsChannel sidebar timestamps clickable `<a>` tags using `getPermalinkUrl` for canonical `/<project>?channel=ops&thread=<id>` permalink URLs
- Top-level message timestamps open the thread panel via `openThread`; thread replies fall through to the `<a>` href for native navigation
- Includes `thread_parent_id` guard matching the pattern in MessageRow

> **Note:** MessageRow and ThreadPanel clickable timestamps were implemented in #1701 (`getPermalinkUrl` with copy-to-clipboard + tooltip). This PR adds the same treatment to OpsChannel — the last remaining plain `<span>` timestamps.

## Visual changes

**Before**: OpsChannel timestamps render as plain `<span>` text — `cursor: default`, no hover effect.

**After**: OpsChannel timestamps render as `<a>` tags styled identically to before (same muted color, same size). On hover, an underline appears and cursor changes to pointer, indicating clickability.

> *Unable to capture screenshots from CLI environment. The visual delta is minimal: timestamps gain `hover:underline` and `cursor: pointer` on hover only. Default appearance is unchanged.*

## Files changed
- `web-app/src/lib/OpsChannel.svelte` — timestamps become clickable `<a>` tags with `thread_parent_id` guard

## Test plan
- [x] `npx vite build` passes
- [x] All 190 vitest tests pass
- [x] Pre-commit hooks pass (cargo clippy + fmt)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)