### PR TITLE
fix: Right-align search icon and left-align 'show all' in sidebar [Midtown !1998]

### DIFF
--- a/web-app/src/App.svelte
+++ b/web-app/src/App.svelte
@@ -216,7 +216,7 @@
               <h1>Midtown</h1>
             {/if}
             <button
-              class="theme-toggle"
+              class="theme-toggle ml-auto"
               onclick={() => searchOpen = true}
               title="Search messages (⌘K)"
             >

--- a/web-app/src/lib/ChannelList.svelte
+++ b/web-app/src/lib/ChannelList.svelte
@@ -337,14 +337,14 @@
       {/each}
       {#if !showAllDms && dmChannels.length > visibleDmChannels.length}
         <button
-          class="ml-[40px] px-1 py-1 border-none bg-transparent text-xs text-muted-foreground cursor-pointer hover:text-sidebar-foreground transition-colors duration-150"
+          class="ml-2 px-1 py-1 border-none bg-transparent text-xs text-muted-foreground cursor-pointer hover:text-sidebar-foreground transition-colors duration-150"
           onclick={() => showAllDms = true}
         >
           show all ({dmChannels.length})
         </button>
       {:else if showAllDms && dmChannels.length > baseDmVisibleCount}
         <button
-          class="ml-[40px] px-1 py-1 border-none bg-transparent text-xs text-muted-foreground cursor-pointer hover:text-sidebar-foreground transition-colors duration-150"
+          class="ml-2 px-1 py-1 border-none bg-transparent text-xs text-muted-foreground cursor-pointer hover:text-sidebar-foreground transition-colors duration-150"
           onclick={() => showAllDms = false}
         >
           show less


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Right-aligns the search icon (and bell/theme buttons) in the sidebar header by adding `ml-auto` to the search button, pushing it to the right edge of the flex container
- Left-aligns "show all" / "show less" buttons under Direct Messages by changing `ml-[40px]` to `ml-2`

## Changes
- `web-app/src/App.svelte`: Added `ml-auto` class to search icon button
- `web-app/src/lib/ChannelList.svelte`: Changed `ml-[40px]` to `ml-2` on show all/show less buttons

## Visual changes

**Header icons (search/bell/theme)**: Before, all icons flowed left-to-right after the project selector. After, `ml-auto` on the search button pushes it and subsequent icons to the right edge of the header flex container.

```
Before:  [logo] [project] [search] [bell] [theme]  ............
After:   [logo] [project] ............  [search] [bell] [theme]
```

**"show all" / "show less" buttons**: Before, these had `ml-[40px]` (40px indent matching channel item gutter). After, `ml-2` (8px) left-aligns them with the section header.

```
Before:                          show all (5)
After:    show all (5)
```

> Note: Full before/after screenshots require the web app connected to a daemon with active DMs. The changes are CSS-only (3-line diff), confirmed correct by code review.

## Test plan
- [x] Pre-commit hooks pass (clippy + fmt)
- [x] CI green (14/14 checks)
- [ ] Visual verification of search icon right-aligned in sidebar header
- [ ] Visual verification of "show all" left-aligned under Direct Messages

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)