### PR TITLE
refactor: Move health monitoring channel posts to workflow script [Midtown !2005]

### DIFF
--- a/sdk/python/midtown/default_workflow.py
+++ b/sdk/python/midtown/default_workflow.py
@@ -53,9 +53,11 @@ Side effects
 * ``pr.merged``          — complete the associated task
 * ``coworker.idle``      — call ``daemon.check-pending`` so pending tasks start immediately;
                            also advance ``in_progress`` tasks to ``merged`` and call
-                           ``complete_task`` so the daemon unblocks downstream tasks
+                           ``complete_task`` so the daemon unblocks downstream tasks;
+                           post a break notification to the channel
                            (side-effect only; no registered transition in ``TRANSITIONS``)
-* ``coworker.stuck``     — post a warning to the channel
+* ``coworker.stuck``     — post a restart notification to the channel (the daemon
+                           handles the actual restart; this script owns the message)
 
 Events with no registered transitions and no explicit side-effect handler
 (``channel.message``, ``coworker.message``, ``timer.tick``, etc.) are silently
@@ -291,12 +293,18 @@ def handle(event: dict, rpc: MidtownRPC, state: dict) -> None:  # noqa: C901
                 wf.task_completed()  # type: ignore[attr-defined]  # injected by Machine
                 _save_task(state, task_id, wf)
                 rpc.complete_task(task_id)
+        # Post a break notification so the channel knows the coworker is
+        # shutting down.  The daemon handles the actual shutdown mechanism;
+        # this script owns the user-facing message.
+        rpc.post_to_channel(f"☕ Letting {coworker} take a break")
 
     elif event_type == "coworker.stuck":
+        # The daemon detects stuck coworkers and restarts them automatically.
+        # This handler owns the user-facing channel notification.
         rpc.post_to_channel(
-            f"⚠️ {coworker} appears stuck"
+            f"🔄 {coworker} appears stuck"
             + (f" on task !{task_id}" if task_id else "")
-            + " — may need intervention"
+            + " — restarting"
         )
 
     # timer.tick and other events are deliberately handled by state transitions

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -11,8 +11,6 @@ use std::time::Duration;
 
 use tracing::{debug, info, warn};
 
-use crate::daemon_messages;
-
 use super::constants::*;
 use super::effects::Effect;
 use super::helpers::format_task_prompt;
@@ -164,14 +162,14 @@ pub fn check_and_shutdown_idle_coworkers(snap: &snapshot::WorldSnapshot) -> Vec<
         // was actually posted before shutting down. All other coworkers can be shut
         // down normally.
         let reviewer_pr = snap.reviewer.reviewer_pr_assignments.get(name).copied();
-        let (should_shutdown, shutdown_msg) = if let Some(pr) = reviewer_pr {
+        let should_shutdown = if let Some(pr) = reviewer_pr {
             // Check if review was actually posted (from snapshot, no API call)
             if snap.reviewer.reviewed_prs.contains(&pr) {
                 info!(
                     "Sending reviewer {} on a break (review verified for PR #{})",
                     name, pr
                 );
-                (true, daemon_messages::break_review_complete(name, pr))
+                true
             } else {
                 warn!(
                     "Reviewer {} is idle but no review found for PR #{} - keeping alive",
@@ -186,17 +184,17 @@ pub fn check_and_shutdown_idle_coworkers(snap: &snapshot::WorldSnapshot) -> Vec<
                     ),
                     channel: Some(OPS_CHANNEL.to_string()),
                 });
-                (false, String::new())
+                false
             }
         } else if snap.pr.coworkers_with_merged_prs.contains(name) {
             info!("Sending idle coworker {} on a break (PR merged)", name);
-            (true, daemon_messages::break_work_merged(name))
+            true
         } else {
             info!(
                 "Sending idle coworker {} on a break (idle for 90+ seconds)",
                 name
             );
-            (true, daemon_messages::break_idle(name))
+            true
         };
 
         if !should_shutdown {
@@ -222,12 +220,8 @@ pub fn check_and_shutdown_idle_coworkers(snap: &snapshot::WorldSnapshot) -> Vec<
             },
         ));
 
