### PR TITLE
feat: Auto-track threads in sidebar when someone replies to your message [Midtown !2071]

### DIFF
--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -662,11 +662,13 @@ export function handleUpdate(update) {
         if (msg.from !== 'user' && msg.from !== get(userSenderName)) {
           // Auto-track: if the parent message was sent by the user, track
           // the thread in the sidebar so the user sees replies to their messages.
+          // Pass undefined for replyCount so trackThread initializes to 0 for new
+          // entries (or preserves existing) — the update block below handles the +1.
           const channelMsgs = get(messagesByChannel)[channelName]
           const parentMsg = channelMsgs?.find((m) => m.id === msg.thread_parent_id)
           const uName = get(userSenderName)
           if (parentMsg && (parentMsg.from === 'user' || parentMsg.from === uName)) {
-            trackThread(msg.thread_parent_id, channelName, parentMsg.content, parentMsg.reply_count)
+            trackThread(msg.thread_parent_id, channelName, parentMsg.content)
           }
 
           const tracked = get(trackedThreads)

--- a/web-app/src/lib/api.test.js
+++ b/web-app/src/lib/api.test.js
@@ -1106,6 +1106,38 @@ describe('handleUpdate — auto-track threads when someone replies to user messa
     expect(tracked[parentId]).toBeTruthy()
     expect(tracked[parentId].channelName).toBe('web')
     expect(tracked[parentId].subject).toContain('my question about auth')
+    // replyCount should match the parent's reply_count (1 after the WS handler
+    // incremented it), not double-count from the subsequent update block.
+    expect(tracked[parentId].replyCount).toBe(1)
+  })
+
+  it('does not double-count replyCount on first auto-tracked reply', () => {
+    // Send two replies — replyCount should be exactly 2, not 3 or 4
+    handleUpdate({
+      type: 'channel_message',
+      data: {
+        id: 'reply-a',
+        from: 'coworker',
+        content: 'first reply',
+        channel: 'web',
+        thread_parent_id: parentId,
+        timestamp: '2026-01-01T00:00:00Z',
+      },
+    })
+    handleUpdate({
+      type: 'channel_message',
+      data: {
+        id: 'reply-b',
+        from: 'coworker',
+        content: 'second reply',
+        channel: 'web',
+        thread_parent_id: parentId,
+        timestamp: '2026-01-01T00:00:01Z',
+      },
+    })
+
+    const tracked = get(trackedThreads)
+    expect(tracked[parentId].replyCount).toBe(2)
   })
 
   it('increments unread count on the first auto-tracked reply', () => {


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- When a WebSocket thread reply arrives from someone other than the user, the handler now checks if the parent message was sent by the user (matching both `'user'` and the configured `userSenderName`)
- If so, calls `trackThread()` to auto-add the thread to the sidebar, so the user sees replies to their messages without needing to manually open the thread first
- Respects `dismissedThreads` — previously dismissed threads won't reappear
- The first auto-tracked reply also increments the unread badge (placement ensures `trackThread()` runs before the unread count check)

## Key changes
- `web-app/src/lib/api.js` (lines 663-670): Added parent message lookup and `trackThread()` call in the WS thread reply handler
- `web-app/src/lib/api.test.js`: Added 6 tests covering auto-tracking, unread increment, non-user parent messages, self-replies, dismissed threads, and custom display names

## Test plan
- [x] All 57 tests pass (`vitest run src/lib/api.test.js`)
- [x] Pre-commit hooks pass (clippy + fmt)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)