### PR TITLE
fix: Skip coworker spawn for review-complete on user-authored PRs [Midtown !2124]

### DIFF
--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -3008,6 +3008,33 @@ pub(crate) async fn collect_reviewer_effects_with_source(
                 continue;
             }
 
+            // Bug !2124: For user-authored PRs (lead/* branches), skip coworker
+            // owner resolution entirely. The owner resolution chain can resolve
+            // to a coworker via task metadata, causing the daemon to spawn a
+            // coworker who sees a clean review, goes idle, and loops every
+            // cooldown period. Only the user can act on their own PRs.
+            if is_lead_branch(pf.head_ref) {
+                let channel = pr_ctx.get_channel(pr_number);
+                let user_msg = format!("@user {}", nudge_msg);
+                effects.push(Effect::PostToChannel {
+                    sender: "midtown".to_string(),
+                    message: user_msg,
+                    channel,
+                    auto_output: false,
+                    message_type: None,
+                    nudge_type: None,
+                    tool_data: None,
+                    provider: None,
+                    tool_use_id: None,
+                    parent_tool_use_id: None,
+                });
+                effects.push(Effect::RecordPrNudge {
+                    pr_number,
+                    issue_type: PrIssueType::ReviewComplete,
+                });
+                continue;
+            }
+
             let owner = resolve_pr_owner_from_session(
                 pr_number,
                 &pr_task_associations,

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -5160,3 +5160,86 @@ fn log_pr_decision_appends_multiple_entries() {
     assert_eq!(first["pr"], 10);
     assert_eq!(second["pr"], 20);
 }
+
+/// Bug !2124: When a user-authored PR (lead/* branch) has a completed review,
+/// the daemon resolves the owner to a coworker via task metadata and spawns them
+/// to "address review feedback." The coworker sees a clean review, goes idle,
+/// and after the 10-minute cooldown the cycle repeats.
+///
+/// Fix: the review-complete path should check `is_lead_branch` and route to
+/// `@user` instead of spawning a coworker.
+#[tokio::test]
+async fn test_review_complete_lead_branch_notifies_user_not_coworker() {
+    use std::collections::{HashMap, HashSet};
+    let pr_number = 1834u64;
+    // Key: this is a lead/* branch (user-authored PR)
+    let pr = json!({
+        "number": pr_number,
+        "headRefName": "lead/essay",
+        "title": "feat: Add essay [Midtown !1834]",
+        "body": "",
+        "isDraft": false,
+        "createdAt": "2026-01-01T00:00:00Z",
+        "state": "OPEN",
+    });
+
+    let (state, _tmp, _guard) = make_test_state("test-repo");
+
+    {
+        let mut ps = state.persistent_state.lock().await;
+        ps.github.mark_reviewed_pr(pr_number);
+        // Store a PR author session that resolves the owner to "columbus".
+        // This simulates the scenario where task metadata links the PR to
+        // a coworker, causing the owner resolution chain to find "columbus"
+        // even though it's a lead/* (user-authored) branch.
+        ps.github.store_pr_author_session(
+            pr_number,
+            "sess-1834",
+            "lead/essay",
+            "columbus",
+            "feat: Add essay [Midtown !1834]",
+        );
+    }
+
+    let branch_owners: HashMap<String, String> = HashMap::new();
+    let registry = crate::worktree_registry::WorktreeRegistry::new();
+    let active_names = HashSet::new();
+
+    let effects = collect_reviewer_effects_with_source(
+        &branch_owners,
+        &registry,
+        &active_names,
+        &state,
+        &[pr],
+        crate::github_state::AssignmentSource::PollingFallback,
+        &HashMap::new(),
+    )
+    .await;
+
+    // Should NOT spawn a coworker — this is a user-authored PR
+    assert!(
+        !effects.iter().any(|e| matches!(
+            e,
+            Effect::SpawnCoworkerWithCallbacks { .. }
+                | Effect::NudgeSessionWithCallbacks { .. }
+                | Effect::NudgeSession { .. }
+        )),
+        "Bug !2124: Should not spawn/nudge a coworker for a user-authored (lead/*) PR. \
+         The daemon was looping because it spawned coworkers who immediately went idle. \
+         Got: {:#?}",
+        effects
+    );
+
+    // Should notify the user via @user channel message
+    assert!(
+        effects.iter().any(|e| matches!(
+            e,
+            Effect::PostToChannel {
+                message,
+                ..
+            } if message.contains("@user")
+        )),
+        "Should post @user notification for user-authored PR review completion, got: {:#?}",
+        effects
+    );
+}


### PR DESCRIPTION
<!-- midtown: york -->

## Summary

- **Bug:** The daemon repeatedly spawned coworkers to "address review feedback" on user-authored PRs (`lead/*` branches) with clean reviews. Observed on PR #1834 where columbus was called in 3+ times and immediately went idle each time, creating a 10-minute cooldown loop.
- **Root cause:** The review-complete path in `collect_reviewer_effects_with_source` didn't check `is_lead_branch` before the owner resolution chain. For `lead/*` branches, fallbacks like `pr_author_names` could resolve to a coworker name, triggering a `SpawnOwner` action.
- **Fix:** Added `is_lead_branch` guard before owner resolution. For user-authored PRs, the daemon now posts a `@user` notification and records the nudge cooldown, consistent with `handle_pr_comment_nudge` which already has this guard.

## Changes

| File | Change |
|------|--------|
| `src/daemon/pr.rs` | Added `is_lead_branch` check in review-complete path (27 lines) |
| `src/daemon/pr_tests.rs` | Added regression test reproducing the bug (83 lines) |

## Test plan

- [x] New test `test_review_complete_lead_branch_notifies_user_not_coworker` — verifies lead/* PRs get `@user` notification instead of coworker spawn
- [x] All 4 existing review-complete tests still pass
- [x] All 127 PR module tests pass
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)