### PR TITLE
feat: Add reviewer.complete workflow event [Midtown !2059]

### DIFF
--- a/sdk/python/midtown/default_workflow.py
+++ b/sdk/python/midtown/default_workflow.py
@@ -52,6 +52,7 @@ Side effects
 * ``pr.auto_merge``      — enable GitHub auto-merge (approved + CI green, no active reviewer)
 * ``pr.ci_passed``       — nudge author if in ``in_review`` or ``approved``: CI green, please merge;
                            retry reviewer spawn (gated by PR_REVIEW_DELAY_SECS age check)
+* ``reviewer.complete``  — nudge author: review is complete, please address feedback and merge
 * ``pr.merged``          — complete the associated task
 * ``coworker.idle``      — call ``daemon.check-pending`` so pending tasks start immediately;
                            also advance ``in_progress`` tasks to ``merged`` and call
@@ -329,6 +330,17 @@ def handle(event: dict, rpc: MidtownRPC, state: dict) -> None:  # noqa: C901
     elif event_type == "pr.merged" and task_id:
         # Mark the task done so downstream blocked tasks become unblocked.
         rpc.complete_task(task_id)
+
+    elif event_type == "reviewer.complete" and pr_number:
+        # A reviewer finished reviewing a PR.  Nudge the PR author so they
+        # address any feedback and merge when ready.
+        author = _get_task_data(state, task_id or "").get("pr_author", coworker)
+        if author:
+            rpc.nudge_coworker(
+                author,
+                f"Your PR #{pr_number} has a completed review — please address "
+                "any feedback and merge if appropriate.",
+            )
 
     elif event_type == "coworker.idle":
         # Coworker finished — dispatch pending tasks immediately so there's no

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -1452,7 +1452,7 @@ fn pr_action_to_effects(
     }
 
     // Fallback: inline effects for issue types without workflow events
