### PR TITLE
fix: Revoke blob URLs on change/cleanup to prevent memory leak [Midtown !2158]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -8,7 +8,7 @@ import { closeThread, getApiBase, openTaskThread, openThread, sendMessage, uploa
 import { openImageLightbox } from "./biggerPicture.js";
 import { findPr as findPrUtil, getPrUrl as getPrUrlUtil, resolveMessageTapAction } from "./channelUtils.js";
 import DayDivider from "./DayDivider.svelte";
-import { extractPastedFile, uploadAndSend } from "./filePaste.js";
+import { extractPastedFile, updatePreviewUrl, uploadAndSend } from "./filePaste.js";
 import MermaidDiagram from "./MermaidDiagram.svelte";
 import MessageRow from "./MessageRow.svelte";
 import { hasMermaid, parseSegments, renderContent } from "./markdown.js";
@@ -49,6 +49,7 @@ let inputText = $state("");
 let scrollAreaViewport = $state(null);
 let autoScroll = $state(true);
 let pendingFile = $state(null);
+let pendingFileUrl = $state(null);
 let uploading = $state(false);
 let textareaElement = $state(null);
 let formWrapperElement = $state(null);
@@ -170,6 +171,18 @@ $effect(() => {
 		});
 	}
 	prevChannel = ch;
