### PR TITLE
fix: Detect and reinstall orphaned Claude Code plugins [Midtown !2070]

### DIFF
--- a/src/platform_launch.rs
+++ b/src/platform_launch.rs
@@ -89,6 +89,9 @@ fn ensure_claude_plugins_installed() -> Result<(), String> {
     eprintln!("Installing {} required Claude plugin(s)...", missing.len());
     for plugin in missing {
         eprint!("  Installing {}... ", plugin);
+        // Uninstall first to clear stale/orphaned entries from installed_plugins.json,
+        // then reinstall fresh. Ignoring uninstall errors (plugin may not be registered).
+        let _ = uninstall_plugin(plugin);
         match install_plugin(plugin) {
             Ok(()) => eprintln!("done"),
             Err(e) => eprintln!("failed: {}", e),
@@ -121,6 +124,47 @@ fn ensure_marketplace_configured() -> Result<(), String> {
     Ok(())
 }
 
+/// Filter plugin list entries to only those with healthy, loadable installations.
+///
+/// Excludes plugins that are orphaned (`.orphaned_at` marker) or missing their
+/// plugin manifest. This causes `ensure_claude_plugins_installed()` to reinstall
+/// them instead of silently accepting broken installations.
+fn filter_healthy_plugins(plugins: &[serde_json::Value]) -> HashSet<String> {
+    plugins
+        .iter()
+        .filter_map(|p| {
+            let id = p.get("id").and_then(|id| id.as_str())?;
+            let install_path = p.get("installPath").and_then(|p| p.as_str())?;
+            let path = Path::new(install_path);
+
+            // Skip plugins whose installation is orphaned or missing content.
+            // Claude Code's plugin auto-updater can mark cached versions as orphaned
+            // (via .orphaned_at marker), stripping their content. Cross-profile
+            // references in installed_plugins.json may point to these stale paths.
+            if path.join(".orphaned_at").exists() {
+                eprintln!(
+                    "Warning: Plugin {} has orphaned installation at {}, will reinstall",
+                    id, install_path
+                );
+                return None;
+            }
+
+            // Verify the plugin has actual content (plugin manifest exists)
+            if !path.join(".claude-plugin").join("plugin.json").exists()
+                && !path.join("plugin.json").exists()
+            {
+                eprintln!(
+                    "Warning: Plugin {} is missing plugin manifest at {}, will reinstall",
+                    id, install_path
+                );
+                return None;
+            }
+
+            Some(id.to_string())
+        })
+        .collect()
+}
+
 fn get_installed_plugins() -> Result<std::collections::HashSet<String>, String> {
     let output = std::process::Command::new("claude")
         .args(["plugin", "list", "--json"])
@@ -143,10 +187,19 @@ fn get_installed_plugins() -> Result<std::collections::HashSet<String>, String> 
     let plugins: Vec<serde_json::Value> = serde_json::from_str(trimmed)
         .map_err(|e| format!("Failed to parse plugin list JSON: {}", e))?;
 
-    Ok(plugins
-        .iter()
-        .filter_map(|p| p.get("id").and_then(|id| id.as_str()).map(String::from))
-        .collect())
+    Ok(filter_healthy_plugins(&plugins))
+}
+
+fn uninstall_plugin(name: &str) -> Result<(), String> {
+    let output = std::process::Command::new("claude")
+        .args(["plugin", "uninstall", name])
+        .output()
+        .map_err(|e| format!("Failed to run claude plugin uninstall: {}", e))?;
+
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+    Ok(())
 }
 
 fn install_plugin(name: &str) -> Result<(), String> {

--- a/src/platform_launch_tests.rs
+++ b/src/platform_launch_tests.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
@@ -75,4 +76,122 @@ fn test_sync_directory_with_cleanup_noop_when_paths_match() {
         fs::read_to_string(shared.join("skill/SKILL.md")).unwrap(),
         "content"
     );
+}
+
+#[test]
+fn test_filter_healthy_plugins_accepts_valid_claude_plugin() {
+    let tmp = tempfile::tempdir().unwrap();
+    let plugin_dir = tmp.path().join("superpowers/1.0.0");
+    write_file(
+        &plugin_dir.join(".claude-plugin/plugin.json"),
+        r#"{"name":"superpowers"}"#,
+    );
+
+    let plugins = vec![serde_json::json!({
+        "id": "superpowers@official",
+        "installPath": plugin_dir.to_str().unwrap()
+    })];
+
+    let result = super::filter_healthy_plugins(&plugins);
+    assert_eq!(result, HashSet::from(["superpowers@official".to_string()]));
+}
+
+#[test]
+fn test_filter_healthy_plugins_accepts_root_plugin_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    let plugin_dir = tmp.path().join("my-plugin/1.0.0");
+    write_file(&plugin_dir.join("plugin.json"), r#"{"name":"my-plugin"}"#);
+
+    let plugins = vec![serde_json::json!({
+        "id": "my-plugin@mp",
+        "installPath": plugin_dir.to_str().unwrap()
+    })];
+
+    let result = super::filter_healthy_plugins(&plugins);
+    assert_eq!(result, HashSet::from(["my-plugin@mp".to_string()]));
+}
+
+#[test]
+fn test_filter_healthy_plugins_rejects_orphaned_installation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let plugin_dir = tmp.path().join("superpowers/4.3.1");
+    write_file(
+        &plugin_dir.join(".claude-plugin/plugin.json"),
+        r#"{"name":"superpowers"}"#,
+    );
+    // Add orphaned marker
+    write_file(&plugin_dir.join(".orphaned_at"), "1772752997808");
+
+    let plugins = vec![serde_json::json!({
+        "id": "superpowers@official",
+        "installPath": plugin_dir.to_str().unwrap()
+    })];
+
+    let result = super::filter_healthy_plugins(&plugins);
+    assert!(
+        result.is_empty(),
+        "Orphaned plugin should be excluded: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_filter_healthy_plugins_rejects_missing_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    let plugin_dir = tmp.path().join("superpowers/4.3.1");
+    // Only LICENSE, no plugin manifest
+    write_file(&plugin_dir.join("LICENSE"), "MIT");
+
+    let plugins = vec![serde_json::json!({
+        "id": "superpowers@official",
+        "installPath": plugin_dir.to_str().unwrap()
+    })];
+
+    let result = super::filter_healthy_plugins(&plugins);
+    assert!(
+        result.is_empty(),
+        "Plugin without manifest should be excluded: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_filter_healthy_plugins_skips_entries_without_install_path() {
+    let plugins = vec![serde_json::json!({
+        "id": "no-path@official"
+    })];
+
+    let result = super::filter_healthy_plugins(&plugins);
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_filter_healthy_plugins_mixed_healthy_and_orphaned() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Healthy plugin
+    let healthy_dir = tmp.path().join("code-review/1.0.0");
+    write_file(
+        &healthy_dir.join(".claude-plugin/plugin.json"),
+        r#"{"name":"code-review"}"#,
+    );
+
+    // Orphaned plugin
+    let orphaned_dir = tmp.path().join("superpowers/4.3.1");
+    write_file(&orphaned_dir.join("LICENSE"), "MIT");
+    write_file(&orphaned_dir.join(".orphaned_at"), "1772752997808");
+
+    let plugins = vec![
+        serde_json::json!({
+            "id": "code-review@official",
+            "installPath": healthy_dir.to_str().unwrap()
+        }),
+        serde_json::json!({
+            "id": "superpowers@official",
+            "installPath": orphaned_dir.to_str().unwrap()
+        }),
+    ];
+
+    let result = super::filter_healthy_plugins(&plugins);
+    assert_eq!(result, HashSet::from(["code-review@official".to_string()]));
 }


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary

- **Root cause found**: Headless sessions (coworkers/channel leads) don't have superpowers because their plugin installation is orphaned — Claude Code's auto-updater marks old cached versions with `.orphaned_at` and strips their content (skills, hooks, commands). The `installed_plugins.json` still references these stale paths, so `ensure_claude_plugins_installed()` thinks the plugin is already installed and skips reinstallation.
- **Fix**: Extract `filter_healthy_plugins()` to validate each plugin's installation integrity before considering it "installed". Checks for `.orphaned_at` marker and verifies the plugin manifest exists. When broken plugins are found, uninstall first (to clear stale registry) then reinstall fresh.

### Investigation findings

1. Superpowers works via a **SessionStart hook** that injects context into Claude's conversation, not via standard skill registration
2. The midtown auth profile's `installed_plugins.json` referenced a superpowers install path at `~/.midtown/auth/claude@quotably.com/claude/plugins/cache/` which had an `.orphaned_at` marker
3. The orphaned directory only contained LICENSE and RELEASE-NOTES.md — no skills/, hooks/, or .claude-plugin/plugin.json
4. Adding `user` to `--setting-sources` does NOT fix the issue (tested empirically)
5. The `CLAUDE_PLUGIN_SYNC_OK` atomic bool prevented re-detection after the first process-level check

### What this does NOT fix

The underlying cross-profile plugin path sharing (where one profile's `installed_plugins.json` references another profile's cache) is a deeper architectural issue. This fix detects the symptom (orphaned installations) and recovers by reinstalling.

## Test plan

- [x] 6 unit tests for `filter_healthy_plugins()` covering: valid plugins (both manifest locations), orphaned plugins, missing manifests, entries without install paths, and mixed healthy/orphaned sets
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- **Note**: `uninstall_plugin()` and `install_plugin()` are thin CLI wrappers (`std::process::Command` calling `claude plugin uninstall/install`) — not unit-testable without mocking the CLI. The uninstall-before-reinstall flow would require E2E testing with real plugin state.

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)