### PR TITLE
feat: Add pr.auto_merge workflow event [Midtown !2060]

### DIFF
--- a/sdk/python/midtown/__init__.py
+++ b/sdk/python/midtown/__init__.py
@@ -307,6 +307,25 @@ class MidtownRPC:
     # PR methods
     # ------------------------------------------------------------------
 
+    def enable_auto_merge(self, pr_number: int) -> Any:
+        """Enable GitHub auto-merge on a pull request.
+
+        Called by workflow scripts in response to a ``pr.auto_merge`` event.
+        The daemon already verified the PR is auto-mergeable before emitting
+        the event — this method triggers the actual ``gh pr merge --auto``
+        command.
+
+        Parameters
+        ----------
+        pr_number:
+            The GitHub PR number to auto-merge.
+
+        Returns
+        -------
+        A dict with a ``"message"`` key describing the outcome.
+        """
+        return self._call("pr.auto-merge", {"pr": pr_number})
+
     def spawn_reviewer(self, pr_number: int) -> Any:
         """Request the daemon to spawn a reviewer for a pull request.
 

--- a/sdk/python/midtown/default_workflow.py
+++ b/sdk/python/midtown/default_workflow.py
@@ -49,6 +49,7 @@ Side effects
 * ``pr.changes_requested``— nudge author: please address review feedback
 * ``pr.ci_failed``       — nudge author: CI failed, please investigate
 * ``pr.conflict``        — nudge author: merge conflict, please rebase
+* ``pr.auto_merge``      — enable GitHub auto-merge (approved + CI green, no active reviewer)
 * ``pr.ci_passed``       — nudge author if in ``in_review`` or ``approved``: CI green, please merge;
                            retry reviewer spawn (gated by PR_REVIEW_DELAY_SECS age check)
 * ``pr.merged``          — complete the associated task
@@ -272,6 +273,18 @@ def handle(event: dict, rpc: MidtownRPC, state: dict) -> None:  # noqa: C901
             rpc.nudge_coworker(
                 author,
                 f"PR #{pr_number} has a merge conflict — please rebase",
+            )
+
+    elif event_type == "pr.auto_merge" and pr_number:
+        # The daemon detected the PR is approved + CI green with no active
+        # reviewer.  Enable GitHub auto-merge.  Customise this handler to
+        # add extra gates (e.g. require a human approval) or to skip
+        # auto-merge entirely for specific PRs.
+        try:
+            rpc.enable_auto_merge(pr_number)
+        except Exception as exc:
+            rpc.post_to_channel(
+                f"⚠️ Failed to enable auto-merge for PR #{pr_number}: {exc}"
             )
 
     elif event_type == "pr.ci_passed" and pr_number:

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -1573,6 +1573,10 @@ struct StuckEvalContext<'a> {
     assigned_prs: HashSet<u64>,
     /// PR numbers with an active reviewer who hasn't finished their cached review.
     active_reviewer_prs: HashSet<u64>,
+    /// PR number → task ID mapping for workflow event routing.
+    pr_task_associations: HashMap<u64, String>,
+    /// Task ID → channel name mapping for workflow event routing.
+    task_channel: HashMap<String, String>,
 }
 
 /// Check for stuck conditions and return effects to nudge the lead.
@@ -1627,6 +1631,8 @@ async fn collect_stuck_condition_effects(
             .collect();
         let channel_lead_names = ps.channel_lead_names();
         let has_available_slots = state.has_available_coworker_slot(&channel_lead_names);
+        let pr_task_associations = ps.github.pr_to_task_map();
+        let task_channel = ps.task_channel.clone();
         StuckEvalContext {
             review_mode,
             branch_owners,
@@ -1636,6 +1642,8 @@ async fn collect_stuck_condition_effects(
             repo_name: &state.repo_name,
             assigned_prs: assigned,
             active_reviewer_prs: active_reviewers,
+            pr_task_associations,
+            task_channel,
         }
     };
 
@@ -1688,6 +1696,39 @@ async fn collect_stuck_condition_effects(
             nudge_count
         );
     }
+
+    // When a workflow script exists, replace AutoMergePr with EmitWorkflowEvent(PrAutoMerge)
+    // so the script controls whether to proceed with auto-merge.
+    let project_root = state.all_repo_paths.first().cloned().unwrap_or_default();
+    effects = effects
+        .into_iter()
+        .map(|effect| {
+            if let Effect::AutoMergePr { pr_number, .. } = &effect {
+                let pr_number = *pr_number;
+                // Look up PR → task → channel
+                if let Some(task_id) = ctx.pr_task_associations.get(&pr_number)
+                    && let Some(channel) = ctx.task_channel.get(task_id)
+                {
+                    let has_script = crate::paths::workflow_script_for_channel(
+                        channel,
+                        &project_root,
+                        &state.repo_name,
+                    )
+                    .is_some();
+                    if has_script {
+                        return Effect::EmitWorkflowEvent(
+                            crate::workflow::WorkflowEvent::PrAutoMerge {
+                                channel: channel.clone(),
+                                task_id: task_id.clone(),
+                                pr_number,
+                            },
+                        );
+                    }
+                }
+            }
+            effect
+        })
+        .collect();
 
     effects
 }

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -4298,6 +4298,144 @@ async fn auto_merge_fires_when_reviewer_assigned_but_review_cached() {
     );
 }
 
+// ── AutoMergePr workflow event authority tests ──────────────────────────────
+
+/// When a workflow script exists and a PR is associated with a task/channel,
+/// AutoMergePr should be replaced with EmitWorkflowEvent(PrAutoMerge).
+/// This lets the script control auto-merge behavior.
+#[tokio::test]
+async fn auto_merge_emits_workflow_event_when_script_exists() {
+    let (state, _tmp, _guard) = make_test_state("test-repo");
+    let pr_number = 42u64;
+    let task_id = "100";
+    let channel = "proj-workflows";
+
+    // Set up PR → task → channel routing and install workflow script
+    {
+        let mut ps = state.persistent_state.lock().await;
+        ps.github.store_pr_author_session(
+            pr_number,
+            "session-1",
+            "lexington/some-feature",
+            "lexington",
+            &format!("feat: some feature [Midtown !{task_id}]"),
+        );
+        ps.task_channel
+            .insert(task_id.to_string(), channel.to_string());
+    }
+    install_workflow_script(&state);
+
+    let pr_json = json!({
+        "number": pr_number,
+        "title": format!("feat: some feature [Midtown !{task_id}]"),
+        "headRefName": "lexington/some-feature",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [{"conclusion": "SUCCESS"}],
+        "reviewDecision": "APPROVED",
+        "isDraft": false,
+        "createdAt": "2026-01-01T00:00:00Z",
+    });
+
+    let reviewed_prs = std::collections::HashSet::new();
+    let branch_owners = std::collections::HashMap::new();
+    let review_mode = crate::config::ReviewMode::Local;
+
+    let effects = collect_stuck_condition_effects(
+        &state,
+        &[pr_json],
+        &reviewed_prs,
+        &branch_owners,
+        review_mode,
+    )
+    .await;
+
+    // AutoMergePr should NOT be present (replaced by workflow event)
+    let has_auto_merge = effects
+        .iter()
+        .any(|e| matches!(e, Effect::AutoMergePr { .. }));
+    assert!(
+        !has_auto_merge,
+        "AutoMergePr should be replaced by EmitWorkflowEvent when workflow script exists. \
+         Got: {:?}",
+        effects
+    );
+
+    // EmitWorkflowEvent(PrAutoMerge) should be present
+    let workflow_events = extract_workflow_events(&effects);
+    let has_pr_auto_merge = workflow_events.iter().any(|e| {
+        matches!(
+            e,
+            crate::workflow::WorkflowEvent::PrAutoMerge { pr_number: 42, .. }
+        )
+    });
+    assert!(
+        has_pr_auto_merge,
+        "EmitWorkflowEvent(PrAutoMerge) should be emitted when workflow script exists. \
+         Workflow events: {:?}",
+        workflow_events
+    );
+}
+
+/// Without a workflow script, AutoMergePr should fire as before (inline effect).
+/// This test complements auto_merge_fires_when_no_reviewer by explicitly setting
+/// up PR → task → channel routing WITHOUT a workflow script.
+#[tokio::test]
+async fn auto_merge_fires_inline_when_no_workflow_script() {
+    let (state, _tmp, _guard) = make_test_state("test-repo");
+    let pr_number = 42u64;
+    let task_id = "100";
+    let channel = "proj-workflows";
+
+    // Set up PR → task → channel routing but NO workflow script
+    {
+        let mut ps = state.persistent_state.lock().await;
+        ps.github.store_pr_author_session(
+            pr_number,
+            "session-1",
+            "lexington/some-feature",
+            "lexington",
+            &format!("feat: some feature [Midtown !{task_id}]"),
+        );
+        ps.task_channel
+            .insert(task_id.to_string(), channel.to_string());
+    }
+    // Note: NO install_workflow_script() call
+
+    let pr_json = json!({
+        "number": pr_number,
+        "title": format!("feat: some feature [Midtown !{task_id}]"),
+        "headRefName": "lexington/some-feature",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [{"conclusion": "SUCCESS"}],
+        "reviewDecision": "APPROVED",
+        "isDraft": false,
+        "createdAt": "2026-01-01T00:00:00Z",
+    });
+
+    let reviewed_prs = std::collections::HashSet::new();
+    let branch_owners = std::collections::HashMap::new();
+    let review_mode = crate::config::ReviewMode::Local;
+
+    let effects = collect_stuck_condition_effects(
+        &state,
+        &[pr_json],
+        &reviewed_prs,
+        &branch_owners,
+        review_mode,
+    )
+    .await;
+
+    let has_auto_merge = effects
+        .iter()
+        .any(|e| matches!(e, Effect::AutoMergePr { .. }));
+    assert!(
+        has_auto_merge,
+        "AutoMergePr should fire as inline effect when no workflow script exists. \
+         Got: {:?}",
+        effects
+    );
+}
+
 // ── Reviewer channel routing tests ──────────────────────────────────────────
 
 /// Reviewers should inherit the topic channel of the PR's associated task.

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -422,6 +422,13 @@ async fn dispatch_request(request: Request, state: &DaemonState) -> Response {
             super::rpc_prs::handle_pr_merge(request.id, pr_number, state).await
         }
 
+        "pr.auto-merge" => {
+            let Some(pr_number) = params.u64_param("pr") else {
+                return Response::error(request.id, RpcError::invalid_params());
+            };
+            super::rpc_prs::handle_pr_auto_merge(request.id, pr_number, state).await
+        }
+
         "pr.review-post" => {
             let Some(pr_number) = params.u64_param("pr") else {
                 return Response::error(request.id, RpcError::invalid_params());

--- a/src/daemon/rpc_prs.rs
+++ b/src/daemon/rpc_prs.rs
@@ -894,6 +894,56 @@ pub(super) async fn handle_pr_merge(
     )
 }
 
+/// Enable GitHub auto-merge on a PR.
+///
+/// Called by workflow scripts in response to a `pr.auto_merge` event.
+/// The daemon already verified the PR is auto-mergeable (approved + CI green,
+/// no active reviewer) before emitting the event, so this handler only needs
+/// to execute the merge effect.
+///
+/// Unlike `handle_pr_merge` (which enforces review/CI/feedback gates for
+/// coworker-initiated merges), this is a lightweight path for the daemon's
+/// proactive auto-merge behavior exposed to workflow scripts.
+pub(super) async fn handle_pr_auto_merge(
+    id: RequestId,
+    pr_number: u64,
+    state: &DaemonState,
+) -> Response {
+    info!(
+        "Auto-merge requested for PR #{} (via workflow script)",
+        pr_number
+    );
+
+    // Fetch the PR title for the merge message
+    let title = match fetch_pr_title(pr_number, state).await {
+        Ok(t) => t,
+        Err(msg) => return Response::error(id, RpcError::new(-32603, msg)),
+    };
+
+    let effects = vec![super::effects::Effect::AutoMergePr {
+        pr_number,
+        title: title.clone(),
+    }];
+    super::effects::execute_effects(effects, state).await;
+
+    Response::success(
+        id,
+        serde_json::json!({
+            "message": format!("Auto-merge enabled for PR #{} ({})", pr_number, title)
+        }),
+    )
+}
+
+/// Fetch just the PR title for auto-merge messages.
+async fn fetch_pr_title(pr_number: u64, state: &DaemonState) -> Result<String, String> {
+    let pr_data = fetch_pr_for_merge(pr_number, state).await?;
+    Ok(pr_data
+        .get("title")
+        .and_then(|t| t.as_str())
+        .unwrap_or("untitled")
+        .to_string())
+}
+
 /// Fetch PR data needed for merge gate checks.
 ///
 /// Retrieves title, state, CI status, comments, mergeable status, and

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -21,7 +21,7 @@
 //! | Group | Events |
 //! |-------|--------|
 //! | task | `task.created`, `task.assigned`, `task.completed` |
-//! | pr | `pr.opened`, `pr.approved`, `pr.changes_requested`, `pr.merged`, `pr.ci_passed`, `pr.ci_failed`, `pr.conflict` |
+//! | pr | `pr.opened`, `pr.approved`, `pr.changes_requested`, `pr.merged`, `pr.ci_passed`, `pr.ci_failed`, `pr.conflict`, `pr.auto_merge` |
 //! | coworker | `coworker.idle`, `coworker.stuck`, `coworker.message` |
 //! | channel | `channel.message` |
 //! | timer | `timer.tick` |
@@ -170,6 +170,18 @@ pub enum WorkflowEvent {
         pr_number: u64,
     },
 
+    /// A PR is eligible for auto-merge (approved + CI green, no active reviewer).
+    ///
+    /// Emitted from the stuck-PR detection path when `is_auto_mergeable()` returns
+    /// true. When a workflow script handles this event, the script decides whether
+    /// to proceed with auto-merge (via `pr.auto-merge` RPC) or block it.
+    #[serde(rename = "pr.auto_merge")]
+    PrAutoMerge {
+        channel: String,
+        task_id: String,
+        pr_number: u64,
+    },
+
     // ── Coworker lifecycle ───────────────────────────────────────────────────
     /// A coworker finished its current turn and is now idle.
     ///
@@ -249,6 +261,7 @@ impl WorkflowEvent {
             | Self::PrCiPassed { channel, .. }
             | Self::PrCiFailed { channel, .. }
             | Self::PrConflict { channel, .. }
+            | Self::PrAutoMerge { channel, .. }
             | Self::CoworkerIdle { channel, .. }
             | Self::CoworkerStuck { channel, .. }
             | Self::CoworkerMessage { channel, .. }
@@ -269,7 +282,8 @@ impl WorkflowEvent {
             | Self::PrMerged { task_id, .. }
             | Self::PrCiPassed { task_id, .. }
             | Self::PrCiFailed { task_id, .. }
-            | Self::PrConflict { task_id, .. } => Some(task_id),
+            | Self::PrConflict { task_id, .. }
+            | Self::PrAutoMerge { task_id, .. } => Some(task_id),
             Self::CoworkerIdle { task_id, .. }
             | Self::CoworkerStuck { task_id, .. }
             | Self::CoworkerMessage { task_id, .. } => task_id.as_deref(),

--- a/src/workflow_tests.rs
+++ b/src/workflow_tests.rs
@@ -126,6 +126,50 @@ fn test_pr_conflict_type_field() {
 }
 
 #[test]
+fn test_pr_auto_merge_type_field() {
+    let event = WorkflowEvent::PrAutoMerge {
+        channel: "proj-workflows".into(),
+        task_id: "42".into(),
+        pr_number: 123,
+    };
+    let json: serde_json::Value = serde_json::to_value(&event).unwrap();
+    assert_eq!(json["type"], "pr.auto_merge");
+}
+
+#[test]
+fn test_pr_auto_merge_fields() {
+    let event = WorkflowEvent::PrAutoMerge {
+        channel: "proj-workflows".into(),
+        task_id: "42".into(),
+        pr_number: 123,
+    };
+    let json: serde_json::Value = serde_json::to_value(&event).unwrap();
+    assert_eq!(json["channel"], "proj-workflows");
+    assert_eq!(json["task_id"], "42");
+    assert_eq!(json["pr_number"], 123);
+}
+
+#[test]
+fn test_pr_auto_merge_channel_accessor() {
+    let event = WorkflowEvent::PrAutoMerge {
+        channel: "my-channel".into(),
+        task_id: "1".into(),
+        pr_number: 99,
+    };
+    assert_eq!(event.channel(), "my-channel");
+}
+
+#[test]
+fn test_pr_auto_merge_task_id_accessor() {
+    let event = WorkflowEvent::PrAutoMerge {
+        channel: "my-channel".into(),
+        task_id: "55".into(),
+        pr_number: 99,
+    };
+    assert_eq!(event.task_id(), Some("55"));
+}
+
+#[test]
 fn test_coworker_idle_type_field() {
     let event = WorkflowEvent::CoworkerIdle {
         channel: "proj-workflows".into(),


### PR DESCRIPTION
<!-- midtown: york -->

## Summary

- Add `pr.auto_merge` WorkflowEvent variant emitted when a PR is eligible for auto-merge (approved + CI green, no active reviewer)
- When a workflow script exists, replaces inline `AutoMergePr` effect with `EmitWorkflowEvent(PrAutoMerge)` — making auto-merge script-authoritative
- Add `pr.auto-merge` RPC handler so workflow scripts can trigger auto-merge via `rpc.enable_auto_merge(pr_number)`
- Add handler in `default_workflow.py` that replicates the compiled-in behavior

## Design

The auto-merge path lives in `merge_ready_scenario()` within the stuck-PR detection loop (`collect_stuck_condition_effects`). Since this function is synchronous and doesn't have channel/task context, the workflow authority check is done as a post-processing step: after the per-PR loop, any `AutoMergePr` effects are replaced with `EmitWorkflowEvent(PrAutoMerge)` when a workflow script exists for the PR's channel.

This follows the same authority pattern established in !2003 for other PR lifecycle events, but adapted for the stuck-condition detection path rather than `pr_action_to_effects`.

## Test plan

- [x] `test_pr_auto_merge_type_field` — serializes as `"pr.auto_merge"`
- [x] `test_pr_auto_merge_fields` — includes channel, task_id, pr_number
- [x] `test_pr_auto_merge_channel_accessor` — `channel()` returns correct value
- [x] `test_pr_auto_merge_task_id_accessor` — `task_id()` returns `Some(id)`
- [x] `auto_merge_emits_workflow_event_when_script_exists` — replaces `AutoMergePr` with `EmitWorkflowEvent(PrAutoMerge)` when workflow script present
- [x] `auto_merge_fires_inline_when_no_workflow_script` — `AutoMergePr` fires as before without script
- [x] Existing auto-merge tests continue passing (reviewer gate, cached review bypass)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)