### PR TITLE
fix: Use one-shot nudge for user-authored PR review-complete notifications [Midtown !2137]

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -259,6 +259,12 @@ pub enum Effect {
         pr_number: u64,
         issue_type: PrIssueType,
     },
+    /// Record a permanent one-shot PR nudge that survives cleanup.
+    /// Used for user-authored PR notifications that should fire exactly once.
+    RecordPermanentPrNudge {
+        pr_number: u64,
+        issue_type: PrIssueType,
+    },
     /// Record an in-memory task assignment for busy tracking.
     ///
     /// Defers the mutation from the decision phase to the effect executor,
@@ -1592,6 +1598,13 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
             } => {
                 let mut tracker = state.pr_issue_tracker.lock().await;
                 tracker.record_nudge(pr_number, issue_type);
+            }
+            Effect::RecordPermanentPrNudge {
+                pr_number,
+                issue_type,
+            } => {
+                let mut tracker = state.pr_issue_tracker.lock().await;
+                tracker.record_permanent_nudge(pr_number, issue_type);
             }
             Effect::RecordReviewerEscalation { pr_number } => {
                 let mut posted = state.reviewer_escalations_posted.lock().unwrap();

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -3031,7 +3031,7 @@ pub(crate) async fn collect_reviewer_effects_with_source(
                     tool_use_id: None,
                     parent_tool_use_id: None,
                 });
