### PR TITLE
perf: Move web channel posts off the main select! loop [Midtown !1978]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -96,7 +96,6 @@ use tracing::{debug, error, info, warn};
 use crate::config;
 use crate::coworker::CoworkerManager;
 use crate::message::Message;
-use crate::rpc::RequestId;
 use crate::web::{self, WebUpdate};
 use crate::webhook::{WebhookConfig, start_webhook_server};
 use crate::worktree::WorktreeManager;
@@ -3157,6 +3156,29 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
         });
     }
 
+    // Spawn dedicated task for web/mobile channel posts so they aren't delayed
+    // by heavier branches in the main select! loop (e.g., session drain, PR polling).
+    if let Some(mut mob_rx) = mobile_rx.take() {
+        let post_state = Arc::clone(&state);
+        tokio::spawn(async move {
+            while let Some(mobile_post) = mob_rx.recv().await {
+                let content = &mobile_post.content;
+                let channel = mobile_post.channel.as_deref();
+                let thread_parent_id = mobile_post.thread_parent_id.as_deref();
+                let sender = post_state.user_display_name.as_deref().unwrap_or("user");
+                rpc_channel::handle_channel_post(
+                    crate::rpc::RequestId::Null,
+                    sender,
+                    content,
+                    channel,
+                    thread_parent_id,
+                    &post_state,
+                )
+                .await;
+            }
+        });
+    }
+
     // Main event loop
     loop {
         let state = Arc::clone(&state);
@@ -3459,27 +3481,6 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
                 if !is_ci_check_passed {
                     chat::route_mentions(&state, &webhook_event.message).await;
                 }
-            }
-
-            // Process user channel posts through the daemon (handles nudge, etc.)
-            Some(mobile_post) = async {
-                match mobile_rx.as_mut() {
-                    Some(rx) => rx.recv().await,
-                    None => std::future::pending().await,
-                }
-            } => {
-                let content = &mobile_post.content;
-                let channel = mobile_post.channel.as_deref();
-                let thread_parent_id = mobile_post.thread_parent_id.as_deref();
-                let sender = state.user_display_name.as_deref().unwrap_or("user");
-                rpc_channel::handle_channel_post(
-                    RequestId::Null,
-                    sender,
-                    content,
-                    channel,
-                    thread_parent_id,
-                    &state,
-                ).await;
             }
 
             // Drain events from headless sessions to prevent stdout buffer filling up.


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Spawns a dedicated `tokio::spawn` task for processing web/mobile channel posts (`mobile_rx`) instead of handling them as a branch in the main `tokio::select!` loop
- Eliminates intermittent multi-second delays for user channel posts from the web app, which occurred when heavier select branches (2-second session drain, PR polling) won the poll race
- The spawned task has everything it needs (`Arc<DaemonState>`, `user_display_name`) and calls the same `handle_channel_post` function, preserving all existing behavior (nudge detection, thread routing, mention routing, etc.)

## Why this works
The `tokio::select!` macro picks one ready branch per iteration. When the session drain interval fires (every 2s), it runs a lengthy operation (draining stdout, updating health, backfilling session IDs, persisting state). During that processing, `mobile_rx` can't be polled. Moving it to its own task gives it an independent executor context — it processes posts as soon as they arrive, regardless of what else the daemon is doing.

`send_and_broadcast_async` already uses `spawn_blocking` for the file write, so the spawned task won't block the Tokio runtime even under file lock contention.

## Test plan
- [x] `cargo build` — clean, no warnings
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes
- [x] `cargo test` — all tests pass
- [x] `cargo fmt` — formatted

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)