### PR TITLE
fix: Wrap {@html} in {#key} block to prevent ChannelNotes crash [Midtown !2130]

### DIFF
--- a/web-app/src/lib/ChannelNotes.svelte
+++ b/web-app/src/lib/ChannelNotes.svelte
@@ -90,9 +90,11 @@ let selectedNote = $derived(notes[selectedIndex] ?? null);
     {:else if selectedNote}
       <!-- Mobile back button -->
       <button class="back-button md:hidden" onclick={backToList}>← Notes</button>
-      <article class="note-body prose">
-        {@html renderContent(selectedNote.content)}
-      </article>
+      {#key selectedNote.filename}
+        <article class="note-body prose">
+          {@html renderContent(selectedNote.content)}
+        </article>
+      {/key}
     {/if}
   </div>
 </div>


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Wraps `{@html renderContent(selectedNote.content)}` in a `{#key selectedNote.filename}` block in `ChannelNotes.svelte`
- Fixes Svelte 5 internal crash (`get_first_child` / "Cannot read properties of undefined (reading 'call')") that occurs during `{#if}` branch transitions when `{@html}` content changes simultaneously with multiple reactive state updates

## Root Cause
Svelte 5's fine-grained reactivity tries to patch `{@html}` DOM nodes in-place during conditional branch switches. When `loading`, `notes`, and `selectedNote` all change during async fetch completion, the runtime's internal `get_first_child` fails because `{@html}` replaces DOM nodes in a way that bypasses Svelte's expected DOM structure. The `{#key}` block forces clean destroy/recreate instead of in-place patching.

## Test plan
- [x] `vite build` passes with no errors
- [x] Pre-commit hooks pass (clippy, fmt, biome)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)