### PR TITLE
feat: Separate DM channels into their own TUI sidebar section [Midtown !2126]

### DIFF
--- a/src/bin/midtown/cli/chat/ui/board.rs
+++ b/src/bin/midtown/cli/chat/ui/board.rs
@@ -118,8 +118,7 @@ pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> (Vec<Hyperl
         );
     }
 
-    // Split channels into regular and DM groups.
-    // Use the `is_dm` flag from ChannelInfo when available, fall back to prefix check.
+    // Split channels into regular and DM groups using the `is_dm` flag from ChannelInfo.
     let dm_names: HashSet<String> = available_channels_clone
         .iter()
         .filter(|ci| ci.is_dm)
@@ -128,7 +127,7 @@ pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> (Vec<Hyperl
     let mut regular_channels: BTreeMap<String, Vec<&KanbanTask>> = BTreeMap::new();
     let mut dm_channels: BTreeMap<String, Vec<&KanbanTask>> = BTreeMap::new();
     for (name, tasks) in channels_to_display {
-        if dm_names.contains(&name) || name.starts_with("dm-") {
+        if dm_names.contains(&name) {
             dm_channels.insert(name, tasks);
         } else {
             regular_channels.insert(name, tasks);
@@ -177,9 +176,13 @@ pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> (Vec<Hyperl
             });
             if task_phase_label(task, task_pr, coworker_phase).is_some() {
                 if title_wraps {
+                    // The phase label is merged into the first continuation line (wrapped_lines[1]).
+                    // That line's position is current_line - wrapped_lines.len() + 1.
+                    // Register it so click-to-attach works on the continuation line too.
                     let continuation_line = current_line - wrapped_lines.len() as u16 + 1;
                     task_line_map.insert(continuation_line, (task.id.clone(), task.owner.clone()));
                 } else {
+                    // Label is a separate line below the title; register it.
                     task_line_map.insert(current_line, (task.id.clone(), task.owner.clone()));
                     current_line += 1;
                 }
@@ -214,10 +217,14 @@ pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> (Vec<Hyperl
                 });
                 if task_phase_label(task, task_pr, coworker_phase).is_some() {
                     if title_wraps {
+                        // The phase label is merged into the first continuation line (wrapped_lines[1]).
+                        // That line's position is current_line - wrapped_lines.len() + 1.
+                        // Register it so click-to-attach works on the continuation line too.
                         let continuation_line = current_line - wrapped_lines.len() as u16 + 1;
                         task_line_map
                             .insert(continuation_line, (task.id.clone(), task.owner.clone()));
                     } else {
+                        // Label is a separate line below the title; register it.
                         task_line_map.insert(current_line, (task.id.clone(), task.owner.clone()));
                         current_line += 1;
                     }

--- a/src/bin/midtown/cli/chat/ui/board_tests.rs
+++ b/src/bin/midtown/cli/chat/ui/board_tests.rs
@@ -417,6 +417,82 @@ fn test_dm_channels_in_channel_line_map() {
     );
 }
 
+/// A non-DM channel whose name starts with "dm-" but has `is_dm: false` must appear
+/// in the regular channels section, not the DM section.
+#[test]
+fn test_dm_prefix_channel_with_is_dm_false_appears_in_regular_section() {
+    use midtown::ChannelInfo;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    let mut app = test_app();
+    app.available_channels = vec![
+        ChannelInfo {
+            name: "tui".to_string(),
+            is_archived: false,
+            is_dm: false,
+        },
+        ChannelInfo {
+            name: "dm-debug-logs".to_string(),
+            is_archived: false,
+            is_dm: false, // NOT a DM despite the "dm-" prefix
+        },
+        ChannelInfo {
+            name: "dm-park".to_string(),
+            is_archived: false,
+            is_dm: true, // actual DM
+        },
+    ];
+
+    let backend = TestBackend::new(40, 30);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    terminal
+        .draw(|f| {
+            let area = f.area();
+            draw_board_panel(f, &mut app, area);
+        })
+        .unwrap();
+
+    // Extract rendered text from the terminal buffer
+    let mut rendered_lines = Vec::new();
+    let buffer = terminal.backend().buffer();
+    for y in 0..buffer.area.height {
+        let mut line = String::new();
+        for x in 0..buffer.area.width {
+            line.push_str(buffer[(x, y)].symbol());
+        }
+        rendered_lines.push(line.trim_end().to_string());
+    }
+
+    let dm_header_y = rendered_lines
+        .iter()
+        .position(|l| l.contains("DIRECT MESSAGES"))
+        .expect("should have DIRECT MESSAGES header since dm-park is a real DM");
+
+    // "dm-debug-logs" (is_dm=false) should appear ABOVE the DM header, in the regular section.
+    // Note: format_channel_display_name renders "dm-*" names as "@*", so it appears as "@debug-logs".
+    let debug_logs_line = rendered_lines
+        .iter()
+        .position(|l| l.contains("@debug-logs"));
+    assert!(
+        debug_logs_line.is_some(),
+        "dm-debug-logs should be rendered in regular section, rendered:\n{}",
+        rendered_lines.join("\n")
+    );
+    assert!(
+        debug_logs_line.unwrap() < dm_header_y,
+        "dm-debug-logs (is_dm=false) should be above DIRECT MESSAGES (in regular section)"
+    );
+
+    // "dm-park" (is_dm=true) should appear BELOW the DM header
+    let park_line = rendered_lines.iter().position(|l| l.contains("@park"));
+    assert!(
+        park_line.is_some() && park_line.unwrap() > dm_header_y,
+        "@park should be below DIRECT MESSAGES"
+    );
+}
+
 /// The project lead named by repo name (canonical naming, e.g. "midtown") should NOT
 /// appear in the coworkers sidebar. test_app() uses project_name = "test".
 /// Regression test for !1723 (Codex review feedback).


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Splits TUI board sidebar channel list into two sections: regular channels and DM channels
- DM channels appear below a dim "DIRECT MESSAGES" section header at the bottom
- Section header only renders when DM channels exist
- Line map calculations updated for click detection on DM channel headers

## Test plan
- [x] 3 new tests in `board_tests.rs`:
  - `test_dm_channels_separated_from_regular_channels` — verifies render order and DM header placement
  - `test_no_dm_header_when_no_dm_channels` — verifies header is absent when no DMs
  - `test_dm_channels_in_channel_line_map` — verifies click detection works for DM channels
- [x] All 62 existing board tests pass
- [x] `cargo clippy --bin midtown -- -D warnings` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)