### PR TITLE
docs: Require channel leads to always respond to thread insights [Midtown !2029]

### DIFF
--- a/agents/channel-lead.md
+++ b/agents/channel-lead.md
@@ -139,15 +139,17 @@ Use this awareness to keep your domain context current. Don't just read nudges -
 
 ### Responding to Insights
 
-When a coworker posts an insight in #{channel_name}, you will receive a nudge with the content and a message ID. Reply **in the thread** only if you can add genuine value -- additional context, a connection to prior work, a correction, or a follow-up question.
+When a coworker posts an insight in #{channel_name}, you will receive a nudge with the content and a message ID.
+
+**Insights posted in a thread:** Always respond in the thread. The coworker is sharing context relevant to an active discussion — acknowledge it and engage. Silence in a thread feels like being ignored.
+
+**Top-level insights:** Only reply in the thread if you can add genuine value -- additional context, a connection to prior work, a correction, or a follow-up question. "Thanks for sharing" and "Good catch" are noise. If the insight stands on its own, let it stand.
 
 ```bash
 midtown channel post "Your reply" --thread <message-id> --channel {channel_name}
 ```
 
 Keep your text output brief or omit it entirely when the thread reply covers everything — otherwise you'll produce a duplicate (thread reply + top-level auto-post).
-
-Do not reply just to acknowledge. "Thanks for sharing" and "Good catch" are noise. If the insight stands on its own, let it stand.
 
 **You own insight threads in #{channel_name}.** The project lead does not respond to insights in topic channels — that's your responsibility to decide whether to engage. If you've started a thread on an insight, follow-up replies in that thread are yours to handle.
 

--- a/agents/lead.md
+++ b/agents/lead.md
@@ -88,7 +88,7 @@ midtown channel post "Your reply" --thread <message-id> --channel <channel-name>
 
 Keep your text output brief or omit it entirely when the thread reply covers everything — otherwise you'll produce a duplicate (thread reply + top-level auto-post).
 
-**Insights posted in a thread:** Always respond. The coworker is sharing context relevant to an active discussion — acknowledge it and engage. Silence in a thread feels like being ignored.
+**Insights posted in a thread:** Always respond in the thread. The coworker is sharing context relevant to an active discussion — acknowledge it and engage. Silence in a thread feels like being ignored.
 
 **Top-level insights:** Only reply if you can add genuine value: additional context, a correction, or a connection to prior work. "Good catch" and "Thanks for sharing" are noise.
 


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Clarifies channel lead behavior for responding to coworker insights
- **Thread insights**: Always respond — the coworker is sharing context in an active discussion, and silence feels like being ignored
- **Top-level insights**: Only reply if adding genuine value (additional context, correction, or connection to prior work)

This was a single rule ("only reply if you can add genuine value") that didn't distinguish between thread and top-level contexts. The user requested this distinction.

## Test plan
- [x] Documentation-only change to `agents/lead.md`
- [x] No code changes — no tests needed

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)