### PR TITLE
fix: Use project_name instead of removed repo_name field in health.rs

### DIFF
--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -1154,7 +1154,7 @@ pub(super) async fn check_and_respawn_dead_processes(
         // Emit a workflow event so channel scripts can react to the dead process.
         effects.push(Effect::EmitWorkflowEvent(
             crate::workflow::WorkflowEvent::CoworkerStuck {
-                channel: channel.clone().unwrap_or_else(|| snap.repo_name.clone()),
+                channel: channel.clone().unwrap_or_else(|| snap.project_name.clone()),
                 task_id: Some(respawn.task_id.clone()),
                 coworker: respawn.name.clone(),
             },


### PR DESCRIPTION
<!-- midtown: midtown -->

## Summary

- Fixes compilation failure on main caused by `snap.repo_name` reference in `health.rs:1157`
- PR #1788 (Emit coworker.stuck workflow event) added code using `snap.repo_name`, but the field was renamed to `project_name`/`dir_key` in the earlier PR #1793 (Separate project_name from dir_key)
- The merge didn't catch this because it was a semantic clash, not a textual conflict — the code compiled against pre-refactor code but failed after both merged to main

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes locally
- [ ] CI passes (all E2E tests were failing due to this compilation error)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)