### PR TITLE
feat: Emit coworker.stuck workflow event for dead processes and reviewers [Midtown !2057]

### DIFF
--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -629,6 +629,21 @@ pub fn check_and_restart_dead_reviewers(snap: &snapshot::WorldSnapshot) -> Vec<E
             restart.name, restart.pr_number, new_restart_count, MAX_REVIEWER_RESTARTS,
         );
 
+        // Emit a workflow event so channel scripts can react to the dead reviewer.
+        let reviewer_task_id = snap
+            .pr
+            .pr_task_associations
+            .get(&restart.pr_number)
+            .cloned();
+        let reviewer_channel = snap.channel_for_pr_or_default(restart.pr_number);
+        effects.push(Effect::EmitWorkflowEvent(
+            crate::workflow::WorkflowEvent::CoworkerStuck {
+                channel: reviewer_channel,
+                task_id: reviewer_task_id,
+                coworker: restart.name.clone(),
+            },
+        ));
+
         // Respawn the reviewer with an incremented restart count.
         effects.extend(build_reviewer_respawn_effects(
             snap,
@@ -1135,6 +1150,15 @@ pub(super) async fn check_and_respawn_dead_processes(
             .iter()
             .find(|t| t.id == respawn.task_id)
             .and_then(|t| t.channel.clone());
+
+        // Emit a workflow event so channel scripts can react to the dead process.
+        effects.push(Effect::EmitWorkflowEvent(
+            crate::workflow::WorkflowEvent::CoworkerStuck {
+                channel: channel.clone().unwrap_or_else(|| snap.repo_name.clone()),
+                task_id: Some(respawn.task_id.clone()),
+                coworker: respawn.name.clone(),
+            },
+        ));
 
         let mut config = crate::launch::LaunchConfig::coworker(
             respawn.name.clone(),

--- a/src/daemon/health_tests.rs
+++ b/src/daemon/health_tests.rs
@@ -3672,3 +3672,89 @@ fn test_stuck_reviewer_respawn_no_escalation_target_without_channel_lead() {
         "Respawned reviewer should have escalation_target=None when no channel lead exists"
     );
 }
+
+/// Dead reviewer respawn emits CoworkerStuck workflow event with PR task channel.
+#[test]
+fn test_dead_reviewer_respawn_emits_coworker_stuck_workflow_event() {
+    use crate::coworker::{Coworker, CoworkerStatus};
+
+    let now = chrono::Utc::now();
+    let mut snap = empty_snap();
+    snap.now_utc = now;
+
+    let pr_number = 55u64;
+    let task_id = "200";
+    let channel_name = "billing-feature";
+
+    snap.coworkers.active_coworkers.push(Coworker {
+        slot_id: uuid::Uuid::new_v4().to_string(),
+        name: "lexington".to_string(),
+        status: CoworkerStatus::Running,
+        working_dir: "/tmp/test".to_string(),
+        started_at: now - chrono::Duration::minutes(5),
+        current_task: None,
+        session_id: Some("sess-rev-200".to_string()),
+        model: "sonnet".to_string(),
+        provider: crate::auth::AuthProvider::Claude,
+        profile: crate::auth::DEFAULT_PROFILE.to_string(),
+    });
+
+    // Dead: process has exited
+    snap.health.headless_process_health.insert(
+        "lexington".to_string(),
+        snapshot::ProcessHealth {
+            is_alive: false,
+            last_event_at: Some(now - chrono::Duration::minutes(2)),
+            has_usage_limit: false,
+            usage_limit_reset_at: None,
+            has_api_error: false,
+            has_auth_error: false,
+            has_running_subagent: false,
+            has_pending_tool: false,
+            has_tool_name_conflict: false,
+            has_pending_api_call: false,
+            exit_code: Some(1),
+        },
+    );
+
+    // Reviewer assignment + not yet reviewed
+    snap.reviewer
+        .reviewer_pr_assignments
+        .insert("lexington".to_string(), pr_number);
+
+    // Session mapping
+    snap.name_session_map
+        .insert("lexington".to_string(), "sess-rev-200".to_string());
+
+    // PR → task → channel chain
+    snap.pr
+        .pr_task_associations
+        .insert(pr_number, task_id.to_string());
+    snap.task_channel
+        .insert(task_id.to_string(), channel_name.to_string());
+
+    let effects = check_and_restart_dead_reviewers(&snap);
+
+    let stuck_event = effects.iter().find_map(|e| {
+        if let Effect::EmitWorkflowEvent(crate::workflow::WorkflowEvent::CoworkerStuck {
+            channel,
+            task_id,
+            coworker,
+        }) = e
+        {
+            Some((channel.clone(), task_id.clone(), coworker.clone()))
+        } else {
+            None
+        }
+    });
+
+    assert!(
+        stuck_event.is_some(),
+        "Dead reviewer respawn should emit CoworkerStuck workflow event, got: {:#?}",
+        effects
+    );
+    let (ch, tid, cw) = stuck_event.unwrap();
+    assert_eq!(ch, channel_name);
+    assert_eq!(tid, Some(task_id.to_string()));
+    assert_eq!(cw, "lexington");
+}


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Emit `CoworkerStuck` workflow event in `check_and_respawn_dead_processes()` for crashed coworkers
- Emit `CoworkerStuck` workflow event in `check_and_restart_dead_reviewers()` for reviewers that exit without posting review
- Previously only stuck-but-alive coworkers/reviewers emitted this event; dead processes were invisible to the workflow script

## What changed

Two functions in `health.rs` were missing workflow event emission:

1. **`check_and_respawn_dead_processes`** — Coworker processes that crash (exit unexpectedly) while still having assigned tasks. Now emits `CoworkerStuck` before respawning, using the task's channel.

2. **`check_and_restart_dead_reviewers`** — Reviewer processes that exit without posting their review. Now emits `CoworkerStuck` before respawning, using the PR's task channel (via `channel_for_pr_or_default`).

Both follow the same pattern already used by `check_and_restart_stuck_coworkers` and `check_and_restart_stuck_reviewers`.

## Test plan
- [x] New test: `test_dead_reviewer_respawn_emits_coworker_stuck_workflow_event` — verifies dead reviewer respawn emits the event with correct channel/task/coworker
- [x] All 65 existing health tests pass
- [x] Clippy clean

Note: `check_and_respawn_dead_processes` is async and requires `DaemonState`, making unit testing harder. The code change follows the identical pattern as the existing `check_and_restart_stuck_coworkers` which is already tested.

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)