### PR TITLE
fix: @mention user on PR review notifications for ownerless PRs [Midtown !2076]

### DIFF
--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -2957,9 +2957,11 @@ pub(crate) async fn collect_reviewer_effects_with_source(
             }
 
             let channel = pr_ctx.get_channel(pr_number);
+            // No coworker owns this PR — @mention the user so they see it
+            let user_msg = format!("@user {}", nudge_msg);
             effects.push(Effect::PostToChannel {
                 sender: "midtown".to_string(),
-                message: nudge_msg,
+                message: user_msg,
                 channel,
                 auto_output: false,
             });

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -3586,10 +3586,11 @@ async fn test_review_complete_without_owner_posts_merge_reminder() {
             e,
             Effect::PostToChannel {
                 sender,
+                message,
                 ..
-            } if sender == "midtown"
+            } if sender == "midtown" && message.contains("@user")
         )),
-        "Expected review-complete fallback post to channel output, got: {:#?}",
+        "Expected review-complete fallback to @mention user, got: {:#?}",
         effects
     );
 


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- When a reviewed PR has no identifiable coworker owner, the daemon now prefixes the channel notification with `@user` so the human gets a bell/push notification
- Previously these notifications went to the channel with no mention, causing users to miss review completions on orphaned PRs (e.g., PR #1787)

## Changes
- `src/daemon/pr.rs`: Added `@user` prefix to the `PostToChannel` message in the ownerless ReviewComplete fallback path
- `src/daemon/pr_tests.rs`: Updated existing test to verify `@user` is present in the ownerless notification

## Test plan
- [x] Existing test `test_review_complete_without_owner_posts_merge_reminder` updated and passes
- [x] All 11 `review_complete` tests pass
- [x] Clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)