### PR TITLE
fix: Stop thread textarea from stealing focus on every new message [Midtown !1973]

### DIFF
--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -365,11 +365,18 @@
     })
   })
 
-  // Focus textarea when thread opens
+  // Focus textarea only when a *new* thread opens — not on every message append.
+  // Uses currentThreadId (stable thread identity) instead of $threadData to avoid
+  // re-firing when the message array grows.
+  let lastFocusedThreadId = $state(null)
   $effect(() => {
-    if ($threadData && textareaEl) {
+    const threadId = currentThreadId
+    const lastId = untrack(() => lastFocusedThreadId)
+    if (threadId && threadId !== lastId && textareaEl) {
+      lastFocusedThreadId = threadId
       tick().then(() => textareaEl.focus())
     }
+    if (!threadId) lastFocusedThreadId = null
   })
 
   function resizeTextarea() {


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Fixed thread textarea stealing focus every time a new message arrives in the thread
- Root cause: `$effect` at ThreadPanel.svelte:369 tracked `$threadData` as a dependency, so every `threadData.update()` (new message append) re-triggered `textareaEl.focus()`
- Fix: narrow the effect's dependency to `currentThreadId` (stable thread identity) so focus only happens when a different thread opens, not on every message update
- Uses `untrack()` on `lastFocusedThreadId` to prevent self-triggering writes

## Test plan
- [x] All 190 web-app tests pass (`pnpm test`)
- [x] Vite dev server starts cleanly (no Svelte compilation errors)
- [x] Pre-commit hooks pass (cargo clippy + fmt)
- [ ] Manual: open a thread, click elsewhere, verify focus doesn't jump back on new message
- [ ] Manual: open a new thread, verify textarea gets focused initially
- [ ] Manual: close thread and reopen same thread, verify textarea gets focused again

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)