### PR TITLE
feat: Fast-retry stale Codex thread on resume [Midtown !2012]

### DIFF
--- a/src/headless.rs
+++ b/src/headless.rs
@@ -842,7 +842,8 @@ fn codex_translate_event(
                 && !state.retried_fresh_start
             {
                 warn!("Codex thread/resume got stale thread error — retrying with thread/start");
-                state.initialized = false;
+                // Don't clear initialized — the process-level initialize handshake
+                // already completed. codex_retry_thread_start() sends only thread/start.
                 state.start_request_id = None;
                 state.resume_thread_id = None;
                 state.retried_fresh_start = true;
@@ -1785,6 +1786,10 @@ impl HeadlessSession {
     ///
     /// For Claude, this is a no-op. For Codex app-server, this sends
     /// `initialize` and one of `thread/start`, `thread/resume`, or `thread/fork`.
+    ///
+    /// This method handles the initial startup handshake only. For stale-thread
+    /// retries mid-session, use [`codex_retry_thread_start()`] instead, which
+    /// skips the redundant `initialize` and sends only `thread/start`.
     pub async fn ensure_ready(&mut self) -> std::io::Result<()> {
         let Some(state) = self.codex_state_mut() else {
             return Ok(());
@@ -1814,6 +1819,42 @@ impl HeadlessSession {
         let (start_method, start_params) = codex_thread_init_request(
             resume_thread_id.as_deref(),
             fork_session,
+            allow_tools,
+            cwd.as_deref(),
+            &model,
+            &system_prompt,
+        );
+
+        let start_id = self.codex_send_request(start_method, start_params).await?;
+        if let Some(state) = self.codex_state_mut() {
+            state.initialized = true;
+            state.start_request_id = Some(start_id);
+            state.start_phase = start_method.to_string();
+        }
+
+        Ok(())
+    }
+
+    /// Send only `thread/start` to the Codex app-server without re-sending `initialize`.
+    ///
+    /// Used by `RetryThreadStart` when a stale thread is detected on resume.
+    /// The process-level `initialize` handshake was already completed on first launch;
+    /// only a new thread needs to be started.
+    async fn codex_retry_thread_start(&mut self) -> std::io::Result<()> {
+        let Some(state) = self.codex_state_mut() else {
+            return Ok(());
+        };
+
+        let model = state.model.clone();
+        let cwd = state.cwd.clone();
+        let system_prompt = state.system_prompt.clone();
+        let allow_tools = state.allow_tools;
+
+        // resume_thread_id was already cleared by codex_translate_event;
+        // fork_session=false since this is a fresh start, not a fork.
+        let (start_method, start_params) = codex_thread_init_request(
+            None,  // no resume — starting fresh
+            false, // not a fork
             allow_tools,
             cwd.as_deref(),
             &model,
@@ -1883,14 +1924,30 @@ impl HeadlessSession {
                     }
                 }
                 CodexPostAction::RetryThreadStart => {
-                    // Stale thread detected — re-initialize with a fresh thread/start.
-                    // ensure_ready() will use thread/start since resume_thread_id was cleared.
+                    // Stale thread detected — send only thread/start (not initialize).
+                    // The app-server process was already initialized on first launch;
+                    // we just need a new thread.
                     info!("Retrying Codex session with fresh thread/start after stale thread");
-                    if let Err(e) = self.ensure_ready().await {
-                        warn!("Failed to retry Codex thread/start: {}", e);
-                        return None;
+
+                    // Clean up the stale resume_thread_id from the routing table
+                    // to prevent misrouted events during the retry window.
+                    if let Some(context) = self.codex_session() {
+                        context
+                            .runtime
+                            .resume_to_session
+                            .write()
+                            .expect("resume_to_session lock poisoned")
+                            .retain(|_, session_token| session_token != &context.token);
                     }
-                    // Continue the loop to receive the thread/start response.
+
+                    let result = self.codex_retry_thread_start().await;
+                    match result {
+                        Ok(()) => {} // Continue the loop to receive the thread/start response.
+                        Err(e) => {
+                            warn!("Failed to retry Codex thread/start: {}", e);
+                            return None;
+                        }
+                    }
                 }
                 CodexPostAction::None => {}
             }

--- a/src/headless_fuzz_tests.rs
+++ b/src/headless_fuzz_tests.rs
@@ -42,7 +42,11 @@ fn codex_state_strategy() -> impl Strategy<Value = CodexProtocolState> {
         proptest::collection::vec(ascii_string(24), 0..4),
         prop::option::of(ascii_string(64)),
         ascii_string(24),
-        ascii_string(24),
+        prop_oneof![
+            Just("thread/start".to_string()),
+            Just("thread/resume".to_string()),
+        ],
+        any::<bool>(),
     )
         .prop_map(
             |(
@@ -54,6 +58,7 @@ fn codex_state_strategy() -> impl Strategy<Value = CodexProtocolState> {
                 latest_agent_message,
                 model,
                 start_phase,
+                retried_fresh_start,
             )| {
                 CodexProtocolState {
                     initialized: true,
@@ -74,12 +79,8 @@ fn codex_state_strategy() -> impl Strategy<Value = CodexProtocolState> {
                     cwd: None,
                     system_prompt: String::new(),
                     output_schema: None,
-                    start_phase: if start_phase.is_empty() {
-                        "thread/start".to_string()
-                    } else {
-                        start_phase
-                    },
-                    retried_fresh_start: false,
+                    start_phase,
+                    retried_fresh_start,
                 }
             },
         )

--- a/src/headless_tests.rs
+++ b/src/headless_tests.rs
@@ -756,8 +756,9 @@ fn test_codex_translate_stale_resume_triggers_retry() {
     // Should NOT emit an error event — swallowed for retry.
     assert!(event.is_none());
     assert_eq!(post_action, CodexPostAction::RetryThreadStart);
-    // State should be reset for a fresh thread/start.
-    assert!(!state.initialized);
+    // State should be ready for a fresh thread/start (initialized stays true
+    // because the process-level initialize handshake was already completed).
+    assert!(state.initialized);
     assert!(state.start_request_id.is_none());
     assert!(state.resume_thread_id.is_none());
     assert!(state.retried_fresh_start);


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Detect stale Codex thread errors early in `codex_translate_event()` during the `thread/resume` JSON-RPC response
- Add `RetryThreadStart` post-action that immediately re-sends `thread/start` without surfacing the error to the daemon
- Reduces recovery from ~30s (full process kill + respawn) to ~2s (in-process retry)
- Guard flag `retried_fresh_start` prevents infinite retry loops — second failure falls through to existing health-check recovery

## How it works

**Before:** `thread/resume` error → `StreamEvent::Result(error)` → session monitor flags `has_tool_name_conflict` → health tick emits `ClearSavedSessionId` + `Shutdown` + `SpawnCoworker` effects → process killed and respawned (~30s)

**After:** `thread/resume` error with "no rollout found for thread id" → `codex_translate_event` clears resume state → returns `(None, RetryThreadStart)` → `next_codex_event` calls `ensure_ready()` which sends `thread/start` → new thread ID arrives via normal init flow (~2s)

## Test plan
- [x] `test_codex_translate_stale_resume_triggers_retry` — verifies retry action and state reset
- [x] `test_codex_translate_stale_resume_only_retries_once` — verifies guard prevents infinite loops
- [x] `test_codex_translate_non_resume_stale_error_not_retried` — only retries on `thread/resume`, not `thread/start`
- [x] `test_codex_translate_resume_generic_error_not_retried` — only retries on stale-thread errors
- [x] `test_is_stale_codex_thread_error_*` — unit tests for error detection
- [x] All existing codex_translate tests + fuzz tests pass
- [x] Full test suite: 3247+ tests, 0 failures
- [x] `cargo clippy` and `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)