### PR TITLE
fix: Retain channel messages when single-channel fetch returns empty [Midtown !1968]

### DIFF
--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -235,11 +235,25 @@ export async function fetchHistory(channelName = null) {
         // The backend can transiently return [] when the channel file is briefly
         // missing (rotation, archiving race). Same "retain last-known-good"
         // pattern used in the catch block below.
-        if (channelMsgs.length === 0) {
+        //
+        // Check data.length (raw response), not channelMsgs.length: a response
+        // containing only thread replies is non-empty but annotateThreadReplyCounts
+        // filters them all out, producing channelMsgs=[]. That's real data and
+        // must not be treated as a transient empty response.
+        if (data.length === 0) {
           const existing = get(messagesByChannel)[channelName]
           if (existing && existing.length > 0) {
-            console.warn(`fetchHistory('${channelName}'): backend returned empty — retaining ${existing.length} cached messages`)
-            return
+            // Strip pending (optimistic) messages from retained data so they
+            // don't linger as ghosts (mirroring the bulk-fetch path's cleanup).
+            const confirmed = existing.filter((m) => !m.pending)
+            if (confirmed.length > 0) {
+              console.warn(`fetchHistory('${channelName}'): backend returned empty — retaining ${confirmed.length} cached messages`)
+              messagesByChannel.update((byChannel) => ({
+                ...byChannel,
+                [channelName]: confirmed,
+              }))
+              return
+            }
           }
         }
 

--- a/web-app/src/lib/api.test.js
+++ b/web-app/src/lib/api.test.js
@@ -111,9 +111,10 @@ describe('fetchHistory', () => {
     expect(store['channel-a'][0].content).toBe('existing message')
   })
 
-  it('allows single-channel fetch to populate an empty channel', async () => {
-    // When a channel has no messages yet, fetchHistory should populate it normally
-    // even if the response is empty (this is the initial state, not a wipe).
+  it('populates a new channel with messages from single-channel fetch', async () => {
+    // Normal population: a channel with no existing messages gets populated
+    // by the fetch response. The empty-response guard does not interfere
+    // because there is no existing data to retain.
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => [
@@ -126,6 +127,88 @@ describe('fetchHistory', () => {
     const store = get(messagesByChannel)
     expect(store['new-channel']).toHaveLength(1)
     expect(store['new-channel'][0].content).toBe('new msg')
+  })
+
+  it('allows empty response to pass through when channel has no existing messages', async () => {
+    // When a channel has no cached messages, an empty response should set the
+    // channel to [] without being blocked by the guard. The guard only retains
+    // data when there IS existing data to protect.
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    })
+
+    await fetchHistory('brand-new-channel')
+
+    const store = get(messagesByChannel)
+    expect(store['brand-new-channel']).toEqual([])
+  })
+
+  it('updates store when response contains only thread replies (post-filter empty)', async () => {
+    // If the backend returns messages that are all thread replies,
+    // annotateThreadReplyCounts filters them out, producing channelMsgs=[].
+    // This is real data (data.length > 0), not a transient empty response,
+    // so the guard must NOT retain stale cached data.
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { id: 20, content: 'thread reply', channel: 'channel-a', thread_parent_id: 'parent-1', timestamp: '2026-01-01T00:00:00Z' },
+      ],
+    })
+
+    await fetchHistory('channel-a')
+
+    const store = get(messagesByChannel)
+    // channel-a should be updated (not retained) — the response was non-empty
+    // even though all messages were thread replies filtered by annotateThreadReplyCounts
+    expect(store['channel-a']).toEqual([])
+  })
+
+  it('strips pending messages from retained data on empty response', async () => {
+    // When the guard retains existing data, pending (optimistic) messages must
+    // be stripped to avoid ghost messages lingering indefinitely (matching the
+    // bulk-fetch path's cleanup behavior).
+    messagesByChannel.set({
+      midtown: [],
+      'channel-a': [
+        { id: 1, content: 'confirmed msg', channel: 'channel-a', from: 'coworker' },
+        { id: 'pending-xyz', content: 'my unsent msg', channel: 'channel-a', from: 'user', pending: true },
+      ],
+    })
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    })
+
+    await fetchHistory('channel-a')
+
+    const store = get(messagesByChannel)
+    // Confirmed message retained, pending message stripped
+    expect(store['channel-a']).toHaveLength(1)
+    expect(store['channel-a'][0].id).toBe(1)
+    expect(store['channel-a'].some((m) => m.pending)).toBe(false)
+  })
+
+  it('does not retain when all existing messages are pending and response is empty', async () => {
+    // If the channel only has pending messages and the backend returns empty,
+    // there's no confirmed data to retain — allow the empty response through.
+    messagesByChannel.set({
+      midtown: [],
+      'channel-a': [
+        { id: 'pending-1', content: 'unsent', channel: 'channel-a', from: 'user', pending: true },
+      ],
+    })
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    })
+
+    await fetchHistory('channel-a')
+
+    const store = get(messagesByChannel)
+    expect(store['channel-a']).toEqual([])
   })
 
   it('replaces existing channel messages when single-channel fetch returns non-empty data', async () => {


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Fix intermittent bug where channel content disappears then reappears
- Guard `fetchHistory(channelName)` against replacing non-empty channel data with empty API responses
- Add 3 regression tests covering the empty-response, new-channel, and refresh scenarios

## Root Cause
`fetchHistory(channelName)` unconditionally replaced a channel's messages with the API response. When the backend transiently returned `[]` (e.g., during channel file rotation or archiving race), the channel display was wiped — only new WebSocket messages appeared until the next successful fetch.

The bulk `fetchHistory()` path already used a merge strategy that preserved existing channels, and the `catch` block retained data on network errors. The single-channel path was the only one missing this "retain last-known-good" guard.

## Fix
Skip the store update when the response is empty but the channel already has cached messages. Log a `console.warn` for observability.

## Test plan
- [x] New test: `retains existing channel messages when single-channel fetch returns empty` — confirms the guard
- [x] New test: `allows single-channel fetch to populate an empty channel` — no false positive on first load
- [x] New test: `replaces existing channel messages when single-channel fetch returns non-empty data` — normal refresh still works
- [x] All 193 existing tests pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)