### PR TITLE
feat: Replace literal @channel-lead with {channel_lead} template variable [Midtown !2055]

### DIFF
--- a/agents/common.md
+++ b/agents/common.md
@@ -3,7 +3,7 @@
 | Role | Scope | Does | Doesn't |
 |---|---|---|---|
 | Main lead (`@{project_name}`) | Cross-cutting | Broad project knowledge, task creation, user-facing | Write code (except quick fixes), deep domain expertise |
-| Channel lead (`@channel-lead`) | Domain-specific | Deep domain expertise, proactive tracking, task creation for own channel | Cross-cutting decisions, user-facing communication |
+| Channel lead (`@{channel_lead}`) | Domain-specific | Deep domain expertise, proactive tracking, task creation for own channel | Cross-cutting decisions, user-facing communication |
 | Coworker | Task-scoped | Implement, test, open PRs | Coordinate, review unless assigned |
 | Reviewer | PR-scoped | Review assigned PRs | Claim tasks, implement features |
 

--- a/agents/coworker.md
+++ b/agents/coworker.md
@@ -16,7 +16,7 @@ midtown channel post "your message here"
 
 **Automatic channel routing:** When your task has an associated channel (topic channel), the `MIDTOWN_CHANNEL` environment variable is set automatically, and all your `midtown channel post` commands will route to that channel by default. You don't need to specify `--channel` unless you want to post to a different channel.
 
-**Channel leads:** Topic channels have a dedicated channel lead — a domain expert who maintains context for that area of the codebase. When you have domain questions (e.g., "how does the auth module work?", "what's the right approach for this feature area?"), ask the channel lead first by posting in your channel with `@channel-lead`. If no channel lead is active for your channel, fall back to `@{project_name}`. Reserve `@{project_name}` for project-wide coordination, priority decisions, and blockers that span channels.
+**Channel leads:** Topic channels have a dedicated channel lead — a domain expert who maintains context for that area of the codebase. When you have domain questions (e.g., "how does the auth module work?", "what's the right approach for this feature area?"), ask the channel lead first by posting in your channel with `@{channel_lead}`. If no channel lead is active for your channel, fall back to `@{project_name}`. Reserve `@{project_name}` for project-wide coordination, priority decisions, and blockers that span channels.
 
 Use `/me` to indicate what you're currently doing:
 ```bash
@@ -88,7 +88,7 @@ Channel messages are freeform. Use `--task <id>` for task-specific updates so th
 ```bash
 midtown channel post "/me found the root cause in auth.rs" --task 42
 midtown channel post "blocked on API spec — need clarification" --task 42
-midtown channel post "@channel-lead should this handle the edge case?" --task 42
+midtown channel post "@{channel_lead} should this handle the edge case?" --task 42
 ```
 
 For project-wide coordination (not tied to a specific task), post without `--task`:
@@ -101,7 +101,7 @@ When replying to someone's channel message, **always @mention them** and **alway
 
 ```bash
 # Channel lead asked about your task → @mention + --task
-midtown channel post "@channel-lead yes, the tests cover that edge case" --task 42
+midtown channel post "@{channel_lead} yes, the tests cover that edge case" --task 42
 
 # Lead asked about your task → @mention + --task
 midtown channel post "@{project_name} yes, the auth module exports a validate function" --task 42
@@ -540,7 +540,7 @@ The key distinction: **don't poll** (repeatedly checking status), but **do use `
 ### Asking Questions
 When unsure about something, **ask in the channel** using @mentions. Follow this escalation hierarchy:
 
-1. **@channel-lead** - Ask the channel lead for domain questions within your task's channel. Channel leads are domain experts with persistent context for their area. Use this for: "how does X work?", "what's the right approach for this feature area?", "does this module have a validate function?"
+1. **@{channel_lead}** - Ask the channel lead for domain questions within your task's channel. Channel leads are domain experts with persistent context for their area. Use this for: "how does X work?", "what's the right approach for this feature area?", "does this module have a validate function?"
 2. **@{project_name}** - Ask the Lead for project-wide coordination, priority decisions, and cross-channel blockers. **Only @{project_name} for genuine questions, decisions, or blockers** — not for routine status updates like "PR is ready" or "task complete" (the daemon handles those automatically).
 3. **@coworker** - Ask a specific coworker if they're actively working on something directly related to your task.
 
