### PR TITLE
feat: Image lightbox display for messages [Midtown !2149]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -5,6 +5,7 @@ import { onMount, tick, untrack } from "svelte";
 import { fly } from "svelte/transition";
 import Autocomplete from "./Autocomplete.svelte";
 import { closeThread, getApiBase, openTaskThread, openThread, sendMessage, uploadFile } from "./api.js";
+import { openImageLightbox } from "./biggerPicture.js";
 import { findPr as findPrUtil, getPrUrl as getPrUrlUtil, resolveMessageTapAction } from "./channelUtils.js";
 import DayDivider from "./DayDivider.svelte";
 import MermaidDiagram from "./MermaidDiagram.svelte";
@@ -461,6 +462,9 @@ onMount(() => {
 		} else if (target.classList.contains("coworker-link")) {
 			// Prevent the browser from following the '#' href; no detail panel action.
 			e.preventDefault();
+		} else if (target.classList.contains("message-image")) {
+			e.preventDefault();
+			openImageLightbox(target.dataset.fullSrc || target.src);
 		}
 	}
 
@@ -485,6 +489,15 @@ function getActionContent(msg) {
 // redundant; they are two separate entry points for the same click on different platforms.
 function handleMessageTap(event, msg) {
 	const target = event.target instanceof Element ? event.target : null;
+
+	// Image taps open the lightbox on all platforms (before mobile thread logic)
+	if (target?.classList.contains("message-image")) {
+		event.stopPropagation();
+		event.preventDefault();
+		openImageLightbox(target.dataset.fullSrc || target.src);
+		return;
+	}
+
 	const isInteractiveControl = !!target?.closest("button, input, textarea, select, label");
 	const anchor = target?.closest("a");
 	const link = anchor
@@ -998,18 +1011,19 @@ function getToolCallStatusIcon(entry) {
 </div>
 
 <style>
-  /* Inline image attachments */
+  /* Inline image attachments — thumbnail with lightbox on click */
   :global(.message-image) {
-    max-width: 320px;
-    max-height: 320px;
+    max-width: 200px;
+    max-height: 200px;
     border-radius: 6px;
     display: block;
     margin-top: 4px;
+    cursor: pointer;
+    transition: opacity 0.15s;
   }
 
-  :global(.attachment-link) {
-    display: inline-block;
-    line-height: 0;
+  :global(.message-image:hover) {
+    opacity: 0.85;
   }
 
   :global(.attachment-ref) {

--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -13,6 +13,7 @@ let prevThreadId = null;
   import { tick, onMount, onDestroy, untrack } from 'svelte'
   import { getSenderColor, isDimSender, parseInsightSegments, dateChanged } from './messageUtils.js'
   import SendHorizontal from '@lucide/svelte/icons/send-horizontal'
+  import { openImageLightbox } from './biggerPicture.js'
   import MermaidDiagram from './MermaidDiagram.svelte'
   import { parseSegments, hasMermaid, renderContent } from './markdown.js'
   import MessageRow from './MessageRow.svelte'
@@ -346,6 +347,9 @@ let prevThreadId = null;
       e.preventDefault()
       const name = target.dataset.coworker
       if (name) selectDm(name)
+    } else if (target.classList.contains('message-image')) {
+      e.preventDefault()
+      openImageLightbox(target.dataset.fullSrc || target.src)
     }
   }
 

--- a/web-app/src/lib/biggerPicture.js
+++ b/web-app/src/lib/biggerPicture.js
@@ -29,6 +29,16 @@ export function getBiggerPicture() {
 }
 
 /**
+ * Open an image in the BiggerPicture lightbox
+ * @param {string} imgUrl - The URL of the image to display
+ */
+export function openImageLightbox(imgUrl) {
+	const bp = getBiggerPicture();
+	if (!bp) return;
+	bp.open({ items: [{ img: imgUrl }], position: 0 });
+}
+
+/**
  * Calculate the initial scale to fit an SVG to viewport width
  * Matches the 95% width fit-to-width behavior from the old MermaidModal
  *

--- a/web-app/src/lib/markdown.js
+++ b/web-app/src/lib/markdown.js
@@ -85,7 +85,7 @@ function renderAttachmentHtml(path, apiBase) {
 		const subdir = path.includes("/screenshots/") ? "screenshots" : "uploads";
 		const url = `${apiBase}/${subdir}/${encodeURIComponent(filename)}`;
 		const safeAlt = filename.replace(/"/g, "&quot;");
-		return `<a href="${url}" target="_blank" rel="noopener" class="attachment-link"><img src="${url}" alt="${safeAlt}" class="message-image" loading="lazy" /></a>`;
+		return `<img src="${url}" alt="${safeAlt}" class="message-image" data-full-src="${url}" loading="lazy" />`;
 	}
 	const safeName = filename.replace(/</g, "&lt;").replace(/>/g, "&gt;");
 	return `<span class="attachment-ref">📎 ${safeName}</span>`;

--- a/web-app/src/lib/markdown.test.js
+++ b/web-app/src/lib/markdown.test.js
@@ -461,11 +461,11 @@ describe("renderContent - image attachments", () => {
 		expect(result).toContain('class="message-image"');
 	});
 
-	it("wraps the image in a clickable link", () => {
+	it("renders image with data-full-src for lightbox (no <a> wrapper)", () => {
 		const result = renderContent("[Attached: /uploads/photo.png]", API);
-		expect(result).toContain("<a");
-		expect(result).toContain('target="_blank"');
-		expect(result).toContain('class="attachment-link"');
+		expect(result).toContain('data-full-src="http://localhost:47023/api/uploads/photo.png"');
+		expect(result).not.toContain('target="_blank"');
+		expect(result).not.toContain('class="attachment-link"');
 	});
 
 	it("renders [Attached file:]\\nPlease read: /path/file.png as an image", () => {


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Replace `<a target="_blank">` image wrapper with BiggerPicture lightbox — clicking an image now opens a full-size overlay instead of a new browser tab
- Reduce inline thumbnail size from 320x320px to 200x200px max for a cleaner message flow
- Add shared `openImageLightbox()` helper in `biggerPicture.js` (reuses the existing singleton)
- Wire up delegated click handlers in both `Channel.svelte` (desktop `handleLinkClick` + mobile `handleMessageTap`) and `ThreadPanel.svelte` (`handleThreadLinkClick`)

## Visual Changes

| Aspect | Before | After |
|--------|--------|-------|
| Thumbnail size | 320x320px max | 200x200px max |
| Click behavior | Opens image in new browser tab (`<a target="_blank">`) | Opens BiggerPicture lightbox overlay within the app |
| Hover state | No visual feedback | `cursor: pointer` + subtle opacity transition |
| Mobile tap | Default link behavior | Intercepted before thread-open logic; opens lightbox |

*Note: Automated screenshot capture unavailable due to npm cache permission issue (`midtown coworker screenshot` broken). No live channels currently have image messages visible in viewport for comparison.*

## Implementation details
- `markdown.js`: `renderAttachmentHtml()` now renders `<img class="message-image" data-full-src="...">` instead of wrapping in `<a target="_blank">`
- Mobile path: Image taps are intercepted in `handleMessageTap` before `resolveMessageTapAction` runs, so they open the lightbox instead of the thread
- CSS adds `cursor: pointer` and a subtle hover opacity transition

## Test plan
- [x] All 258 unit tests pass (8 test files)
- [x] `vite build` succeeds
- [x] Updated existing test to verify `data-full-src` attribute and absence of `<a>` wrapper
- [x] Pre-commit hooks pass (clippy, fmt, biome)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)