### PR TITLE
feat: Add structured JSONL logging for PR decisions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -479,6 +479,14 @@ PR-to-coworker resolution uses two paths depending on context:
 
 Key functions: `determine_pr_coworker()` (webhook.rs, frontmatter-only), `resolve_pr_owner()` (pr.rs, session + branch map), `coworker_from_branch()` (helpers.rs, pure map lookup).
 
+### PR Decision Logging
+
+Every PR decision (both polling and webhook paths) is logged as a JSONL line to `~/.midtown/projects/<repo>/pr-decisions.jsonl`. Each entry captures the full decision context: PR number, detected issue type, owner state (active/idle), action chosen by the rules engine, and the effects emitted. The `source` field distinguishes `"polling"` from `"webhook"` triggers.
+
+Call sites: `process_pr_issue_nudges` (polling), `collect_review_feedback_effects` (polling), `handle_pr_comment_nudge` (webhook), `handle_webhook_review_state_change` (webhook), `handle_webhook_ci_failure` (webhook). All use `log_pr_decision()` with a `PrDecisionEntry` struct.
+
+This corpus enables verifying functional equivalence when migrating PR workflow logic from Rust to Python workflow scripts. Logging failures are silently swallowed — they must never crash the daemon.
+
 ## Webhook Ports
 
 Each project daemon runs its own webhook server for GitHub integration. Port 47022 is reserved for the shared multi-project webserver. Per-project daemons auto-assign ports starting at 47023, persisting the assignment in the project's `config.toml` for stability across restarts.

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -886,30 +886,25 @@ async fn process_pr_issue_nudges(
                 &message,
             );
 
-            let action_name = match &action {
-                crate::rules::PrAction::NudgeOwner { .. } => "NudgeOwner",
-                crate::rules::PrAction::SpawnOwner { .. } => "SpawnOwner",
-                crate::rules::PrAction::HandoffToCoworker { .. } => "HandoffToCoworker",
-                crate::rules::PrAction::PostToChannel { .. } => "PostToChannel",
-                crate::rules::PrAction::Skip { .. } => "Skip",
-            };
+            let action_name = pr_action_name(&action);
 
             let new_effects =
                 pr_action_to_effects(action, pf.number, pf.title, issue_type, state, &pr_ctx);
 
-            log_pr_decision(
-                &state.repo_name,
-                pf.number,
-                pf.title,
-                &owner,
+            log_pr_decision(&PrDecisionEntry {
+                repo_name: state.paths.dir_key(),
+                pr_number: pf.number,
+                title: pf.title,
+                owner: &owner,
                 issue_type,
                 action_name,
-                &new_effects,
-                &pr_ctx,
-                active_coworkers.contains(&owner),
-                idle_coworkers.contains(&owner),
+                effects: &new_effects,
+                ctx: &pr_ctx,
+                owner_is_active: active_coworkers.contains(&owner),
+                owner_is_idle: idle_coworkers.contains(&owner),
                 at_dev_limit,
-            );
+                source: "polling",
+            });
 
             effects.extend(new_effects);
         }
@@ -1283,23 +1278,43 @@ async fn collect_green_with_feedback_effects(
         pr_ctx.augment_reviewer_from_snapshot(pr_number, snap);
 
         // Decide action using handoff-aware decision function (matches webhook path)
+        let at_dev_limit = state.is_at_dev_limit(&channel_lead_names);
         let action = crate::rules::decide_pr_issue_action_with_handoff(
             &owner,
             active_coworkers,
             idle_coworkers,
-            state.is_at_dev_limit(&channel_lead_names),
+            at_dev_limit,
             pr_ctx.session_context.as_ref(),
             &message,
         );
 
-        effects.extend(pr_action_to_effects(
+        let action_name = pr_action_name(&action);
+
+        let new_effects = pr_action_to_effects(
             action,
             pr_number,
             pf.title,
             PrIssueType::GreenWithFeedback,
             state,
             &pr_ctx,
-        ));
+        );
+
+        log_pr_decision(&PrDecisionEntry {
+            repo_name: state.paths.dir_key(),
+            pr_number,
+            title: pf.title,
+            owner: &owner,
+            issue_type: PrIssueType::GreenWithFeedback,
+            action_name,
+            effects: &new_effects,
+            ctx: &pr_ctx,
+            owner_is_active: active_coworkers.contains(&owner),
+            owner_is_idle: idle_coworkers.contains(&owner),
+            at_dev_limit,
+            source: "polling",
+        });
+
+        effects.extend(new_effects);
     }
 
     effects
