### PR TITLE
fix: Use Codex turn/completed result text as fallback for channel posts [Midtown !2013]

### DIFF
--- a/src/daemon/stream.rs
+++ b/src/daemon/stream.rs
@@ -37,6 +37,7 @@ fn extract_text_blocks(message: &serde_json::Value) -> String {
 pub fn extract_assistant_text(events: &[StreamEvent]) -> String {
     let mut aggregated = String::new();
     let mut has_codex_completed = false;
+    let mut has_codex_deltas = false;
 
     for event in events {
         if let StreamEvent::Assistant { message, extra, .. } = event {
@@ -59,6 +60,8 @@ pub fn extract_assistant_text(events: &[StreamEvent]) -> String {
                 // to avoid duplicate posts when delta/completed split across drains.
                 has_codex_completed = true;
                 aggregated.push_str(&text);
+            } else {
+                has_codex_deltas = true;
             }
         }
     }
@@ -66,7 +69,11 @@ pub fn extract_assistant_text(events: &[StreamEvent]) -> String {
     // Codex fallback: the normal Codex protocol flow is deltas → turn/completed
     // without a separate item/completed for agentMessage items. When no
     // item/completed text was found, use the turn/completed result text instead.
-    if aggregated.is_empty() && !has_codex_completed {
+    //
+    // Guard: only fall back when Codex deltas were present in this drain cycle.
+    // A bare Result without deltas likely means item/completed was already posted
+    // in a previous drain — using Result here would duplicate the post.
+    if aggregated.is_empty() && !has_codex_completed && has_codex_deltas {
         for event in events {
             if let StreamEvent::Result {
                 result: Some(text),

--- a/src/daemon/stream_tests.rs
+++ b/src/daemon/stream_tests.rs
@@ -284,6 +284,25 @@ fn test_extract_assistant_text_non_codex_result_ignored() {
     assert_eq!(extract_assistant_text(&events), "");
 }
 
+#[test]
+fn test_extract_assistant_text_codex_bare_result_no_deltas_ignored() {
+    // Cross-drain dedup: a bare Result event (no deltas in this drain cycle)
+    // should NOT produce output. This prevents duplicate posts when
+    // item/completed was already handled in a previous drain cycle.
+    let events = vec![StreamEvent::Result {
+        subtype: "success".to_string(),
+        is_error: false,
+        result: Some("Already posted text".to_string()),
+        duration_ms: None,
+        total_cost_usd: None,
+        session_id: Some("thread_123".to_string()),
+        usage: None,
+        extra: json!({"provider": "codex", "status": "completed"}),
+    }];
+
+    assert_eq!(extract_assistant_text(&events), "");
+}
+
 // ── process_lead_output tests ───────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary

- **Root cause**: `extract_assistant_text()` filtered out Codex delta events (to avoid duplication with `item/completed`) but the normal Codex protocol flow sends only deltas → `turn/completed` without a separate `item/completed` for agentMessage items. This meant Codex text was never posted to the channel.
- **Fix**: When no `item/completed` assistant text is found for Codex, fall back to the `turn/completed` result text (`StreamEvent::Result`). If `item/completed` IS available, it still takes precedence (no behavior change for that path).
- Added 5 new tests covering: delta+result fallback, completed-takes-precedence, error results ignored, empty results ignored, non-Codex results ignored.

## Test plan
- [x] New test `test_extract_assistant_text_codex_delta_plus_turn_completed_uses_result_text` confirms the fix (failed before, passes after)
- [x] Existing test `test_extract_assistant_text_codex_completed_supersedes_deltas` still passes (no regression for item/completed path)
- [x] Full test suite: 2254 unit + 751 integration tests pass
- [x] Clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)