### PR TITLE
fix: Port TDW dict-order bug fix to hookimpl architecture [Midtown !2093]

### DIFF
--- a/.midtown/channels/tdw/scripts/hooks.py
+++ b/.midtown/channels/tdw/scripts/hooks.py
@@ -62,6 +62,7 @@ DEFAULT_PATTERNS = [
 ]
 
 STAGES = ["research", "outline", "draft", "critique", "revise", "final"]
+ACTIVE_STAGES = ("draft", "critique", "revise")
 
 
 # ---------------------------------------------------------------------------
@@ -95,19 +96,68 @@ def _build_critique_prompt(criteria: list[str], patterns: list[str]) -> str:
 
 
 def _find_active_task_id(ctx: HookContext) -> str | None:
-    """Find the first active TDW task (in a writable stage).
+    """Find the sole active TDW task (in a writable stage).
 
-    Returns the task_id or None.
+    Returns the task_id when exactly one task is active, or ``None`` when
+    there are zero or multiple active tasks.  Callers that need to resolve
+    ambiguity should use ``ctx.task_id`` from the event context instead.
     """
     tasks = ctx.state.get("tasks", {})
-    for task_id, task_data in tasks.items():
-        if isinstance(task_data, dict) and task_data.get("stage") in (
-            "draft",
-            "critique",
-            "revise",
-        ):
-            return task_id
+    active: list[str] = [
+        tid
+        for tid, td in tasks.items()
+        if isinstance(td, dict) and td.get("stage") in ACTIVE_STAGES
+    ]
+    if len(active) == 1:
+        return active[0]
     return None
+
+
+def _resolve_target_task(
+    ctx: HookContext,
+) -> tuple[str | None, dict]:
+    """Resolve the target task for a channel command.
+
+    When ``ctx.task_id`` is provided (e.g. the message was posted with
+    ``--task``), return that task directly — but only if it's in an active
+    stage.  Otherwise fall back to ``_find_active_task_id`` which requires
+    exactly one active task to avoid ambiguity.
+    """
+    tasks = ctx.state.get("tasks", {})
+    if ctx.task_id:
+        task_data = tasks.get(ctx.task_id, {})
+        if isinstance(task_data, dict) and task_data.get("stage") in ACTIVE_STAGES:
+            return ctx.task_id, task_data
+        return None, {}
+    tid = _find_active_task_id(ctx)
+    if tid:
+        return tid, tasks.get(tid, {})
+    return None, {}
+
+
+def _warn_no_target(ctx: HookContext) -> list[DaemonAction]:
+    """Return a user-facing warning when no target task could be resolved."""
+    tasks = ctx.state.get("tasks", {})
+    active = [
+        tid
+        for tid, td in tasks.items()
+        if isinstance(td, dict) and td.get("stage") in ACTIVE_STAGES
+    ]
+    if ctx.task_id:
+        return [
+            Actions.post_to_channel(
+                f"Task {ctx.task_id} is not in an active stage "
+                "(draft/critique/revise). Criterion or pattern not added."
+            )
+        ]
+    elif len(active) > 1:
+        return [
+            Actions.post_to_channel(
+                f"Multiple active tasks ({', '.join(active)}). "
+                "Use --task <id> to specify which task to update."
+            )
+        ]
+    return []
 
 
 # ---------------------------------------------------------------------------
@@ -147,7 +197,9 @@ def on_coworker_message(ctx: HookContext) -> Sequence[DaemonAction] | None:
     if not task_id:
         return None
 
-    stage = ctx.state.get(f"tasks.{task_id}.stage")
+    tasks = ctx.state.get("tasks", {})
+    task_data = tasks.get(task_id, {})
+    stage = task_data.get("stage") if isinstance(task_data, dict) else None
     if not stage:
         return None
 
@@ -177,8 +229,8 @@ def on_coworker_message(ctx: HookContext) -> Sequence[DaemonAction] | None:
 
     # Do -> Observe: draft -> critique
     if stage == "draft" and "draft complete" in msg_lower:
-        criteria = ctx.state.get(f"tasks.{task_id}.criteria") or DEFAULT_CRITERIA
-        patterns = ctx.state.get(f"tasks.{task_id}.patterns") or DEFAULT_PATTERNS
+        criteria = task_data.get("criteria") or DEFAULT_CRITERIA
+        patterns = task_data.get("patterns") or DEFAULT_PATTERNS
 
         criteria_display = "\n".join(f"- [ ] {c}" for c in criteria)
         patterns_display = "\n".join(f"- {p}" for p in patterns)
@@ -234,9 +286,9 @@ def on_coworker_message(ctx: HookContext) -> Sequence[DaemonAction] | None:
 
     # Do -> Observe loop: revise -> re-critique
     if stage == "revise" and "revision complete" in msg_lower:
-        count = ctx.state.get(f"tasks.{task_id}.revision_count") or 0
+        count = task_data.get("revision_count") or 0
 
-        criteria = ctx.state.get(f"tasks.{task_id}.criteria") or DEFAULT_CRITERIA
+        criteria = task_data.get("criteria") or DEFAULT_CRITERIA
         return [
             Actions.set_state(f"tasks.{task_id}.revision_count", count + 1),
             Actions.set_state(f"tasks.{task_id}.stage", "critique"),
@@ -246,7 +298,7 @@ def on_coworker_message(ctx: HookContext) -> Sequence[DaemonAction] | None:
             ),
             Actions.spawn_coworker(prompt=_build_critique_prompt(
                 criteria,
-                ctx.state.get(f"tasks.{task_id}.patterns") or DEFAULT_PATTERNS,
+                task_data.get("patterns") or DEFAULT_PATTERNS,
             )),
         ]
 
@@ -266,35 +318,39 @@ def on_channel_message(ctx: HookContext) -> Sequence[DaemonAction] | None:
         )
         if match:
             new_criterion = match.group(1).strip()
-            task_id = _find_active_task_id(ctx)
-            if task_id:
-                criteria = list(ctx.state.get(f"tasks.{task_id}.criteria") or [])
+            tid, task_data = _resolve_target_task(ctx)
+            if tid:
+                criteria = list(task_data.get("criteria") or [])
                 criteria.append(new_criterion)
                 return [
-                    Actions.set_state(f"tasks.{task_id}.criteria", criteria),
+                    Actions.set_state(f"tasks.{tid}.criteria", criteria),
                     Actions.post_to_channel(
                         f'Added criterion: "{new_criterion}"\n'
                         "Every human edit teaches the system. "
                         "This will be checked in future critiques."
                     ),
                 ]
+            else:
+                return _warn_no_target(ctx) or None
 
     # Detect "add pattern:" for guidance (not blocking)
     elif "add pattern:" in msg_lower:
         match = re.search(r"add pattern:\s*(.+)", message, re.IGNORECASE)
         if match:
             new_pattern = match.group(1).strip()
-            task_id = _find_active_task_id(ctx)
-            if task_id:
-                patterns = list(ctx.state.get(f"tasks.{task_id}.patterns") or [])
+            tid, task_data = _resolve_target_task(ctx)
+            if tid:
+                patterns = list(task_data.get("patterns") or [])
                 patterns.append(new_pattern)
                 return [
-                    Actions.set_state(f"tasks.{task_id}.patterns", patterns),
+                    Actions.set_state(f"tasks.{tid}.patterns", patterns),
                     Actions.post_to_channel(
                         f'Added pattern: "{new_pattern}"\n'
                         "This is guidance, not a requirement. "
                         "It helps without blocking."
                     ),
                 ]
+            else:
+                return _warn_no_target(ctx) or None
 
     return None

--- a/.midtown/channels/tdw/scripts/test_hooks.py
+++ b/.midtown/channels/tdw/scripts/test_hooks.py
@@ -2,50 +2,61 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-from unittest.mock import MagicMock
+from midtown.actions import Actions
+from midtown.hooks import HookContext
 
 from hooks import (
+    ACTIVE_STAGES,
     DEFAULT_CRITERIA,
     DEFAULT_PATTERNS,
     _build_critique_prompt,
     _find_active_task_id,
+    _resolve_target_task,
+    _warn_no_target,
     on_channel_message,
     on_coworker_message,
     on_task_created,
 )
 
 
-def _make_context(state: dict | None = None) -> MagicMock:
-    """Create a mock HookContext with an in-memory state store."""
-    ctx = MagicMock()
-    store: dict = state if state is not None else {}
-
-    def get_state(key: str):
-        parts = key.split(".")
-        current = store
-        for part in parts:
-            if not isinstance(current, dict) or part not in current:
-                return None
-            current = current[part]
-        return current
-
-    def set_state(key: str, value):
-        parts = key.split(".")
-        current = store
-        for part in parts[:-1]:
-            current = current.setdefault(part, {})
-        current[parts[-1]] = value
-
-    ctx.rpc.get_state = MagicMock(side_effect=get_state)
-    ctx.rpc.set_state = MagicMock(side_effect=set_state)
-    ctx._store = store  # expose for assertions
-    return ctx
+def _make_ctx(
+    state: dict | None = None,
+    *,
+    task_id: str | None = None,
+    message: str = "",
+    subject: str = "",
+    **extra: object,
+) -> HookContext:
+    """Create a HookContext with the given state and event fields."""
+    st = state if state is not None else {}
+    event: dict = {"message": message}
+    if task_id:
+        event["task_id"] = task_id
+    if subject:
+        event["subject"] = subject
+    event.update(extra)
+    return HookContext(
+        event_type="",
+        event=event,
+        task_id=task_id,
+        state=st,
+        actions=Actions,
+    )
 
 
-def _make_event(**kwargs) -> SimpleNamespace:
-    """Create a simple event object with given attributes."""
-    return SimpleNamespace(**kwargs)
+def _apply_actions(actions, state: dict) -> None:
+    """Execute set_state actions against a nested state dict (for test setup)."""
+    if actions is None:
+        return
+    for action in actions:
+        if action.method == "state.set":
+            key = action.params["key"]
+            value = action.params["value"]
+            parts = key.split(".")
+            current = state
+            for part in parts[:-1]:
+                current = current.setdefault(part, {})
+            current[parts[-1]] = value
 
 
 def _action_messages(actions):
@@ -62,6 +73,13 @@ def _has_spawn(actions):
     return any(a.method == "coworker.spawn" for a in actions)
 
 
+def _init_task(state: dict, task_id: str) -> None:
+    """Shorthand: run on_task_created and apply its state mutations."""
+    ctx = _make_ctx(state, task_id=task_id, subject="test")
+    actions = on_task_created(ctx)
+    _apply_actions(actions, state)
+
+
 # ---------------------------------------------------------------------------
 # on_task_created
 # ---------------------------------------------------------------------------
@@ -69,15 +87,16 @@ def _has_spawn(actions):
 
 class TestOnTaskCreated:
     def test_initialises_state_and_returns_actions(self) -> None:
-        ctx = _make_context()
-        event = _make_event(task_id="10", subject="Write blog post")
+        state: dict = {}
+        ctx = _make_ctx(state, task_id="10", subject="Write blog post")
 
-        actions = on_task_created(event, ctx)
+        actions = on_task_created(ctx)
+        _apply_actions(actions, state)
 
-        assert ctx._store["tasks"]["10"]["stage"] == "research"
-        assert ctx._store["tasks"]["10"]["criteria"] == DEFAULT_CRITERIA
-        assert ctx._store["tasks"]["10"]["patterns"] == DEFAULT_PATTERNS
-        assert ctx._store["tasks"]["10"]["revision_count"] == 0
+        assert state["tasks"]["10"]["stage"] == "research"
+        assert state["tasks"]["10"]["criteria"] == DEFAULT_CRITERIA
+        assert state["tasks"]["10"]["patterns"] == DEFAULT_PATTERNS
+        assert state["tasks"]["10"]["revision_count"] == 0
 
         msgs = _action_messages(actions)
         assert len(msgs) == 1
@@ -85,21 +104,22 @@ class TestOnTaskCreated:
         assert "Research" in msgs[0]
 
     def test_no_task_id_returns_none(self) -> None:
-        ctx = _make_context()
-        event = _make_event(subject="No ID")
+        state: dict = {}
+        ctx = _make_ctx(state, subject="No ID")
 
-        actions = on_task_created(event, ctx)
+        actions = on_task_created(ctx)
 
         assert actions is None
-        assert "tasks" not in ctx._store
+        assert "tasks" not in state
 
     def test_copies_defaults(self) -> None:
         """Ensure criteria/patterns are copies, not shared references."""
-        ctx = _make_context()
-        event = _make_event(task_id="42", subject="Test")
+        state: dict = {}
+        ctx = _make_ctx(state, task_id="42", subject="Test")
 
-        on_task_created(event, ctx)
-        ctx._store["tasks"]["42"]["criteria"].append("extra")
+        actions = on_task_created(ctx)
+        _apply_actions(actions, state)
+        state["tasks"]["42"]["criteria"].append("extra")
 
         assert "extra" not in DEFAULT_CRITERIA
 
@@ -111,54 +131,54 @@ class TestOnTaskCreated:
 
 class TestResearchToOutline:
     def test_research_complete_advances_stage(self) -> None:
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
+        state: dict = {}
+        _init_task(state, "10")
 
-        actions = on_coworker_message(
-            _make_event(task_id="10", message="Research complete, moving on"), ctx
-        )
+        ctx = _make_ctx(state, task_id="10", message="Research complete, moving on")
+        actions = on_coworker_message(ctx)
+        _apply_actions(actions, state)
 
-        assert ctx._store["tasks"]["10"]["stage"] == "outline"
+        assert state["tasks"]["10"]["stage"] == "outline"
         msgs = _action_messages(actions)
         assert any("Outline" in m for m in msgs)
 
     def test_research_complete_case_insensitive(self) -> None:
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
+        state: dict = {}
+        _init_task(state, "10")
 
-        on_coworker_message(
-            _make_event(task_id="10", message="RESEARCH COMPLETE"), ctx
-        )
+        ctx = _make_ctx(state, task_id="10", message="RESEARCH COMPLETE")
+        actions = on_coworker_message(ctx)
+        _apply_actions(actions, state)
 
-        assert ctx._store["tasks"]["10"]["stage"] == "outline"
+        assert state["tasks"]["10"]["stage"] == "outline"
 
 
 class TestOutlineToDraft:
     def test_outline_ready_advances_stage(self) -> None:
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
-        ctx._store["tasks"]["10"]["stage"] = "outline"
+        state: dict = {}
+        _init_task(state, "10")
+        state["tasks"]["10"]["stage"] = "outline"
 
-        actions = on_coworker_message(
-            _make_event(task_id="10", message="Outline ready for review"), ctx
-        )
+        ctx = _make_ctx(state, task_id="10", message="Outline ready for review")
+        actions = on_coworker_message(ctx)
+        _apply_actions(actions, state)
 
-        assert ctx._store["tasks"]["10"]["stage"] == "draft"
+        assert state["tasks"]["10"]["stage"] == "draft"
         msgs = _action_messages(actions)
         assert any("Draft" in m for m in msgs)
 
 
 class TestDraftToCritique:
     def test_draft_complete_spawns_critic(self) -> None:
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
-        ctx._store["tasks"]["10"]["stage"] = "draft"
+        state: dict = {}
+        _init_task(state, "10")
+        state["tasks"]["10"]["stage"] = "draft"
 
-        actions = on_coworker_message(
-            _make_event(task_id="10", message="Draft complete"), ctx
-        )
+        ctx = _make_ctx(state, task_id="10", message="Draft complete")
+        actions = on_coworker_message(ctx)
+        _apply_actions(actions, state)
 
-        assert ctx._store["tasks"]["10"]["stage"] == "critique"
+        assert state["tasks"]["10"]["stage"] == "critique"
         assert _has_spawn(actions)
 
         # Verify the critique prompt includes criteria
@@ -170,15 +190,14 @@ class TestDraftToCritique:
             assert criterion in prompt
 
     def test_draft_complete_uses_custom_criteria(self) -> None:
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
-        ctx._store["tasks"]["10"]["stage"] = "draft"
-        ctx._store["tasks"]["10"]["criteria"] = ["Custom rule 1"]
-        ctx._store["tasks"]["10"]["patterns"] = ["Custom pattern 1"]
+        state: dict = {}
+        _init_task(state, "10")
+        state["tasks"]["10"]["stage"] = "draft"
+        state["tasks"]["10"]["criteria"] = ["Custom rule 1"]
+        state["tasks"]["10"]["patterns"] = ["Custom pattern 1"]
 
-        actions = on_coworker_message(
-            _make_event(task_id="10", message="Draft complete"), ctx
-        )
+        ctx = _make_ctx(state, task_id="10", message="Draft complete")
+        actions = on_coworker_message(ctx)
 
         spawn_action = [a for a in actions if a.method == "coworker.spawn"][0]
         prompt = spawn_action.params["prompt"]
@@ -188,124 +207,129 @@ class TestDraftToCritique:
 
 class TestCritiqueResults:
     def test_all_criteria_pass_goes_to_final(self) -> None:
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
-        ctx._store["tasks"]["10"]["stage"] = "critique"
+        state: dict = {}
+        _init_task(state, "10")
+        state["tasks"]["10"]["stage"] = "critique"
 
-        actions = on_coworker_message(
-            _make_event(task_id="10", message="CRITIQUE COMPLETE - 0 criteria failed"), ctx
-        )
+        ctx = _make_ctx(state, task_id="10", message="CRITIQUE COMPLETE - 0 criteria failed")
+        actions = on_coworker_message(ctx)
+        _apply_actions(actions, state)
 
-        assert ctx._store["tasks"]["10"]["stage"] == "final"
+        assert state["tasks"]["10"]["stage"] == "final"
         msgs = _action_messages(actions)
         assert any("All criteria passed" in m for m in msgs)
         assert any("Final Review" in m for m in msgs)
 
     def test_failures_go_to_revise(self) -> None:
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
-        ctx._store["tasks"]["10"]["stage"] = "critique"
+        state: dict = {}
+        _init_task(state, "10")
+        state["tasks"]["10"]["stage"] = "critique"
 
-        actions = on_coworker_message(
-            _make_event(task_id="10", message="CRITIQUE COMPLETE - 3 criteria failed"), ctx
-        )
+        ctx = _make_ctx(state, task_id="10", message="CRITIQUE COMPLETE - 3 criteria failed")
+        actions = on_coworker_message(ctx)
+        _apply_actions(actions, state)
 
-        assert ctx._store["tasks"]["10"]["stage"] == "revise"
+        assert state["tasks"]["10"]["stage"] == "revise"
         msgs = _action_messages(actions)
         assert any("3 criteria failed" in m for m in msgs)
         assert any("Revise" in m for m in msgs)
 
     def test_malformed_critique_stays_in_critique(self) -> None:
         """If critique message doesn't match expected format, stay in critique (fail-closed)."""
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
-        ctx._store["tasks"]["10"]["stage"] = "critique"
+        state: dict = {}
+        _init_task(state, "10")
+        state["tasks"]["10"]["stage"] = "critique"
 
