### PR TITLE
fix: Guard thread textarea auto-focus behind isDesktop check [Midtown !2144]

### DIFF
--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -433,7 +433,7 @@ let prevThreadId = null;
     const lastId = lastFocusedThreadId
     if (threadId && threadId !== lastId && textareaEl) {
       lastFocusedThreadId = threadId
-      tick().then(() => textareaEl.focus())
+      tick().then(() => { if (isDesktop) textareaEl.focus() })
     }
     if (!threadId) lastFocusedThreadId = null
   })


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- On mobile, opening a thread unconditionally focused the textarea, triggering the virtual keyboard and shifting the viewport
- Added an `isDesktop` guard around the `textareaEl.focus()` call in `ThreadPanel.svelte` so focus only fires on desktop viewports (≥1024px)

## Changes
- `web-app/src/lib/ThreadPanel.svelte`: Wrapped `textareaEl.focus()` in `if (isDesktop)` check (line 436)

## Test plan
- [x] Open a thread on mobile — keyboard should NOT auto-appear
- [x] Open a thread on desktop — textarea should still auto-focus

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)