### PR TITLE
fix: Resolve Svelte a11y build warnings across web app [Midtown !1972]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -786,6 +786,7 @@
           {#if dayLabel}
             <DayDivider label={dayLabel} />
           {/if}
+          <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
           <div
             data-testid="message-row"
             in:fly={{ y: 16, duration: isNewMessage($activeChannel, globalIndex) ? 180 : 0, opacity: 0 }}

--- a/web-app/src/lib/ChannelList.svelte
+++ b/web-app/src/lib/ChannelList.svelte
@@ -218,6 +218,7 @@
 
   {#if showCreateInput}
     <div class="px-3 py-2 mb-2 bg-sidebar-accent rounded-md">
+      <!-- svelte-ignore a11y_autofocus -->
       <input
         type="text"
         class="w-full px-2 py-1.5 border border-sidebar-border rounded bg-sidebar text-sidebar-foreground text-sm font-mono outline-none focus:border-primary disabled:opacity-50"

--- a/web-app/src/lib/MermaidDiagram.svelte
+++ b/web-app/src/lib/MermaidDiagram.svelte
@@ -90,13 +90,13 @@
     <pre class="text-muted-foreground m-0 whitespace-pre-wrap break-words">{error}</pre>
   </div>
 {:else}
-  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-  <div
-    class="group bg-accent rounded-md p-3 my-1.5 overflow-x-auto leading-none cursor-pointer relative hover:outline hover:outline-1 hover:outline-link-default [&>svg]:max-w-full [&>svg]:h-auto [&>svg]:block"
+  <button
+    type="button"
+    class="group bg-accent rounded-md p-3 my-1.5 overflow-x-auto leading-none cursor-pointer relative hover:outline hover:outline-1 hover:outline-link-default [&>svg]:max-w-full [&>svg]:h-auto [&>svg]:block w-full text-left border-none font-inherit text-inherit"
     onclick={handleExpand}
     title="Click to expand"
   >
     {@html svgHtml}
     <div class="absolute top-1.5 right-2 text-[0.7rem] text-muted-foreground opacity-0 transition-opacity duration-150 pointer-events-none font-['SF_Mono',Menlo,Consolas,monospace] group-hover:opacity-100">Click to expand</div>
-  </div>
+  </button>
 {/if}

--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -412,6 +412,7 @@
     data-testid="thread-panel"
   >
     <!-- Resize handle on left edge -->
+    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
     <div
       role="separator"
       aria-label="Resize thread panel"


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- **Channel.svelte**: Added `svelte-ignore` with comma-separated codes (required for Svelte 5 runes mode) to suppress a11y warnings on the mobile tap handler div — interactive children already have proper a11y
- **ChannelList.svelte**: Suppressed `a11y_autofocus` on the channel create input — autofocus is intentional UX when user clicks "Create channel"
- **ThreadPanel.svelte**: Suppressed `a11y_no_noninteractive_element_interactions` on the resize handle — `role="separator"` with mouse events is valid per WAI-ARIA but Svelte's checker doesn't recognize it as interactive
- **MermaidDiagram.svelte**: Converted click-to-expand `<div>` to semantic `<button>` element, which eliminates the a11y warning entirely and provides proper keyboard accessibility (Enter/Space to expand)

## Key finding
Svelte 5 runes mode requires comma-separated warning codes in `<!-- svelte-ignore -->` comments. Space-separated codes (valid in Svelte 4) only suppress the first code — subsequent ones are silently ignored.

## Test plan
- [x] `pnpm build` produces zero a11y warnings (previously had 4)
- [x] Build succeeds without errors
- [x] No visual or behavioral changes — suppressions and button conversion preserve existing functionality

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)