-        actions = on_coworker_message(
-            _make_event(task_id="10", message="critique complete - all good"), ctx
-        )
+        ctx = _make_ctx(state, task_id="10", message="critique complete - all good")
+        actions = on_coworker_message(ctx)
 
-        assert ctx._store["tasks"]["10"]["stage"] == "critique"
+        assert state["tasks"]["10"]["stage"] == "critique"
         msgs = _action_messages(actions)
         assert any("Unable to parse" in m for m in msgs)
 
 
 class TestRevisionLoop:
     def test_revision_complete_triggers_re_critique(self) -> None:
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
-        ctx._store["tasks"]["10"]["stage"] = "revise"
+        state: dict = {}
+        _init_task(state, "10")
+        state["tasks"]["10"]["stage"] = "revise"
 
-        actions = on_coworker_message(
-            _make_event(task_id="10", message="Revision complete"), ctx
-        )
+        ctx = _make_ctx(state, task_id="10", message="Revision complete")
+        actions = on_coworker_message(ctx)
+        _apply_actions(actions, state)
 
-        assert ctx._store["tasks"]["10"]["stage"] == "critique"
-        assert ctx._store["tasks"]["10"]["revision_count"] == 1
+        assert state["tasks"]["10"]["stage"] == "critique"
+        assert state["tasks"]["10"]["revision_count"] == 1
         assert _has_spawn(actions)
         msgs = _action_messages(actions)
         assert any("revision #1" in m for m in msgs)
 
     def test_multiple_revisions_increment_count(self) -> None:
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
-        ctx._store["tasks"]["10"]["stage"] = "revise"
-        ctx._store["tasks"]["10"]["revision_count"] = 2
+        state: dict = {}
+        _init_task(state, "10")
+        state["tasks"]["10"]["stage"] = "revise"
+        state["tasks"]["10"]["revision_count"] = 2
 
