### PR TITLE
fix: Lazy fork restoration after daemon restart [Midtown !2079]

### DIFF
--- a/src/daemon/rpc_channel.rs
+++ b/src/daemon/rpc_channel.rs
@@ -338,7 +338,7 @@ pub(super) async fn handle_channel_post(
             // - For thread replies: route to the existing dedicated session bound to that thread.
             // - For new top-level messages: no auto-fork. The channel lead handles directly.
             //   Users can manually dedicate a session via the web UI.
-            let topic_session_id = if let Some(parent_id) = thread_parent_id {
+            let mut topic_session_id = if let Some(parent_id) = thread_parent_id {
                 // Thread reply: route to existing fork session (if any).
                 // Filter out "pending" — a concurrent fork is in progress but not yet
                 // ready. Treating "pending" as None falls back to NudgeChannelLead rather
@@ -354,6 +354,14 @@ pub(super) async fn handle_channel_post(
                 // New top-level message: channel lead handles directly.
                 None
             };
+
+            // Lazy fork restoration: if the fork session exists in topic_sessions
+            // but the process is dead (e.g., after daemon restart), attempt to
+            // respawn it so thread messages aren't silently dropped.
+            if let (Some(fork_sid), Some(parent_id)) = (&topic_session_id, thread_parent_id) {
+                topic_session_id = try_lazy_fork_respawn(state, fork_sid, parent_id).await;
+            }
+
             if let Some(fork_session_id) = topic_session_id.as_deref() {
                 debug!(
                     "channel.post: routing to fork session {} (thread anchor {})",
@@ -963,6 +971,120 @@ pub(crate) fn build_topic_thread_nudge_effect(
             reason,
         }
     }
+}
+
+/// Lazy fork restoration: check if a fork session is alive and respawn if dead.
+///
+/// After a daemon restart, `topic_sessions` is rebuilt from persisted state but
+/// the actual headless processes are not running. When a thread reply arrives for
+/// a dead fork, this function attempts to respawn it so the message can be
+/// delivered to a live session.
+///
+/// Returns `Some(new_session_id)` if the fork is alive or was successfully
+/// respawned, or `None` if respawn failed (caller should fall back to channel lead).
+async fn try_lazy_fork_respawn(
+    state: &DaemonState,
+    fork_sid: &str,
+    thread_parent_id: &str,
+) -> Option<String> {
+    // Look up the fork's process name
+    let fork_name = state.session_to_name.lock().unwrap().get(fork_sid).cloned();
+
+    let Some(ref name) = fork_name else {
+        // No name mapping — stale topic_sessions entry, clean it up
+        warn!(
+            "channel.post: no name mapping for fork session {} — removing stale topic_sessions entry",
+            fork_sid
+        );
+        state
+            .topic_sessions
+            .lock()
+            .unwrap()
+            .remove(thread_parent_id);
+        return None;
+    };
+
+    // Check if the fork process is alive
+    if state.session_manager.is_alive(name).await {
+        // Fork is alive, use the existing session
+        return Some(fork_sid.to_string());
+    }
+
+    info!(
+        "channel.post: fork session {} ({}) is dead — attempting lazy respawn for thread {}",
+        fork_sid, name, thread_parent_id
+    );
+
+    // Get fork metadata from persisted state
+    let respawn_meta = {
+        let ps = state.persistent_state.lock().await;
+        ps.sessions.get(fork_sid).map(|record| {
+            (
+                if record.working_dir.is_empty() {
+                    None
+                } else {
+                    Some(record.working_dir.clone())
+                },
+                record.provider.unwrap_or(crate::auth::AuthProvider::Claude),
+                record.coworker_type == "channel-lead",
+                record.initial_prompt.clone(),
+                record.channel.clone(),
+            )
+        })
+    };
+
+    let Some((working_dir, auth_provider, is_channel_lead, initial_prompt, channel)) = respawn_meta
+    else {
+        warn!(
+            "channel.post: no persisted record for dead fork {} — removing stale topic_sessions entry",
+            fork_sid
+        );
+        state
+            .topic_sessions
+            .lock()
+            .unwrap()
+            .remove(thread_parent_id);
+        return None;
+    };
+
+    // Execute respawn
+    let respawn_effect = crate::daemon::effects::Effect::RespawnFork {
+        fork_name: name.clone(),
+        thread_parent_id: thread_parent_id.to_string(),
+        channel,
+        working_dir,
+        auth_provider,
+        is_channel_lead,
+        initial_prompt,
+    };
+    crate::daemon::effects::execute_effects(vec![respawn_effect], state).await;
+
+    // Re-read topic_sessions — respawn_fork updates it with the new session_id.
+    // If the session_id changed, respawn succeeded. If it's the same (or gone),
+    // respawn failed.
+    let new_session_id = state
+        .topic_sessions
+        .lock()
+        .unwrap()
+        .get(thread_parent_id)
+        .filter(|s| s.as_str() != "pending" && s.as_str() != fork_sid)
+        .cloned();
+
+    if new_session_id.is_none() {
+        // Respawn failed — clean up stale entry so future messages fall back
+        // to channel lead instead of trying to nudge a dead session.
+        warn!(
+            "channel.post: fork respawn failed for thread {} — falling back to channel lead",
+            thread_parent_id
+        );
+        state
+            .topic_sessions
+            .lock()
+            .unwrap()
+            .remove(thread_parent_id);
+    }
+
+    new_session_id
 }
 
 #[path = "rpc_channel_tests.rs"]

--- a/src/daemon/rpc_channel_tests.rs
+++ b/src/daemon/rpc_channel_tests.rs
@@ -1353,12 +1353,26 @@ async fn test_thread_routing_with_topic_session_routes_to_fork() {
         .headed_poll(&state.project_name, adapter_id, 0, 10)
         .await;
 
+    let fork_name = "auth-refactor-thread-fork";
+
     // Register a topic session for this thread
     state
         .topic_sessions
         .lock()
         .unwrap()
         .insert(thread_id.clone(), fork_session_id.to_string());
+    // Register session_to_name so the lazy respawn check can look up the fork name
+    state
+        .session_to_name
+        .lock()
+        .unwrap()
+        .insert(fork_session_id.to_string(), fork_name.to_string());
+    // Mark the fork as alive so it's not treated as dead
+    state
+        .session_manager
+        .set_test_is_alive_hook(Some(std::sync::Arc::new(move |name: &str| {
+            name == fork_name
+        })));
 
     // User posts a thread reply in the topic channel
     let response = handle_channel_post(
@@ -1865,6 +1879,7 @@ async fn test_thread_reply_routes_to_existing_fork_session() {
     // Post a parent message in the topic channel to get a valid thread_parent_id
     let thread_parent_id = post_parent_message(&state, Some("web")).await;
     let fork_session_id = "existing-fork-session-id";
+    let fork_name = "web-thread-existing";
 
     // Pre-register a fork session for this thread
     state
@@ -1872,6 +1887,18 @@ async fn test_thread_reply_routes_to_existing_fork_session() {
         .lock()
         .unwrap()
         .insert(thread_parent_id.clone(), fork_session_id.to_string());
+    // Register session_to_name so the lazy respawn check can look up the fork name
+    state
+        .session_to_name
+        .lock()
+        .unwrap()
+        .insert(fork_session_id.to_string(), fork_name.to_string());
+    // Mark the fork as alive so it's not treated as dead
+    state
+        .session_manager
+        .set_test_is_alive_hook(Some(std::sync::Arc::new(move |name: &str| {
+            name == fork_name
+        })));
 
     // User posts a thread reply to this thread
     let response = handle_channel_post(
@@ -1971,6 +1998,188 @@ async fn test_thread_reply_during_pending_fork_does_not_route_to_pending_session
         topic.get(&thread_parent_id).map(String::as_str),
         Some("pending"),
         "pending sentinel should be untouched by a thread reply"
+    );
+}
+
+// ── Lazy fork restoration tests ───────────────────────────────────────────────
+
+/// When a thread reply targets a fork session that is dead (e.g., after daemon
+/// restart), the stale `topic_sessions` entry should be cleaned up and the
+/// message should fall back to the channel lead instead of being silently dropped.
+#[tokio::test]
+async fn test_thread_reply_to_dead_fork_cleans_up_stale_entry() {
+    let (state, _tmp, _guard) = make_test_state("midtown-test-dead-fork-cleanup");
+
+    // Post a parent message to get a valid thread_parent_id
+    let thread_parent_id = post_parent_message(&state, Some("web")).await;
+    let dead_fork_sid = "dead-fork-session-after-restart";
+    let dead_fork_name = "web-thread-abc123";
+
+    // Simulate post-restart state: topic_sessions and session_to_name have
+    // entries rebuilt from persisted state, but no process is running.
+    state
+        .topic_sessions
+        .lock()
+        .unwrap()
+        .insert(thread_parent_id.clone(), dead_fork_sid.to_string());
+    state
+        .session_to_name
+        .lock()
+        .unwrap()
+        .insert(dead_fork_sid.to_string(), dead_fork_name.to_string());
+    state
+        .name_to_session
+        .lock()
+        .unwrap()
+        .insert(dead_fork_name.to_string(), dead_fork_sid.to_string());
+
+    // Also insert a persisted SessionRecord so respawn metadata can be read
+    {
+        let mut ps = state.persistent_state.lock().await;
+        ps.sessions.insert(
+            dead_fork_sid.to_string(),
+            crate::daemon::state::SessionRecord {
+                session_id: dead_fork_sid.to_string(),
+                task_id: None,
+                current_name: Some(dead_fork_name.to_string()),
+                preferred_name: Some(dead_fork_name.to_string()),
+                working_dir: String::new(),
+                branch: None,
+                pr_number: None,
+                initial_prompt: None,
+                is_reviewer: false,
+                coworker_type: "channel-lead".to_string(),
+                is_running: false,
+                created_at: chrono::Utc::now(),
+                resume_on_startup: false,
+                bound_thread_id: Some(thread_parent_id.clone()),
+                last_active: chrono::Utc::now(),
+                purpose: "test fork".to_string(),
+                pid: None,
+                channel: Some("web".to_string()),
+                provider: Some(crate::auth::AuthProvider::Claude),
+                platform: None,
+                profile: None,
+            },
+        );
+    }
+
+    // is_alive returns false by default (no process in session_manager),
+    // so the fork will be detected as dead.
+
+    // Post a thread reply — should detect dead fork and clean up
+    let response = handle_channel_post(
+        1_i64.into(),
+        "user",
+        "follow-up question in thread",
+        Some("web"),
+        Some(&thread_parent_id),
+        &state,
+    )
+    .await;
+    assert!(
+        response.error.is_none(),
+        "channel.post should succeed even with dead fork"
+    );
+
+    // The stale topic_sessions entry should be cleaned up since respawn
+    // fails in test env (no actual headless process can be spawned).
+    let topic = state.topic_sessions.lock().unwrap();
+    assert!(
+        !topic.contains_key(&thread_parent_id)
+            || topic.get(&thread_parent_id).map(String::as_str) != Some(dead_fork_sid),
+        "stale topic_sessions entry for dead fork should be cleaned up"
+    );
+}
+
+/// When a fork session is alive, thread replies should route to it normally
+/// without triggering any respawn logic.
+#[tokio::test]
+async fn test_thread_reply_to_alive_fork_routes_normally() {
+    let (state, _tmp, _guard) = make_test_state("midtown-test-alive-fork-routing");
+
+    let thread_parent_id = post_parent_message(&state, Some("web")).await;
+    let fork_sid = "alive-fork-session-id";
+    let fork_name = "web-thread-xyz789";
+
+    // Register the fork in topic_sessions and session_to_name
+    state
+        .topic_sessions
+        .lock()
+        .unwrap()
+        .insert(thread_parent_id.clone(), fork_sid.to_string());
+    state
+        .session_to_name
+        .lock()
+        .unwrap()
+        .insert(fork_sid.to_string(), fork_name.to_string());
+
+    // Hook is_alive to return true for this fork
+    state
+        .session_manager
+        .set_test_is_alive_hook(Some(std::sync::Arc::new(move |name: &str| {
+            name == fork_name
+        })));
+
+    // Post a thread reply
+    let response = handle_channel_post(
+        1_i64.into(),
+        "user",
+        "follow-up in thread",
+        Some("web"),
+        Some(&thread_parent_id),
+        &state,
+    )
+    .await;
+    assert!(
+        response.error.is_none(),
+        "channel.post should succeed for alive fork"
+    );
+
+    // topic_sessions should be unchanged — fork is alive, no cleanup needed
+    let topic = state.topic_sessions.lock().unwrap();
+    assert_eq!(
+        topic.get(&thread_parent_id).map(String::as_str),
+        Some(fork_sid),
+        "alive fork session should remain in topic_sessions"
+    );
+}
+
+/// When `topic_sessions` has a fork entry but `session_to_name` has no mapping
+/// (orphaned entry), the stale entry should be cleaned up.
+#[tokio::test]
+async fn test_thread_reply_to_orphaned_fork_entry_cleans_up() {
+    let (state, _tmp, _guard) = make_test_state("midtown-test-orphaned-fork-cleanup");
+
+    let thread_parent_id = post_parent_message(&state, Some("web")).await;
+    let orphaned_sid = "orphaned-fork-no-name-mapping";
+
+    // topic_sessions has an entry but session_to_name does NOT
+    state
+        .topic_sessions
+        .lock()
+        .unwrap()
+        .insert(thread_parent_id.clone(), orphaned_sid.to_string());
+
+    let response = handle_channel_post(
+        1_i64.into(),
+        "user",
+        "question in thread",
+        Some("web"),
+        Some(&thread_parent_id),
+        &state,
+    )
+    .await;
+    assert!(
+        response.error.is_none(),
+        "channel.post should succeed with orphaned fork entry"
+    );
+
+    // Orphaned entry should be cleaned up
+    let topic = state.topic_sessions.lock().unwrap();
+    assert!(
+        !topic.contains_key(&thread_parent_id),
+        "orphaned topic_sessions entry should be removed"
     );
 }
 


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- When the daemon restarts, forked lead sessions have their `topic_sessions` entries rebuilt from persisted state, but the actual headless processes are not running
- Thread replies to these dead forks were silently dropped — `send_session_nudge` failed because no live process existed
- Added `try_lazy_fork_respawn()` in the channel post handler that detects dead fork sessions and attempts to respawn them on-demand when a thread message arrives
- If respawn fails, the stale `topic_sessions` entry is cleaned up and the message falls back to the channel lead
- This lazy approach avoids eagerly respawning all forks on startup — only forks that receive new messages are brought back online

## How it works
1. When a thread reply arrives, `topic_sessions` is checked for an existing fork binding (existing behavior)
2. **New:** If a fork binding exists, `try_lazy_fork_respawn()` checks if the fork process is alive via `session_manager.is_alive()`
3. If dead, it reads the fork's metadata from `persistent_state` and executes a `RespawnFork` effect
4. After respawn, `topic_sessions` is re-read for the new session ID
5. If respawn failed or the entry was orphaned (no `session_to_name` mapping), the stale entry is removed and the message falls back to `NudgeChannelLead`

## Test plan
- [x] `test_thread_reply_to_dead_fork_cleans_up_stale_entry` — dead fork entry cleaned up, message not dropped
- [x] `test_thread_reply_to_alive_fork_routes_normally` — alive fork routes normally without respawn
- [x] `test_thread_reply_to_orphaned_fork_entry_cleans_up` — orphaned entry (no session_to_name) cleaned up
- [x] All 70 existing `rpc_channel::tests` pass (including updated tests for existing fork routing)
- [x] `cargo clippy` clean, `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)