-                effects.push(Effect::RecordPrNudge {
+                effects.push(Effect::RecordPermanentPrNudge {
                     pr_number,
                     issue_type: PrIssueType::ReviewComplete,
                 });
@@ -5025,6 +5025,7 @@ fn effect_variant_name(e: &Effect) -> &'static str {
         Effect::AssignAndSpawn { .. } => "AssignAndSpawn",
         Effect::MarkRemindersFired { .. } => "MarkRemindersFired",
         Effect::RecordPrNudge { .. } => "RecordPrNudge",
+        Effect::RecordPermanentPrNudge { .. } => "RecordPermanentPrNudge",
         Effect::RecordTaskAssignment { .. } => "RecordTaskAssignment",
         Effect::ClearPrBreakSession { .. } => "ClearPrBreakSession",
         Effect::AssignReviewer { .. } => "AssignReviewer",

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -5273,11 +5273,14 @@ async fn test_review_complete_lead_branch_no_repeat_after_cooldown() {
         ps.github.mark_reviewed_pr(pr_number);
     }
 
-    // Simulate that we already nudged for this PR's ReviewComplete, but the
-    // cooldown has expired (11 minutes ago). With the bug, should_nudge()
-    // returns true and the notification re-fires.
+    // Simulate that we already permanently nudged for this PR's ReviewComplete,
+    // but the cooldown has expired (11 minutes ago). With the bug, should_nudge()
+    // returns true and the notification re-fires. With the fix, has_nudge()
+    // checks the permanent set which survives cooldown expiry.
     {
         let mut tracker = state.pr_issue_tracker.lock().await;
+        tracker.record_permanent_nudge(pr_number, PrIssueType::ReviewComplete);
+        // Backdate the regular entry so cooldown has expired
         tracker.record_nudge_at(
             pr_number,
             PrIssueType::ReviewComplete,
@@ -5309,6 +5312,74 @@ async fn test_review_complete_lead_branch_no_repeat_after_cooldown() {
         )),
         "Bug !2137: Should not re-post @user review-complete notification after cooldown expires. \
          The notification should be one-shot for user-authored PRs. Got: {:#?}",
+        effects
+    );
+}
+
+/// Regression test for the cleanup eviction path: after cleanup() runs and
+/// evicts the regular nudge entry (older than ORPHANED_PR_NUDGE_COOLDOWN_SECS),
+/// the permanent set still prevents re-notification.
+#[tokio::test]
+async fn test_review_complete_lead_branch_survives_cleanup() {
+    use std::collections::{HashMap, HashSet};
+    use std::time::{Duration, Instant};
+    let pr_number = 1838u64;
+    let pr = json!({
+        "number": pr_number,
+        "headRefName": "lead/release-v0.7.0",
+        "title": "Release v0.7.0 [Midtown !1838]",
+        "body": "",
+        "isDraft": false,
+        "createdAt": "2026-01-01T00:00:00Z",
+        "state": "OPEN",
+    });
+
+    let (state, _tmp, _guard) = make_test_state("test-repo");
+
+    {
+        let mut ps = state.persistent_state.lock().await;
+        ps.github.mark_reviewed_pr(pr_number);
+    }
+
+    // Record a permanent nudge, backdate past ORPHANED_PR_NUDGE_COOLDOWN_SECS,
+    // then run cleanup. The permanent entry should survive.
+    {
+        let mut tracker = state.pr_issue_tracker.lock().await;
+        tracker.record_permanent_nudge(pr_number, PrIssueType::ReviewComplete);
+        tracker.record_nudge_at(
+            pr_number,
+            PrIssueType::ReviewComplete,
+            Instant::now()
+                - Duration::from_secs(
+                    crate::daemon::constants::ORPHANED_PR_NUDGE_COOLDOWN_SECS + 60,
+                ),
+        );
+        tracker.cleanup();
+    }
+
+    let branch_owners: HashMap<String, String> = HashMap::new();
+    let registry = crate::worktree_registry::WorktreeRegistry::new();
+    let active_names = HashSet::new();
+
+    let effects = collect_reviewer_effects_with_source(
+        &branch_owners,
+        &registry,
+        &active_names,
+        &state,
+        &[pr],
+        crate::github_state::AssignmentSource::PollingFallback,
+        &HashMap::new(),
+    )
+    .await;
+
+    // Should NOT re-post — permanent nudge survives cleanup
+    assert!(
+        !effects.iter().any(|e| matches!(
+            e,
+            Effect::PostToChannel { message, .. } if message.contains("@user")
+        )),
+        "Permanent nudge should survive cleanup(). After eviction of the regular entry, \
+         the permanent set should still prevent re-notification. Got: {:#?}",
         effects
     );
 }

--- a/src/daemon/trackers.rs
+++ b/src/daemon/trackers.rs
@@ -3,7 +3,7 @@
 //! These trackers prevent the daemon from spamming the same PR issues
 //! or assigning duplicate reviews.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use super::constants::{
@@ -59,6 +59,10 @@ impl std::fmt::Display for PrIssueType {
 pub struct PrIssueTracker {
     /// Map of (pr_number, issue_type) -> last_nudge_time
     nudged: HashMap<(u64, PrIssueType), Instant>,
+    /// Permanent one-shot nudge entries that survive cleanup.
+    /// Used for notifications that should fire exactly once (e.g., user-authored
+    /// PR review-complete), regardless of how long the PR stays open.
+    permanent: HashSet<(u64, PrIssueType)>,
 }
 
 impl PrIssueTracker {
@@ -97,11 +101,20 @@ impl PrIssueTracker {
     /// Clear a specific nudge entry (e.g., when retrying after coworker death)
     pub fn clear_nudge(&mut self, pr_number: u64, issue_type: PrIssueType) {
         self.nudged.remove(&(pr_number, issue_type));
+        self.permanent.remove(&(pr_number, issue_type));
     }
 
-    /// Check if a nudge has been recorded for this issue
+    /// Check if a nudge has been recorded for this issue (including permanent entries)
     pub fn has_nudge(&self, pr_number: u64, issue_type: PrIssueType) -> bool {
         self.nudged.contains_key(&(pr_number, issue_type))
+            || self.permanent.contains(&(pr_number, issue_type))
+    }
+
+    /// Record a permanent one-shot nudge that survives cleanup.
+    /// Also records in the regular nudged map so should_nudge() works consistently.
+    pub fn record_permanent_nudge(&mut self, pr_number: u64, issue_type: PrIssueType) {
+        self.permanent.insert((pr_number, issue_type));
+        self.nudged.insert((pr_number, issue_type), Instant::now());
     }
 
     /// Record a nudge with a backdated timestamp (test helper).
@@ -113,10 +126,12 @@ impl PrIssueTracker {
     /// Clean up old entries (older than the longest cooldown period).
     /// Uses ORPHANED_PR_NUDGE_COOLDOWN_SECS since orphaned PR alerts use a
     /// longer suppression window than the standard PR_NUDGE_COOLDOWN_SECS.
+    /// Skips entries in the permanent set — those survive indefinitely.
     pub fn cleanup(&mut self) {
         let cutoff = Duration::from_secs(ORPHANED_PR_NUDGE_COOLDOWN_SECS);
-        self.nudged
-            .retain(|_, last_nudge| last_nudge.elapsed() < cutoff);
+        self.nudged.retain(|key, last_nudge| {
+            self.permanent.contains(key) || last_nudge.elapsed() < cutoff
+        });
     }
 }
 


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- For user-authored PRs (lead/* branches), the review-complete notification was re-posting every 10 minutes because the cooldown-based `should_nudge()` kept expiring while the PR state hadn't changed
- Replaced `should_nudge()` (cooldown-based, 10 min) with `has_nudge()` (one-shot) for lead branches so the notification fires exactly once
- Coworker PRs retain the existing cooldown-based nudging behavior

## Changes
- **`src/daemon/pr.rs`**: Moved the `is_lead_branch` check before the `should_nudge` check. Lead branches use `has_nudge()` (permanent, fire-once). Coworker branches continue using `should_nudge()` (cooldown-based)
- **`src/daemon/trackers.rs`**: Added `record_nudge_at()` test helper for backdating nudge timestamps
- **`src/daemon/pr_tests.rs`**: Added `test_review_complete_lead_branch_no_repeat_after_cooldown` — reproduces the bug by inserting an expired nudge and verifying no re-notification occurs

## Test plan
- [x] New test reproduces the bug (confirmed FAILED before fix, PASSED after)
- [x] Existing `test_review_complete_lead_branch_notifies_user_not_coworker` still passes (first notification works)
- [x] All 106 PR tests pass
- [x] All 34 tracker tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)