### PR TITLE
fix: Close mobile sidebar on channel select and DM navigation [Midtown !2147]

### DIFF
--- a/web-app/src/lib/ChannelList.svelte
+++ b/web-app/src/lib/ChannelList.svelte
@@ -1,6 +1,7 @@
 <script>
 import ArchiveIcon from "@lucide/svelte/icons/archive";
 import { SvelteSet } from "svelte/reactivity";
+import { useSidebar } from "$lib/components/ui/sidebar/context.svelte.js";
 import { closeThread, fetchChannels, fetchHistory, getApiBase, pushNavState } from "./api.js";
 import {
 	computeExpandedAfterChannelNameClick,
@@ -30,6 +31,8 @@ import {
 } from "./store.js";
 import TaskList from "./TaskList.svelte";
 import ThreadList from "./ThreadList.svelte";
+
+const sidebar = useSidebar();
 
 // Build a map of coworker name → coworker object for quick lookup
 $: coworkerMap = new Map($coworkers.map((cw) => [cw.name, cw]));
@@ -106,6 +109,9 @@ function selectChannel(channelName) {
 	// until the network request completed (~100-500ms), making channel switching
 	// feel sluggish on desktop. Now the channel switches instantly and messages
 	// appear when the fetch completes.
+
+	// Close mobile sidebar overlay when navigating to a channel
+	sidebar.setOpenMobile(false);
 
 	// Close thread panel when switching channels — thread context is
 	// channel-scoped and should not carry over to a different channel.

--- a/web-app/src/lib/CoworkerStatus.svelte
+++ b/web-app/src/lib/CoworkerStatus.svelte
@@ -1,10 +1,13 @@
 <script>
 import { onDestroy, onMount, untrack } from "svelte";
 import { SvelteMap } from "svelte/reactivity";
+import { useSidebar } from "$lib/components/ui/sidebar/context.svelte.js";
 import * as Tooltip from "$lib/components/ui/tooltip/index.js";
 import { openTaskThread, selectDm } from "./api.js";
 import { getSenderColor } from "./messageUtils.js";
 import { coworkers, kanbanData, maxCoworkers, repoStatus } from "./store.js";
+
+const sidebar = useSidebar();
 
 const OFFLINE_GRACE_MS = 10 * 60 * 1000;
 
@@ -130,7 +133,7 @@ function openPrDetail(prNumber) {
             </Tooltip.Root>
             <button
               class="bg-transparent border-none p-0 m-0 cursor-pointer text-inherit text-[0.75rem] font-mono hover:underline leading-none"
-              onclick={() => selectDm(cw.name)}
+              onclick={() => { sidebar.setOpenMobile(false); selectDm(cw.name); }}
               title="Open DM with {cw.name}"
             >{cw.name}</button>
             {#if cw.phase}


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Add `useSidebar()` + `setOpenMobile(false)` to `ChannelList.selectChannel` so tapping a channel on mobile closes the sidebar overlay
- Add the same pattern to `CoworkerStatus` DM button so tapping a coworker name closes the sidebar before navigating to the DM

Pre-existing gap identified during PR #1864 review — PR #1864 fixed TaskList and ThreadList but these two handlers had the same issue.

## Test plan
- [x] `vite build` passes
- [x] `biome check` passes
- [x] Pre-commit hooks (clippy, fmt, biome) pass
- Manual: on mobile, tap a channel name → sidebar should close and show channel content
- Manual: on mobile, tap a coworker name → sidebar should close and show DM

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)