### PR TITLE
fix: Update stale screenshot API paths in doc comments [Midtown !2000]

### DIFF
--- a/src/bin/midtown/cli/coworker.rs
+++ b/src/bin/midtown/cli/coworker.rs
@@ -126,7 +126,8 @@ impl Drop for TempFileGuard {
 ///
 /// Does not require a daemon connection — runs Playwright locally and saves
 /// the screenshot to the project's screenshots directory with a UUID filename.
-/// The file is then served by the daemon at `/api/screenshots/<uuid>.<ext>`.
+/// The file is then served at `/api/projects/:name/screenshots/:filename`
+/// on the shared gateway and `/api/screenshots/:filename` on the per-project daemon.
 pub fn handle_screenshot(
     url: &str,
     output: Option<&str>,

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -288,7 +288,8 @@ pub fn assets_dir_for_repo(repo: &str) -> PathBuf {
 /// in PR descriptions. Unlike the uploads directory (which stores files
 /// uploaded via multipart POST), screenshots are saved directly by the
 /// `midtown coworker screenshot` command and served at
-/// `/api/screenshots/<filename>` by the per-project daemon.
+/// `/api/projects/:name/screenshots/:filename` on the shared gateway
+/// and `/api/screenshots/:filename` on the per-project daemon.
 pub fn screenshots_dir_for_repo(repo: &str) -> PathBuf {
     projects_dir_for_repo(repo).join("screenshots")
 }


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Updated doc comment in `coworker.rs` (`handle_screenshot`) to reference the correct gateway path `/api/projects/:name/screenshots/:filename` instead of stale `/api/screenshots/<uuid>.<ext>`
- Updated doc comment in `paths.rs` (`screenshots_dir_for_repo`) to mention both the shared gateway and per-project daemon paths

## Context
Follow-up from park's review of PR #1731 — these stale doc comments pre-date commit 8de958a which added the screenshot serving endpoint.

## Test plan
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes
- [x] Doc-only change — no runtime behavior affected

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)