### PR TITLE
fix: Add w-full to TaskRow button for proper width [Midtown !2061]

### DIFF
--- a/web-app/src/lib/TaskRow.svelte
+++ b/web-app/src/lib/TaskRow.svelte
@@ -78,7 +78,7 @@
 </script>
 
 <button
-  class="task-row flex items-stretch gap-1.5 py-[5px] cursor-pointer transition-[background] duration-100 text-left font-mono text-[0.72rem] leading-[1.3] text-muted-foreground {isCard ? 'border border-[hsl(var(--border))] bg-[hsl(var(--card))] mb-2 hover:bg-[hsl(var(--accent)_/_0.3)] pr-3 rounded-md' : 'border-none bg-transparent pr-0 rounded-[5px] hover:bg-sidebar-accent'} {isActive ? 'text-sidebar-foreground' : ''} {isBlocked ? 'opacity-65' : ''}"
+  class="task-row w-full flex items-stretch gap-1.5 py-[5px] cursor-pointer transition-[background] duration-100 text-left font-mono text-[0.72rem] leading-[1.3] text-muted-foreground {isCard ? 'border border-[hsl(var(--border))] bg-[hsl(var(--card))] mb-2 hover:bg-[hsl(var(--accent)_/_0.3)] pr-3 rounded-md' : 'border-none bg-transparent pr-0 rounded-[5px] hover:bg-sidebar-accent'} {isActive ? 'text-sidebar-foreground' : ''} {isBlocked ? 'opacity-65' : ''}"
   onclick={isCard ? undefined : onclick}
   data-testid={isCard ? 'task-card' : undefined}
 >


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Added `w-full` to the TaskRow `<button>` element so it always fills its parent container width
- **Fixes TaskCard width**: In the thread panel, the card variant now stretches to the full pane width instead of collapsing to the width of the title text
- **Fixes blocker clipping**: In the sidebar, the button now properly constrains to parent width, so the title text truncates (via existing `text-ellipsis`) before the blocker indicator (`⧗ !N`) overflows off-screen

## Why this works
HTML `<button>` elements don't auto-stretch in flex containers like `<div>` does — they shrink-wrap their content by default. Adding `width: 100%` forces the button to fill its parent, which means the inner flex row's `min-w-0` / `overflow-hidden` / `text-ellipsis` on the title span can actually kick in.

## Test plan
- [x] Verified the single-line diff is correct
- [x] Pre-commit hooks pass (clippy + fmt)
- [ ] Visual verification of both variants (card in thread panel, row in sidebar)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)