+});
+
+// Manage blob preview URL: create on file change, revoke old URL to prevent memory leaks.
+$effect(() => {
+	const file = pendingFile;
+	pendingFileUrl = updatePreviewUrl(pendingFileUrl, file);
+	return () => {
+		if (pendingFileUrl) {
+			URL.revokeObjectURL(pendingFileUrl);
+			pendingFileUrl = null;
+		}
+	};
 });
 
 function isNewMessage(channelName, index) {
@@ -942,7 +955,7 @@ function getToolCallStatusIcon(entry) {
       {#if pendingFile}
         <div class="relative inline-block max-w-[200px] border border-border rounded-lg p-2 bg-card" data-testid="file-preview">
           {#if pendingFile.type.startsWith('image/')}
-            <img src={URL.createObjectURL(pendingFile)} alt="Preview" class="max-w-full max-h-[120px] rounded block" />
+            <img src={pendingFileUrl} alt="Preview" class="max-w-full max-h-[120px] rounded block" />
           {:else}
             <div class="flex items-center gap-2 text-foreground">
               <span class="text-[1.5rem]">&#128196;</span>

--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -9,7 +9,7 @@ let prevThreadId = null;
 <script>
   import { threadData, agentToolItems, threadToolItems, deepLinkMsgId, threadOwnership, threadForkParents, threadForkOwners, activeProject, channels as channelsStore, activeChannel, daemonStatus, kanbanData, repoStatus, repoStatuses } from './store.js'
   import { sendMessage, closeThread, getApiBase, forkThread, unforkThread, openTaskThread, selectDm } from './api.js'
-  import { extractPastedFile, uploadAndSend } from './filePaste.js'
+  import { extractPastedFile, updatePreviewUrl, uploadAndSend } from './filePaste.js'
   import { getPrUrl as getPrUrlUtil } from './channelUtils.js'
   import { tick, onMount, onDestroy, untrack } from 'svelte'
   import { getSenderColor, isDimSender, parseInsightSegments, dateChanged } from './messageUtils.js'
@@ -96,6 +96,7 @@ let prevThreadId = null;
 
   let replyText = $state('')
   let pendingFile = $state(null)
+  let pendingFileUrl = $state(null)
   let uploading = $state(false)
   let desktopScrollArea = $state(null)
   let mobileScrollArea = $state(null)
@@ -438,6 +439,18 @@ let prevThreadId = null;
     pendingFile = null
   }
 
+  // Manage blob preview URL: create on file change, revoke old URL to prevent memory leaks.
+  $effect(() => {
+    const file = pendingFile
+    pendingFileUrl = updatePreviewUrl(pendingFileUrl, file)
+    return () => {
+      if (pendingFileUrl) {
+        URL.revokeObjectURL(pendingFileUrl)
+        pendingFileUrl = null
+      }
+    }
+  })
+
   // Auto-scroll when new messages or edit diffs arrive (only if user is near bottom)
   $effect(() => {
     if ((mergedTimeline.length > 0) && scrollArea && untrack(() => autoScroll)) {
@@ -765,7 +778,7 @@ let prevThreadId = null;
       {#if pendingFile}
         <div class="relative inline-block max-w-[200px] border border-border rounded-lg p-2 bg-card" data-testid="thread-file-preview">
           {#if pendingFile.type.startsWith('image/')}
-            <img src={URL.createObjectURL(pendingFile)} alt="Preview" class="max-w-full max-h-[120px] rounded block" />
+            <img src={pendingFileUrl} alt="Preview" class="max-w-full max-h-[120px] rounded block" />
           {:else}
             <div class="flex items-center gap-2 text-foreground">
               <span class="text-[1.5rem]">&#128196;</span>
@@ -1019,7 +1032,7 @@ let prevThreadId = null;
       {#if pendingFile}
         <div class="relative inline-block max-w-[200px] border border-border rounded-lg p-2 bg-card" data-testid="thread-file-preview">
           {#if pendingFile.type.startsWith('image/')}
-            <img src={URL.createObjectURL(pendingFile)} alt="Preview" class="max-w-full max-h-[120px] rounded block" />
+            <img src={pendingFileUrl} alt="Preview" class="max-w-full max-h-[120px] rounded block" />
           {:else}
             <div class="flex items-center gap-2 text-foreground">
               <span class="text-[1.5rem]">&#128196;</span>

--- a/web-app/src/lib/filePaste.js
+++ b/web-app/src/lib/filePaste.js
@@ -33,6 +33,15 @@ export function extractPastedFile(e) {
  * @param {string|null} threadParentId - Thread parent message ID (null for top-level)
  * @returns {Promise<{ok: boolean, error?: string}>}
  */
+/**
+ * Create a blob preview URL for a file, revoking any previous URL to prevent leaks.
+ * Returns the new URL, or null if file is null/undefined.
+ */
+export function updatePreviewUrl(previousUrl, file) {
+	if (previousUrl) URL.revokeObjectURL(previousUrl);
+	return file ? URL.createObjectURL(file) : null;
+}
+
 export async function uploadAndSend(file, text, channel, threadParentId = null) {
 	const result = await uploadFile(file);
 

--- a/web-app/src/lib/filePaste.test.js
+++ b/web-app/src/lib/filePaste.test.js
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { updatePreviewUrl } from "./filePaste.js";
+
+describe("updatePreviewUrl", () => {
+	let mockCreate;
+	let mockRevoke;
+
+	beforeEach(() => {
+		let counter = 0;
+		mockCreate = vi.fn(() => `blob:mock-${++counter}`);
+		mockRevoke = vi.fn();
+		globalThis.URL.createObjectURL = mockCreate;
+		globalThis.URL.revokeObjectURL = mockRevoke;
+	});
+
+	test("creates blob URL for a file", () => {
+		const file = new File([""], "test.png", { type: "image/png" });
+		const url = updatePreviewUrl(null, file);
+		expect(mockCreate).toHaveBeenCalledWith(file);
+		expect(url).toBe("blob:mock-1");
+	});
+
+	test("revokes previous URL when creating new one", () => {
+		const file = new File([""], "test.png", { type: "image/png" });
+		updatePreviewUrl("blob:old-url", file);
+		expect(mockRevoke).toHaveBeenCalledWith("blob:old-url");
+		expect(mockCreate).toHaveBeenCalledWith(file);
+	});
+
+	test("returns null and revokes when file is null", () => {
+		const url = updatePreviewUrl("blob:old-url", null);
+		expect(mockRevoke).toHaveBeenCalledWith("blob:old-url");
+		expect(url).toBeNull();
+	});
+
+	test("returns null without revoking when both are null", () => {
+		const url = updatePreviewUrl(null, null);
+		expect(mockRevoke).not.toHaveBeenCalled();
+		expect(url).toBeNull();
+	});
+});


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- **Channel.svelte** called `URL.createObjectURL()` inline in a template expression, creating a new blob URL on every re-render without revoking previous ones — each leaked URL held a reference to file data in browser memory
- Fix: derive the preview URL reactively via `$effect()`, revoking the previous URL on file change and on component teardown
- Extract shared `updatePreviewUrl()` into `filePaste.js` and apply the same pattern to **ThreadPanel.svelte** for consistency
- Added unit tests for `updatePreviewUrl()` covering create, revoke-on-change, revoke-on-null, and no-op cases

## Test plan
- [x] `npx vitest run` — all 262 tests pass (including 4 new filePaste tests)
- [x] Blob URLs are revoked on file change (tested via `updatePreviewUrl`)
- [x] Blob URLs are revoked on cleanup (effect teardown)
- [x] No inline `createObjectURL()` calls remain in template expressions

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)