### PR TITLE
fix: Guard against undefined threadData.messages in ThreadPanel [Midtown !2150]

### DIFF
--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -299,7 +299,7 @@ let prevThreadId = null;
   // instead of using indexOf (which would be O(N) per call, O(N^2) total).
   let mergedTimeline = $derived.by(() => {
     if (!$threadData) return []
-    const msgs = $threadData.messages.map((m, i) => ({ type: 'message', data: m, timestamp: m.timestamp, msgIndex: i }))
+    const msgs = ($threadData.messages ?? []).map((m, i) => ({ type: 'message', data: m, timestamp: m.timestamp, msgIndex: i }))
     if (!isDmChannel || editDiffs.length === 0) return msgs
     const edits = editDiffs.map((d) => ({ type: 'edit', data: d, timestamp: d.timestamp, msgIndex: -1 }))
     const sorted = [...msgs, ...edits].sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''))
@@ -623,7 +623,7 @@ let prevThreadId = null;
         <!-- Separator with reply count -->
         <div class="flex items-center gap-2 py-3 text-muted-foreground/50 text-[0.72rem]">
           <div class="flex-1 h-px bg-border/60"></div>
-          <span>{$threadData.messages.length === 0 ? 'no replies yet' : $threadData.messages.length === 1 ? '1 reply' : `${$threadData.messages.length} replies`}</span>
+          <span>{($threadData.messages?.length ?? 0) === 0 ? 'no replies yet' : $threadData.messages.length === 1 ? '1 reply' : `${$threadData.messages.length} replies`}</span>
           <div class="flex-1 h-px bg-border/60"></div>
         </div>
       {/if}
@@ -858,7 +858,7 @@ let prevThreadId = null;
         <!-- Separator with reply count -->
         <div class="flex items-center gap-2 py-3 text-muted-foreground/50 text-[0.72rem]">
           <div class="flex-1 h-px bg-border/60"></div>
-          <span>{$threadData.messages.length === 0 ? 'no replies yet' : $threadData.messages.length === 1 ? '1 reply' : `${$threadData.messages.length} replies`}</span>
+          <span>{($threadData.messages?.length ?? 0) === 0 ? 'no replies yet' : $threadData.messages.length === 1 ? '1 reply' : `${$threadData.messages.length} replies`}</span>
           <div class="flex-1 h-px bg-border/60"></div>
         </div>
       {/if}


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Fixed `Cannot read properties of undefined (reading 'length')` crash in ThreadPanel.svelte
- Added nullish coalescing (`?? []`) to `$threadData.messages` in the `mergedTimeline` derived computation (line 302)
- Added optional chaining (`?.length`) to reply count displays in both desktop (line 626) and mobile (line 861) template blocks

## Root Cause
The `$derived.by` block computing `mergedTimeline` checks `if (!$threadData) return []` but then accesses `$threadData.messages.map(...)` without guarding against `messages` being `undefined`. During Svelte 5's fine-grained reactive transitions (rapid thread open/close, channel switching), `$threadData` can briefly be truthy while `messages` is undefined, causing the crash.

Similarly, the template's reply count displays accessed `$threadData.messages.length` inside `{#if $threadData.parentMessage}` blocks, but the `{#if}` guard only protects against `parentMessage` being falsy, not `messages`.

## Test plan
- [x] All 258 existing vitest tests pass
- [x] Vite production build succeeds
- [x] Pre-commit hooks pass (clippy, fmt, biome)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)