-    // (ReviewComment, ReviewComplete, NeedsReview), PRs without channel/task
+    // (ReviewComment, NeedsReview), PRs without channel/task
     // associations, or channels without a configured workflow script.
     // When a workflow event exists, it's appended alongside inline effects.
     let mut effects = match action {
@@ -3322,7 +3322,64 @@ fn review_complete_action_to_effects(
     // Look up topic channel for this PR's task (falls back to main if not found)
     let channel = ctx.get_channel(pr_number);
 
-    match action {
+    // Build the workflow event (if task-linked with a channel).
+    let workflow_event = if let (Some(channel_name), Some(task_id)) =
+        (&channel, ctx.pr_task_associations.get(&pr_number))
+    {
+        Some(crate::workflow::WorkflowEvent::ReviewerComplete {
+            channel: channel_name.clone(),
+            task_id: task_id.clone(),
+            pr_number,
+        })
+    } else {
+        None
+    };
+
+    // When a workflow script exists AND we have a workflow event, the script is
+    // authoritative for simple nudge actions (NudgeOwner, SpawnOwner, PostToChannel):
+    // emit only cooldown tracking + the event. The script handles nudging via
+    // rpc.nudge_coworker().
+    //
+    // HandoffToCoworker is excluded: it involves spawning a different coworker with
+    // session context and task reassignment, which rpc.nudge_coworker() cannot
+    // replicate. Those effects fire alongside the workflow event instead.
+    if let Some(ref event) = workflow_event {
+        let is_handoff = matches!(action, PrAction::HandoffToCoworker { .. });
+
+        if !is_handoff {
+            let project_root = state.all_repo_paths.first().cloned().unwrap_or_default();
+            let has_script = channel.as_ref().is_some_and(|ch| {
+                crate::paths::workflow_script_for_channel(ch, &project_root, state.paths.dir_key())
+                    .is_some()
+            });
+
+            if has_script {
+                return vec![
+                    Effect::RecordPrNudge {
+                        pr_number,
+                        issue_type,
+                    },
+                    Effect::EmitWorkflowEvent(event.clone()),
+                ];
+            }
+        }
+    }
+
+    // Skip actions: no inline effects. Still emit the workflow event if one was
+    // built so the script's state machine stays in sync.
+    if let PrAction::Skip { reason } = &action {
+        debug!("{}", reason);
+        let mut effects = Vec::new();
+        if let Some(event) = workflow_event {
+            effects.push(Effect::EmitWorkflowEvent(event));
+        }
+        return effects;
+    }
+
+    // Fallback: inline effects for PRs without channel/task associations or
+    // channels without a configured workflow script. When a workflow event
+    // exists, it's appended alongside inline effects.
+    let mut effects = match action {
         PrAction::NudgeOwner { owner, message } => {
             vec![Effect::nudge_session_with_callbacks(
                 state.session_id_for_name(&owner),
@@ -3449,7 +3506,15 @@ fn review_complete_action_to_effects(
             debug!("{}", reason);
             vec![]
         }
+    };
+
+    // Append workflow event alongside inline effects (no-op if no script exists,
+    // but keeps the event available for future script adoption).
+    if let Some(event) = workflow_event {
+        effects.push(Effect::EmitWorkflowEvent(event));
     }
+
+    effects
 }
 
 // NOTE: process_pending_review_spawns and handle_ci_completion_for_review_spawn

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -22,6 +22,7 @@
 //! |-------|--------|
 //! | task | `task.created`, `task.assigned`, `task.completed` |
 //! | pr | `pr.opened`, `pr.approved`, `pr.changes_requested`, `pr.merged`, `pr.ci_passed`, `pr.ci_failed`, `pr.conflict`, `pr.auto_merge` |
+//! | reviewer | `reviewer.complete` |
 //! | coworker | `coworker.idle`, `coworker.stuck`, `coworker.message` |
 //! | channel | `channel.message` |
 //! | timer | `timer.tick` |
@@ -182,6 +183,18 @@ pub enum WorkflowEvent {
         pr_number: u64,
     },
 
+    /// A reviewer finished reviewing a PR.
+    ///
+    /// Emitted when `collect_reviewer_effects` detects a completed review on an
+    /// open PR. The workflow script can customise the author notification message
+    /// or add additional side effects (e.g. auto-merge gating, team pings).
+    #[serde(rename = "reviewer.complete")]
+    ReviewerComplete {
+        channel: String,
+        task_id: String,
+        pr_number: u64,
+    },
+
     // ── Coworker lifecycle ───────────────────────────────────────────────────
     /// A coworker finished its current turn and is now idle.
     ///
@@ -262,6 +275,7 @@ impl WorkflowEvent {
             | Self::PrCiFailed { channel, .. }
             | Self::PrConflict { channel, .. }
             | Self::PrAutoMerge { channel, .. }
+            | Self::ReviewerComplete { channel, .. }
             | Self::CoworkerIdle { channel, .. }
             | Self::CoworkerStuck { channel, .. }
             | Self::CoworkerMessage { channel, .. }
@@ -283,7 +297,8 @@ impl WorkflowEvent {
             | Self::PrCiPassed { task_id, .. }
             | Self::PrCiFailed { task_id, .. }
             | Self::PrConflict { task_id, .. }
-            | Self::PrAutoMerge { task_id, .. } => Some(task_id),
+            | Self::PrAutoMerge { task_id, .. }
+            | Self::ReviewerComplete { task_id, .. } => Some(task_id),
             Self::CoworkerIdle { task_id, .. }
             | Self::CoworkerStuck { task_id, .. }
             | Self::CoworkerMessage { task_id, .. } => task_id.as_deref(),

--- a/src/workflow_tests.rs
+++ b/src/workflow_tests.rs
@@ -150,8 +150,42 @@ fn test_pr_auto_merge_fields() {
 }
 
 #[test]
+fn test_reviewer_complete_type_field() {
+    let event = WorkflowEvent::ReviewerComplete {
+        channel: "proj-workflows".into(),
+        task_id: "42".into(),
+        pr_number: 123,
+    };
+    let json: serde_json::Value = serde_json::to_value(&event).unwrap();
+    assert_eq!(json["type"], "reviewer.complete");
+}
+
+#[test]
+fn test_reviewer_complete_fields() {
+    let event = WorkflowEvent::ReviewerComplete {
+        channel: "proj-workflows".into(),
+        task_id: "42".into(),
+        pr_number: 123,
+    };
+    let json: serde_json::Value = serde_json::to_value(&event).unwrap();
+    assert_eq!(json["channel"], "proj-workflows");
+    assert_eq!(json["task_id"], "42");
+    assert_eq!(json["pr_number"], 123);
+}
+
+#[test]
 fn test_pr_auto_merge_channel_accessor() {
     let event = WorkflowEvent::PrAutoMerge {
+        channel: "my-channel".into(),
+        task_id: "1".into(),
+        pr_number: 99,
+    };
+    assert_eq!(event.channel(), "my-channel");
+}
+
+#[test]
+fn test_reviewer_complete_channel_accessor() {
+    let event = WorkflowEvent::ReviewerComplete {
         channel: "my-channel".into(),
         task_id: "1".into(),
         pr_number: 99,
@@ -167,6 +201,16 @@ fn test_pr_auto_merge_task_id_accessor() {
         pr_number: 99,
     };
     assert_eq!(event.task_id(), Some("55"));
+}
+
+#[test]
+fn test_reviewer_complete_task_id_accessor() {
+    let event = WorkflowEvent::ReviewerComplete {
+        channel: "proj-workflows".into(),
+        task_id: "42".into(),
+        pr_number: 123,
+    };
+    assert_eq!(event.task_id(), Some("42"));
 }
 
 #[test]


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Add `reviewer.complete` WorkflowEvent variant emitted when a reviewer finishes reviewing a PR
- Apply the !2003 early-return pattern to `review_complete_action_to_effects`: when a workflow script exists, inline nudging is suppressed and the script handles author notification
- Handle the new event in `default_workflow.py` to nudge the PR author with a review-complete message
- Add serialization and accessor tests for the new variant

## Key changes
- `src/workflow.rs`: New `ReviewerComplete` variant with channel, task_id, pr_number fields
- `src/daemon/pr.rs`: Build and emit `reviewer.complete` event in `review_complete_action_to_effects`, with script-authoritative early return (HandoffToCoworker excluded, matching `pr_action_to_effects` pattern)
- `sdk/python/midtown/default_workflow.py`: Handle `reviewer.complete` event — nudge PR author to address feedback and merge
- `src/workflow_tests.rs`: 4 new tests for type field, field values, channel accessor, task_id accessor

## Test plan
- [x] All 76 workflow-related tests pass (including 4 new tests)
- [x] `cargo clippy` clean
- [x] `cargo build` succeeds

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)