### PR TITLE
fix: Filter out tool-call label text from DM coworker messages [Midtown !2154]

### DIFF
--- a/src/daemon/stream.rs
+++ b/src/daemon/stream.rs
@@ -453,6 +453,32 @@ fn extract_assistant_text_split(events: &[StreamEvent]) -> (String, HashMap<Stri
     (top_level, sub_agent)
 }
 
+/// Strip tool-call label lines from text destined for DM channels.
+///
+/// Claude Code emits `[ToolName]` text blocks alongside `tool_use` blocks in
+/// assistant messages. In DM channels, the tool calls are rendered separately
+/// via `extract_tool_blocks()`, so these labels are noise. This function removes
+/// lines that consist solely of a bracketed PascalCase/camelCase word (e.g.,
+/// `[Bash]`, `[ToolSearch]`) while preserving all other text.
+fn strip_tool_labels(text: &str) -> String {
+    text.lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            // Keep non-empty lines that aren't bare tool labels like [Bash], [ToolSearch]
+            if trimmed.is_empty() {
+                return false;
+            }
+            !(trimmed.starts_with('[')
+                && trimmed.ends_with(']')
+                && trimmed.len() > 2
+                && trimmed[1..trimmed.len() - 1]
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric()))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Process agent output and generate DM channel posting effects.
 ///
 /// DM channels are a complete stream of the agent — text AND tool calls.