-        actions = on_coworker_message(
-            _make_event(task_id="10", message="Revision complete"), ctx
-        )
+        ctx = _make_ctx(state, task_id="10", message="Revision complete")
+        actions = on_coworker_message(ctx)
+        _apply_actions(actions, state)
 
-        assert ctx._store["tasks"]["10"]["revision_count"] == 3
+        assert state["tasks"]["10"]["revision_count"] == 3
         msgs = _action_messages(actions)
         assert any("revision #3" in m for m in msgs)
 
     def test_full_sdoh_cycle(self) -> None:
         """End-to-end: research -> outline -> draft -> critique -> revise -> critique -> final."""
-        ctx = _make_context()
+        state: dict = {}
 
         # task created
-        on_task_created(_make_event(task_id="1", subject="Blog post"), ctx)
-        assert ctx._store["tasks"]["1"]["stage"] == "research"
+        _init_task(state, "1")
+        assert state["tasks"]["1"]["stage"] == "research"
 
         # research -> outline
-        on_coworker_message(
-            _make_event(task_id="1", message="research complete"), ctx
+        actions = on_coworker_message(
+            _make_ctx(state, task_id="1", message="research complete")
         )
-        assert ctx._store["tasks"]["1"]["stage"] == "outline"
+        _apply_actions(actions, state)
+        assert state["tasks"]["1"]["stage"] == "outline"
 
         # outline -> draft
-        on_coworker_message(
-            _make_event(task_id="1", message="outline ready"), ctx
+        actions = on_coworker_message(
+            _make_ctx(state, task_id="1", message="outline ready")
         )
-        assert ctx._store["tasks"]["1"]["stage"] == "draft"
+        _apply_actions(actions, state)
+        assert state["tasks"]["1"]["stage"] == "draft"
 
         # draft -> critique (spawns critic)
         actions = on_coworker_message(
-            _make_event(task_id="1", message="draft complete"), ctx
+            _make_ctx(state, task_id="1", message="draft complete")
         )
-        assert ctx._store["tasks"]["1"]["stage"] == "critique"
+        _apply_actions(actions, state)
+        assert state["tasks"]["1"]["stage"] == "critique"
         assert _has_spawn(actions)
 
         # critique with failures -> revise
-        on_coworker_message(
-            _make_event(task_id="1", message="CRITIQUE COMPLETE - 2 criteria failed"), ctx
+        actions = on_coworker_message(
+            _make_ctx(state, task_id="1", message="CRITIQUE COMPLETE - 2 criteria failed")
         )
-        assert ctx._store["tasks"]["1"]["stage"] == "revise"
+        _apply_actions(actions, state)
+        assert state["tasks"]["1"]["stage"] == "revise"
 
         # revise -> re-critique (spawns critic again)
         actions = on_coworker_message(
-            _make_event(task_id="1", message="revision complete"), ctx
+            _make_ctx(state, task_id="1", message="revision complete")
         )
-        assert ctx._store["tasks"]["1"]["stage"] == "critique"
-        assert ctx._store["tasks"]["1"]["revision_count"] == 1
+        _apply_actions(actions, state)
+        assert state["tasks"]["1"]["stage"] == "critique"
+        assert state["tasks"]["1"]["revision_count"] == 1
         assert _has_spawn(actions)
 
         # critique passes -> final
-        on_coworker_message(
-            _make_event(task_id="1", message="CRITIQUE COMPLETE - 0 criteria failed"), ctx
+        actions = on_coworker_message(
+            _make_ctx(state, task_id="1", message="CRITIQUE COMPLETE - 0 criteria failed")
         )
-        assert ctx._store["tasks"]["1"]["stage"] == "final"
+        _apply_actions(actions, state)
+        assert state["tasks"]["1"]["stage"] == "final"
 
 
 # ---------------------------------------------------------------------------
@@ -315,73 +339,140 @@ class TestRevisionLoop:
 
 class TestAddCriterion:
     def test_add_criterion_to_active_task(self) -> None:
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
-        ctx._store["tasks"]["10"]["stage"] = "draft"
+        state: dict = {}
+        _init_task(state, "10")
+        state["tasks"]["10"]["stage"] = "draft"
 
-        actions = on_channel_message(
-            _make_event(message="add criterion: No passive voice in opening"), ctx
-        )
+        ctx = _make_ctx(state, message="add criterion: No passive voice in opening")
+        actions = on_channel_message(ctx)
+        _apply_actions(actions, state)
 
-        assert "No passive voice in opening" in ctx._store["tasks"]["10"]["criteria"]
+        assert "No passive voice in opening" in state["tasks"]["10"]["criteria"]
         msgs = _action_messages(actions)
         assert any("No passive voice in opening" in m for m in msgs)
 
+    def test_add_criterion_uses_task_id_from_context(self) -> None:
+        """With multiple active tasks, task_id from context targets the correct task."""
+        state: dict = {}
+        _init_task(state, "10")
+        _init_task(state, "20")
+        state["tasks"]["10"]["stage"] = "draft"
+        state["tasks"]["20"]["stage"] = "draft"
+
+        ctx = _make_ctx(state, task_id="20", message="add criterion: Must include a quote")
+        actions = on_channel_message(ctx)
+        _apply_actions(actions, state)
+
+        # Criterion should be added to task 20 (from context), not task 10
+        assert "Must include a quote" in state["tasks"]["20"]["criteria"]
+        assert "Must include a quote" not in state["tasks"]["10"]["criteria"]
+
+    def test_add_criterion_ambiguous_multiple_active_tasks(self) -> None:
+        """Without task_id context, multiple active tasks should warn about ambiguity."""
+        state: dict = {}
+        _init_task(state, "10")
+        _init_task(state, "20")
+        state["tasks"]["10"]["stage"] = "draft"
+        state["tasks"]["20"]["stage"] = "critique"
+
+        ctx = _make_ctx(state, message="add criterion: something")
+        actions = on_channel_message(ctx)
+
+        # Should NOT silently modify a random task — should warn about ambiguity
+        assert "something" not in state["tasks"]["10"].get("criteria", [])
+        assert "something" not in state["tasks"]["20"].get("criteria", [])
+        msgs = _action_messages(actions)
+        assert len(msgs) == 1
+        assert "Multiple active tasks" in msgs[0]
+        assert "--task" in msgs[0]
+
+    def test_add_criterion_explicit_task_id_inactive_stage(self) -> None:
+        """Explicit task_id targeting an inactive task should warn the user."""
+        state: dict = {}
+        _init_task(state, "10")
+        _init_task(state, "20")
+        state["tasks"]["10"]["stage"] = "draft"
+        state["tasks"]["20"]["stage"] = "final"
+
+        ctx = _make_ctx(state, task_id="20", message="add criterion: something")
+        actions = on_channel_message(ctx)
+
+        # Neither task should have the criterion added
+        assert "something" not in state["tasks"]["10"].get("criteria", [])
+        assert "something" not in state["tasks"]["20"].get("criteria", [])
+        # Should warn that the targeted task is not active
+        msgs = _action_messages(actions)
+        assert len(msgs) == 1
+        assert "20" in msgs[0]
+        assert "not in an active stage" in msgs[0]
+
     def test_new_rule_alias(self) -> None:
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
-        ctx._store["tasks"]["10"]["stage"] = "critique"
+        state: dict = {}
+        _init_task(state, "10")
+        state["tasks"]["10"]["stage"] = "critique"
 
-        on_channel_message(
-            _make_event(message="new rule: Every paragraph under 5 sentences"), ctx
-        )
+        ctx = _make_ctx(state, message="new rule: Every paragraph under 5 sentences")
+        actions = on_channel_message(ctx)
+        _apply_actions(actions, state)
 
-        assert "Every paragraph under 5 sentences" in ctx._store["tasks"]["10"]["criteria"]
+        assert "Every paragraph under 5 sentences" in state["tasks"]["10"]["criteria"]
 
     def test_no_active_task_returns_none(self) -> None:
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
+        state: dict = {}
+        _init_task(state, "10")
         # research stage is not "active" for criteria changes
-        ctx._store["tasks"]["10"]["stage"] = "research"
+        state["tasks"]["10"]["stage"] = "research"
 
-        actions = on_channel_message(
-            _make_event(message="add criterion: something"), ctx
-        )
+        ctx = _make_ctx(state, message="add criterion: something")
+        actions = on_channel_message(ctx)
 
         assert actions is None
 
 
 class TestAddPattern:
     def test_add_pattern_to_active_task(self) -> None:
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
-        ctx._store["tasks"]["10"]["stage"] = "draft"
+        state: dict = {}
+        _init_task(state, "10")
+        state["tasks"]["10"]["stage"] = "draft"
 
-        actions = on_channel_message(
-            _make_event(message="add pattern: Use metaphors sparingly"), ctx
-        )
+        ctx = _make_ctx(state, message="add pattern: Use metaphors sparingly")
+        actions = on_channel_message(ctx)
+        _apply_actions(actions, state)
 
-        assert "Use metaphors sparingly" in ctx._store["tasks"]["10"]["patterns"]
+        assert "Use metaphors sparingly" in state["tasks"]["10"]["patterns"]
         msgs = _action_messages(actions)
         assert len(msgs) == 1
 
-    def test_add_pattern_inactive_stage_returns_none(self) -> None:
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
-        ctx._store["tasks"]["10"]["stage"] = "research"
+    def test_add_pattern_uses_task_id_from_context(self) -> None:
+        """With multiple active tasks, task_id from context targets the correct task."""
+        state: dict = {}
+        _init_task(state, "10")
+        _init_task(state, "20")
+        state["tasks"]["10"]["stage"] = "draft"
+        state["tasks"]["20"]["stage"] = "revise"
 
-        actions = on_channel_message(
-            _make_event(message="add pattern: something"), ctx
-        )
+        ctx = _make_ctx(state, task_id="20", message="add pattern: Vary sentence length")
+        actions = on_channel_message(ctx)
+        _apply_actions(actions, state)
+
+        assert "Vary sentence length" in state["tasks"]["20"]["patterns"]
+        assert "Vary sentence length" not in state["tasks"]["10"]["patterns"]
+
+    def test_add_pattern_inactive_stage_returns_none(self) -> None:
+        state: dict = {}
+        _init_task(state, "10")
+        state["tasks"]["10"]["stage"] = "research"
+
+        ctx = _make_ctx(state, message="add pattern: something")
+        actions = on_channel_message(ctx)
 
         assert actions is None
 
     def test_empty_state_returns_none(self) -> None:
-        ctx = _make_context()
+        state: dict = {}
 
-        actions = on_channel_message(
-            _make_event(message="add pattern: something"), ctx
-        )
+        ctx = _make_ctx(state, message="add pattern: something")
+        actions = on_channel_message(ctx)
 
         assert actions is None
 
@@ -393,44 +484,40 @@ class TestAddPattern:
 
 class TestEdgeCases:
     def test_coworker_message_without_task_id_returns_none(self) -> None:
-        ctx = _make_context()
+        state: dict = {}
 
-        actions = on_coworker_message(
-            _make_event(message="research complete"), ctx
-        )
+        ctx = _make_ctx(state, message="research complete")
+        actions = on_coworker_message(ctx)
 
         assert actions is None
 
     def test_coworker_message_unknown_task_returns_none(self) -> None:
-        ctx = _make_context()
+        state: dict = {}
 
-        actions = on_coworker_message(
-            _make_event(task_id="999", message="research complete"), ctx
-        )
+        ctx = _make_ctx(state, task_id="999", message="research complete")
+        actions = on_coworker_message(ctx)
 
         assert actions is None
         # No state pollution
-        assert "tasks" not in ctx._store
+        assert "tasks" not in state
 
     def test_wrong_stage_transition_returns_none(self) -> None:
         """Sending 'draft complete' during research stage does nothing."""
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
+        state: dict = {}
+        _init_task(state, "10")
 
-        actions = on_coworker_message(
-            _make_event(task_id="10", message="draft complete"), ctx
-        )
+        ctx = _make_ctx(state, task_id="10", message="draft complete")
+        actions = on_coworker_message(ctx)
 
-        assert ctx._store["tasks"]["10"]["stage"] == "research"
+        assert state["tasks"]["10"]["stage"] == "research"
         assert actions is None
 
     def test_missing_message_field(self) -> None:
-        ctx = _make_context()
-        on_task_created(_make_event(task_id="10", subject="test"), ctx)
+        state: dict = {}
+        _init_task(state, "10")
 
-        actions = on_coworker_message(
-            _make_event(task_id="10"), ctx
-        )
+        ctx = _make_ctx(state, task_id="10")
+        actions = on_coworker_message(ctx)
 
         assert actions is None
 
@@ -459,25 +546,89 @@ class TestBuildCritiquePrompt:
 
 class TestFindActiveTaskId:
     def test_finds_draft_stage(self) -> None:
-        ctx = _make_context({"tasks": {"1": {"stage": "draft"}}})
+        ctx = _make_ctx({"tasks": {"1": {"stage": "draft"}}})
         assert _find_active_task_id(ctx) == "1"
 
     def test_finds_critique_stage(self) -> None:
-        ctx = _make_context({"tasks": {"2": {"stage": "critique"}}})
+        ctx = _make_ctx({"tasks": {"2": {"stage": "critique"}}})
         assert _find_active_task_id(ctx) == "2"
 
     def test_finds_revise_stage(self) -> None:
-        ctx = _make_context({"tasks": {"3": {"stage": "revise"}}})
+        ctx = _make_ctx({"tasks": {"3": {"stage": "revise"}}})
         assert _find_active_task_id(ctx) == "3"
 
     def test_none_in_research(self) -> None:
-        ctx = _make_context({"tasks": {"1": {"stage": "research"}}})
+        ctx = _make_ctx({"tasks": {"1": {"stage": "research"}}})
         assert _find_active_task_id(ctx) is None
 
     def test_none_in_final(self) -> None:
-        ctx = _make_context({"tasks": {"1": {"stage": "final"}}})
+        ctx = _make_ctx({"tasks": {"1": {"stage": "final"}}})
         assert _find_active_task_id(ctx) is None
 
     def test_empty_state(self) -> None:
-        ctx = _make_context({})
+        ctx = _make_ctx({})
         assert _find_active_task_id(ctx) is None
+
+    def test_none_when_multiple_active(self) -> None:
+        """Multiple active tasks should return None (ambiguous)."""
+        ctx = _make_ctx({"tasks": {"1": {"stage": "draft"}, "2": {"stage": "revise"}}})
+        assert _find_active_task_id(ctx) is None
+
+
+class TestResolveTargetTask:
+    def test_explicit_task_id_active(self) -> None:
+        """Explicit task_id targeting an active task returns it."""
+        state = {"tasks": {"10": {"stage": "draft"}, "20": {"stage": "revise"}}}
+        ctx = _make_ctx(state, task_id="20")
+        tid, td = _resolve_target_task(ctx)
+        assert tid == "20"
+        assert td.get("stage") == "revise"
+
+    def test_explicit_task_id_inactive(self) -> None:
+        """Explicit task_id targeting an inactive task returns (None, {})."""
+        state = {"tasks": {"10": {"stage": "draft"}, "20": {"stage": "final"}}}
+        ctx = _make_ctx(state, task_id="20")
+        tid, td = _resolve_target_task(ctx)
+        assert tid is None
+        assert td == {}
+
+    def test_fallback_single_active(self) -> None:
+        """No task_id, single active task: returns it."""
+        state = {"tasks": {"10": {"stage": "draft"}}}
+        ctx = _make_ctx(state)
+        tid, td = _resolve_target_task(ctx)
+        assert tid == "10"
+
+    def test_fallback_multiple_active(self) -> None:
+        """No task_id, multiple active tasks: returns (None, {})."""
+        state = {"tasks": {"10": {"stage": "draft"}, "20": {"stage": "revise"}}}
+        ctx = _make_ctx(state)
+        tid, td = _resolve_target_task(ctx)
+        assert tid is None
+        assert td == {}
+
+
+class TestWarnNoTarget:
+    def test_warns_about_inactive_explicit_task(self) -> None:
+        state = {"tasks": {"10": {"stage": "draft"}, "20": {"stage": "final"}}}
+        ctx = _make_ctx(state, task_id="20")
+        actions = _warn_no_target(ctx)
+        msgs = _action_messages(actions)
+        assert len(msgs) == 1
+        assert "20" in msgs[0]
+        assert "not in an active stage" in msgs[0]
+
+    def test_warns_about_ambiguity(self) -> None:
+        state = {"tasks": {"10": {"stage": "draft"}, "20": {"stage": "revise"}}}
+        ctx = _make_ctx(state)
+        actions = _warn_no_target(ctx)
+        msgs = _action_messages(actions)
+        assert len(msgs) == 1
+        assert "Multiple active tasks" in msgs[0]
+        assert "--task" in msgs[0]
+
+    def test_no_warning_when_no_active_tasks(self) -> None:
+        state = {"tasks": {"10": {"stage": "research"}}}
+        ctx = _make_ctx(state)
+        actions = _warn_no_target(ctx)
+        assert actions == []


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
After PR #1809 restructured the TDW workflow from `sdk/python/midtown/tdw_workflow.py` into `.midtown/channels/tdw/scripts/hooks.py` (hookimpl-based architecture), this PR ports the original dict-order bug fix to the new location.

### Bug fix
- `_find_active_task_id` returned the **first** active task from `dict.items()` iteration — dict iteration order is insertion-dependent, so with multiple active tasks the wrong one could be silently targeted
- Fixed to require **exactly one** active task, returning `None` when ambiguous

### New features
- `ACTIVE_STAGES` constant replaces duplicated `("draft", "critique", "revise")` tuples
- `_resolve_target_task(ctx)` uses `ctx.task_id` when available (e.g. `--task` flag), falls back to single-active-task lookup
- `_warn_no_target(ctx)` returns user-facing `DaemonAction` warnings for ambiguity and inactive-task targeting

### Test infrastructure fixes (from PR #1809)
- Fixed all tests to use `HookContext` instead of broken `(event, ctx)` two-arg calls that didn't match hookimpl signatures (32 tests were failing with `TypeError`)
- Fixed `on_coworker_message` to use nested dict access consistently (was using dot-path keys incompatible with nested state dicts)
- Added `_apply_actions` helper to execute `set_state` actions on state dict for test setup

### Test coverage
- 44 tests (up from 32), all passing
- New tests cover: dict-order ambiguity, explicit task_id targeting, inactive task warnings, `_resolve_target_task`, `_warn_no_target`

## Test plan
- [x] All 44 TDW hook tests pass
- [x] All 49 SDK Python tests pass  
- [x] Rust clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)