### PR TITLE
fix: Mark PR as reviewed in handle_pr_review_post to prevent race [Midtown !2152]

### DIFF
--- a/src/daemon/rpc_prs.rs
+++ b/src/daemon/rpc_prs.rs
@@ -1110,6 +1110,14 @@ pub(super) async fn handle_pr_review_post(
                 comment_id, repo_full_name
             );
 
+            // Mark the PR as reviewed immediately so the stuck-reviewer
+            // check doesn't kill the reviewer and overwrite the real review
+            // before the webhook/polling discovers it.
+            {
+                let mut ps = state.persistent_state.lock().await;
+                ps.github.mark_reviewed_pr(pr_number);
+            }
+
             // Clear the placeholder cache since the comment has been updated
             {
                 let mut cache = state.reviewer_placeholder_cache.lock().unwrap();

--- a/src/daemon/rpc_prs_tests.rs
+++ b/src/daemon/rpc_prs_tests.rs
@@ -411,6 +411,17 @@ fi
             "Placeholder cache should be cleared after posting the final review"
         );
     }
+
+    // The PR should be marked as reviewed so the stuck-reviewer check
+    // doesn't kill the reviewer and overwrite the real review.
+    {
+        let ps = state.persistent_state.lock().await;
+        assert!(
+            ps.github.has_cached_review(pr_number),
+            "PR should be marked as reviewed after successful review post \
+             (prevents stuck-reviewer check from overwriting the real review)"
+        );
+    }
 }
 
 /// Verify the final body format: frontmatter tag + user body + Midtown footer.


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- **Bug**: When a reviewer posts their review via `pr.review-post` RPC, `handle_pr_review_post` updates the placeholder GitHub comment but does NOT call `mark_reviewed_pr()`. The daemon only discovers the review via webhook/polling. In the gap, `check_and_restart_stuck_reviewers()` can kill the reviewer and overwrite the real review with an "abandoned" placeholder.
- **Fix**: Call `mark_reviewed_pr()` immediately after the comment update succeeds in `handle_pr_review_post`, closing the race window at the RPC layer.
- **Test**: Extended `test_review_post_with_stored_comment_id_succeeds` to assert `has_cached_review()` is true after a successful review post.

## Test plan
- [x] New assertion fails before the fix (verified RED phase)
- [x] New assertion passes after the fix (verified GREEN phase)
- [x] All 15 `rpc_prs` tests pass
- [x] `cargo clippy` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)