### PR TITLE
feat: User-controlled thread forking with avatar indicator [Midtown !1959]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -2859,6 +2859,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
     let mut webhook_rx = None;
     let mut web_updates_tx = None;
     let mut mobile_rx: Option<tokio::sync::mpsc::Receiver<crate::web::MobileChannelPost>> = None;
+    let mut web_rpc_rx: Option<tokio::sync::mpsc::Receiver<crate::web::WebRpcRequest>> = None;
     let mut shared_push_manager: Option<std::sync::Arc<crate::push::PushManager>> = None;
     let (forwarder_shutdown_tx, forwarder_shutdown_rx) = watch::channel(false);
 
@@ -2884,11 +2885,12 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
         )
         .await
         {
-            Ok((rx, updates_tx, mob_rx, push_mgr)) => {
+            Ok((rx, updates_tx, mob_rx, push_mgr, wrpc_rx)) => {
                 info!("Webhook server started on port {}", port);
                 webhook_rx = Some(rx);
                 web_updates_tx = Some(updates_tx);
                 mobile_rx = Some(mob_rx);
+                web_rpc_rx = Some(wrpc_rx);
                 shared_push_manager = push_mgr;
 
                 // Spawn webhook forwarder watchdog task
@@ -3467,6 +3469,16 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
                     thread_parent_id,
                     &state,
                 ).await;
+            }
+
+            // Process web RPC requests (thread fork/unfork/ownership from web UI)
+            Some(web_rpc) = async {
+                match web_rpc_rx.as_mut() {
+                    Some(rx) => rx.recv().await,
+                    None => std::future::pending().await,
+                }
+            } => {
+                rpc_session::handle_web_rpc(web_rpc, &state).await;
             }
 
             // Drain events from headless sessions to prevent stdout buffer filling up.

--- a/src/daemon/rpc_channel.rs
+++ b/src/daemon/rpc_channel.rs
@@ -77,7 +77,7 @@ fn parse_duration(s: &str) -> Option<Duration> {
 /// This message establishes the fork's thread-scoped role before the user's
 /// message arrives. It reinforces that the fork is a coordinator — it investigates,
 /// scopes work, and creates tasks, but never implements code.
-fn fork_initial_framing(channel_name: &str) -> String {
+pub(super) fn fork_initial_framing(channel_name: &str) -> String {
     format!(
         "You are a thread-scoped fork of the channel lead for #{channel_name}. \
          Your job is to investigate the user's request, scope the work, and create a task. \
@@ -290,13 +290,11 @@ pub(super) async fn handle_channel_post(
         } else if is_topic_channel {
             // Resolve the fork session for this message:
             // - For thread replies: route to the existing fork session bound to that thread.
-            // - For new top-level messages: auto-fork the channel lead so every user
-            //   message immediately gets its own thread-scoped session. This ensures the
-            //   fork exists before the nudge arrives, making per-thread tool-call display
-            //   and context isolation reliable without relying on the lead to fork manually.
+            // - For new top-level messages: route to the channel lead directly.
+            //   Users can opt into dedicated thread sessions via the web UI.
             let topic_session_id = if let Some(parent_id) = thread_parent_id {
                 // Thread reply: route to existing fork session (if any).
-                // Filter out "pending" — a concurrent auto-fork is in progress but not yet
+                // Filter out "pending" — a concurrent fork is in progress but not yet
                 // ready. Treating "pending" as None falls back to NudgeChannelLead rather
                 // than producing a NudgeSession with an invalid "pending" session_id.
                 state
@@ -307,80 +305,8 @@ pub(super) async fn handle_channel_post(
                     .filter(|s| s.as_str() != "pending")
                     .cloned()
             } else {
-                // New top-level message: auto-fork from the channel lead session.
-                // Look up the channel lead's session ID from persistent state.
-                // Use try_lock to avoid blocking the channel post path — if persistent_state
-                // is momentarily held, fall through to NudgeChannelLead rather than queuing.
-                let lead_session_id = state.persistent_state.try_lock().ok().and_then(
-                    |mut ps| {
-                        let sid = ps
-                            .channel_lead_sessions
-                            .get(channel_name)
-                            .filter(|s| !s.is_empty())
-                            .cloned()?;
-                        if ps.sessions.contains_key(&sid) {
-                            Some(sid)
-                        } else {
-                            // Stale mapping — session no longer exists. Clear it
-                            // so we don't keep trying to fork from a dead session.
-                            debug!(
-                                "channel.post: clearing stale channel lead mapping for {} (session {} not found)",
-                                channel_name, sid
-                            );
-                            ps.channel_lead_sessions.remove(channel_name);
-                            None
-                        }
-                    },
-                );
-                if let Some(lead_sid) = lead_session_id {
-                    match super::rpc_session::create_fork_session(
-                        &wake_msg_id,
-                        &lead_sid,
-                        Some(channel_name),
-                        Some(&content),
-                        "channel.post",
-                        state,
-                    )
-                    .await
-                    {
-                        Ok((fork_sid, is_existing)) => {
-                            debug!(
-                                "channel.post: auto-forked for message {} → fork session {} (existing={})",
-                                wake_msg_id, fork_sid, is_existing
-                            );
-                            // Fresh forks get a framing nudge that establishes their
-                            // thread-scoped role before the user message arrives.
-                            // Note: if this nudge fails (e.g., session not yet ready),
-                            // the fork still has hard tool restrictions via --disallowedTools
-                            // and inherits the parent's system prompt context.
-                            if !is_existing {
-                                let framing = fork_initial_framing(channel_name);
-                                let framing_effect = crate::daemon::effects::Effect::NudgeSession {
-                                    session_id: fork_sid.clone(),
-                                    reason: crate::daemon::wake_reason::WakeReason::Nudge {
-                                        message: framing,
-                                    },
-                                };
-                                crate::daemon::effects::execute_effects(
-                                    vec![framing_effect],
-                                    state,
-                                )
-                                .await;
-                            }
-                            Some(fork_sid)
-                        }
-                        Err(e) => {
-                            debug!(
-                                "channel.post: auto-fork skipped ({}), nudging channel lead",
-                                e
-                            );
-                            None
-                        }
-                    }
-                } else {
-                    // No channel lead running yet — NudgeChannelLead will spawn one.
-                    None
-                }
+                // New top-level message: no auto-fork. Route to channel lead.
+                None
             };
             if let Some(fork_session_id) = topic_session_id.as_deref() {
                 debug!(

--- a/src/daemon/rpc_channel_tests.rs
+++ b/src/daemon/rpc_channel_tests.rs
@@ -1779,13 +1779,12 @@ async fn test_dm_post_from_coworker_is_not_blocked() {
 // Auto-fork tests
 // ============================================================================
 
-/// When a user posts a new top-level message to a topic channel that has a known
-/// channel lead session, an auto-fork is attempted. In tests the spawn fails
-/// (no real claude process), but the sentinel should be cleaned up and the
-/// overall channel.post should still succeed.
+/// New top-level messages to a topic channel with a known channel lead route
+/// to the channel lead without auto-forking. Users can opt into dedicated
+/// sessions via the web UI.
 #[tokio::test]
-async fn test_user_message_to_topic_channel_with_lead_cleans_up_sentinel_on_failed_fork() {
-    let (state, _tmp, _guard) = make_test_state("midtown-test-autofork-sentinel-cleanup");
+async fn test_user_message_to_topic_channel_routes_to_lead_without_fork() {
+    let (state, _tmp, _guard) = make_test_state("midtown-test-no-autofork");
 
     // Register a fake channel lead session for the "web" topic channel
     {
@@ -1805,15 +1804,14 @@ async fn test_user_message_to_topic_channel_with_lead_cleans_up_sentinel_on_fail
     .await;
     assert!(
         response.error.is_none(),
-        "channel.post should succeed even when auto-fork spawn fails"
+        "channel.post should succeed for topic channel messages"
     );
 
-    // The auto-fork attempt fails (no real claude process), so the pending sentinel
-    // must be removed. topic_sessions should have no "pending" entries.
+    // No auto-fork: topic_sessions should remain empty (no fork created).
     let topic = state.topic_sessions.lock().unwrap();
     assert!(
-        !topic.values().any(|v| v == "pending"),
-        "no pending sentinels should remain after failed auto-fork"
+        topic.is_empty(),
+        "no fork sessions should be created for new top-level messages"
     );
 }
 
@@ -1862,8 +1860,8 @@ async fn test_thread_reply_routes_to_existing_fork_session() {
     );
 }
 
-/// When no channel lead session is registered for a topic channel, auto-fork
-/// is skipped gracefully and channel.post succeeds.
+/// When no channel lead session is registered for a topic channel, channel.post
+/// succeeds and routes via NudgeChannelLead (which spawns the lead).
 #[tokio::test]
 async fn test_user_message_to_topic_channel_without_lead_skips_fork() {
     let (state, _tmp, _guard) = make_test_state("midtown-test-autofork-no-lead");

--- a/src/daemon/rpc_session.rs
+++ b/src/daemon/rpc_session.rs
@@ -1219,17 +1219,17 @@ pub(super) fn build_fork_config(
 
 /// Create a fork session bound to a thread, or return an existing one.
 ///
-/// This is the shared implementation used by both `handle_session_fork` (explicit fork
-/// via `midtown session fork`) and the daemon's auto-fork path in `handle_channel_post`
-/// (automatic fork on new top-level user messages to topic channels).
+/// This is the shared implementation used by `handle_session_fork` (explicit fork
+/// via `midtown session fork`), the web UI fork button (`handle_web_fork_thread`),
+/// and any other callers that need to create a thread-scoped session.
 ///
 /// Uses an atomic check-and-reserve on `topic_sessions` to prevent duplicate forks for
 /// the same thread: inserts a "pending" sentinel, then replaces it with the real
 /// session_id on success (or removes it on failure).
 ///
 /// `channel_hint` lets callers provide a known channel name that takes priority over the
-/// session record's channel field. The auto-fork path uses this since `handle_channel_post`
-/// already knows the channel from the incoming message.
+/// session record's channel field. The web fork path uses this since it already knows
+/// the channel from the UI request.
 ///
 /// `fork_name_hint` provides a human-readable description for the fork session name.
 /// When provided, the hint is slugified (non-alphanumeric chars replaced with hyphens,
@@ -1308,8 +1308,8 @@ pub(super) async fn create_fork_session(
         }
     };
 
-    // Determine channel for the fork — explicit hint takes priority (the auto-fork
-    // path knows the channel from the incoming message), then session record, then
+    // Determine channel for the fork — explicit hint takes priority (the web fork
+    // path knows the channel from the UI request), then session record, then
     // caller name (channel leads are named after their channel).
     let fork_channel = channel_hint
         .map(String::from)
@@ -1499,7 +1499,7 @@ pub(super) async fn handle_session_fork(
             }),
         ),
         Err(ref e) if e.starts_with("fork in progress") => {
-            // The daemon's auto-fork path already reserved this slot.
+            // Another concurrent fork attempt already reserved this slot.
             // Return a distinct pending response so the channel lead can
             // distinguish "retry shortly" from a hard spawn failure.
             crate::rpc::Response::success(
@@ -1512,6 +1512,185 @@ pub(super) async fn handle_session_fork(
             )
         }
         Err(e) => crate::rpc::Response::error(id, crate::rpc::RpcError::new(-32603, e)),
+    }
+}
+
+// ============================================================================
+// Web RPC handlers (thread fork/unfork/ownership from web UI)
+// ============================================================================
+
+/// Dispatch a web RPC request to the appropriate handler.
+pub(super) async fn handle_web_rpc(request: crate::web::WebRpcRequest, state: &DaemonState) {
+    use crate::web::WebRpcRequest;
+    match request {
+        WebRpcRequest::ForkThread {
+            thread_parent_id,
+            channel_name,
+            response_tx,
+        } => {
+            let result = handle_web_fork_thread(&thread_parent_id, &channel_name, state).await;
+            let _ = response_tx.send(result);
+        }
+        WebRpcRequest::UnforkThread {
+            thread_parent_id,
+            response_tx,
+        } => {
+            let result = handle_web_unfork_thread(&thread_parent_id, state).await;
+            let _ = response_tx.send(result);
+        }
+        WebRpcRequest::ThreadOwnership {
+            thread_parent_id,
+            channel_name,
+            response_tx,
+        } => {
+            let result = handle_web_thread_ownership(&thread_parent_id, &channel_name, state).await;
+            let _ = response_tx.send(result);
+        }
+    }
+}
+
+/// Fork a thread from the web UI: create a dedicated session for the given thread.
+///
+/// Looks up the channel lead for the given channel and delegates to `create_fork_session`.
+/// On success, sends a framing nudge to the new fork so it understands its thread scope.
+async fn handle_web_fork_thread(
+    thread_parent_id: &str,
+    channel_name: &str,
+    state: &DaemonState,
+) -> Result<serde_json::Value, String> {
+    // Look up the channel lead's session ID
+    let lead_session_id = {
+        let ps = state.persistent_state.lock().await;
+        ps.channel_lead_sessions
+            .get(channel_name)
+            .filter(|s| !s.is_empty())
+            .cloned()
+    };
+
+    let lead_sid = lead_session_id
+        .ok_or_else(|| format!("No channel lead running for channel '{}'", channel_name))?;
+
+    match create_fork_session(
+        thread_parent_id,
+        &lead_sid,
+        Some(channel_name),
+        None, // no name hint from UI
+        "web.fork_thread",
+        state,
+    )
+    .await
+    {
+        Ok((fork_sid, is_existing)) => {
+            if !is_existing {
+                // Fresh fork: send framing nudge
+                let framing = super::rpc_channel::fork_initial_framing(channel_name);
+                let framing_effect = crate::daemon::effects::Effect::NudgeSession {
+                    session_id: fork_sid.clone(),
+                    reason: crate::daemon::wake_reason::WakeReason::Nudge { message: framing },
+                };
+                crate::daemon::effects::execute_effects(vec![framing_effect], state).await;
+            }
+            Ok(serde_json::json!({
+                "session_id": fork_sid,
+                "thread_parent_id": thread_parent_id,
+                "already_exists": is_existing,
+            }))
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Unfork a thread from the web UI: kill the dedicated session and clean up.
+///
+/// Looks up the fork session bound to the thread, shuts it down, and removes
+/// all transient state so future replies route to the channel lead.
+async fn handle_web_unfork_thread(
+    thread_parent_id: &str,
+    state: &DaemonState,
+) -> Result<serde_json::Value, String> {
+    // Find the fork session for this thread
+    let fork_session_id = {
+        let topic = state.topic_sessions.lock().unwrap();
+        topic
+            .get(thread_parent_id)
+            .filter(|s| s.as_str() != "pending")
+            .cloned()
+    };
+
+    let fork_sid =
+        fork_session_id.ok_or_else(|| "No dedicated session exists for this thread".to_string())?;
+
+    // Look up the fork's name
+    let fork_name = {
+        let s2n = state.session_to_name.lock().unwrap();
+        s2n.get(&fork_sid).cloned()
+    };
+
+    // Shut down the fork session
+    if let Some(ref name) = fork_name {
+        if let Err(e) = state.session_manager.shutdown(name).await {
+            warn!(
+                "web.unfork_thread: failed to shut down fork session {}: {}",
+                name, e
+            );
+        }
+        // Clean up all transient state
+        state.cleanup_coworker_state(name).await;
+    }
+
+    // Also remove from topic_sessions directly in case cleanup didn't cover it
+    {
+        let mut topic = state.topic_sessions.lock().unwrap();
+        topic.remove(thread_parent_id);
+    }
+
+    info!(
+        "web.unfork_thread: removed fork session for thread {} (name={:?}, sid={})",
+        thread_parent_id, fork_name, fork_sid
+    );
+
+    Ok(serde_json::json!({
+        "thread_parent_id": thread_parent_id,
+        "removed_session": fork_name,
+    }))
+}
+
+/// Query thread ownership: who handles this thread?
+async fn handle_web_thread_ownership(
+    thread_parent_id: &str,
+    channel_name: &str,
+    state: &DaemonState,
+) -> Result<crate::web::ThreadOwnershipInfo, String> {
+    // Check if there's a fork session for this thread
+    let fork_session_id = {
+        let topic = state.topic_sessions.lock().unwrap();
+        topic
+            .get(thread_parent_id)
+            .filter(|s| s.as_str() != "pending")
+            .cloned()
+    };
+
+    if let Some(fork_sid) = fork_session_id {
+        // Thread has a dedicated session
+        let owner_name = {
+            let s2n = state.session_to_name.lock().unwrap();
+            s2n.get(&fork_sid)
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string())
+        };
+        Ok(crate::web::ThreadOwnershipInfo {
+            owner: owner_name,
+            is_fork: true,
+            channel: Some(channel_name.to_string()),
+        })
+    } else {
+        // Thread handled by channel lead
+        let lead_name = channel_name.to_string();
+        Ok(crate::web::ThreadOwnershipInfo {
+            owner: lead_name,
+            is_fork: false,
+            channel: Some(channel_name.to_string()),
+        })
     }
 }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -145,6 +145,38 @@ pub struct MobileChannelPost {
     pub thread_parent_id: Option<String>,
 }
 
+/// Thread ownership info returned by the thread_ownership API.
+#[derive(Debug, Clone, Serialize)]
+pub struct ThreadOwnershipInfo {
+    /// Display name of the session that owns this thread (channel lead or fork name).
+    pub owner: String,
+    /// True when the thread is handled by a dedicated fork session.
+    pub is_fork: bool,
+    /// Channel name this thread belongs to.
+    pub channel: Option<String>,
+}
+
+/// A request from the web server to the daemon that expects a response.
+pub enum WebRpcRequest {
+    /// Fork a thread: create a dedicated session for the given thread.
+    ForkThread {
+        thread_parent_id: String,
+        channel_name: String,
+        response_tx: tokio::sync::oneshot::Sender<Result<serde_json::Value, String>>,
+    },
+    /// Unfork a thread: kill the dedicated session and return to channel lead.
+    UnforkThread {
+        thread_parent_id: String,
+        response_tx: tokio::sync::oneshot::Sender<Result<serde_json::Value, String>>,
+    },
+    /// Query thread ownership (who handles this thread).
+    ThreadOwnership {
+        thread_parent_id: String,
+        channel_name: String,
+        response_tx: tokio::sync::oneshot::Sender<Result<ThreadOwnershipInfo, String>>,
+    },
+}
+
 /// Shared state for WebSocket connections
 pub struct WebState {
     pub config: WebConfig,
@@ -165,6 +197,9 @@ pub struct WebState {
     /// Cached GitHub repo full names (owner/repo) by repo path.
     /// Repo names never change during a session, so we cache indefinitely.
     pub repo_name_cache: std::sync::RwLock<std::collections::HashMap<std::path::PathBuf, String>>,
+    /// Sender for thread fork/unfork/ownership RPCs to the daemon.
+    /// Optional because standalone webserver tests don't need the daemon.
+    pub web_rpc_tx: Option<mpsc::Sender<WebRpcRequest>>,
 }
 
 impl WebState {
@@ -381,6 +416,9 @@ pub fn create_web_router(state: Arc<WebState>) -> Router {
         .route("/api/search", get(api_search))
         .route("/api/upload", post(api_upload))
         .route("/api/uploads/{filename}", get(api_get_upload))
+        .route("/api/threads/fork", post(api_thread_fork))
+        .route("/api/threads/unfork", post(api_thread_unfork))
+        .route("/api/threads/ownership", get(api_thread_ownership))
         .layer(DefaultBodyLimit::max(11 * 1024 * 1024))
         .with_state(state)
 }
@@ -2222,6 +2260,129 @@ pub fn channel_message_update(message: &Message) -> WebUpdate {
         reply_count: None,
         last_reply: None,
     })
+}
+
+// ── Thread fork/unfork/ownership API ──────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct ThreadForkRequest {
+    thread_parent_id: String,
+    channel_name: String,
+}
+
+#[derive(Deserialize)]
+struct ThreadUnforkRequest {
+    thread_parent_id: String,
+}
+
+#[derive(Deserialize)]
+struct ThreadOwnershipQuery {
+    thread_parent_id: String,
+    channel_name: String,
+}
+
+async fn api_thread_fork(
+    State(state): State<Arc<WebState>>,
+    Json(body): Json<ThreadForkRequest>,
+) -> Result<impl IntoResponse, StatusCode> {
+    let rpc_tx = state.web_rpc_tx.as_ref().ok_or_else(|| {
+        warn!("api_thread_fork: no web_rpc_tx available");
+        StatusCode::SERVICE_UNAVAILABLE
+    })?;
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    rpc_tx
+        .send(WebRpcRequest::ForkThread {
+            thread_parent_id: body.thread_parent_id,
+            channel_name: body.channel_name,
+            response_tx: tx,
+        })
+        .await
+        .map_err(|_| {
+            error!("api_thread_fork: failed to send to daemon");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    match rx.await {
+        Ok(Ok(value)) => Ok(Json(value)),
+        Ok(Err(e)) => {
+            warn!("api_thread_fork: daemon error: {}", e);
+            Ok(Json(serde_json::json!({ "error": e })))
+        }
+        Err(_) => {
+            error!("api_thread_fork: response channel dropped");
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
+}
+
+async fn api_thread_unfork(
+    State(state): State<Arc<WebState>>,
+    Json(body): Json<ThreadUnforkRequest>,
+) -> Result<impl IntoResponse, StatusCode> {
+    let rpc_tx = state.web_rpc_tx.as_ref().ok_or_else(|| {
+        warn!("api_thread_unfork: no web_rpc_tx available");
+        StatusCode::SERVICE_UNAVAILABLE
+    })?;
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    rpc_tx
+        .send(WebRpcRequest::UnforkThread {
+            thread_parent_id: body.thread_parent_id,
+            response_tx: tx,
+        })
+        .await
+        .map_err(|_| {
+            error!("api_thread_unfork: failed to send to daemon");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    match rx.await {
+        Ok(Ok(value)) => Ok(Json(value)),
+        Ok(Err(e)) => {
+            warn!("api_thread_unfork: daemon error: {}", e);
+            Ok(Json(serde_json::json!({ "error": e })))
+        }
+        Err(_) => {
+            error!("api_thread_unfork: response channel dropped");
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
+}
+
+async fn api_thread_ownership(
+    State(state): State<Arc<WebState>>,
+    Query(params): Query<ThreadOwnershipQuery>,
+) -> Result<impl IntoResponse, StatusCode> {
+    let rpc_tx = state.web_rpc_tx.as_ref().ok_or_else(|| {
+        warn!("api_thread_ownership: no web_rpc_tx available");
+        StatusCode::SERVICE_UNAVAILABLE
+    })?;
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    rpc_tx
+        .send(WebRpcRequest::ThreadOwnership {
+            thread_parent_id: params.thread_parent_id,
+            channel_name: params.channel_name,
+            response_tx: tx,
+        })
+        .await
+        .map_err(|_| {
+            error!("api_thread_ownership: failed to send to daemon");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    match rx.await {
+        Ok(Ok(info)) => Ok(Json(serde_json::json!(info))),
+        Ok(Err(e)) => {
+            warn!("api_thread_ownership: daemon error: {}", e);
+            Ok(Json(serde_json::json!({ "error": e })))
+        }
+        Err(_) => {
+            error!("api_thread_ownership: response channel dropped");
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
 }
 
 /// Broadcast a new channel message to all WebSocket clients

--- a/src/web_tests.rs
+++ b/src/web_tests.rs
@@ -55,6 +55,7 @@ async fn test_mobile_send_message_forwards_to_daemon() {
         default_branch: "main".to_string(),
         max_coworkers: 8,
         repo_name_cache: std::sync::RwLock::new(std::collections::HashMap::new()),
+        web_rpc_tx: None,
     });
 
     let json = r#"{"type": "send_message", "content": "hello from mobile"}"#;
@@ -237,6 +238,7 @@ async fn test_coworker_nudge_returns_error() {
         default_branch: "main".to_string(),
         max_coworkers: 8,
         repo_name_cache: std::sync::RwLock::new(std::collections::HashMap::new()),
+        web_rpc_tx: None,
     });
 
     let json = r#"{"type": "nudge", "target": "lexington", "message": "test nudge"}"#;
@@ -296,6 +298,7 @@ async fn test_coworker_nudge_not_supported_via_web_ui() {
         default_branch: "main".to_string(),
         max_coworkers: 8,
         repo_name_cache: std::sync::RwLock::new(std::collections::HashMap::new()),
+        web_rpc_tx: None,
     });
 
     // Try to nudge a coworker (not "lead")
@@ -357,6 +360,7 @@ async fn test_error_channel_backpressure() {
         default_branch: "main".to_string(),
         max_coworkers: 8,
         repo_name_cache: std::sync::RwLock::new(std::collections::HashMap::new()),
+        web_rpc_tx: None,
     });
 
     // Trigger 20 errors (channel capacity is 10) by sending invalid messages.
@@ -615,6 +619,7 @@ async fn test_answer_question_invalid_coworker_name() {
         default_branch: "main".to_string(),
         max_coworkers: 8,
         repo_name_cache: std::sync::RwLock::new(std::collections::HashMap::new()),
+        web_rpc_tx: None,
     });
 
     let json =
@@ -642,6 +647,7 @@ async fn test_answer_question_empty_answer() {
         default_branch: "main".to_string(),
         max_coworkers: 8,
         repo_name_cache: std::sync::RwLock::new(std::collections::HashMap::new()),
+        web_rpc_tx: None,
     });
 
     let json = r#"{"type": "answer_question", "coworker_name": "lexington", "answer": ""}"#;

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -299,10 +299,12 @@ pub async fn start_webhook_server(
     broadcast::Sender<WebUpdate>,
     mpsc::Receiver<MobileChannelPost>,
     Option<Arc<crate::push::PushManager>>,
+    mpsc::Receiver<web::WebRpcRequest>,
 )> {
     let (tx, rx) = mpsc::channel(100);
     let (web_updates_tx, _) = broadcast::channel(100);
     let (mobile_tx, mobile_rx) = mpsc::channel(100);
+    let (web_rpc_tx, web_rpc_rx) = mpsc::channel(32);
 
     let webhook_state = Arc::new(WebhookState {
         config: config.clone(),
@@ -336,6 +338,7 @@ pub async fn start_webhook_server(
         default_branch,
         max_coworkers,
         repo_name_cache: std::sync::RwLock::new(std::collections::HashMap::new()),
+        web_rpc_tx: Some(web_rpc_tx),
     });
 
     // CORS layer for development (allows requests from Vite dev server)
@@ -365,7 +368,7 @@ pub async fn start_webhook_server(
         }
     });
 
-    Ok((rx, web_updates_tx, mobile_rx, push_manager))
+    Ok((rx, web_updates_tx, mobile_rx, push_manager, web_rpc_rx))
 }
 
 /// Health check endpoint

--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -8,7 +8,7 @@
 
 <script>
   import { threadData, agentToolItems, threadToolItems, deepLinkMsgId } from './store.js'
-  import { sendMessage, closeThread, getApiBase } from './api.js'
+  import { sendMessage, closeThread, getApiBase, fetchThreadOwnership, forkThread, unforkThread } from './api.js'
   import { tick, onMount, onDestroy, untrack } from 'svelte'
   import { getSenderColor, isDimSender, parseInsightSegments, dateChanged } from './messageUtils.js'
   import MermaidDiagram from './MermaidDiagram.svelte'
@@ -101,6 +101,18 @@
   let thinking = $state(false)
   let thinkingTimeout = null
 
+  // Thread ownership state: tracks whether this thread has a dedicated fork session.
+  // { owner: string, is_fork: boolean, channel?: string } or null when loading/unknown.
+  let threadOwnership = $state(null)
+  let forkLoading = $state(false)
+
+  // Whether the current channel is a topic channel (non-default, non-DM)
+  let isTopicChannel = $derived(
+    $threadData?.channelName
+    && $threadData.channelName !== 'midtown'
+    && !$threadData.channelName.startsWith('dm-')
+  )
+
   // Stable thread identity: changes only when a different thread is opened or closed.
   // Using $derived ensures the clearing effect below re-runs only on actual thread switches,
   // not on every message-array update (which reassigns $threadData but keeps the same id).
@@ -120,6 +132,42 @@
       thinkingTimeout = null
     }
   })
+
+  // Fetch thread ownership when the thread panel opens or switches threads.
+  $effect(() => {
+    const tid = currentThreadId
+    const channel = $threadData?.channelName
+    threadOwnership = null
+    if (tid && channel && channel !== 'midtown' && !channel.startsWith('dm-')) {
+      fetchThreadOwnership(tid, channel).then((info) => {
+        // Guard against stale fetch
+        if (currentThreadId === tid) {
+          threadOwnership = info
+        }
+      })
+    }
+  })
+
+  async function handleToggleFork() {
+    const tid = currentThreadId
+    const channel = $threadData?.channelName
+    if (!tid || !channel) return
+    forkLoading = true
+    try {
+      if (threadOwnership?.is_fork) {
+        await unforkThread(tid)
+      } else {
+        await forkThread(tid, channel)
+      }
+      // Refresh ownership after toggle
+      const info = await fetchThreadOwnership(tid, channel)
+      if (currentThreadId === tid) {
+        threadOwnership = info
+      }
+    } finally {
+      forkLoading = false
+    }
+  }
 
   // Save/restore drafts when switching threads
   $effect(() => {
@@ -385,7 +433,36 @@
 
     <!-- Header -->
     <div class="flex items-center justify-between px-4 py-2 bg-card border-b-2 border-border shrink-0">
-      <h2 class="text-[0.85rem] font-bold text-foreground m-0">Thread</h2>
+      <div class="flex items-center gap-2 min-w-0">
+        <div class="relative shrink-0">
+          <h2 class="text-[0.85rem] font-bold text-foreground m-0">Thread</h2>
+          {#if threadOwnership?.is_fork}
+            <span
+              class="absolute -top-0.5 -right-2 w-2 h-2 rounded-full bg-primary"
+              title="Running in a dedicated thread session"
+            ></span>
+          {/if}
+        </div>
+        {#if isTopicChannel && currentThreadId}
+          <button
+            class="text-[0.7rem] px-2 py-0.5 rounded border transition-all duration-150 shrink-0 {threadOwnership?.is_fork
+              ? 'border-primary/40 bg-primary/10 text-primary hover:bg-primary/20'
+              : 'border-border bg-transparent text-muted-foreground hover:bg-accent hover:text-foreground'}"
+            onclick={handleToggleFork}
+            disabled={forkLoading}
+            title={threadOwnership?.is_fork ? 'Return thread to channel lead' : 'Create a dedicated session for this thread'}
+            data-testid="thread-fork-toggle"
+          >
+            {#if forkLoading}
+              ...
+            {:else if threadOwnership?.is_fork}
+              Return to main
+            {:else}
+              Dedicate session
+            {/if}
+          </button>
+        {/if}
+      </div>
       <button
         class="w-8 h-8 flex items-center justify-center bg-transparent border border-border rounded-md text-muted-foreground text-[1.3rem] cursor-pointer transition-all duration-150 leading-none hover:bg-accent hover:border-destructive hover:text-destructive ml-2 shrink-0"
         onclick={handleClose}
@@ -587,7 +664,34 @@
         aria-label="Back to channel"
         data-testid="thread-back-button"
       >&larr;</button>
-      <h2 class="text-[0.85rem] font-bold text-foreground m-0">Thread</h2>
+      <div class="relative shrink-0">
+        <h2 class="text-[0.85rem] font-bold text-foreground m-0">Thread</h2>
+        {#if threadOwnership?.is_fork}
+          <span
+            class="absolute -top-0.5 -right-2 w-2 h-2 rounded-full bg-primary"
+            title="Running in a dedicated thread session"
+          ></span>
+        {/if}
+      </div>
+      {#if isTopicChannel && currentThreadId}
+        <button
+          class="text-[0.7rem] px-2 py-0.5 rounded border transition-all duration-150 shrink-0 ml-auto {threadOwnership?.is_fork
+            ? 'border-primary/40 bg-primary/10 text-primary hover:bg-primary/20'
+            : 'border-border bg-transparent text-muted-foreground hover:bg-accent hover:text-foreground'}"
+          onclick={handleToggleFork}
+          disabled={forkLoading}
+          title={threadOwnership?.is_fork ? 'Return thread to channel lead' : 'Create a dedicated session for this thread'}
+          data-testid="thread-fork-toggle-mobile"
+        >
+          {#if forkLoading}
+            ...
+          {:else if threadOwnership?.is_fork}
+            Return to main
+          {:else}
+            Dedicate session
+          {/if}
+        </button>
+      {/if}
     </div>
 
     <!-- Mobile messages -->

--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -1091,6 +1091,53 @@ export function closeThread({ pushState = true } = {}) {
   }
 }
 
+// ── Thread fork/unfork/ownership API ────────────────────────────────────────
+
+// Query thread ownership — returns { owner, is_fork, channel }
+export async function fetchThreadOwnership(threadParentId, channelName) {
+  try {
+    const params = new URLSearchParams({
+      thread_parent_id: threadParentId,
+      channel_name: channelName,
+    })
+    const res = await fetch(`${getApiBase()}/threads/ownership?${params}`)
+    if (res.ok) return await res.json()
+    return { owner: channelName, is_fork: false, channel: channelName }
+  } catch {
+    return { owner: channelName, is_fork: false, channel: channelName }
+  }
+}
+
+// Fork a thread: create a dedicated session
+export async function forkThread(threadParentId, channelName) {
+  try {
+    const res = await fetch(`${getApiBase()}/threads/fork`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ thread_parent_id: threadParentId, channel_name: channelName }),
+    })
+    return await res.json()
+  } catch (err) {
+    console.error('Failed to fork thread:', err)
+    return { error: err.message }
+  }
+}
+
+// Unfork a thread: return to channel lead
+export async function unforkThread(threadParentId) {
+  try {
+    const res = await fetch(`${getApiBase()}/threads/unfork`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ thread_parent_id: threadParentId }),
+    })
+    return await res.json()
+  } catch (err) {
+    console.error('Failed to unfork thread:', err)
+    return { error: err.message }
+  }
+}
+
 // Search messages across all channels
 export async function searchMessages(query, limit = 50) {
   try {


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- **Replaced auto-fork with user-controlled forking** for topic channel threads. New top-level messages now route to the channel lead directly instead of auto-forking. Thread replies still route to existing forks when present.
- **Added web RPC infrastructure** (`WebRpcRequest` channel with oneshot response) enabling request-response communication from the web server to the daemon event loop.
- **Added 3 new daemon handlers and REST API endpoints**: `POST /api/threads/fork`, `POST /api/threads/unfork`, `GET /api/threads/ownership` — supporting the web UI toggle.
- **Added "Dedicate session" / "Return to main" toggle button** in the thread panel header (both desktop and mobile layouts), with a primary-colored dot indicator when a dedicated fork session is active.
- **Updated tests** to reflect the new no-auto-fork behavior.

## User-facing vocabulary
- "Dedicate session" (not "fork") when enabling a thread session
- "Return to main" (not "unfork") to revert to channel lead
- Tooltip: "Running in a dedicated thread session"

## Backend changes
| File | Change |
|------|--------|
| `rpc_channel.rs` | Removed auto-fork code path (kept thread reply routing to existing forks) |
| `rpc_session.rs` | Added `handle_web_rpc`, `handle_web_fork_thread`, `handle_web_unfork_thread`, `handle_web_thread_ownership` |
| `web.rs` | Added `WebRpcRequest` enum, `ThreadOwnershipInfo`, 3 REST endpoints, `web_rpc_tx` on WebState |
| `webhook.rs` | Plumbed `web_rpc_rx` through server startup |
| `mod.rs` | Added `web_rpc_rx` event loop handler |

## Frontend changes
| File | Change |
|------|--------|
| `api.js` | Added `fetchThreadOwnership`, `forkThread`, `unforkThread` API functions |
| `ThreadPanel.svelte` | Added ownership state, fork toggle button, avatar dot indicator |

## Test plan
- [x] All 2264 unit tests pass
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt` clean
- [x] Updated auto-fork test to verify no-fork behavior
- [ ] Manual: open thread in topic channel, verify "Dedicate session" button appears
- [ ] Manual: click "Dedicate session", verify fork is created and dot indicator shows
- [ ] Manual: click "Return to main", verify fork is killed and dot disappears

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)