@@ -3980,20 +3995,38 @@ pub(super) async fn handle_pr_comment_nudge(
     };
 
     // Decide action using pure decision function with handoff support
+    let at_dev_limit = state.is_at_dev_limit(&channel_lead_names);
     let action = crate::rules::decide_pr_comment_action_with_handoff(
         &owner,
         &activity.actor,
         &active_coworkers,
         &idle_coworkers,
-        state.is_at_dev_limit(&channel_lead_names),
+        at_dev_limit,
         pr_ctx.session_context.as_ref(),
         &nudge_msg,
     );
+
+    let action_name = pr_action_name(&action);
 
     // Convert PrAction → Effects using the same pure converter as polling,
     // then execute via the standard effect pipeline.
     let is_actionable = !matches!(action, crate::rules::PrAction::Skip { .. });
     let mut effects = comment_action_to_effects(action, pr_number, "", state, &pr_ctx);
+
+    log_pr_decision(&PrDecisionEntry {
+        repo_name: state.paths.dir_key(),
+        pr_number,
+        title: "",
+        owner: &owner,
+        issue_type: PrIssueType::ReviewComment,
+        action_name,
+        effects: &effects,
+        ctx: &pr_ctx,
+        owner_is_active: active_coworkers.contains(&owner),
+        owner_is_idle: idle_coworkers.contains(&owner),
+        at_dev_limit,
+        source: "webhook",
+    });
 
     // If this is a lead/* branch, also nudge the lead so they see review feedback
     if let Some(branch) = get_pr_branch_async(pr_number).await
@@ -4125,18 +4158,37 @@ pub(super) async fn handle_webhook_review_state_change(
         (ctx, ps.channel_lead_names())
     };
 
+    let at_dev_limit = state.is_at_dev_limit(&channel_lead_names);
     let action = crate::rules::decide_pr_issue_action_with_handoff(
         &owner,
         &active_coworkers,
         &idle_coworkers,
-        state.is_at_dev_limit(&channel_lead_names),
+        at_dev_limit,
         pr_ctx.session_context.as_ref(),
         &nudge_msg,
     );
 
+    let action_name = pr_action_name(&action);
+
     // Convert PrAction → Effects using the same pure converter as polling,
     // then execute via the standard effect pipeline.
     let effects = pr_action_to_effects(action, pr_number, "", issue_type, state, &pr_ctx);
+
+    log_pr_decision(&PrDecisionEntry {
+        repo_name: state.paths.dir_key(),
+        pr_number,
+        title: "",
+        owner: &owner,
+        issue_type,
+        action_name,
+        effects: &effects,
+        ctx: &pr_ctx,
+        owner_is_active: active_coworkers.contains(&owner),
+        owner_is_idle: idle_coworkers.contains(&owner),
+        at_dev_limit,
+        source: "webhook",
+    });
+
     super::effects::execute_effects(effects, state).await;
 }
 
@@ -4210,24 +4262,38 @@ pub(super) async fn handle_webhook_ci_failure(
         )
     };
 
+    let at_dev_limit = state.is_at_dev_limit(&channel_lead_names);
     let action = crate::rules::decide_pr_issue_action_with_handoff(
         &owner,
         &active_coworkers,
         &idle_coworkers,
-        state.is_at_dev_limit(&channel_lead_names),
+        at_dev_limit,
         pr_ctx.session_context.as_ref(),
         &nudge_msg,
     );
 
-    info!(
-        "PR #{} CI failure: owner={}, action={:?}",
-        pr_number, owner, action
-    );
+    let action_name = pr_action_name(&action);
 
     // Convert PrAction → Effects using the same pure converter as polling,
     // then execute via the standard effect pipeline.
     let effects =
         pr_action_to_effects(action, pr_number, "", PrIssueType::CiFailed, state, &pr_ctx);
+
+    log_pr_decision(&PrDecisionEntry {
+        repo_name: state.paths.dir_key(),
+        pr_number,
+        title: "",
+        owner: &owner,
+        issue_type: PrIssueType::CiFailed,
+        action_name,
+        effects: &effects,
+        ctx: &pr_ctx,
+        owner_is_active: active_coworkers.contains(&owner),
+        owner_is_idle: idle_coworkers.contains(&owner),
+        at_dev_limit,
+        source: "webhook",
+    });
+
     super::effects::execute_effects(effects, state).await;
 }
 
