### PR TITLE
fix: Skip coworker spawn for review-complete on user-authored PRs [Midtown !2124]

### DIFF
--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -3008,6 +3008,33 @@ pub(crate) async fn collect_reviewer_effects_with_source(
                 continue;
             }
 
+            // Bug !2124: For user-authored PRs (lead/* branches), skip coworker
+            // owner resolution entirely. The owner resolution chain can resolve
+            // to a coworker via task metadata, causing the daemon to spawn a
+            // coworker who sees a clean review, goes idle, and loops every
+            // cooldown period. Only the user can act on their own PRs.
+            if is_lead_branch(pf.head_ref) {
+                let channel = pr_ctx.get_channel(pr_number);
+                let user_msg = format!("@user {}", nudge_msg);
+                effects.push(Effect::PostToChannel {
+                    sender: "midtown".to_string(),
+                    message: user_msg,
+                    channel,
+                    auto_output: false,
+                    message_type: None,
+                    nudge_type: None,
+                    tool_data: None,
+                    provider: None,
+                    tool_use_id: None,
+                    parent_tool_use_id: None,
+                });
+                effects.push(Effect::RecordPrNudge {
+                    pr_number,
+                    issue_type: PrIssueType::ReviewComplete,
+                });
+                continue;
+            }
+
             let owner = resolve_pr_owner_from_session(
                 pr_number,
                 &pr_task_associations,

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -5160,3 +5160,86 @@ fn log_pr_decision_appends_multiple_entries() {
     assert_eq!(first["pr"], 10);
     assert_eq!(second["pr"], 20);
 }
+
+/// Bug !2124: When a user-authored PR (lead/* branch) has a completed review,
+/// the daemon resolves the owner to a coworker via task metadata and spawns them
+/// to "address review feedback." The coworker sees a clean review, goes idle,
+/// and after the 10-minute cooldown the cycle repeats.
+///
+/// Fix: the review-complete path should check `is_lead_branch` and route to
+/// `@user` instead of spawning a coworker.
+#[tokio::test]
+async fn test_review_complete_lead_branch_notifies_user_not_coworker() {
+    use std::collections::{HashMap, HashSet};
+    let pr_number = 1834u64;
+    // Key: this is a lead/* branch (user-authored PR)
+    let pr = json!({
+        "number": pr_number,
+        "headRefName": "lead/essay",
+        "title": "feat: Add essay [Midtown !1834]",
+        "body": "",
+        "isDraft": false,
+        "createdAt": "2026-01-01T00:00:00Z",
+        "state": "OPEN",
+    });
+
+    let (state, _tmp, _guard) = make_test_state("test-repo");
+
+    {
+        let mut ps = state.persistent_state.lock().await;
+        ps.github.mark_reviewed_pr(pr_number);
+        // Store a PR author session that resolves the owner to "columbus".
+        // This simulates the scenario where task metadata links the PR to
+        // a coworker, causing the owner resolution chain to find "columbus"
+        // even though it's a lead/* (user-authored) branch.
+        ps.github.store_pr_author_session(
+            pr_number,
+            "sess-1834",
+            "lead/essay",
+            "columbus",
+            "feat: Add essay [Midtown !1834]",
+        );
+    }
+
+    let branch_owners: HashMap<String, String> = HashMap::new();
+    let registry = crate::worktree_registry::WorktreeRegistry::new();
+    let active_names = HashSet::new();
+
+    let effects = collect_reviewer_effects_with_source(
+        &branch_owners,
+        &registry,
+        &active_names,
+        &state,
+        &[pr],
+        crate::github_state::AssignmentSource::PollingFallback,
+        &HashMap::new(),
+    )
+    .await;
+
+    // Should NOT spawn a coworker — this is a user-authored PR
+    assert!(
+        !effects.iter().any(|e| matches!(
+            e,
+            Effect::SpawnCoworkerWithCallbacks { .. }
+                | Effect::NudgeSessionWithCallbacks { .. }
+                | Effect::NudgeSession { .. }
+        )),
+        "Bug !2124: Should not spawn/nudge a coworker for a user-authored (lead/*) PR. \
+         The daemon was looping because it spawned coworkers who immediately went idle. \
+         Got: {:#?}",
+        effects
+    );
+
+    // Should notify the user via @user channel message
+    assert!(
+        effects.iter().any(|e| matches!(
+            e,
+            Effect::PostToChannel {
+                message,
+                ..
+            } if message.contains("@user")
+        )),
+        "Should post @user notification for user-authored PR review completion, got: {:#?}",
+        effects
+    );
+}


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- When a user-authored PR (lead/* branch) gets a completed review, the daemon's owner resolution chain could resolve to a coworker via task metadata. This caused the daemon to spawn a coworker to "address review feedback" — but the coworker sees a clean review, goes idle, and after the 10-minute cooldown the cycle repeats.
- Fix: check `is_lead_branch` before owner resolution in the review-complete path. For user-authored PRs, post an `@user` channel notification instead of spawning a coworker. Only the user can act on their own PRs.
- Observed on PR #1834 where columbus was called in 3+ times with nothing to do.

## Test plan
- [x] New test `test_review_complete_lead_branch_notifies_user_not_coworker` verifies lead/* PRs produce `@user` PostToChannel instead of SpawnCoworker/NudgeSession effects
- [x] `cargo clippy` clean
- [x] Existing PR tests still pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)