### PR TITLE
feat: Add left drop shadow to desktop thread panel [Midtown !1971]

### DIFF
--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -407,7 +407,7 @@
 {#if $threadData}
   <!-- Desktop: side panel with resize handle -->
   <div
-    class="hidden lg:flex flex-col h-full bg-background border-l-2 border-border shrink-0 relative shadow-[-8px_0_8px_-8px_rgba(0,0,0,0.15)] dark:shadow-[-8px_0_8px_-8px_rgba(0,0,0,0.4)]"
+    class="hidden lg:flex flex-col h-full bg-background border-l-2 border-border shrink-0 relative shadow-[inset_8px_0_8px_-8px_rgba(0,0,0,0.15)] dark:shadow-[inset_8px_0_8px_-8px_rgba(0,0,0,0.4)]"
     style="width: {panelWidth}px"
     data-testid="thread-panel"
   >


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Add a left-facing inset box-shadow to the desktop thread panel, creating a visual depth hierarchy: sidebar < channel pane < thread panel
- Uses the same inset shadow technique as the sidebar (`inset 8px 0 8px -8px` vs sidebar's `inset -8px 0 8px -8px`) — mirrored x-offset for opposite edges
- Theme-aware opacity: 0.15 in light mode, 0.4 in dark mode (matching the sidebar pattern exactly)
- Inset shadow avoids clipping by parent `overflow-hidden` on `board-content`
- Desktop only — mobile thread panel is a full-screen overlay and doesn't need a shadow
- Keeps the existing `border-l-2` for a crisp edge alongside the shadow

## Screenshots
_(Unable to capture — Playwright blocked by npm cache permissions issue in sandbox. Visual verification needed by reviewer.)_

## Test plan
- [x] Web app builds cleanly (`vite build`)
- [x] Pre-commit hooks pass (clippy + fmt)
- [ ] Visual check: desktop thread panel shows a subtle left inset shadow
- [ ] Visual check: shadow is more visible in dark mode
- [ ] Visual check: shadow not clipped by parent overflow-hidden
- [ ] Verify mobile thread panel is unaffected

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)