### PR TITLE
fix: Use is_pr_reviewed() in idle handler to prevent reviewer nudge loop [Midtown !1990]

### DIFF
--- a/src/daemon/rpc_coworker.rs
+++ b/src/daemon/rpc_coworker.rs
@@ -378,11 +378,18 @@ pub(super) async fn handle_coworker_report_state(
         // before completing their review (e.g., thinking they're done but forgot to post).
         //
         // Use `is_pr_reviewed()` instead of the snapshot's `reviewed_prs` cache so that
-        // a fresh GitHub API check is made when the persistent cache has no record yet.
+        // a GitHub API check can be made when the persistent cache has no record yet.
         // Without this, a reviewer who posts their review and immediately goes idle can
         // get stuck in a nudge loop: the webhook marking the review as cached hasn't
         // arrived yet, the poll tick hasn't run, so the snapshot says "not reviewed"
-        // even though the review exists on GitHub. (Bug fix for !1990)
+        // even though the review exists on GitHub.
+        //
+        // Note: `is_pr_reviewed()` has a negative-result cache with a 2-minute TTL
+        // (`PR_REVIEW_NEGATIVE_CACHE_SECS`). If a recent poll tick confirmed no review,
+        // the API call is skipped within that window. This is acceptable: the negative
+        // cache only populates during poll ticks, and the common nudge-loop scenario
+        // (reviewer posts then immediately idles) happens before any poll tick runs,
+        // so the negative cache is empty. (Bug fix for !1990)
         let pre_snap = snapshot::collect_world_snapshot(state).await;
         if let Some(&pr_number) = pre_snap.reviewer.reviewer_pr_assignments.get(name)
             && !state.is_pr_reviewed(pr_number).await

--- a/src/daemon/rpc_coworker_tests.rs
+++ b/src/daemon/rpc_coworker_tests.rs
@@ -988,12 +988,46 @@ async fn test_reviewer_idle_not_nudged_when_review_cached() {
 /// Complement to the above: when the review has NOT been posted (neither cached
 /// nor on GitHub), the reviewer SHOULD be nudged. This verifies the nudge still
 /// fires for genuinely unposted reviews.
+///
+/// Uses PATH_LOCK + mock `gh` to control the subprocess call that
+/// `is_pr_reviewed()` makes when the persistent cache has no record.
 #[tokio::test]
+#[allow(clippy::await_holding_lock)] // Intentionally hold PATH_LOCK across await to prevent test interference
 async fn test_reviewer_idle_nudged_when_review_not_posted() {
+    use crate::daemon::PATH_LOCK;
+
     let (state, _tmp, _guard) = make_test_state();
 
     let reviewer_name = "park";
     let pr_number = 43u64;
+
+    // Acquire PATH_LOCK to prevent parallel tests from interfering with PATH mocking
+    let _path_guard = PATH_LOCK.lock().unwrap();
+
+    // Mock gh CLI to return no reviews/comments so is_pr_reviewed() returns false.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mock_gh_dir = temp_dir.path().join("bin");
+    std::fs::create_dir_all(&mock_gh_dir).unwrap();
+    let mock_gh_script = mock_gh_dir.join("gh");
+
+    #[cfg(unix)]
+    {
+        std::fs::write(
+            &mock_gh_script,
+            "#!/bin/bash\necho '{\"reviews\":[],\"comments\":[]}'",
+        )
+        .unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&mock_gh_script, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    unsafe {
+        std::env::set_var(
+            "PATH",
+            format!("{}:{}", mock_gh_dir.display(), original_path),
+        );
+    }
 
     // Insert the reviewer as a running coworker
     let inserted = state
@@ -1034,6 +1068,11 @@ async fn test_reviewer_idle_nudged_when_review_not_posted() {
         &state,
     )
     .await;
+
+    // Restore PATH before assertions (cleanup)
+    unsafe {
+        std::env::set_var("PATH", &original_path);
+    }
 
     assert!(!response.is_error(), "idle report should succeed");
     let message = response


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Fix reviewer nudge loop where reviewers get repeated nudges to post their review even after it's already posted
- Root cause: the idle handler checked only the snapshot's `reviewed_prs` cache, which can be stale when the GitHub webhook hasn't arrived yet and the poll tick hasn't run
- Replace snapshot cache check with `is_pr_reviewed()` call that checks persistent state first (fast path) and falls back to a GitHub API call when needed

## Details
When a reviewer posts their review and immediately goes idle:
1. The `issue_comment` webhook from GitHub may not have arrived yet
2. The periodic poll tick (which calls `is_pr_reviewed()`) may not have run
3. The idle handler's snapshot only reflects the persistent cache, missing the review

The fix calls `is_pr_reviewed()` directly in the idle handler. This method first checks the persistent cache (O(1) fast path — same as before when webhook has arrived), and only falls back to a `gh pr view` API call when the cache misses. This closes the race window between posting a review and the webhook/poll updating the cache.

## Test plan
- [x] Added `test_reviewer_idle_not_nudged_when_review_cached` — verifies cached reviews prevent nudge
- [x] Added `test_reviewer_idle_nudged_when_review_not_posted` — verifies nudge still fires for unposted reviews
- [x] All 3,243 existing tests pass
- [x] Clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)