### PR TITLE
fix: Guard thread textarea auto-focus behind isDesktop check [Midtown !2144]

### DIFF
--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -433,7 +433,7 @@ let prevThreadId = null;
     const lastId = lastFocusedThreadId
     if (threadId && threadId !== lastId && textareaEl) {
       lastFocusedThreadId = threadId
-      tick().then(() => textareaEl.focus())
+      tick().then(() => { if (isDesktop) textareaEl.focus() })
     }
     if (!threadId) lastFocusedThreadId = null
   })


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Guard `textareaEl.focus()` in ThreadPanel.svelte behind `isDesktop` check to prevent the virtual keyboard from auto-opening when a thread is selected on mobile
- One-line change: `tick().then(() => textareaEl.focus())` → `tick().then(() => { if (isDesktop) textareaEl.focus() })`

## Test plan
- [x] Vite build passes
- [ ] On mobile (or narrow viewport < 1024px): opening a thread should NOT auto-focus the textarea or trigger the keyboard
- [ ] On desktop (>= 1024px): opening a thread should still auto-focus the textarea as before

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)