### PR TITLE
fix: Resolve state_unsafe_mutation in ThreadList.svelte [Midtown !2047]

### DIFF
--- a/web-app/src/lib/ChannelList.svelte
+++ b/web-app/src/lib/ChannelList.svelte
@@ -282,7 +282,7 @@
           <div class="flex items-center gap-1.5">
             {#if !isExpanded && (hasActiveTasks || hasTrackedThreads)}
               {@const tasks = hasActiveTasks ? getChannelTasks(channel.name, $kanbanData) : []}
-              {@const threads = hasTrackedThreads ? getChannelThreads(channel.name, $trackedThreads, $threadUnreadCounts, taskThreadIds) : []}
+              {@const threads = hasTrackedThreads ? getChannelThreads(channel.name, $trackedThreads, $threadUnreadCounts, taskThreadIds).threads : []}
               {@const unreadThreads = threads.filter(t => t.unread > 0)}
               <div class="flex items-center gap-[3px]">
                 {#each tasks as task}

--- a/web-app/src/lib/ThreadList.svelte
+++ b/web-app/src/lib/ThreadList.svelte
@@ -9,20 +9,23 @@
   // Build the set of thread IDs already represented by tasks
   const taskThreadIds = $derived(getTaskThreadIds($kanbanData))
 
-  // Cleanup callback: permanently remove task-backed threads from stores
-  function cleanupTaskBacked(ids) {
+  // Threads for this channel, filtered and sorted (pure derivation — no side effects)
+  const threadData = $derived(
+    getChannelThreads(channelName, $trackedThreads, $threadUnreadCounts, taskThreadIds)
+  )
+  const channelThreads = $derived(threadData.threads)
+
+  // Side effect: permanently remove task-backed threads from stores
+  $effect(() => {
+    const ids = threadData.toClean
+    if (ids.length === 0) return
     trackedThreads.update((t) => {
       const next = { ...t }
       for (const id of ids) delete next[id]
       return next
     })
     dismissedThreads.update((s) => new Set([...s, ...ids]))
-  }
-
-  // Threads for this channel, filtered and sorted
-  const channelThreads = $derived(
-    getChannelThreads(channelName, $trackedThreads, $threadUnreadCounts, taskThreadIds, cleanupTaskBacked)
-  )
+  })
 
   function handleClick(thread) {
     // Try to find the parent message in the channel's message store

--- a/web-app/src/lib/channelUtils.js
+++ b/web-app/src/lib/channelUtils.js
@@ -203,17 +203,16 @@ export function getTaskThreadIds(kanban) {
 
 /**
  * Get tracked threads for a channel, sorted by lastActivity (newest first).
- * Filters out threads that are represented by tasks (dedup) and permanently
- * removes them from trackedThreads + adds to dismissedThreads.
+ * Pure function — filters out task-backed threads and returns their IDs
+ * in `toClean` for the caller to handle cleanup separately (e.g. in a $effect).
  *
  * @param {string} channelName
  * @param {object} tracked - $trackedThreads store value
  * @param {object} unreadCounts - $threadUnreadCounts store value
  * @param {Set} taskThreadIds - from getTaskThreadIds()
- * @param {Function} cleanupFn - callback(idsToRemove) to permanently remove task-backed threads
- * @returns {Array<{id, subject, lastActivity, replyCount, unread}>}
+ * @returns {{ threads: Array<{id, subject, lastActivity, replyCount, unread}>, toClean: string[] }}
  */
-export function getChannelThreads(channelName, tracked, unreadCounts, taskThreadIds, cleanupFn) {
+export function getChannelThreads(channelName, tracked, unreadCounts, taskThreadIds) {
   const threads = []
   const toClean = []
   for (const [id, entry] of Object.entries(tracked)) {
@@ -231,12 +230,8 @@ export function getChannelThreads(channelName, tracked, unreadCounts, taskThread
       unread: unreadCounts[id] || 0,
     })
   }
-  // Side-effect: permanently remove task-backed threads
-  if (toClean.length > 0 && cleanupFn) {
-    cleanupFn(toClean)
-  }
   threads.sort((a, b) => (b.lastActivity || '').localeCompare(a.lastActivity || ''))
-  return threads
+  return { threads, toClean }
 }
 
 /**

--- a/web-app/src/lib/channelUtils.test.js
+++ b/web-app/src/lib/channelUtils.test.js
@@ -3,6 +3,7 @@ import {
   getChannelTaskCount,
   getChannelCiStatus,
   getChannelPrs,
+  getChannelThreads,
   computeExpandedAfterTriangleClick,
   computeExpandedAfterChannelNameClick,
   computeVisibleDmChannels,
@@ -224,6 +225,55 @@ describe('getChannelPrs', () => {
     const prs = getChannelPrs('special-channel', kanban)
     expect(prs).toHaveLength(1)
     expect(prs[0].number).toBe(99)
+  })
+})
+
+describe('getChannelThreads', () => {
+  const tracked = {
+    'thread-1': { channelName: 'web', subject: 'Thread 1', lastActivity: '2026-03-04T10:00:00Z', replyCount: 3 },
+    'thread-2': { channelName: 'web', subject: 'Thread 2', lastActivity: '2026-03-04T11:00:00Z', replyCount: 1 },
+    'thread-3': { channelName: 'auth', subject: 'Auth thread', lastActivity: '2026-03-04T09:00:00Z' },
+    'task-thread': { channelName: 'web', subject: 'Task-backed thread', lastActivity: '2026-03-04T12:00:00Z' },
+  }
+  const unreadCounts = { 'thread-1': 2, 'thread-2': 0, 'task-thread': 5 }
+  const taskThreadIds = new Set(['task-thread'])
+
+  it('returns threads for the given channel, filtered and sorted by lastActivity', () => {
+    const result = getChannelThreads('web', tracked, unreadCounts, taskThreadIds)
+    expect(result.threads).toHaveLength(2)
+    // sorted newest first: thread-2 (11:00) before thread-1 (10:00)
+    expect(result.threads[0].id).toBe('thread-2')
+    expect(result.threads[1].id).toBe('thread-1')
+  })
+
+  it('includes unread counts in thread objects', () => {
+    const result = getChannelThreads('web', tracked, unreadCounts, taskThreadIds)
+    const t1 = result.threads.find(t => t.id === 'thread-1')
+    const t2 = result.threads.find(t => t.id === 'thread-2')
+    expect(t1.unread).toBe(2)
+    expect(t2.unread).toBe(0)
+  })
+
+  it('excludes task-backed threads from the thread list', () => {
+    const result = getChannelThreads('web', tracked, unreadCounts, taskThreadIds)
+    const ids = result.threads.map(t => t.id)
+    expect(ids).not.toContain('task-thread')
+  })
+
+  it('returns toClean IDs for task-backed threads (no side-effect callback)', () => {
+    const result = getChannelThreads('web', tracked, unreadCounts, taskThreadIds)
+    expect(result.toClean).toEqual(['task-thread'])
+  })
+
+  it('returns empty toClean when no task-backed threads exist', () => {
+    const result = getChannelThreads('web', tracked, unreadCounts, new Set())
+    expect(result.toClean).toEqual([])
+  })
+
+  it('filters by channel name', () => {
+    const result = getChannelThreads('auth', tracked, unreadCounts, taskThreadIds)
+    expect(result.threads).toHaveLength(1)
+    expect(result.threads[0].id).toBe('thread-3')
   })
 })
 


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Fixed `state_unsafe_mutation` error in ThreadList.svelte caused by calling `trackedThreads.update()` inside a `$derived()` block
- Made `getChannelThreads()` a pure function that returns `{ threads, toClean }` instead of invoking a cleanup callback
- Moved the cleanup side effect into a separate `$effect` in ThreadList.svelte
- Updated ChannelList.svelte to destructure `.threads` from the new return type
- Added 6 unit tests for `getChannelThreads` covering filtering, sorting, unread counts, and toClean extraction

## Test plan
- [x] All 6 new `getChannelThreads` tests pass
- [x] Full web-app test suite passes (235 tests across 7 files)
- [x] Pre-commit hooks (clippy + fmt) pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)