@@ -4740,7 +4806,25 @@ fn effect_variant_name(e: &Effect) -> &'static str {
         Effect::AutoMergePr { .. } => "AutoMergePr",
         Effect::PostPrComment { .. } => "PostPrComment",
         Effect::EmitWorkflowEvent(_) => "EmitWorkflowEvent",
+        Effect::RespawnFork { .. } => "RespawnFork",
     }
+}
+
+/// Captures the full context of a single PR decision for JSONL logging.
+struct PrDecisionEntry<'a> {
+    repo_name: &'a str,
+    pr_number: u64,
+    title: &'a str,
+    owner: &'a str,
+    issue_type: PrIssueType,
+    action_name: &'a str,
+    effects: &'a [Effect],
+    ctx: &'a PrContext,
+    owner_is_active: bool,
+    owner_is_idle: bool,
+    at_dev_limit: bool,
+    /// "polling" or "webhook" — distinguishes the trigger source.
+    source: &'a str,
 }
 
 /// Log a single PR decision as a JSONL line to `~/.midtown/projects/<repo>/pr-decisions.jsonl`.
@@ -4750,53 +4834,52 @@ fn effect_variant_name(e: &Effect) -> &'static str {
 /// a corpus for verifying functional equivalence when migrating to workflow scripts.
 ///
 /// Logging failures are silently swallowed (debug-logged) — this must never crash the daemon.
-#[allow(clippy::too_many_arguments)]
-fn log_pr_decision(
-    repo_name: &str,
-    pr_number: u64,
-    title: &str,
-    owner: &str,
-    issue_type: PrIssueType,
-    action_name: &str,
-    effects: &[Effect],
-    ctx: &PrContext,
-    owner_is_active: bool,
-    owner_is_idle: bool,
-    at_dev_limit: bool,
-) {
+fn log_pr_decision(entry: &PrDecisionEntry<'_>) {
     use std::fs::OpenOptions;
     use std::io::Write;
 
-    let channel = ctx.get_channel(pr_number);
-    let task_id = ctx.pr_task_associations.get(&pr_number);
+    let channel = entry.ctx.get_channel(entry.pr_number);
+    let task_id = entry.ctx.pr_task_associations.get(&entry.pr_number);
 
-    let entry = serde_json::json!({
+    let json = serde_json::json!({
         "ts": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-        "pr": pr_number,
-        "title": title,
-        "owner": owner,
-        "issue": issue_type.to_string(),
-        "owner_active": owner_is_active,
-        "owner_idle": owner_is_idle,
-        "at_dev_limit": at_dev_limit,
-        "has_active_reviewer": ctx.has_active_reviewer,
-        "has_session_context": ctx.session_context.is_some(),
+        "pr": entry.pr_number,
+        "title": entry.title,
+        "owner": entry.owner,
+        "issue": entry.issue_type.to_string(),
+        "owner_active": entry.owner_is_active,
+        "owner_idle": entry.owner_is_idle,
+        "at_dev_limit": entry.at_dev_limit,
+        "has_active_reviewer": entry.ctx.has_active_reviewer,
+        "has_session_context": entry.ctx.session_context.is_some(),
         "task_id": task_id,
         "channel": channel,
-        "action": action_name,
-        "effect_count": effects.len(),
-        "effects": effects.iter().map(effect_variant_name).collect::<Vec<_>>(),
+        "action": entry.action_name,
+        "source": entry.source,
+        "effect_count": entry.effects.len(),
+        "effects": entry.effects.iter().map(effect_variant_name).collect::<Vec<_>>(),
     });
 
-    let dir = crate::paths::projects_dir_for_repo(repo_name);
+    let dir = crate::paths::projects_dir_for_repo(entry.repo_name);
     let path = dir.join("pr-decisions.jsonl");
     if let Err(e) = (|| -> std::io::Result<()> {
         std::fs::create_dir_all(&dir)?;
         let mut file = OpenOptions::new().append(true).create(true).open(&path)?;
-        writeln!(file, "{}", entry)?;
+        writeln!(file, "{}", json)?;
         Ok(())
     })() {
         debug!("Failed to write PR decision log: {}", e);
+    }
+}
+
+/// Extract a display name from a `PrAction` variant for logging.
+fn pr_action_name(action: &crate::rules::PrAction) -> &'static str {
+    match action {
+        crate::rules::PrAction::NudgeOwner { .. } => "NudgeOwner",
+        crate::rules::PrAction::SpawnOwner { .. } => "SpawnOwner",
+        crate::rules::PrAction::HandoffToCoworker { .. } => "HandoffToCoworker",
+        crate::rules::PrAction::PostToChannel { .. } => "PostToChannel",
+        crate::rules::PrAction::Skip { .. } => "Skip",
     }
 }
 

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -4958,6 +4958,8 @@ async fn test_polling_uses_normal_delay_without_workflow_script() {
         !effects.is_empty(),
         "Without workflow script, polling should use normal 45s delay and not skip PR at 60s old"
     );
+}
+
 // ── log_pr_decision ─────────────────────────────────────────────────────────
 
 #[test]
@@ -4989,19 +4991,20 @@ fn log_pr_decision_writes_valid_jsonl() {
         },
     ];
 