-        // Post to ops channel, broadcast status, and shut down
-        effects.push(Effect::PostToChannel {
-            sender: "midtown".to_string(),
-            message: shutdown_msg,
-            channel: Some(OPS_CHANNEL.to_string()),
-        });
+        // Broadcast status and shut down. Channel notification is handled
+        // by the workflow script's coworker.idle handler.
         effects.push(Effect::BroadcastCoworkerUpdate {
             name: name.clone(),
             status: "stopped".to_string(),
@@ -393,16 +387,8 @@ pub(super) async fn check_and_restart_stuck_coworkers(
             ),
         ));
         effects.push(Effect::SpawnCoworker(config));
-        effects.push(Effect::PostToChannel {
-            sender: "midtown".to_string(),
-            message: format!(
-                "🔄 Restarted stuck coworker {} (no events for {}s) — resuming task !{}",
-                restart.name,
-                COWORKER_STUCK_DURATION.as_secs(),
-                restart.task_id
-            ),
-            channel: Some(OPS_CHANNEL.to_string()),
-        });
+        // Channel notification is handled by the workflow script's
+        // coworker.stuck handler (via the EmitWorkflowEvent above).
     }
 
     effects
@@ -480,6 +466,7 @@ pub fn check_and_restart_stuck_reviewers(snap: &snapshot::WorldSnapshot) -> Vec<
         ));
 
         // Emit a workflow event so channel scripts can react to the stuck reviewer.
+        // Channel notification is handled by the workflow script's coworker.stuck handler.
         // Look up the PR's task and channel so the event is routed correctly.
         let reviewer_task_id = snap
             .pr
@@ -498,19 +485,6 @@ pub fn check_and_restart_stuck_reviewers(snap: &snapshot::WorldSnapshot) -> Vec<
                 coworker: restart.name.clone(),
             },
         ));
-
-        effects.push(Effect::PostToChannel {
-            sender: "midtown".to_string(),
-            message: format!(
-                "🔄 Restarted stuck reviewer {} for PR #{} (no events for {}s, attempt {}/{})",
-                restart.name,
-                restart.pr_number,
-                effective_duration.as_secs(),
-                new_restart_count,
-                MAX_REVIEWER_RESTARTS,
-            ),
-            channel: Some(OPS_CHANNEL.to_string()),
-        });
     }
 
     // Check for reviewers that have hit the restart limit and emit escalation warnings.


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Removed inline `PostToChannel` effects from `health.rs` for stuck coworker restarts, stuck reviewer restarts, and idle coworker break messages
- Updated `default_workflow.py` to own the user-facing channel messages for `coworker.stuck` and `coworker.idle` events
- Keeps detection logic, `EmitWorkflowEvent` emissions, restart/shutdown mechanism, and escalation messages in the daemon

## What changed

**health.rs** — 3 `PostToChannel` effects removed:
1. `check_and_restart_stuck_coworkers`: Removed "Restarted stuck coworker X" ops channel post (the `EmitWorkflowEvent(CoworkerStuck)` already fires, and the script handles user-facing messaging)
2. `check_and_restart_stuck_reviewers`: Removed "Restarted stuck reviewer X for PR #Y" ops channel post (same pattern)
3. `check_and_shutdown_idle_coworkers`: Removed break message ops channel post (the `EmitWorkflowEvent(CoworkerIdle)` already fires)

Also removed the now-unused `daemon_messages` import and simplified the `shutdown_msg` tuple to a plain `should_shutdown` bool.

**default_workflow.py** — Updated to match the removed daemon behavior:
- `coworker.stuck`: Changed from "may need intervention" to "restarting" since the daemon auto-restarts
- `coworker.idle`: Added break notification post ("Letting X take a break") so channels know when a coworker shuts down

**What stays in the daemon:** Escalation messages (restart budget exceeded, reviewer max restarts), auth/API error notifications, usage limit messages — these are safety-cap and infrastructure notifications without corresponding workflow events.

## Why
This is part of making the workflow script authoritative (not additive). Previously, both the daemon and the script posted messages for the same events, making workflow customization pointless. Now a user who overrides `coworker.stuck` or `coworker.idle` in their custom `workflow.py` actually controls the messaging.

## Test plan
- [x] `cargo test` — all 3098+ tests pass (0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Verified existing health tests still pass (51 tests in `daemon::health::tests`)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)