### PR TITLE
fix: Add canonicalize defense-in-depth to api_get_screenshot [Midtown !1997]

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -1959,8 +1959,9 @@ async fn api_get_upload(
 /// Serve a screenshot file by filename.
 ///
 /// Files are served from `~/.midtown/projects/<repo>/screenshots/<filename>`.
-/// The filename must not contain path separators or `..` to prevent traversal.
-/// Only image content types are served.
+/// Only image content types are served. Includes path traversal protection:
+/// the resolved file path must remain within the screenshots directory
+/// (validated via `canonicalize` containment, matching `project_asset`).
 async fn api_get_screenshot(
     State(state): State<Arc<WebState>>,
     Path(filename): Path<String>,
@@ -1969,18 +1970,35 @@ async fn api_get_screenshot(
         return Err(StatusCode::BAD_REQUEST);
     }
 
-    let file_path = crate::paths::screenshots_dir_for_repo(&state.config.repo).join(&filename);
+    let screenshots_dir = crate::paths::screenshots_dir_for_repo(&state.config.repo);
+    let file_path = screenshots_dir.join(&filename);
 
-    let data = tokio::fs::read(&file_path)
+    // Canonicalize containment check (defense-in-depth, matching project_asset)
+    let canonical_dir = match std::fs::canonicalize(&screenshots_dir) {
+        Ok(p) => p,
+        Err(_) => return Err(StatusCode::NOT_FOUND),
+    };
+
+    if !file_path.exists() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let canonical_file = std::fs::canonicalize(&file_path).map_err(|_| StatusCode::NOT_FOUND)?;
+
+    if !canonical_file.starts_with(&canonical_dir) {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let content = tokio::fs::read(&canonical_file)
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
 
-    let content_type = crate::webserver::mime_type_for_path(&file_path);
+    let content_type = crate::webserver::mime_type_for_path(&canonical_file);
     if !content_type.starts_with("image/") {
         return Err(StatusCode::UNSUPPORTED_MEDIA_TYPE);
     }
 
-    Ok(([(axum::http::header::CONTENT_TYPE, content_type)], data))
+    Ok(([(axum::http::header::CONTENT_TYPE, content_type)], content))
 }
 
 /// WebSocket upgrade handler

--- a/src/web_tests.rs
+++ b/src/web_tests.rs
@@ -932,3 +932,170 @@ fn test_validate_channel_name_rejects_main_channel() {
         "the main channel name 'offload' should be rejected for a project named offload"
     );
 }
+
+// --- api_get_screenshot tests ---
+
+#[tokio::test]
+async fn test_api_get_screenshot_rejects_path_traversal() {
+    let (updates_tx, _) = broadcast::channel(10);
+    let (channel_post_tx, _) = mpsc::channel(10);
+    let state = Arc::new(WebState {
+        config: WebConfig::default(),
+        updates_tx,
+        coworkers: None,
+        channel_post_tx,
+        push_manager: None,
+        all_repo_paths: Vec::new(),
+        default_branch: "main".to_string(),
+        max_coworkers: 8,
+        repo_name_cache: std::sync::RwLock::new(std::collections::HashMap::new()),
+    });
+
+    let result = api_get_screenshot(State(state.clone()), Path("../etc/passwd".to_string())).await;
+    assert_eq!(result.err(), Some(StatusCode::BAD_REQUEST));
+
+    let result = api_get_screenshot(State(state.clone()), Path("foo/bar.png".to_string())).await;
+    assert_eq!(result.err(), Some(StatusCode::BAD_REQUEST));
+
+    let result = api_get_screenshot(State(state.clone()), Path("foo\\bar.png".to_string())).await;
+    assert_eq!(result.err(), Some(StatusCode::BAD_REQUEST));
+}
+
+#[tokio::test]
+async fn test_api_get_screenshot_not_found_for_missing_file() {
+    use crate::paths::set_test_midtown_base_dir;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = set_test_midtown_base_dir(tmp.path().to_path_buf());
+
+    // Create the screenshots directory so canonicalize succeeds on the dir
+    let screenshots_dir = crate::paths::screenshots_dir_for_repo("test-proj");
+    std::fs::create_dir_all(&screenshots_dir).unwrap();
+
+    let (updates_tx, _) = broadcast::channel(10);
+    let (channel_post_tx, _) = mpsc::channel(10);
+    let state = Arc::new(WebState {
+        config: WebConfig {
+            repo: "test-proj".to_string(),
+        },
+        updates_tx,
+        coworkers: None,
+        channel_post_tx,
+        push_manager: None,
+        all_repo_paths: Vec::new(),
+        default_branch: "main".to_string(),
+        max_coworkers: 8,
+        repo_name_cache: std::sync::RwLock::new(std::collections::HashMap::new()),
+    });
+
+    let result = api_get_screenshot(State(state), Path("nonexistent.png".to_string())).await;
+    assert_eq!(result.err(), Some(StatusCode::NOT_FOUND));
+}
+
+#[tokio::test]
+async fn test_api_get_screenshot_canonicalize_containment() {
+    use crate::paths::{screenshots_dir_for_repo, set_test_midtown_base_dir};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = set_test_midtown_base_dir(tmp.path().to_path_buf());
+
+    let screenshots_dir = screenshots_dir_for_repo("test-proj");
+    std::fs::create_dir_all(&screenshots_dir).unwrap();
+
+    // Create a file outside the screenshots directory
+    let outside_dir = tmp.path().join("outside");
+    std::fs::create_dir_all(&outside_dir).unwrap();
+    std::fs::write(outside_dir.join("secret.png"), b"secret data").unwrap();
+
+    // Create a symlink inside screenshots dir pointing outside
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(
+            outside_dir.join("secret.png"),
+            screenshots_dir.join("escape.png"),
+        )
+        .unwrap();
+
+        let (updates_tx, _) = broadcast::channel(10);
+        let (channel_post_tx, _) = mpsc::channel(10);
+        let state = Arc::new(WebState {
+            config: WebConfig {
+                repo: "test-proj".to_string(),
+            },
+            updates_tx,
+            coworkers: None,
+            channel_post_tx,
+            push_manager: None,
+            all_repo_paths: Vec::new(),
+            default_branch: "main".to_string(),
+            max_coworkers: 8,
+            repo_name_cache: std::sync::RwLock::new(std::collections::HashMap::new()),
+        });
+
+        // The symlink should be rejected by canonicalize containment check
+        let result = api_get_screenshot(State(state), Path("escape.png".to_string())).await;
+        assert_eq!(result.err(), Some(StatusCode::BAD_REQUEST));
+    }
+}
+
+#[tokio::test]
+async fn test_api_get_screenshot_serves_valid_image() {
+    use crate::paths::{screenshots_dir_for_repo, set_test_midtown_base_dir};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = set_test_midtown_base_dir(tmp.path().to_path_buf());
+
+    let screenshots_dir = screenshots_dir_for_repo("test-proj");
+    std::fs::create_dir_all(&screenshots_dir).unwrap();
+    std::fs::write(screenshots_dir.join("test-image.png"), b"PNG fake data").unwrap();
+
+    let (updates_tx, _) = broadcast::channel(10);
+    let (channel_post_tx, _) = mpsc::channel(10);
+    let state = Arc::new(WebState {
+        config: WebConfig {
+            repo: "test-proj".to_string(),
+        },
+        updates_tx,
+        coworkers: None,
+        channel_post_tx,
+        push_manager: None,
+        all_repo_paths: Vec::new(),
+        default_branch: "main".to_string(),
+        max_coworkers: 8,
+        repo_name_cache: std::sync::RwLock::new(std::collections::HashMap::new()),
+    });
+
+    let result = api_get_screenshot(State(state), Path("test-image.png".to_string())).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_api_get_screenshot_rejects_non_image() {
+    use crate::paths::{screenshots_dir_for_repo, set_test_midtown_base_dir};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = set_test_midtown_base_dir(tmp.path().to_path_buf());
+
+    let screenshots_dir = screenshots_dir_for_repo("test-proj");
+    std::fs::create_dir_all(&screenshots_dir).unwrap();
+    std::fs::write(screenshots_dir.join("script.js"), b"alert('xss')").unwrap();
+
+    let (updates_tx, _) = broadcast::channel(10);
+    let (channel_post_tx, _) = mpsc::channel(10);
+    let state = Arc::new(WebState {
+        config: WebConfig {
+            repo: "test-proj".to_string(),
+        },
+        updates_tx,
+        coworkers: None,
+        channel_post_tx,
+        push_manager: None,
+        all_repo_paths: Vec::new(),
+        default_branch: "main".to_string(),
+        max_coworkers: 8,
+        repo_name_cache: std::sync::RwLock::new(std::collections::HashMap::new()),
+    });
+
+    let result = api_get_screenshot(State(state), Path("script.js".to_string())).await;
+    assert_eq!(result.err(), Some(StatusCode::UNSUPPORTED_MEDIA_TYPE));
+}


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Added canonicalize containment check to `api_get_screenshot()` in `web.rs`, matching the established two-layer defense pattern in `project_asset` and `project_screenshot`
- The endpoint previously relied only on string-level checks (`..`, `/`, `\`), which can miss symlink attacks
- Now resolves the actual filesystem path via `canonicalize()` and verifies it stays within the screenshots directory
- Added 5 unit tests: path traversal rejection, missing file, symlink containment, valid image serving, non-image rejection

## Test plan
- [x] All 5 new `api_get_screenshot` tests pass
- [x] All 46 web module tests pass
- [x] Clippy clean, fmt clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)