### PR TITLE
fix: Enable autoCompact for headless sessions

### DIFF
--- a/agents/common-settings.json
+++ b/agents/common-settings.json
@@ -1,3 +1,4 @@
 {
-  "autoUpdates": false
+  "autoUpdates": false,
+  "autoCompact": true
 }


### PR DESCRIPTION
## Summary

- Adds `"autoCompact": true` to `agents/common-settings.json` so all headless sessions (leads, coworkers, forks) auto-compact before hitting the 200K context window limit

## Problem

Headless sessions were hitting "Prompt is too long" synthetic errors (`model: "<synthetic>"`, `error: "invalid_request"`) when conversations grew large. This was especially bad for forked sessions that inherit the parent's full context — they'd fail immediately and loop on the error indefinitely.

Root cause: Midtown passes `--setting-sources project,local` (excluding user-level settings) and its own `--settings` file to all sessions. Neither included the `autoCompact` setting, so headless mode skipped compaction and returned the synthetic error instead.

## Test plan

- [x] Existing settings tests pass (`cargo test --lib settings::tests`)
- [x] `cargo install --path .` + `midtown restart` — verified sessions start without "Prompt is too long" errors
- [x] Manual verification: long-running lead and fork sessions no longer hit the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)