### PR TITLE
feat: Add image paste support to ThreadPanel [Midtown !2148]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -4,9 +4,10 @@ import SendHorizontal from "@lucide/svelte/icons/send-horizontal";
 import { onMount, tick, untrack } from "svelte";
 import { fly } from "svelte/transition";
 import Autocomplete from "./Autocomplete.svelte";
-import { closeThread, getApiBase, openTaskThread, openThread, sendMessage, uploadFile } from "./api.js";
+import { closeThread, getApiBase, openTaskThread, openThread, sendMessage } from "./api.js";
 import { findPr as findPrUtil, getPrUrl as getPrUrlUtil, resolveMessageTapAction } from "./channelUtils.js";
 import DayDivider from "./DayDivider.svelte";
+import { extractPastedFile, uploadAndSend } from "./filePaste.js";
 import MermaidDiagram from "./MermaidDiagram.svelte";
 import MessageRow from "./MessageRow.svelte";
 import { hasMermaid, parseSegments, renderContent } from "./markdown.js";
@@ -586,16 +587,10 @@ async function handleSubmit(e) {
 	// If there's a pending file, upload it first
 	if (pendingFile && !uploading) {
 		uploading = true;
-		const result = await uploadFile(pendingFile);
+		const result = await uploadAndSend(pendingFile, inputText, $activeChannel);
 		uploading = false;
 
 		if (result.ok) {
-			// Send message to lead with file path
-			const message = inputText.trim()
-				? `${inputText.trim()}\n\n[Attached: ${result.path}]`
-				: `[Attached file: ${result.filename}]\nPlease read: ${result.path}`;
-
-			sendMessage(message, $activeChannel);
 			inputText = "";
 			if (textareaElement) textareaElement.value = "";
 			pendingFile = null;
@@ -615,29 +610,8 @@ async function handleSubmit(e) {
 }
 
 function handlePaste(e) {
-	const items = e.clipboardData?.items;
-	if (!items) return;
-
-	for (const item of items) {
-		// Check for image types
-		if (item.type.startsWith("image/")) {
-			e.preventDefault();
-			const file = item.getAsFile();
-			if (file) {
-				pendingFile = file;
-			}
-			return;
-		}
-		// Check for files (PDFs, etc.)
-		if (item.kind === "file") {
-			e.preventDefault();
-			const file = item.getAsFile();
-			if (file) {
-				pendingFile = file;
-			}
-			return;
-		}
-	}
+	const file = extractPastedFile(e);
+	if (file) pendingFile = file;
 }
 
 function clearPendingFile() {

--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -9,6 +9,7 @@ let prevThreadId = null;
 <script>
   import { threadData, agentToolItems, threadToolItems, deepLinkMsgId, threadOwnership, threadForkParents, threadForkOwners, activeProject, channels as channelsStore, activeChannel, daemonStatus, kanbanData, repoStatus, repoStatuses } from './store.js'
   import { sendMessage, closeThread, getApiBase, forkThread, unforkThread, openTaskThread, selectDm } from './api.js'
+  import { extractPastedFile, uploadAndSend } from './filePaste.js'
   import { getPrUrl as getPrUrlUtil } from './channelUtils.js'
   import { tick, onMount, onDestroy, untrack } from 'svelte'
   import { getSenderColor, isDimSender, parseInsightSegments, dateChanged } from './messageUtils.js'
@@ -93,6 +94,8 @@ let prevThreadId = null;
   }
 
   let replyText = $state('')
+  let pendingFile = $state(null)
+  let uploading = $state(false)
   let desktopScrollArea = $state(null)
   let mobileScrollArea = $state(null)
   let autoScroll = $state(true)
@@ -374,15 +377,33 @@ let prevThreadId = null;
     if (event.key === 'Escape' && !event.defaultPrevented) handleClose()
   }
 
-  function handleSubmit(e) {
+  async function handleSubmit(e) {
     e.preventDefault()
-    if (!replyText.trim() || !$threadData) return
-    // If no parentMessage (task without message_id), send as top-level channel message
+    if (!$threadData) return
     const parentId = $threadData.parentMessage?.id ?? null
-    sendMessage(replyText.trim(), $threadData.channelName, parentId)
-    replyText = ''
-    if (currentThreadId) threadDrafts.delete(currentThreadId)
-    clearMobileTextarea(textareaEl, () => { replyText = '' })
+
+    if (pendingFile && !uploading) {
+      uploading = true
+      const result = await uploadAndSend(pendingFile, replyText, $threadData.channelName, parentId)
+      uploading = false
+      if (result.ok) {
+        replyText = ''
+        pendingFile = null
+        if (currentThreadId) threadDrafts.delete(currentThreadId)
+        clearMobileTextarea(textareaEl, () => { replyText = '' })
+      } else {
+        alert(`Upload failed: ${result.error}`)
+        return
+      }
+    } else if (replyText.trim()) {
+      sendMessage(replyText.trim(), $threadData.channelName, parentId)
+      replyText = ''
+      if (currentThreadId) threadDrafts.delete(currentThreadId)
+      clearMobileTextarea(textareaEl, () => { replyText = '' })
+    } else {
+      return
+    }
+
     // Optimistic: show the drawer immediately while waiting for tool calls to arrive
     thinking = true
     if (thinkingTimeout) clearTimeout(thinkingTimeout)
@@ -397,6 +418,15 @@ let prevThreadId = null;
       e.preventDefault()
       handleSubmit(e)
     }
+  }
+
+  function handlePaste(e) {
+    const file = extractPastedFile(e)
+    if (file) pendingFile = file
+  }
+
+  function clearPendingFile() {
+    pendingFile = null
   }
 
   // Auto-scroll when new messages or edit diffs arrive (only if user is near bottom)
@@ -722,7 +752,25 @@ let prevThreadId = null;
     <ThreadActivityDrawer channelName={$threadData?.channelName} threadParentId={$threadData?.parentMessage?.id} {thinking} />
 
     <!-- Input -->
-    <form class="px-3 py-1.5 bg-card border-t border-border shrink-0" onsubmit={handleSubmit}>
+    <form class="flex flex-col gap-2 px-3 py-1.5 bg-card border-t border-border shrink-0" onsubmit={handleSubmit}>
+      {#if pendingFile}
+        <div class="relative inline-block max-w-[200px] border border-border rounded-lg p-2 bg-card" data-testid="thread-file-preview">
+          {#if pendingFile.type.startsWith('image/')}
+            <img src={URL.createObjectURL(pendingFile)} alt="Preview" class="max-w-full max-h-[120px] rounded block" />
+          {:else}
+            <div class="flex items-center gap-2 text-foreground">
+              <span class="text-[1.5rem]">&#128196;</span>
+              <span class="text-[0.85rem] overflow-hidden text-ellipsis whitespace-nowrap">{pendingFile.name}</span>
+            </div>
+          {/if}
+          <button
+            type="button"
+            class="absolute top-1 right-1 w-6 h-6 p-0 rounded-full bg-[rgba(0,0,0,0.7)] text-white text-[1.2rem] leading-none flex items-center justify-center cursor-pointer border border-border hover:bg-[rgba(255,87,87,0.8)] hover:border-destructive"
+            onclick={clearPendingFile}
+            aria-label="Remove file"
+          >&times;</button>
+        </div>
+      {/if}
       <div class="relative">
         <textarea
           data-testid="thread-input"
@@ -732,11 +780,12 @@ let prevThreadId = null;
           rows="1"
           class="block w-full py-[13px] px-[17px] pr-[48px] border-2 border-input rounded-[18px] bg-background text-foreground text-[1.02rem] font-inherit outline-none resize-none min-h-[1.6em] max-h-[50vh] overflow-y-hidden focus:border-primary placeholder:text-muted-foreground"
           onkeydown={handleTextareaKeyDown}
+          onpaste={handlePaste}
           oninput={resizeTextarea}
         ></textarea>
         <button
           type="submit"
-          disabled={!replyText.trim()}
+          disabled={!replyText.trim() && !pendingFile || uploading}
           data-testid="thread-send-button"
           class="absolute right-[12px] bottom-[10px] p-1.5 rounded-full border-none bg-primary text-primary-foreground cursor-pointer transition-all duration-200 disabled:opacity-30 disabled:cursor-not-allowed hover:bg-primary/90"
         ><SendHorizontal size={18} /></button>
@@ -957,7 +1006,25 @@ let prevThreadId = null;
     <ThreadActivityDrawer channelName={$threadData?.channelName} threadParentId={$threadData?.parentMessage?.id} {thinking} />
 
     <!-- Mobile input -->
-    <form class="px-3 pt-2 pb-safe-offset-2 bg-card border-t border-border shrink-0" onsubmit={handleSubmit}>
+    <form class="flex flex-col gap-2 px-3 pt-2 pb-safe-offset-2 bg-card border-t border-border shrink-0" onsubmit={handleSubmit}>
+      {#if pendingFile}
+        <div class="relative inline-block max-w-[200px] border border-border rounded-lg p-2 bg-card" data-testid="thread-file-preview">
+          {#if pendingFile.type.startsWith('image/')}
+            <img src={URL.createObjectURL(pendingFile)} alt="Preview" class="max-w-full max-h-[120px] rounded block" />
+          {:else}
+            <div class="flex items-center gap-2 text-foreground">
+              <span class="text-[1.5rem]">&#128196;</span>
+              <span class="text-[0.85rem] overflow-hidden text-ellipsis whitespace-nowrap">{pendingFile.name}</span>
+            </div>
+          {/if}
+          <button
+            type="button"
+            class="absolute top-1 right-1 w-6 h-6 p-0 rounded-full bg-[rgba(0,0,0,0.7)] text-white text-[1.2rem] leading-none flex items-center justify-center cursor-pointer border border-border hover:bg-[rgba(255,87,87,0.8)] hover:border-destructive"
+            onclick={clearPendingFile}
+            aria-label="Remove file"
+          >&times;</button>
+        </div>
+      {/if}
       <div class="relative">
         <textarea
           data-testid="thread-input"
@@ -967,11 +1034,12 @@ let prevThreadId = null;
           rows="1"
           class="block w-full py-[10px] px-[14px] pr-[42px] border-2 border-input rounded-[14px] bg-background text-foreground text-[0.9rem] font-inherit outline-none resize-none min-h-[1.6em] max-h-[50vh] overflow-y-hidden focus:border-primary placeholder:text-muted-foreground"
           onkeydown={handleTextareaKeyDown}
+          onpaste={handlePaste}
           oninput={resizeTextarea}
         ></textarea>
         <button
           type="submit"
-          disabled={!replyText.trim()}
+          disabled={!replyText.trim() && !pendingFile || uploading}
           data-testid="thread-send-button"
           class="absolute right-[12px] bottom-[6px] p-1.5 rounded-full border-none bg-primary text-primary-foreground cursor-pointer transition-all duration-200 disabled:opacity-30 disabled:cursor-not-allowed hover:bg-primary/90"
         ><SendHorizontal size={18} /></button>

--- a/web-app/src/lib/filePaste.js
+++ b/web-app/src/lib/filePaste.js
@@ -1,0 +1,49 @@
+// Shared paste/upload logic used by Channel.svelte and ThreadPanel.svelte.
+
+import { sendMessage, uploadFile } from "./api.js";
+
+/**
+ * Handle a paste event — extract a file (image or other) from the clipboard.
+ * Returns the File if one was found, or null otherwise.
+ * Calls e.preventDefault() when a file is consumed.
+ */
+export function extractPastedFile(e) {
+	const items = e.clipboardData?.items;
+	if (!items) return null;
+
+	for (const item of items) {
+		if (item.type.startsWith("image/")) {
+			e.preventDefault();
+			return item.getAsFile();
+		}
+		if (item.kind === "file") {
+			e.preventDefault();
+			return item.getAsFile();
+		}
+	}
+	return null;
+}
+
+/**
+ * Upload a pending file and send it as a message.
+ *
+ * @param {File} file - The file to upload
+ * @param {string} text - Optional message text to accompany the file
+ * @param {string} channel - Channel name
+ * @param {string|null} threadParentId - Thread parent message ID (null for top-level)
+ * @returns {Promise<{ok: boolean, error?: string}>}
+ */
+export async function uploadAndSend(file, text, channel, threadParentId = null) {
+	const result = await uploadFile(file);
+
+	if (!result.ok) {
+		return { ok: false, error: result.error };
+	}
+
+	const message = text.trim()
+		? `${text.trim()}\n\n[Attached: ${result.path}]`
+		: `[Attached file: ${result.filename}]\nPlease read: ${result.path}`;
+
+	sendMessage(message, channel, threadParentId);
+	return { ok: true };
+}


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Extract shared paste/upload logic from Channel.svelte into `lib/filePaste.js` (`extractPastedFile` + `uploadAndSend`)
- Add image paste support to ThreadPanel (both desktop and mobile textareas)
- Add file preview UI with dismiss button above thread input
- Wire up upload flow in ThreadPanel's `handleSubmit`
- Refactor Channel.svelte to use the same shared module

## Changes
- **`web-app/src/lib/filePaste.js`** (new) — shared `extractPastedFile(e)` and `uploadAndSend(file, text, channel, threadParentId)` functions
- **`web-app/src/lib/Channel.svelte`** — refactored to import and use shared module instead of inline paste/upload logic
- **`web-app/src/lib/ThreadPanel.svelte`** — added `pendingFile` state, paste handler, file preview UI, and upload flow in submit handler for both desktop and mobile views

## Test plan
- [x] Biome lint passes on all changed files
- [ ] Paste an image into thread textarea — preview appears
- [ ] Click × to dismiss preview
- [ ] Submit with image — uploads and sends message in thread
- [ ] Submit with image + text — text included in message
- [ ] Channel paste still works as before (regression)
- [ ] Mobile thread textarea paste works

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)