### PR TITLE
fix: Preserve fork initial_prompt across crash recovery [Midtown !2073]

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -574,6 +574,10 @@ pub enum Effect {
         working_dir: Option<String>,
         auth_provider: crate::auth::AuthProvider,
         is_channel_lead: bool,
+        /// The original nudge message from when the fork was first created.
+        /// When present, crash recovery resends this instead of generic framing,
+        /// so the respawned fork retains context about what it was supposed to do.
+        initial_prompt: Option<String>,
     },
 }
 
@@ -3062,6 +3066,7 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 working_dir,
                 auth_provider,
                 is_channel_lead,
+                initial_prompt,
             } => {
                 respawn_fork(
                     state,
@@ -3071,6 +3076,7 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                     working_dir.as_deref(),
                     auth_provider,
                     is_channel_lead,
+                    initial_prompt.as_deref(),
                 )
                 .await;
             }
@@ -3581,6 +3587,7 @@ fn auto_detach_suffix_message(
 /// Builds a fresh fork HeadlessConfig (no parent resume), spawns it via
 /// SessionManager, and re-establishes the topic_sessions and reverse-map
 /// bindings so the thread continues routing to the new fork.
+#[allow(clippy::too_many_arguments)]
 async fn respawn_fork(
     state: &DaemonState,
     fork_name: &str,
@@ -3589,6 +3596,7 @@ async fn respawn_fork(
     working_dir: Option<&str>,
     auth_provider: crate::auth::AuthProvider,
     is_channel_lead: bool,
+    initial_prompt: Option<&str>,
 ) {
     // Build a fork config. We pass an empty calling_session_id and override
     // resume_session_id to None — crash recovery spawns fresh, not from parent.
@@ -3640,7 +3648,7 @@ async fn respawn_fork(
                 working_dir: working_dir.unwrap_or_default().to_string(),
                 branch: None,
                 pr_number: None,
-                initial_prompt: None,
+                initial_prompt: initial_prompt.map(String::from),
                 is_reviewer: false,
                 coworker_type: if is_channel_lead {
                     "channel-lead".to_string()
@@ -3702,7 +3710,16 @@ async fn respawn_fork(
     // Send an initial nudge so the fork has a message to act on.
     // Without this, the fork session sits idle forever with no initial prompt
     // (same issue as the original fork creation path — see rpc_session.rs).
-    let nudge_message = if is_channel_lead {
+    //
+    // Priority: preserved initial_prompt (from the original fork) > generic framing.
+    // This ensures crash-recovered forks retain context about their original task
+    // instead of getting confused by generic "crash recovery" framing.
+    let nudge_message = if let Some(prompt) = initial_prompt {
+        Some(format!(
+            "{}\n\n(This is a crash recovery session — the previous fork for this thread exited unexpectedly.)",
+            prompt
+        ))
+    } else if is_channel_lead {
         channel
             .map(|ch| {
                 format!(

--- a/src/daemon/effects_tests.rs
+++ b/src/daemon/effects_tests.rs
@@ -1673,3 +1673,59 @@ async fn test_post_pr_comment_parses_bare_numeric_url() {
         );
     }
 }
+
+// ============================================================================
+// RespawnFork initial_prompt preservation tests
+// ============================================================================
+
+/// When `RespawnFork` carries an `initial_prompt`, the respawned fork's nudge
+/// should include the original message (not generic "crash recovery" framing).
+/// This test verifies the Effect can be constructed with the field and that the
+/// pattern match in execute_effects destructures correctly.
+#[test]
+fn test_respawn_fork_effect_carries_initial_prompt() {
+    let effect = Effect::RespawnFork {
+        fork_name: "fork-investigate-auth".to_string(),
+        thread_parent_id: "msg-abc123".to_string(),
+        channel: Some("daemon-core".to_string()),
+        working_dir: Some("/tmp/worktree".to_string()),
+        auth_provider: crate::auth::AuthProvider::Claude,
+        is_channel_lead: true,
+        initial_prompt: Some("Investigate the auth bug in the login flow".to_string()),
+    };
+
+    // Verify the initial_prompt is preserved through pattern matching
+    if let Effect::RespawnFork { initial_prompt, .. } = &effect {
+        assert_eq!(
+            initial_prompt.as_deref(),
+            Some("Investigate the auth bug in the login flow"),
+            "RespawnFork should carry the original initial_prompt"
+        );
+    } else {
+        panic!("Expected RespawnFork variant");
+    }
+}
+
+/// When `RespawnFork` has `initial_prompt: None`, it should fall back to
+/// generic framing (the pre-fix behavior).
+#[test]
+fn test_respawn_fork_effect_without_initial_prompt() {
+    let effect = Effect::RespawnFork {
+        fork_name: "fork-some-thread".to_string(),
+        thread_parent_id: "msg-xyz789".to_string(),
+        channel: Some("daemon-core".to_string()),
+        working_dir: None,
+        auth_provider: crate::auth::AuthProvider::Claude,
+        is_channel_lead: false,
+        initial_prompt: None,
+    };
+
+    if let Effect::RespawnFork { initial_prompt, .. } = &effect {
+        assert!(
+            initial_prompt.is_none(),
+            "RespawnFork without preserved context should have None initial_prompt"
+        );
+    } else {
+        panic!("Expected RespawnFork variant");
+    }
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3859,7 +3859,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
                         };
                         if should_respawn {
                             // Get fork metadata from persistent state (record persists after cleanup)
-                            let (working_dir, auth_provider, is_channel_lead) =
+                            let (working_dir, auth_provider, is_channel_lead, initial_prompt) =
                                 if let Some(ref sid) = session_id_for_cleanup {
                                     let ps = state.persistent_state.lock().await;
                                     if let Some(record) = ps.sessions.get(sid) {
@@ -3873,12 +3873,13 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
                                                 .provider
                                                 .unwrap_or(crate::auth::AuthProvider::Claude),
                                             record.coworker_type == "channel-lead",
+                                            record.initial_prompt.clone(),
                                         )
                                     } else {
-                                        (None, crate::auth::AuthProvider::Claude, false)
+                                        (None, crate::auth::AuthProvider::Claude, false, None)
                                     }
                                 } else {
-                                    (None, crate::auth::AuthProvider::Claude, false)
+                                    (None, crate::auth::AuthProvider::Claude, false, None)
                                 };
 
                             warn!(
@@ -3893,6 +3894,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
                                 working_dir,
                                 auth_provider,
                                 is_channel_lead,
+                                initial_prompt,
                             });
                             fork_respawn_effects.push(effects::Effect::RecordCooldown {
                                 category: "process_respawn".to_string(),

--- a/src/daemon/rpc_session.rs
+++ b/src/daemon/rpc_session.rs
@@ -1618,6 +1618,17 @@ pub(super) async fn handle_session_fork(
                 }
             };
             if let Some(message) = nudge_message {
+                // Persist the nudge message as initial_prompt so crash recovery
+                // can resend it instead of generic "crash recovery" framing.
+                {
+                    let mut ps = state.persistent_state.lock().await;
+                    if let Some(record) = ps.sessions.get_mut(&sid) {
+                        record.initial_prompt = Some(message.clone());
+                    }
+                    if let Err(e) = ps.save_for_repo(state.paths.dir_key()) {
+                        warn!("session.fork: failed to persist initial_prompt: {}", e);
+                    }
+                }
                 let nudge = crate::daemon::effects::Effect::NudgeSession {
                     session_id: sid.clone(),
                     reason: crate::daemon::wake_reason::WakeReason::Nudge { message },
@@ -1738,6 +1749,19 @@ pub(super) async fn handle_session_fork_thread(
             // Send framing nudge to fresh forks
             if !is_existing {
                 let framing = super::rpc_channel::fork_initial_framing(channel);
+                // Persist the framing as initial_prompt for crash recovery
+                {
+                    let mut ps = state.persistent_state.lock().await;
+                    if let Some(record) = ps.sessions.get_mut(&sid) {
+                        record.initial_prompt = Some(framing.clone());
+                    }
+                    if let Err(e) = ps.save_for_repo(state.paths.dir_key()) {
+                        warn!(
+                            "session.fork_thread: failed to persist initial_prompt: {}",
+                            e
+                        );
+                    }
+                }
                 let framing_effect = crate::daemon::effects::Effect::NudgeSession {
                     session_id: sid.clone(),
                     reason: crate::daemon::wake_reason::WakeReason::Nudge { message: framing },


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- When a forked session crashes and gets respawned by the daemon, the crash recovery path was sending generic "crash recovery" framing instead of the original `--initial-message`. This caused respawned forks to lose all context about what they were supposed to do (e.g., talking about "clusterer removal" instead of investigating channel lead nudges).
- **Root cause**: The nudge message sent to a fork on creation was never persisted in `SessionRecord.initial_prompt`. The `RespawnFork` effect had no field to carry it, so `respawn_fork()` fell back to generic framing.
- **Fix**: Store the nudge message in `SessionRecord.initial_prompt` at fork creation time, thread it through the crash recovery path via the `RespawnFork` effect, and use it in `respawn_fork()` to reconstruct the original context (with a crash recovery annotation appended).

## Changes
- `rpc_session.rs`: Persist nudge message as `initial_prompt` in fork's `SessionRecord` after construction (both CLI `handle_session_fork` and web UI `handle_session_fork_thread` paths)
- `effects.rs`: Add `initial_prompt: Option<String>` to `RespawnFork` effect; update `respawn_fork()` to prefer preserved prompt over generic framing
- `mod.rs`: Read `initial_prompt` from session record in crash recovery path and pass it to `RespawnFork` effect

## Test plan
- [x] Added unit tests verifying `RespawnFork` carries `initial_prompt` through pattern matching
- [x] All 51 effects tests pass
- [x] Clippy clean, fmt clean
- [x] Full test suite passes (18 pre-existing env-related failures in worktree tests, unrelated)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)