@@ -550,7 +550,7 @@ Collaboration is encouraged! Don't make assumptions - it's better to ask than to
 
 ```bash
 # Domain question → ask the channel lead first
-midtown channel post "@channel-lead how does the auth module handle token refresh?"
+midtown channel post "@{channel_lead} how does the auth module handle token refresh?"
 
 # Project coordination or cross-channel blocker → ask lead
 midtown channel post "@{project_name} should I handle the error case here, or let it bubble up?"

--- a/agents/project-lead.md
+++ b/agents/project-lead.md
@@ -111,7 +111,7 @@ Topic channels have dedicated **channel leads** — domain experts with persiste
 
 ```bash
 # Post to a topic channel — the channel lead responds
-midtown channel post "@channel-lead <question or topic>" --channel ops
+midtown channel post "@{channel_lead} <question or topic>" --channel ops
 ```
 
 **When ops escalates to you** (via `@{project_name} ...` in the main channel):

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -8,6 +8,7 @@
 //! Template variables:
 //! - `{name}` — the agent's name (coworker name, channel name, or project name for Project Lead)
 //! - `{project_name}` — the project name (e.g., "midtown")
+//! - `{channel_lead}` — the channel lead name to @mention for domain questions (falls back to project_name)
 //! - `{escalation_target}` — reviewer only: who to @mention for review notes (channel lead or project name)
 
 use std::path::PathBuf;
@@ -120,18 +121,27 @@ pub fn main_lead_system_prompt(project_name: &str) -> String {
     format!("{project_lead}\n\n{lead}\n\n{common}")
         .replace("{name}", project_name)
         .replace("{project_name}", project_name)
+        .replace("{channel_lead}", project_name)
 }
 
 /// Load the coworker agent's system prompt with name and project substitution.
 ///
 /// Assembly: coworker.md + common.md
-pub fn coworker_system_prompt(name: &str, project_name: &str) -> String {
+///
+/// `channel_lead` is the name of the channel lead to @mention for domain questions.
+/// Falls back to `project_name` when `None` (e.g., when no topic channel is assigned).
+pub fn coworker_system_prompt(
+    name: &str,
+    project_name: &str,
+    channel_lead: Option<&str>,
+) -> String {
     let template =
         load_prompt_file("coworker.md").unwrap_or_else(|| DEFAULT_COWORKER_PROMPT.to_string());
     let common = common_prompt();
     format!("{template}\n{common}")
         .replace("{name}", name)
         .replace("{project_name}", project_name)
+        .replace("{channel_lead}", channel_lead.unwrap_or(project_name))
 }
 
 /// Load the reviewer agent's system prompt with name and project substitution.
@@ -153,6 +163,7 @@ pub fn reviewer_system_prompt(
     format!("{coworker_template}\n{common}\n\n## Reviewer Instructions\n\n{reviewer}")
         .replace("{name}", name)
         .replace("{project_name}", project_name)
+        .replace("{channel_lead}", escalation_target)
         .replace("{escalation_target}", escalation_target)
         .replace("{code_review_invocation}", &invocation)
 }
@@ -343,6 +354,7 @@ pub fn channel_lead_system_prompt(
         .replace("{channel_name}", channel_name)
         .replace("{domain_context}", domain_context)
         .replace("{project_name}", project_name)
+        .replace("{channel_lead}", channel_name) // channel lead IS the lead
         .replace("{name}", channel_name) // channel lead's {name} = channel name
 }
 

--- a/src/agents_tests.rs
+++ b/src/agents_tests.rs
@@ -10,15 +10,43 @@ fn test_main_lead_system_prompt_loads() {
 
 #[test]
 fn test_coworker_system_prompt_substitutes_name() {
-    let prompt = coworker_system_prompt("lexington", "midtown");
+    let prompt = coworker_system_prompt("lexington", "midtown", None);
     assert!(prompt.contains("**lexington**"));
     assert!(prompt.contains("git checkout -b lexington/"));
     assert!(!prompt.contains("{name}"));
 }
 
 #[test]
+fn test_coworker_system_prompt_channel_lead_defaults_to_project_name() {
+    let prompt = coworker_system_prompt("park", "midtown", None);
+    // With no channel_lead, {channel_lead} should resolve to project_name
+    assert!(
+        prompt.contains("@midtown"),
+        "When no channel_lead is provided, @{{channel_lead}} should resolve to project_name"
+    );
+    assert!(
+        !prompt.contains("{channel_lead}"),
+        "Coworker prompt should not contain unreplaced {{channel_lead}} placeholders"
+    );
+}
+
+#[test]
+fn test_coworker_system_prompt_channel_lead_substitutes_channel_name() {
+    let prompt = coworker_system_prompt("park", "midtown", Some("ops"));
+    // With channel_lead="ops", @{channel_lead} should resolve to @ops
+    assert!(
+        prompt.contains("@ops"),
+        "When channel_lead is provided, @{{channel_lead}} should resolve to that name"
+    );
+    assert!(
+        !prompt.contains("{channel_lead}"),
+        "Coworker prompt should not contain unreplaced {{channel_lead}} placeholders"
+    );
+}
+
+#[test]
 fn test_coworker_system_prompt_contains_required_sections() {
-    let prompt = coworker_system_prompt("park", "midtown");
+    let prompt = coworker_system_prompt("park", "midtown", None);
     assert!(prompt.contains("Channel Usage"));
     assert!(prompt.contains("Your Task"));
     assert!(prompt.contains("Git Workflow"));
@@ -62,7 +90,7 @@ fn test_common_prompt_included_in_lead() {
 
 #[test]
 fn test_common_prompt_included_in_coworker() {
-    let prompt = coworker_system_prompt("park", "midtown");
+    let prompt = coworker_system_prompt("park", "midtown", None);
     assert!(
         prompt.contains("CRITICAL: NEVER use @mentions in GitHub"),
         "Coworker prompt should include GitHub @mentions rule from common.md"
@@ -88,11 +116,15 @@ fn test_common_prompt_name_substitution_in_lead() {
         !prompt.contains("{name}"),
         "Lead prompt should not contain unreplaced {{name}} placeholders"
     );
+    assert!(
+        !prompt.contains("{channel_lead}"),
+        "Lead prompt should not contain unreplaced {{channel_lead}} placeholders"
+    );
 }
 
 #[test]
 fn test_common_prompt_name_substitution_in_coworker() {
-    let prompt = coworker_system_prompt("broadway", "midtown");
+    let prompt = coworker_system_prompt("broadway", "midtown", None);
     assert!(
         prompt.contains("<!-- midtown: broadway -->"),
         "Coworker prompt should have {{name}} replaced in common content"
@@ -261,6 +293,10 @@ fn test_reviewer_system_prompt_substitutes_escalation_target() {
         !prompt.contains("{escalation_target}"),
         "Reviewer system prompt should not contain unreplaced {{escalation_target}}"
     );
+    assert!(
+        !prompt.contains("{channel_lead}"),
+        "Reviewer system prompt should not contain unreplaced {{channel_lead}}"
+    );
 
     // project_name should still be substituted elsewhere (e.g., coworker prompt sections)
     assert!(
@@ -395,7 +431,7 @@ fn test_lead_notes_path_is_absolute() {
 
 #[test]
 fn test_coworker_prompt_prevents_orphaned_branches() {
-    let prompt = coworker_system_prompt("park", "midtown");
+    let prompt = coworker_system_prompt("park", "midtown", None);
 
     assert!(
         prompt.contains("Before pushing"),
@@ -434,7 +470,7 @@ fn test_coworker_prompt_prevents_orphaned_branches() {
 
 #[test]
 fn test_coworker_prompt_requires_issue_comment_reviews() {
-    let prompt = coworker_system_prompt("park", "midtown");
+    let prompt = coworker_system_prompt("park", "midtown", None);
 
     assert!(
         prompt.contains("**Before merging**, complete ALL of these checks"),
@@ -579,7 +615,7 @@ fn test_all_task_prompts_include_reply_instruction() {
 
 #[test]
 fn test_coworker_prompt_uses_task_flag_for_threading() {
-    let prompt = coworker_system_prompt("park", "midtown");
+    let prompt = coworker_system_prompt("park", "midtown", None);
     assert!(
         prompt.contains("--task"),
         "Coworker prompt should document --task flag for auto-threading task-related posts"

--- a/src/bin/midtown/cli/coworker.rs
+++ b/src/bin/midtown/cli/coworker.rs
@@ -333,7 +333,7 @@ pub fn handle_coworker_boot(task_id: Option<&str>) -> Result<(), String> {
     config.auth_profile_dir = Some(profile_dir);
 
     // Generate system prompt and write to temp file
-    let system_prompt = midtown::agents::coworker_system_prompt(&worktree_id, &repo_name);
+    let system_prompt = midtown::agents::coworker_system_prompt(&worktree_id, &repo_name, None);
     let prompt_file =
         std::env::temp_dir().join(format!("midtown-coworker-prompt-{}.md", std::process::id()));
     std::fs::write(&prompt_file, &system_prompt)

--- a/src/bin/midtown/cli/session.rs
+++ b/src/bin/midtown/cli/session.rs
@@ -824,7 +824,7 @@ pub(crate) fn build_attach_shell_command(
             midtown::agents::reviewer_system_prompt(name, &repo_name, &repo_name, provider, None)
         }
         midtown::launch::CoworkerRole::Coworker => {
-            midtown::agents::coworker_system_prompt(name, &repo_name)
+            midtown::agents::coworker_system_prompt(name, &repo_name, None)
         }
         midtown::launch::CoworkerRole::ChannelLead {
             channel_name,

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -542,9 +542,11 @@ impl LaunchConfig {
                 self.pr_number,
             ),
             CoworkerRole::Lead => crate::agents::main_lead_system_prompt(project_name),
-            CoworkerRole::Coworker => {
-                crate::agents::coworker_system_prompt(&self.name, project_name)
-            }
+            CoworkerRole::Coworker => crate::agents::coworker_system_prompt(
+                &self.name,
+                project_name,
+                self.channel.as_deref(),
+            ),
             CoworkerRole::ChannelLead {
                 channel_name,
                 domain_context,


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Replaced all literal `@channel-lead` strings in agent prompt files (`coworker.md`, `common.md`, `project-lead.md`) with `@{channel_lead}` template variable
- Added `channel_lead: Option<&str>` parameter to `coworker_system_prompt()` that resolves to the actual channel lead name
- Template resolution: coworker → channel name (via `LaunchConfig.channel`), reviewer → escalation target, lead → project name, channel lead → channel name
- Falls back to project name when no topic channel is assigned
- 100% diff coverage on changed lines

## Why
Coworkers and reviewers were posting literal `@channel-lead` in channel messages because the agent prompts contained raw `@channel-lead` text instead of template variables. This meant messages like `@channel-lead [Review Note]` appeared in channels instead of the actual lead name (e.g., `@ops`).

## Test plan
- [x] New tests for channel_lead substitution with explicit channel name
- [x] New test for channel_lead fallback to project_name when no channel
- [x] Existing agent tests updated and passing (42 tests)
- [x] No unreplaced `{channel_lead}` placeholders in any prompt
- [x] Clippy clean, fmt clean
- [x] 100% diff coverage

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)