### PR TITLE
feat: Add external_url config for screenshot URLs in PR descriptions [Midtown !2051]

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ chat_monitor_enabled = true           # Enable @mention routing
 [webserver]
 tls_cert = "/path/to/cert.pem"       # TLS certificate (PEM format)
 tls_key = "/path/to/key.pem"         # TLS private key (PEM format)
+external_url = "https://myhost.ts.net:47022"  # Base URL for screenshot links in PRs
 
 [execution]
 lead_provider = "claude"              # Default for all leads ("claude", "codex", or "zai")

--- a/src/bin/midtown/cli/coworker.rs
+++ b/src/bin/midtown/cli/coworker.rs
@@ -197,15 +197,16 @@ pub fn handle_screenshot(
         .ok_or("Not in a git repository. Cannot determine screenshot directory.")?;
     let screenshots_dir = midtown::paths::screenshots_dir_for_repo(&repo);
 
-    let webserver_scheme = if github {
+    let (webserver_scheme, external_url) = if github {
         let config = midtown::config::GlobalConfig::load();
-        if config.webserver.tls_cert.is_some() && config.webserver.tls_key.is_some() {
+        let scheme = if config.webserver.tls_cert.is_some() && config.webserver.tls_key.is_some() {
             Some("https")
         } else {
             Some("http")
-        }
+        };
+        (scheme, config.webserver.external_url.clone())
     } else {
-        None
+        (None, None)
     };
 
     save_screenshot_locally(
@@ -216,6 +217,7 @@ pub fn handle_screenshot(
         &screenshots_dir,
         webserver_scheme,
         &repo,
+        external_url.as_deref(),
     )
 }
 
@@ -227,7 +229,10 @@ pub fn handle_screenshot(
 /// filename and copies the screenshot to the provided directory.
 ///
 /// When `webserver_scheme` is `Some("http")` or `Some("https")`, returns GitHub-compatible
-/// markdown image syntax using the webserver's screenshot endpoint.
+/// markdown image syntax using the webserver's screenshot endpoint. If `external_url` is
+/// provided (e.g. `https://macbook-pro.taile2dd2b.ts.net:47022`), it is used as the base
+/// URL instead of constructing from localhost.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn save_screenshot_locally(
     tmp_path: &std::path::Path,
     ext: &str,
@@ -236,6 +241,7 @@ pub(crate) fn save_screenshot_locally(
     screenshots_dir: &std::path::Path,
     webserver_scheme: Option<&str>,
     repo: &str,
+    external_url: Option<&str>,
 ) -> Result<Response, String> {
     // Guard ensures temp file is cleaned up on all exit paths (including early returns)
     let _guard = TempFileGuard {
@@ -262,7 +268,6 @@ pub(crate) fn save_screenshot_locally(
     eprintln!("Screenshot saved: {}", dest_path.display());
 
     if let Some(scheme) = webserver_scheme {
-        let port = midtown::webserver::DEFAULT_WEBSERVER_PORT;
         // Encode characters unsafe in URL path segments while preserving - . _ ~
         const PATH_SEGMENT: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
             .remove(b'-')
@@ -270,9 +275,15 @@ pub(crate) fn save_screenshot_locally(
             .remove(b'_')
             .remove(b'~');
         let encoded_repo = percent_encoding::utf8_percent_encode(repo, PATH_SEGMENT);
+        let base = if let Some(ext_url) = external_url {
+            ext_url.trim_end_matches('/').to_string()
+        } else {
+            let port = midtown::webserver::DEFAULT_WEBSERVER_PORT;
+            format!("{}://localhost:{}", scheme, port)
+        };
         let url = format!(
-            "{}://localhost:{}/api/projects/{}/screenshots/{}",
-            scheme, port, encoded_repo, filename
+            "{}/api/projects/{}/screenshots/{}",
+            base, encoded_repo, filename
         );
         let alt = if before {
             "before"

--- a/src/bin/midtown/cli/coworker_tests.rs
+++ b/src/bin/midtown/cli/coworker_tests.rs
@@ -73,6 +73,7 @@ fn save_screenshot_locally_saves_and_cleans_up_temp() {
         &screenshots_dir,
         None,
         "test-repo",
+        None,
     );
 
     // Should succeed
@@ -130,6 +131,7 @@ fn save_screenshot_locally_before_after_prefix() {
         &screenshots_dir,
         None,
         "test-repo",
+        None,
     );
     assert!(result.is_ok());
 
@@ -166,6 +168,7 @@ fn save_screenshot_locally_github_flag_produces_markdown_image() {
         &screenshots_dir,
         Some("http"),
         "my-project",
+        None,
     );
 
     assert!(result.is_ok(), "Expected success, got: {:?}", result);
@@ -211,6 +214,7 @@ fn save_screenshot_locally_github_before_uses_before_alt_text() {
         &screenshots_dir,
         Some("http"),
         "my-project",
+        None,
     );
 
     assert!(result.is_ok());
@@ -246,6 +250,7 @@ fn save_screenshot_locally_github_url_encodes_repo_name() {
         &screenshots_dir,
         Some("http"),
         "my project#1",
+        None,
     );
 
     assert!(result.is_ok(), "Expected success, got: {:?}", result);
@@ -281,6 +286,7 @@ fn save_screenshot_locally_github_after_uses_after_alt_text() {
         &screenshots_dir,
         Some("http"),
         "my-project",
+        None,
     );
 
     assert!(result.is_ok());
@@ -289,6 +295,93 @@ fn save_screenshot_locally_github_after_uses_after_alt_text() {
         assert!(
             message.starts_with("![after]("),
             "After screenshot should use 'after' alt text, got: {}",
+            message
+        );
+    } else {
+        panic!("Expected Message response");
+    }
+}
+
+#[test]
+fn save_screenshot_locally_external_url_overrides_localhost() {
+    let screenshots_tmp = tempfile::tempdir().unwrap();
+    let screenshots_dir = screenshots_tmp.path().join("screenshots");
+
+    let dir = std::env::temp_dir();
+    let tmp_path = dir.join(format!(
+        "midtown-test-screenshot-external-url-{}",
+        std::process::id()
+    ));
+    std::fs::write(&tmp_path, b"fake png data").unwrap();
+
+    let result = super::save_screenshot_locally(
+        &tmp_path,
+        "png",
+        false,
+        false,
+        &screenshots_dir,
+        Some("https"),
+        "my-project",
+        Some("https://macbook-pro.taile2dd2b.ts.net:47022"),
+    );
+
+    assert!(result.is_ok(), "Expected success, got: {:?}", result);
+
+    if let super::super::Response::Message { message } = result.unwrap() {
+        assert!(
+            message.starts_with("![screenshot](https://macbook-pro.taile2dd2b.ts.net:47022/api/projects/my-project/screenshots/"),
+            "External URL should override localhost, got: {}",
+            message
+        );
+        assert!(
+            !message.contains("localhost"),
+            "Should not contain localhost when external_url is set, got: {}",
+            message
+        );
+        assert!(
+            message.ends_with(".png)"),
+            "URL should end with .png), got: {}",
+            message
+        );
+    } else {
+        panic!("Expected Message response");
+    }
+}
+
+#[test]
+fn save_screenshot_locally_external_url_trailing_slash_stripped() {
+    let screenshots_tmp = tempfile::tempdir().unwrap();
+    let screenshots_dir = screenshots_tmp.path().join("screenshots");
+
+    let dir = std::env::temp_dir();
+    let tmp_path = dir.join(format!(
+        "midtown-test-screenshot-external-url-slash-{}",
+        std::process::id()
+    ));
+    std::fs::write(&tmp_path, b"fake png data").unwrap();
+
+    let result = super::save_screenshot_locally(
+        &tmp_path,
+        "png",
+        false,
+        false,
+        &screenshots_dir,
+        Some("https"),
+        "my-project",
+        Some("https://example.com:47022/"),
+    );
+
+    assert!(result.is_ok(), "Expected success, got: {:?}", result);
+
+    if let super::super::Response::Message { message } = result.unwrap() {
+        assert!(
+            message.contains("https://example.com:47022/api/projects/"),
+            "Trailing slash should be stripped to avoid double slash, got: {}",
+            message
+        );
+        assert!(
+            !message.contains("//api"),
+            "Should not have double slash before api, got: {}",
             message
         );
     } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -598,6 +598,7 @@ impl DaemonSection {
 /// [webserver]
 /// tls_cert = "/path/to/cert.pem"
 /// tls_key = "/path/to/key.pem"
+/// external_url = "https://macbook-pro.taile2dd2b.ts.net:47022"
 /// ```
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct WebserverSection {
@@ -610,6 +611,12 @@ pub struct WebserverSection {
     /// For Tailscale: `tailscale cert <hostname>` generates `<hostname>.key`.
     #[serde(default)]
     pub tls_key: Option<PathBuf>,
+
+    /// External URL for the webserver, used in screenshot URLs for GitHub PRs.
+    /// When set, screenshot `--github` URLs use this as the base instead of
+    /// `localhost`. Example: `https://macbook-pro.taile2dd2b.ts.net:47022`
+    #[serde(default)]
+    pub external_url: Option<String>,
 }
 
 /// Role-specific execution provider settings.


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Adds `external_url` field (`Option<String>`) to `WebserverSection` in config
- When set, `midtown coworker screenshot --github` uses this as the base URL instead of `localhost:47022`
- Allows screenshot URLs in GitHub PR descriptions to be accessible via Tailscale/external hostname

## Changes
- **src/config.rs**: Added `external_url: Option<String>` to `WebserverSection` with doc comments
- **src/bin/midtown/cli/coworker.rs**: `handle_screenshot()` reads `external_url` from config and passes it through; `save_screenshot_locally()` uses it as the base URL when present (with trailing slash stripping)
- **src/bin/midtown/cli/coworker_tests.rs**: Two new tests — one verifying external_url overrides localhost, one verifying trailing slash handling
- **README.md**: Added `external_url` to the config example

## Example config
```toml
[webserver]
external_url = "https://macbook-pro.taile2dd2b.ts.net:47022"
```

## Test plan
- [x] `save_screenshot_locally_external_url_overrides_localhost` — verifies external URL replaces localhost
- [x] `save_screenshot_locally_external_url_trailing_slash_stripped` — verifies no double-slash
- [x] All existing screenshot tests pass (no regressions)
- [x] `cargo clippy` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)