### PR TITLE
fix: Guard pr.ci_passed spawn_reviewer with PR age check [Midtown !2021]

### DIFF
--- a/sdk/python/midtown/default_workflow.py
+++ b/sdk/python/midtown/default_workflow.py
@@ -192,7 +192,10 @@ def handle(event: dict, rpc: MidtownRPC, state: dict) -> None:  # noqa: C901
         extra: dict = {}
         if event_type == "pr.opened" and coworker:
             extra["pr_author"] = coworker
-            extra["pr_opened_at"] = time.time()
+            # Only record on the first real open — replays must not reset the
+            # timestamp or the pr.ci_passed age gate would re-suppress spawns.
+            if _get_task_data(state, task_id or "").get("pr_opened_at") is None:
+                extra["pr_opened_at"] = time.time()
         elif event_type == "task.assigned" and coworker:
             extra["coworker"] = coworker
 

--- a/sdk/python/tests/test_default_workflow.py
+++ b/sdk/python/tests/test_default_workflow.py
@@ -129,3 +129,25 @@ class TestPrOpenedRecordsTimestamp:
         opened_at = state["tasks"]["100"].get("pr_opened_at")
         assert opened_at is not None
         assert before <= opened_at <= after
+
+    def test_pr_opened_replay_preserves_timestamp(self) -> None:
+        """A replayed pr.opened must NOT overwrite the original pr_opened_at."""
+        rpc = _make_rpc()
+        state: dict = {}
+        original_time = time.time() - 120  # opened 2 minutes ago
+        _setup_pr_opened(state, "100", opened_at=original_time)
+
+        # Replay the event — task is already in_review so no state transition
+        handle(
+            {
+                "type": "pr.opened",
+                "task_id": "100",
+                "pr_number": 42,
+                "coworker": "park",
+                "channel": "test",
+            },
+            rpc,
+            state,
+        )
+
+        assert state["tasks"]["100"]["pr_opened_at"] == original_time


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- The `pr.ci_passed` handler in `default_workflow.py` called `spawn_reviewer()` unconditionally, bypassing the `PR_REVIEW_DELAY_SECS` timing gate that the daemon's polling backstop enforces
- Records `pr_opened_at` timestamp in workflow state when `pr.opened` fires
- Checks elapsed time in `pr.ci_passed` before calling `spawn_reviewer()` — blocks spawn if PR is younger than 45 seconds
- Falls through to spawn when `pr_opened_at` is missing (safe default for state loss/restart)

## Test plan
- [x] 6 Python unit tests covering: spawn blocked when new, allowed when old, safe fallthrough on missing state, boundary behavior, and timestamp recording
- [x] All Rust tests pass (no Rust changes)
- [x] Clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)