### PR TITLE
fix: Show progress bar during author-to-reviewer transition [Midtown !2094]

### DIFF
--- a/web-app/src/lib/TaskRow.svelte
+++ b/web-app/src/lib/TaskRow.svelte
@@ -117,7 +117,7 @@
         {/if}
       </div>
     {/if}
-    {#if isActive && hasProgress && task.owner}
+    {#if isActive && (hasProgress || effectiveReviewer) && task.owner}
       {@const segments = lifecycleSegments(effectiveCw?.progress ?? 0, effectiveReviewer, effectiveReviewPosted, getSenderColor(task.owner), effectiveReviewer ? getSenderColor(effectiveReviewer) : null)}
       {@const totalPct = Math.round(segments.reduce((sum, s) => sum + s.width, 0))}
       <div class="flex items-center gap-1.5 pr-0.5">


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Fixed progress bar disappearing when a task transitions from author to reviewer
- Root cause: render condition required `hasProgress` (author's live coworker progress), but when author goes idle, their progress becomes null — hiding the bar entirely
- Fix: also render progress bar when a reviewer exists (`effectiveReviewer`), since `lifecycleSegments()` already handles that case correctly (hardcodes author segment at 70%)

## Changes
- `web-app/src/lib/TaskRow.svelte` line 120: `isActive && hasProgress && task.owner` → `isActive && (hasProgress || effectiveReviewer) && task.owner`

## Visual Change

**Before**: When a task transitions from author to reviewer (author goes idle, reviewer spawns), the progress bar disappears entirely because `hasProgress` becomes false (author's coworker progress is null). The task row shows no lifecycle progress during the handoff gap.

**After**: The progress bar remains visible during the transition. When `effectiveReviewer` exists, the bar renders showing the author segment at 70% width (hardcoded in `lifecycleSegments()`) and the reviewer segment starting. No gap in visual feedback.

Note: Automated screenshots could not be captured due to Playwright permission restrictions in the current environment.

## Test plan
- [x] Vite build passes
- [x] Pre-commit hooks pass (clippy + fmt)
- Manually verify: when a task's author finishes and reviewer is spawned, the progress bar should remain visible showing author at 70% + reviewer segment

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)