### PR TITLE
fix: Preserve task_id across session clear, detach, fork, and auth relaunch

### DIFF
--- a/src/daemon/rpc_auth_tests.rs
+++ b/src/daemon/rpc_auth_tests.rs
@@ -648,11 +648,19 @@ fn test_build_fresh_coworker_relaunch_config_preserves_task_id() {
         Some("42".to_string()),
         "task_id must be passed through to the config"
     );
+    assert!(
+        config_with.initial_prompt.as_ref().unwrap().contains("42"),
+        "initial prompt should reference the task ID"
+    );
 
     let config_without = build_fresh_coworker_relaunch_config(&coworker, "midtown", None);
     assert_eq!(
         config_without.task_id, None,
         "task_id must be None when not provided"
+    );
+    assert!(
+        config_without.initial_prompt.is_none(),
+        "initial prompt must be None when task_id is not provided"
     );
 }
 

--- a/src/daemon/rpc_session.rs
+++ b/src/daemon/rpc_session.rs
@@ -1395,7 +1395,7 @@ pub(super) async fn create_fork_session(
             fork_session_id.clone(),
             crate::daemon::state::SessionRecord {
                 session_id: fork_session_id.clone(),
-                task_id: None,
+                task_id: parent_record.as_ref().and_then(|r| r.task_id.clone()),
                 current_name: Some(fork_name.clone()),
                 preferred_name: Some(fork_name.clone()),
                 working_dir: working_dir.clone().unwrap_or_default(),


### PR DESCRIPTION
## Summary

Addresses review feedback from columbus on PR #1842:

- **Auth relaunch**: `build_fresh_coworker_relaunch_config()` now passes `task_id` through to `LaunchConfig` instead of `None`, so coworkers relaunched after auth rotation get `MIDTOWN_TASK_ID` set
- **Session clear**: Handler preserves `session_info.task_id` in the rebuilt `LaunchConfig`
- **Session detach**: Handler preserves `session_info.task_id` in the rebuilt `LaunchConfig`
- **Fork session**: Propagates `parent_record.task_id` to the forked `SessionRecord`

All four were one-line fixes changing `None` → the available task_id field.

## Test plan

- [x] Added unit tests for `build_fresh_coworker_relaunch_config` with `Some("42")` and `None`
- [x] Existing session clear tests pass (7/7)
- [x] `cargo clippy` clean
- [x] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)