### PR TITLE
test: Update !1902 PR lifecycle tests for workflow-event-only behavior [Midtown !2019]

### DIFF
--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -3436,6 +3436,56 @@ fn pr_approved_re_emitted_after_reviewer_clears() {
     );
 }
 
+/// !2003, !2019: Fallback path — without a workflow script, inline effects are
+/// preserved alongside the workflow event.
+///
+/// When no `workflow.py` exists, `pr_action_to_effects` falls through to the
+/// inline-effects path (NudgeSession + RecordPrNudge) and appends the workflow
+/// event. This preserves backward compatibility for projects that haven't
+/// adopted workflow scripts.
+#[test]
+fn fallback_inline_effects_without_workflow_script() {
+    let (state, _tmp, _guard) = make_test_state("test-repo");
+    // No install_workflow_script() — deliberately testing the no-script fallback
+
+    let ctx = make_pr_context_with_channel(42, "100", "daemon-core");
+
+    let effects = pr_action_to_effects(
+        crate::rules::PrAction::NudgeOwner {
+            owner: "broadway".to_string(),
+            message: "PR #42 — approved".to_string(),
+        },
+        42,
+        "Fix auth",
+        PrIssueType::Approved,
+        &state,
+        &ctx,
+    );
+
+    // Without a script: inline NudgeSession effect fires AND workflow event is appended
+    let has_nudge = effects
+        .iter()
+        .any(|e| matches!(e, Effect::NudgeSessionWithCallbacks { .. }));
+    assert!(
+        has_nudge,
+        "Fallback path should produce NudgeSessionWithCallbacks when no workflow script exists"
+    );
+
+    let workflow_events = extract_workflow_events(&effects);
+    assert_eq!(
+        workflow_events.len(),
+        1,
+        "Workflow event should still be appended in fallback path"
+    );
+    assert!(
+        matches!(
+            workflow_events[0],
+            crate::workflow::WorkflowEvent::PrApproved { pr_number: 42, .. }
+        ),
+        "Event should be PrApproved for PR #42"
+    );
+}
+
 /// !2003: HandoffToCoworker effects are preserved even when a workflow event exists.
 ///
 /// When the action is HandoffToCoworker (idle coworker available for session handoff),


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Updated 4 tests from !1902 that still described old dual-path behavior (inline effects + workflow events) to assert the new !2003 invariant: when workflow scripts are present, only `RecordPrNudge` + `EmitWorkflowEvent` are emitted
- Added `install_workflow_script()` test helper to create a stub `workflow.py` in the test's temp directory, activating the script-authoritative code path
- Fixed `pr_approved_re_emitted_after_reviewer_clears` Step 2 which simulated a cooldown the new code can no longer produce (active reviewer now returns `vec![]` with no cooldown recording)

## Test plan
- [x] All 6 updated/related tests pass (`pr_approved_*`, `non_approved_*`, `handoff_to_coworker_*`)
- [x] Full `cargo test` suite passes
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)