-    log_pr_decision(
-        "midtown",
-        42,
-        "Add feature X",
-        "broadway",
-        PrIssueType::Approved,
-        "NudgeOwner",
-        &effects,
-        &ctx,
-        true,
-        false,
-        false,
-    );
+    log_pr_decision(&PrDecisionEntry {
+        repo_name: "midtown",
+        pr_number: 42,
+        title: "Add feature X",
+        owner: "broadway",
+        issue_type: PrIssueType::Approved,
+        action_name: "NudgeOwner",
+        effects: &effects,
+        ctx: &ctx,
+        owner_is_active: true,
+        owner_is_idle: false,
+        at_dev_limit: false,
+        source: "polling",
+    });
 
     let path = crate::paths::projects_dir_for_repo("midtown").join("pr-decisions.jsonl");
     let content = std::fs::read_to_string(&path).expect("read decision log");
@@ -5019,6 +5022,7 @@ fn log_pr_decision_writes_valid_jsonl() {
     assert_eq!(entry["task_id"], "7");
     assert_eq!(entry["channel"], "installer");
     assert_eq!(entry["action"], "NudgeOwner");
+    assert_eq!(entry["source"], "polling");
     assert_eq!(entry["effect_count"], 2);
     assert_eq!(
         entry["effects"],
@@ -5046,19 +5050,20 @@ fn log_pr_decision_appends_multiple_entries() {
 
     // Write two entries
     for pr in [10, 20] {
-        log_pr_decision(
-            "midtown",
-            pr,
-            "Test PR",
-            "park",
-            PrIssueType::CiFailed,
-            "Skip",
-            &[],
-            &ctx,
-            false,
-            false,
-            false,
-        );
+        log_pr_decision(&PrDecisionEntry {
+            repo_name: "midtown",
+            pr_number: pr,
+            title: "Test PR",
+            owner: "park",
+            issue_type: PrIssueType::CiFailed,
+            action_name: "Skip",
+            effects: &[],
+            ctx: &ctx,
+            owner_is_active: false,
+            owner_is_idle: false,
+            at_dev_limit: false,
+            source: "webhook",
+        });
     }
 
     let path = crate::paths::projects_dir_for_repo("midtown").join("pr-decisions.jsonl");


### PR DESCRIPTION
## Summary
- Adds `log_pr_decision()` helper that writes a JSONL line per PR issue decision to `~/.midtown/projects/<repo>/pr-decisions.jsonl`
- Each entry captures: PR number, title, owner, issue type, action chosen, emitted effects, and full decision context (active/idle status, dev limit, reviewer state, session context)
- Adds `effect_variant_name()` helper to extract `Effect` enum variant names as `&'static str` without requiring `Serialize`
- Wired into `process_pr_issue_nudges()` — captures action name before the move into `pr_action_to_effects()`

This creates a decision corpus for verifying functional equivalence when migrating PR workflow logic from Rust to Python workflow scripts.

## Test plan
- [x] `log_pr_decision_writes_valid_jsonl` — verifies JSON structure and all fields
- [x] `log_pr_decision_appends_multiple_entries` — verifies append semantics
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] Full `cargo test` suite passes (2352 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)