### PR TITLE
fix: Handle commit status entries in statusCheckRollup CI checks [Midtown !2121]

### DIFF
--- a/src/daemon/helpers.rs
+++ b/src/daemon/helpers.rs
@@ -394,11 +394,8 @@ pub fn detect_pr_issues(pr: &serde_json::Value) -> Vec<PrIssueType> {
     // Check for CI failures
     if let Some(checks) = pr.get("statusCheckRollup").and_then(|c| c.as_array()) {
         let has_failure = checks.iter().any(|check| {
-            let conclusion = check
-                .get("conclusion")
-                .and_then(|c| c.as_str())
-                .unwrap_or("");
-            conclusion == "FAILURE"
+            let status = resolve_check_status(check);
+            status == "FAILURE" || status == "ERROR"
         });
         if has_failure {
             issues.push(PrIssueType::CiFailed);

--- a/src/daemon/helpers_tests.rs
+++ b/src/daemon/helpers_tests.rs
@@ -234,6 +234,47 @@ fn detect_issues_finds_ci_failure() {
 }
 
 #[test]
+fn detect_issues_finds_ci_failure_from_commit_status() {
+    // Commit statuses (e.g. Codecov) use `state` instead of `conclusion`
+    let pr = json!({
+        "number": 42,
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [
+            {"conclusion": "SUCCESS"},
+            {"state": "failure"}
+        ],
+        "reviewDecision": ""
+    });
+
+    let issues = detect_pr_issues(&pr);
+
+    assert!(
+        issues.contains(&PrIssueType::CiFailed),
+        "should detect CI failure from commit status `state` field"
+    );
+}
+
+#[test]
+fn detect_issues_finds_ci_error_from_commit_status() {
+    // Commit statuses can also report `error`
+    let pr = json!({
+        "number": 42,
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [
+            {"state": "error"}
+        ],
+        "reviewDecision": ""
+    });
+
+    let issues = detect_pr_issues(&pr);
+
+    assert!(
+        issues.contains(&PrIssueType::CiFailed),
+        "should detect CI error from commit status `state` field"
+    );
+}
+
+#[test]
 fn detect_issues_finds_changes_requested() {
     // Polling discovers review state via `gh pr list --json reviewDecision`
     let pr = json!({


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- **Bug**: `all_ci_checks_passed()` and `is_auto_mergeable()` only read the `conclusion` field from `statusCheckRollup` entries. GitHub commit statuses (like Codecov) use `state` instead of `conclusion`, so they were treated as pending — blocking merges even when all checks passed.
- **Fix**: Added `resolve_check_status()` helper that checks `conclusion` first, falls back to `state`, and normalizes to uppercase for consistent comparison.
- Also added `ERROR` state handling (used by commit statuses) to both functions.

## Test plan
- [x] 6 new tests covering commit status entries (`state` field) in both `all_ci_checks_passed` and `is_auto_mergeable`
- [x] All 108 existing helpers tests still pass
- [x] Full test suite passes
- [x] Clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)