### PR TITLE
fix: Skip stuck reviewer restarts when review already posted [Midtown !2104]

### DIFF
--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -422,6 +422,7 @@ pub fn check_and_restart_stuck_reviewers(snap: &snapshot::WorldSnapshot) -> Vec<
     let restarts = crate::rules::decide_stuck_reviewer_restarts(
         &snap.health.headless_process_health,
         &snap.reviewer.reviewer_pr_assignments,
+        &snap.reviewer.reviewed_prs,
         &snap.reviewer.reviewer_restart_counts,
         &exemptions,
         snap.now_utc,
@@ -503,6 +504,10 @@ pub fn check_and_restart_stuck_reviewers(snap: &snapshot::WorldSnapshot) -> Vec<
             Some(pr) => *pr,
             None => continue,
         };
+        // Review already posted — no escalation needed.
+        if snap.reviewer.reviewed_prs.contains(&pr_number) {
+            continue;
+        }
         // Use the shorter threshold for PRs with a placeholder comment (matches detection logic).
         let effective_duration = if prs_with_in_progress_comment.contains(&pr_number) {
             REVIEWER_PLACEHOLDER_STUCK_DURATION

--- a/src/daemon/health_tests.rs
+++ b/src/daemon/health_tests.rs
@@ -1268,6 +1268,7 @@ fn stuck_reviewer_restart_propagates_session_id() {
     let restarts = crate::rules::decide_stuck_reviewer_restarts(
         &snap.health.headless_process_health,
         &snap.reviewer.reviewer_pr_assignments,
+        &snap.reviewer.reviewed_prs,
         &snap.reviewer.reviewer_restart_counts,
         &exemptions,
         snap.now_utc,
@@ -1560,6 +1561,7 @@ fn pending_api_call_exempts_reviewer_from_stuck_detection() {
     let restarts = crate::rules::decide_stuck_reviewer_restarts(
         &snap.health.headless_process_health,
         &snap.reviewer.reviewer_pr_assignments,
+        &snap.reviewer.reviewed_prs,
         &snap.reviewer.reviewer_restart_counts,
         &exemptions,
         snap.now_utc,
@@ -2307,6 +2309,49 @@ fn dead_reviewer_at_max_restarts_escalates_to_ops() {
     assert!(
         has_record_escalation,
         "expected RecordReviewerEscalation for PR #1352, got: {:#?}",
+        effects
+    );
+}
+
+/// Bug !2104: The stuck reviewer escalation logic in `check_and_restart_stuck_reviewers`
+/// must skip reviewers whose PRs have already been reviewed. Previously, the inline
+/// escalation code didn't check `reviewed_prs`, causing spurious escalation warnings.
+#[test]
+fn stuck_reviewer_escalation_skipped_when_review_already_posted() {
+    let now = chrono::Utc::now();
+    let mut snap = empty_snap();
+    snap.now_utc = now;
+
+    // Reviewer is alive but stuck (no events for a long time)
+    snap.health.headless_process_health.insert(
+        "broadway".to_string(),
+        snapshot::ProcessHealth {
+            is_alive: true,
+            last_event_at: Some(now - chrono::Duration::minutes(20)),
+            ..Default::default()
+        },
+    );
+    snap.reviewer
+        .reviewer_pr_assignments
+        .insert("broadway".to_string(), 1825u64);
+    snap.reviewer
+        .reviewer_restart_counts
+        .insert(1825u64, MAX_REVIEWER_RESTARTS); // at max restarts
+    // Review was already posted
+    snap.reviewer.reviewed_prs.insert(1825u64);
+
+    let effects = check_and_restart_stuck_reviewers(&snap);
+
+    // Should produce no effects — review was posted, no escalation needed
+    let has_escalation = effects.iter().any(|e| {
+        matches!(
+            e,
+            Effect::PostToChannel { message, .. } if message.contains("1825")
+        )
+    });
+    assert!(
+        !has_escalation,
+        "no escalation expected when review was already posted, got: {:#?}",
         effects
     );
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -925,6 +925,7 @@ pub(crate) struct StuckReviewerRestart {
 pub(crate) fn decide_stuck_reviewer_restarts(
     process_health: &HashMap<String, crate::daemon::snapshot::ProcessHealth>,
     reviewer_pr_assignments: &HashMap<String, u64>,
+    reviewed_prs: &std::collections::HashSet<u64>,
     reviewer_restart_counts: &HashMap<u64, u32>,
     exemptions: &StuckExemptions<'_>,
     now_utc: DateTime<Utc>,
@@ -945,6 +946,11 @@ pub(crate) fn decide_stuck_reviewer_restarts(
             Some(pr) => *pr,
             None => continue,
         };
+
+        // Review was already posted — no need to restart.
+        if reviewed_prs.contains(&pr_number) {
+            continue;
+        }
 
         // Use shorter threshold if reviewer posted a placeholder (they started but may have frozen)
         let effective_threshold = if prs_with_in_progress_comment.contains(&pr_number) {
@@ -4127,6 +4133,7 @@ mod tests {
         decide_stuck_reviewer_restarts(
             &map,
             &assignments,
+            &HashSet::new(), // no reviewed PRs
             restart_counts,
             &exemptions,
             now,
@@ -4219,6 +4226,7 @@ mod tests {
         let restarts = decide_stuck_reviewer_restarts(
             &map,
             &HashMap::new(), // no reviewer assignment
+            &HashSet::new(),
             &HashMap::new(),
             &exemptions,
             now,
@@ -4262,6 +4270,7 @@ mod tests {
         let restarts = decide_stuck_reviewer_restarts(
             &map,
             &assignments,
+            &HashSet::new(),
             &HashMap::new(),
             &exemptions,
             now,
@@ -4307,6 +4316,7 @@ mod tests {
         let restarts = decide_stuck_reviewer_restarts(
             &map,
             &assignments,
+            &HashSet::new(),
             &HashMap::new(),
             &exemptions,
             now,
@@ -4320,6 +4330,47 @@ mod tests {
         assert!(
             restarts.is_empty(),
             "reviewer with no events but recently started should NOT be stuck yet"
+        );
+    }
+
+    /// Bug !2104: A reviewer whose review has already been posted (PR is in
+    /// `reviewed_prs`) should NOT be flagged for restart. Previously,
+    /// `decide_stuck_reviewer_restarts` didn't check `reviewed_prs`, causing
+    /// reviewers to be restarted and re-nudged even after posting their review.
+    #[test]
+    fn stuck_reviewer_skipped_when_review_already_posted() {
+        let now = Utc::now();
+        let mut process_health = HashMap::new();
+        process_health.insert("columbus".to_string(), stuck_health(now));
+        let mut assignments = HashMap::new();
+        assignments.insert("columbus".to_string(), 1823u64);
+        let mut reviewed_prs: HashSet<u64> = HashSet::new();
+        reviewed_prs.insert(1823); // review WAS posted
+        let exemptions = StuckExemptions {
+            usage_limited: &HashSet::new(),
+            api_error: &HashSet::new(),
+            auth_error: &HashSet::new(),
+            attached: &HashMap::new(),
+        };
+
+        let restarts = decide_stuck_reviewer_restarts(
+            &process_health,
+            &assignments,
+            &reviewed_prs,
+            &HashMap::new(),
+            &exemptions,
+            now,
+            Duration::from_secs(300),
+            Duration::from_secs(120),
+            2,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashSet::new(),
+        );
+
+        assert!(
+            restarts.is_empty(),
+            "reviewer whose review was already posted should NOT be restarted"
         );
     }
 

--- a/src/rules_session_tests.rs
+++ b/src/rules_session_tests.rs
@@ -173,6 +173,7 @@ fn stuck_reviewer_restart_includes_session_id_from_map() {
     let restarts = decide_stuck_reviewer_restarts(
         &health_map,
         &assignments,
+        &HashSet::new(),
         &HashMap::new(),
         &exemptions,
         now,
@@ -209,6 +210,7 @@ fn stuck_reviewer_restart_session_id_none_when_no_mapping() {
     let restarts = decide_stuck_reviewer_restarts(
         &health_map,
         &assignments,
+        &HashSet::new(),
         &HashMap::new(),
         &exemptions,
         now,
@@ -256,6 +258,7 @@ fn stuck_reviewer_with_placeholder_uses_shorter_threshold() {
     let restarts = decide_stuck_reviewer_restarts(
         &map,
         &assignments,
+        &HashSet::new(),
         &HashMap::new(),
         &exemptions,
         now,
@@ -304,6 +307,7 @@ fn stuck_reviewer_without_placeholder_uses_standard_threshold() {
     let restarts = decide_stuck_reviewer_restarts(
         &map,
         &assignments,
+        &HashSet::new(),
         &HashMap::new(),
         &exemptions,
         now,


### PR DESCRIPTION
<!-- midtown: york -->

## Summary

- `decide_stuck_reviewer_restarts()` was missing a `reviewed_prs` check that its counterpart `decide_dead_reviewer_respawns()` already had
- This caused reviewers to be restarted and re-nudged even after posting their review, because the assignment in `pr_reviewers` persists until the next PR poll cycle clears it
- Also adds the same `reviewed_prs` guard to the inline escalation logic in `check_and_restart_stuck_reviewers()` for max-restart-count reviewers

## Root Cause

Two parallel code paths handle reviewer lifecycle:
1. **Dead reviewer path** (`decide_dead_reviewer_respawns`) — correctly checks `reviewed_prs` before respawning
2. **Stuck reviewer path** (`decide_stuck_reviewer_restarts`) — was **missing** the `reviewed_prs` check

When a reviewer posted their review via webhook, `mark_reviewed_pr()` was called. But between the webhook and the next PR poll (which clears the assignment via `remove_assignment`), the health tick could fire `decide_stuck_reviewer_restarts`. Without the `reviewed_prs` filter, it would flag the reviewer as stuck and restart them — sending a new nudge to review an already-reviewed PR.

## Changes

- Added `reviewed_prs: &HashSet<u64>` parameter to `decide_stuck_reviewer_restarts()` 
- Added early `reviewed_prs.contains(&pr_number)` check matching the dead reviewer path
- Added `reviewed_prs` check to the inline escalation logic in `check_and_restart_stuck_reviewers()`
- Updated all call sites (rules.rs, health.rs, rules_session_tests.rs, health_tests.rs)

## Test plan

- [x] New test: `stuck_reviewer_skipped_when_review_already_posted` — verifies the fix
- [x] New test: `stuck_reviewer_escalation_skipped_when_review_already_posted` — verifies escalation guard
- [x] All 22 existing `stuck_reviewer` tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)