### PR TITLE
fix: Resolve Svelte 5 state_unsafe_mutation in ThreadPanel [Midtown !2046]

### DIFF
--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -117,18 +117,10 @@
   let forkPending = $state(false)
 
   // Clear forkPending when ownership state updates.
-  // Uses a version counter to prevent stale microtasks from overwriting a
-  // synchronous `forkPending = true` set by a subsequent handleForkToggle call.
-  let forkPendingVersion = 0
   $effect(() => {
     if ($threadData?.parentMessage?.id) {
       const _ownership = $threadOwnership[$threadData.parentMessage.id]
-      // Defer state write to avoid state_unsafe_mutation during derived evaluation
-      const version = ++forkPendingVersion
-      queueMicrotask(() => {
-        if (version !== forkPendingVersion) return
-        forkPending = false
-      })
+      untrack(() => { forkPending = false })
     }
   })
 
@@ -136,7 +128,6 @@
 
   function handleForkToggle() {
     if (!$threadData?.parentMessage?.id || !$threadData?.channelName) return
-    forkPendingVersion++  // invalidate any pending microtask that would clear forkPending
     forkPending = true
     forkError = null
     const onError = (msg) => {
@@ -165,8 +156,7 @@
   // Clear thinking when the thread is closed or switched to a different thread.
   $effect(() => {
     currentThreadId // track dependency — re-runs only when thread identity changes
-    // Defer state write to avoid state_unsafe_mutation during derived evaluation
-    queueMicrotask(() => { thinking = false })
+    untrack(() => { thinking = false })
     if (thinkingTimeout) {
       clearTimeout(thinkingTimeout)
       thinkingTimeout = null
@@ -185,14 +175,10 @@
       }
     }
     if (prevThreadId !== tid) {
-      // Defer state write to avoid state_unsafe_mutation during derived evaluation.
-      // resizeTextarea must run after the state write so the textarea height reflects
-      // the restored draft content, not the stale empty value.
       const draft = tid !== null ? (threadDrafts.get(tid) ?? '') : ''
-      queueMicrotask(() => {
-        replyText = draft
-        tick().then(() => resizeTextarea())
-      })
+      untrack(() => { replyText = draft })
+      // resizeTextarea must run after the DOM reflects the new draft content
+      tick().then(() => resizeTextarea())
     }
     prevThreadId = tid
   })
@@ -212,8 +198,7 @@
     const items = threadItems.length > 0 ? threadItems : channelItems
     const hasInProgress = items.some((item) => item.status === 'InProgress')
     if (hasInProgress) {
-      // Defer state write to avoid state_unsafe_mutation during derived evaluation
-      queueMicrotask(() => { thinking = false })
+      untrack(() => { thinking = false })
       if (thinkingTimeout) {
         clearTimeout(thinkingTimeout)
         thinkingTimeout = null
@@ -378,7 +363,7 @@
         el.scrollIntoView({ behavior: 'smooth', block: 'center' })
         el.classList.add('deep-link-highlight')
         setTimeout(() => el.classList.remove('deep-link-highlight'), 2000)
-        deepLinkMsgId.set(null)
+        untrack(() => deepLinkMsgId.set(null))
       }
     })
   })


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Replace all `queueMicrotask` workarounds for `state_unsafe_mutation` with idiomatic Svelte 5 `untrack()` calls
- `queueMicrotask` deferred state mutations to avoid the error, but introduced timing issues and required a race-condition guard (version counter for `forkPending`)
- `untrack()` suspends the reactive tracking context synchronously, avoiding the error without async timing concerns
- Specific fixes:
  - **forkPending effect**: removed `queueMicrotask` + version counter, replaced with `untrack(() => { forkPending = false })`
  - **thinking clear on thread switch**: synchronous `untrack()` reset
  - **draft restore**: synchronous `untrack()` write + `tick()` for DOM measurement
  - **thinking clear on tool items**: synchronous `untrack()` reset
  - **deepLinkMsgId**: wrapped `set(null)` in `untrack()` to guard against batching edge cases
  - **lastFocusedThreadId**: changed from `$state` to plain variable (not reactive, doesn't need tracking)

## Test plan
- [x] Web app builds cleanly (`vite build`)
- [x] Pre-commit hooks pass (cargo clippy + cargo fmt)
- [ ] Manual verification: open/close/switch threads — no `state_unsafe_mutation` console error
- [ ] Verify fork toggle, thinking indicator, and draft restore still work correctly

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)