### PR TITLE
feat: Make tool call activity drawer clickable and expandable [Midtown !1991]

### DIFF
--- a/web-app/src/lib/ThreadActivityDrawer.svelte
+++ b/web-app/src/lib/ThreadActivityDrawer.svelte
@@ -112,15 +112,21 @@
   // in collapsed mode), so users can always click to expand and see past tool calls.
   let isVisible = $derived(merged.length > 0 || thinking)
 
-  // Auto-scroll to bottom when new items arrive in expanded mode
+  // Auto-scroll to bottom when new items arrive in expanded mode,
+  // but only if the user hasn't manually scrolled up to read history.
+  const SCROLL_THRESHOLD = 50 // px from bottom to consider "at bottom"
   $effect(() => {
     if (expanded && scrollContainer && displayItems.length) {
-      // Tick: wait for DOM update before scrolling
-      requestAnimationFrame(() => {
-        if (scrollContainer) {
-          scrollContainer.scrollTop = scrollContainer.scrollHeight
-        }
-      })
+      // Check if user is near the bottom before the DOM update
+      const { scrollTop, scrollHeight, clientHeight } = scrollContainer
+      const isNearBottom = scrollHeight - scrollTop - clientHeight < SCROLL_THRESHOLD
+      if (isNearBottom) {
+        requestAnimationFrame(() => {
+          if (scrollContainer) {
+            scrollContainer.scrollTop = scrollContainer.scrollHeight
+          }
+        })
+      }
     }
   })
 
@@ -145,8 +151,9 @@
 
   function handleKeydown(e) {
     if (e.key === 'Escape' && expanded) {
+      // Collapse the drawer; do NOT stopPropagation so a second Escape
+      // naturally bubbles to parent handlers (e.g. close thread panel).
       toggleExpanded()
-      e.stopPropagation()
     } else if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
       toggleExpanded()
@@ -202,30 +209,29 @@
       class:pb-1.5={!expanded || displayItems.length === 0}
       style={expanded ? 'max-height: 50vh;' : ''}
     >
-      {#if displayItems.length === 0 && thinking}
-        <!-- Optimistic waiting state: blinking dots -->
+      {#each displayItems as entry (entry.item.item_id)}
+        {@const dimmed = expanded && completedAt.has(entry.item.item_id)}
+        <div class="flex items-center gap-[0.4em] py-[1px]" class:opacity-45={dimmed}>
+          <span class="flex-shrink-0 select-none text-[0.78rem] leading-[1.35]">
+            {#if entry.status === 'error'}
+              <span class="text-red-400">✗</span>
+            {:else if entry.status === 'ok'}
+              <span class="text-[#5faf5f]">✓</span>
+            {:else}
+              <span class="text-[#4a8a4a]">›</span>
+            {/if}
+          </span>
+          <span
+            class="font-mono text-[0.78rem] leading-[1.35] whitespace-nowrap overflow-hidden text-ellipsis min-w-0 {entry.status === 'error' ? 'text-red-400' : entry.status === 'ok' ? 'text-[#8fbf8f]' : 'text-[#5faf5f]'}"
+          >{describeItem(entry.item)}</span>
+        </div>
+      {/each}
+      {#if thinking}
+        <!-- Thinking indicator: shown alongside history when waiting for new tool calls -->
         <div class="flex items-center gap-[0.4em] py-[1px]">
           <span class="text-[#4a6a4a] select-none flex-shrink-0 text-[0.78rem]">›</span>
           <span class="font-mono text-[0.78rem] leading-[1.35] text-[#4a6a4a] thinking-blink">...</span>
         </div>
-      {:else}
-        {#each displayItems as entry (entry.item.item_id)}
-          {@const dimmed = expanded && completedAt.has(entry.item.item_id)}
-          <div class="flex items-center gap-[0.4em] py-[1px]" class:opacity-45={dimmed}>
-            <span class="flex-shrink-0 select-none text-[0.78rem] leading-[1.35]">
-              {#if entry.status === 'error'}
-                <span class="text-red-400">✗</span>
-              {:else if entry.status === 'ok'}
-                <span class="text-[#5faf5f]">✓</span>
-              {:else}
-                <span class="text-[#4a8a4a]">›</span>
-              {/if}
-            </span>
-            <span
-              class="font-mono text-[0.78rem] leading-[1.35] whitespace-nowrap overflow-hidden text-ellipsis min-w-0 {entry.status === 'error' ? 'text-red-400' : entry.status === 'ok' ? 'text-[#8fbf8f]' : 'text-[#5faf5f]'}"
-            >{describeItem(entry.item)}</span>
-          </div>
-        {/each}
       {/if}
     </div>
   </div>


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Click the tool call activity drawer to expand into a scrollable panel showing the **full tool call history** (no age-out, no 10-item cap)
- Click again or press **Escape** to collapse back to the compact view
- Age-out pauses while expanded so items remain visible for scrolling
- Header bar shows item count when expanded, "+N more" hint when collapsed with hidden items
- Chevron indicator (▾/▴) and hover state provide visual click affordance
- Auto-scrolls to bottom when new items arrive in expanded mode
- Full a11y: `role="button"`, `aria-expanded`, `aria-label`, keyboard support (Enter/Space/Escape)
- `expanded` state resets when switching threads

## Changes
Single file: `web-app/src/lib/ThreadActivityDrawer.svelte`

**New state:**
- `expanded` — toggles between compact (filtered/capped) and expanded (full history) view
- `displayItems` — derived that switches between `visibleItems` (collapsed) and `merged` (expanded)
- `hiddenCount` — derived showing how many items are hidden in collapsed mode

**Behavior changes:**
- Age-out interval skips phase 2 (expiring) when expanded, so completed items stay visible
- Outer div gains click/keyboard handlers and ARIA attributes
- Header bar with chevron and count appears when there are tool call items
- Scroll container gets `max-height: 50vh` and `overflow-y: auto` when expanded

## Test plan
- [x] Svelte compilation passes with no errors
- [x] All 197 vitest tests pass
- [x] Pre-commit hooks (clippy + fmt) pass
- [ ] Manual test: click drawer to expand, verify full history shown
- [ ] Manual test: click again to collapse, verify compact view restored
- [ ] Manual test: press Escape to collapse from expanded state
- [ ] Manual test: verify auto-scroll when new items arrive while expanded

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)