@@ -485,7 +511,8 @@ pub fn process_agent_output(
             let (top_text, sub_agent_texts) = extract_assistant_text_split(coworker_events);
 
             // Post top-level text output (assistant prose).
-            let trimmed = top_text.trim().to_string();
+            // Strip tool-call labels (e.g. "[Bash]") that duplicate rendered tool blocks.
+            let trimmed = strip_tool_labels(&top_text).trim().to_string();
             if !trimmed.is_empty() {
                 // Extract insights from the text before posting to DM.
                 for insight in extract_insights(&trimmed) {
@@ -568,7 +595,7 @@ pub fn process_agent_output(
 
             // Post sub-agent text as thread replies (grouped by parent_tool_use_id).
             for (parent_id, text) in &sub_agent_texts {
-                let trimmed = text.trim().to_string();
+                let trimmed = strip_tool_labels(text).trim().to_string();
                 if !trimmed.is_empty() {
                     effects.push(Effect::PostToChannel {
                         sender: name.clone(),

--- a/src/daemon/stream_tests.rs
+++ b/src/daemon/stream_tests.rs
@@ -2231,6 +2231,124 @@ fn test_extract_assistant_text_split_with_parent_tool_use_id() {
     );
 }
 
+// ── tool-label stripping tests (DM noise filtering) ─────────────────
+
+#[test]
+fn test_strip_tool_labels_removes_bare_label() {
+    assert_eq!(strip_tool_labels("[Bash]"), "");
+    assert_eq!(strip_tool_labels("[Read]"), "");
+    assert_eq!(strip_tool_labels("[Edit]"), "");
+    assert_eq!(strip_tool_labels("[Skill]"), "");
+    assert_eq!(strip_tool_labels("[Agent]"), "");
+    assert_eq!(strip_tool_labels("[ToolSearch]"), "");
+}
+
+#[test]
+fn test_strip_tool_labels_removes_multiple_labels() {
+    assert_eq!(strip_tool_labels("[Bash]\n[Read]"), "");
+    assert_eq!(strip_tool_labels("[Edit]\n\n[Grep]"), "");
+}
+
+#[test]
+fn test_strip_tool_labels_preserves_real_text() {
+    assert_eq!(strip_tool_labels("Working on it"), "Working on it");
+    assert_eq!(
+        strip_tool_labels("Let me read the file."),
+        "Let me read the file."
+    );
+}
+
+#[test]
+fn test_strip_tool_labels_preserves_text_mixed_with_labels() {
+    // Real text alongside labels — keep the text, strip the labels
+    assert_eq!(strip_tool_labels("Let me check.\n[Bash]"), "Let me check.");
+    assert_eq!(
+        strip_tool_labels("[Read]\nHere are the results."),
+        "Here are the results."
+    );
+}
+
+#[test]
+fn test_strip_tool_labels_preserves_brackets_in_prose() {
+    // Text that contains brackets but isn't a bare tool label
+    assert_eq!(
+        strip_tool_labels("See [this section] for details"),
+        "See [this section] for details"
+    );
+    assert_eq!(
+        strip_tool_labels("The [Bash] command worked great"),
+        "The [Bash] command worked great"
+    );
+}
+
+#[test]
+fn test_process_agent_output_filters_tool_label_text() {
+    // Bug scenario: assistant message has "[Bash]" text + tool_use block.
+    // The "[Bash]" text should NOT be posted as a standalone message.
+    let mut events = HashMap::new();
+    events.insert(
+        "park".to_string(),
+        vec![StreamEvent::Assistant {
+            message: json!({
+                "content": [
+                    {"type": "text", "text": "[Bash]"},
+                    {"type": "tool_use", "id": "tc_1", "name": "Bash", "input": {"command": "cargo test"}}
+                ]
+            }),
+            session_id: None,
+            extra: json!(null),
+        }],
+    );
+    let coworker_names = HashSet::from(["park".to_string()]);
+
+    let effects = process_agent_output(&events, &coworker_names);
+    // Should only have the tool_data effect, NOT a text "[Bash]" effect.
+    assert_eq!(
+        effects.len(),
+        1,
+        "should only have tool_data effect, not a text label effect"
+    );
+    match &effects[0] {
+        Effect::PostToChannel { tool_data, .. } => {
+            assert!(tool_data.is_some(), "should be the tool_data effect");
+        }
+        _ => panic!("Expected PostToChannel with tool_data"),
+    }
+}
+
+#[test]
+fn test_process_agent_output_keeps_real_text_alongside_tool() {
+    // Real text alongside a tool call should still be posted.
+    let mut events = HashMap::new();
+    events.insert(
+        "park".to_string(),
+        vec![StreamEvent::Assistant {
+            message: json!({
+                "content": [
+                    {"type": "text", "text": "Let me run the tests.\n[Bash]"},
+                    {"type": "tool_use", "id": "tc_1", "name": "Bash", "input": {"command": "cargo test"}}
+                ]
+            }),
+            session_id: None,
+            extra: json!(null),
+        }],
+    );
+    let coworker_names = HashSet::from(["park".to_string()]);
+
+    let effects = process_agent_output(&events, &coworker_names);
+    // Should have 2 effects: the real text + the tool_data
+    assert_eq!(effects.len(), 2);
+    match &effects[0] {
+        Effect::PostToChannel {
+            message, tool_data, ..
+        } => {
+            assert_eq!(message, "Let me run the tests.");
+            assert!(tool_data.is_none());
+        }
+        _ => panic!("Expected text PostToChannel"),
+    }
+}
+
 // ── progress event extraction tests (legacy format) ──────────────────
 #[test]
 fn test_extract_tool_blocks_from_progress_events() {


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Strip bare tool-call labels (`[Bash]`, `[Read]`, `[ToolSearch]`, etc.) from DM coworker text messages before posting
- These labels are noise — the same tool calls are already rendered as structured tool blocks via `extract_tool_blocks()`
- Applied in `process_agent_output()` only (DM-specific), not in `extract_assistant_text()` which serves leads/channel leads

## Implementation
Added `strip_tool_labels()` helper that filters out lines consisting solely of a `[PascalCaseWord]` pattern while preserving all other text (including brackets used in prose like "See [this section] for details").

Applied to both top-level and sub-agent text paths in `process_agent_output()`.

## Test plan
- [x] Unit tests for `strip_tool_labels` (bare labels, multiple labels, real text, mixed text, brackets in prose)
- [x] Integration test: `process_agent_output` with `[Bash]` text + tool_use produces only tool_data effect
- [x] Integration test: real text alongside tool labels is preserved
- [x] All 88 existing stream tests still pass
- [x] clippy + fmt clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)