### PR TITLE
fix: Use camelCase mergedAt key in merged PR JSON [Midtown !2136]

### DIFF
--- a/src/daemon/rpc_prs.rs
+++ b/src/daemon/rpc_prs.rs
@@ -348,7 +348,18 @@ fn fetch_prs_all(
         .unwrap_or_default();
 
     // Process merged PRs
-    let merged_prs = repository
+    let merged_prs = parse_merged_prs(repository, repo_label);
+
+    (open_prs, merged_prs)
+}
+
+/// Parse merged PRs from the GraphQL repository response into JSON objects
+/// with keys matching the frontend's camelCase convention.
+fn parse_merged_prs(
+    repository: &serde_json::Value,
+    repo_label: Option<&str>,
+) -> Vec<serde_json::Value> {
+    repository
         .pointer("/mergedPrs/nodes")
         .and_then(|v| v.as_array())
         .map(|nodes| {
@@ -369,15 +380,13 @@ fn fetch_prs_all(
                     Some(serde_json::json!({
                         "number": number,
                         "title": title,
-                        "merged_at": merged_at,
+                        "mergedAt": merged_at,
                         "repo": repo_label,
                     }))
                 })
                 .collect()
         })
-        .unwrap_or_default();
-
-    (open_prs, merged_prs)
+        .unwrap_or_default()
 }
 
 /// Extract coworker name from PR body frontmatter (<!-- midtown: name -->).

--- a/src/daemon/rpc_prs_tests.rs
+++ b/src/daemon/rpc_prs_tests.rs
@@ -186,6 +186,40 @@ async fn test_merge_not_blocked_after_reviewer_assignment_removed() {
     }
 }
 
+/// Merged PR JSON must use camelCase `mergedAt` key to match the frontend
+/// expectation in `web-app/src/lib/api.js` and `ChannelPrList.svelte`.
+/// Regression test for !2136: snake_case `merged_at` caused the column to
+/// always show '—'.
+#[test]
+fn test_merged_pr_json_uses_camel_case_merged_at() {
+    let repository = serde_json::json!({
+        "mergedPrs": {
+            "nodes": [
+                {
+                    "number": 100,
+                    "title": "feat: Add feature",
+                    "mergedAt": "2026-03-01T12:00:00Z"
+                }
+            ]
+        }
+    });
+
+    let result = parse_merged_prs(&repository, Some("midtown"));
+    assert_eq!(result.len(), 1);
+
+    let pr = &result[0];
+    // The frontend reads `pr.mergedAt` — this key MUST be camelCase
+    assert!(
+        pr.get("mergedAt").is_some(),
+        "Merged PR JSON must use camelCase 'mergedAt' key, but found keys: {:?}",
+        pr.as_object().unwrap().keys().collect::<Vec<_>>()
+    );
+    assert_eq!(pr["mergedAt"], "2026-03-01T12:00:00Z");
+    assert_eq!(pr["number"], 100);
+    assert_eq!(pr["title"], "feat: Add feature");
+    assert_eq!(pr["repo"], "midtown");
+}
+
 #[test]
 fn test_extract_coworker_from_pr_body() {
     assert_eq!(


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Fixed the PR tab "merged" column always showing `—` by changing the JSON key from snake_case `merged_at` to camelCase `mergedAt` in `rpc_prs.rs`
- Extracted `parse_merged_prs()` from `fetch_prs_all()` for testability
- Added regression test verifying the camelCase key convention

## Root cause
The backend (`rpc_prs.rs:372`) serialized the field as `"merged_at"` (snake_case), but the frontend (`api.js:513`, `ChannelPrList.svelte:124`) reads `pr.mergedAt` (camelCase). Since `mergedAt` was never defined on the object, the Svelte template always fell through to the `'—'` fallback.

## Test plan
- [x] New test `test_merged_pr_json_uses_camel_case_merged_at` — RED (failed with snake_case key), then GREEN (passes with camelCase)
- [x] All existing tests pass (2529 passed; 18 pre-existing worktree PermissionDenied failures unrelated to this change)
- [x] `cargo clippy` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)