### PR TITLE
feat: Show default workflow diagram for unassigned channels [Midtown !2161]

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -2159,22 +2159,32 @@ async fn api_channel_workflow(
     // Get workflow state for this channel
     let workflow_state = persistent_state.workflow_state.get(channel).cloned();
 
-    // Generate mermaid diagram from assigned workflow's transitions metadata
-    let mermaid = assigned_workflow.as_ref().and_then(|assigned_name| {
-        discovered
-            .iter()
-            .find(|w| &w.name == assigned_name)
-            .and_then(|w| w.metadata.as_ref())
-            .and_then(|meta| {
-                if meta.transitions.is_empty() {
-                    return None;
-                }
-                Some(generate_mermaid_from_transitions(
-                    &meta.states,
-                    &meta.transitions,
-                ))
-            })
-    });
+    // Generate mermaid diagram: use assigned workflow's transitions if available,
+    // otherwise fall back to the default workflow diagram.
+    let mermaid = assigned_workflow
+        .as_ref()
+        .and_then(|assigned_name| {
+            discovered
+                .iter()
+                .find(|w| &w.name == assigned_name)
+                .and_then(|w| w.metadata.as_ref())
+                .and_then(|meta| {
+                    if meta.transitions.is_empty() {
+                        return None;
+                    }
+                    Some(generate_mermaid_from_transitions(
+                        &meta.states,
+                        &meta.transitions,
+                    ))
+                })
+        })
+        .or_else(|| {
+            if assigned_workflow.is_none() {
+                Some(DEFAULT_WORKFLOW_MERMAID.to_string())
+            } else {
+                None
+            }
+        });
 
     Ok(Json(serde_json::json!({
         "assigned_workflow": assigned_workflow,
@@ -2221,6 +2231,25 @@ async fn api_list_workflows(
         "assignments": assignments,
     })))
 }
+
+/// Mermaid stateDiagram for the built-in default workflow.
+///
+/// Matches the state machine in `sdk/python/midtown/default_workflow.py`:
+/// pending → in_progress → in_review → approved → merged
+/// with back-edges for changes_requested and direct merge paths.
+const DEFAULT_WORKFLOW_MERMAID: &str = "\
+stateDiagram-v2
+    [*] --> pending
+    pending --> in_progress : task assigned
+    in_progress --> in_review : PR opened
+    in_progress --> approved : PR approved
+    in_review --> approved : PR approved
+    in_review --> in_progress : changes requested
+    approved --> in_progress : changes requested
+    in_progress --> merged : PR merged
+    in_review --> merged : PR merged
+    approved --> merged : PR merged
+    merged --> [*]";
 
 /// Generate a mermaid stateDiagram-v2 string from workflow states and transitions.
 fn generate_mermaid_from_transitions(

--- a/src/web_tests.rs
+++ b/src/web_tests.rs
@@ -1242,7 +1242,14 @@ async fn test_workflow_returns_no_assignment_when_empty() {
     assert!(data["assigned_workflow"].is_null());
     assert!(data["available_workflows"].as_array().unwrap().is_empty());
     assert!(data["state"].is_null());
-    assert!(data["mermaid"].is_null());
+    // When no workflow is assigned, the default workflow diagram is returned
+    assert!(data["mermaid"].is_string());
+    assert!(
+        data["mermaid"]
+            .as_str()
+            .unwrap()
+            .contains("stateDiagram-v2")
+    );
 }
 
 #[tokio::test]

--- a/web-app/src/lib/ChannelWorkflow.svelte
+++ b/web-app/src/lib/ChannelWorkflow.svelte
@@ -137,9 +137,9 @@ let taskEntries = $derived(data?.state?.tasks ? Object.entries(data.state.tasks)
       </section>
 
       <!-- Mermaid diagram -->
-      {#if data.assigned_workflow && data.mermaid}
+      {#if data.mermaid}
         <section class="workflow-section">
-          <h2 class="section-title">State Machine</h2>
+          <h2 class="section-title">{data.assigned_workflow ? 'State Machine' : 'Default State Machine'}</h2>
           <div class="diagram-container">
             <MermaidDiagram code={data.mermaid} />
           </div>
@@ -147,7 +147,7 @@ let taskEntries = $derived(data?.state?.tasks ? Object.entries(data.state.tasks)
       {/if}
 
       <!-- Task positions -->
-      {#if data.assigned_workflow && taskEntries.length > 0}
+      {#if taskEntries.length > 0}
         <section class="workflow-section">
           <h2 class="section-title">Task Positions</h2>
           <div class="info-card">


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Add `DEFAULT_WORKFLOW_MERMAID` constant matching the built-in daemon workflow (pending → in_progress → in_review → approved → merged) with labeled transitions and back-edges
- Serve the default diagram from `GET /api/workflow?channel=` when no custom workflow is assigned, so every channel always has a visible state machine
- Remove the `data.assigned_workflow` guard from the Mermaid diagram and task positions sections in `ChannelWorkflow.svelte` so both render regardless of assignment status
- Update section title to distinguish "Default State Machine" from custom "State Machine"

## Visual Changes

**Before:** When a channel has no assigned workflow ("None — daemon defaults"), the Workflow tab shows only the dropdown selector with empty space below it.

**After:** The Workflow tab now shows:
1. The same dropdown selector
2. A new "Default State Machine" section with a Mermaid diagram showing the built-in workflow: `pending → in_progress → in_review → approved → merged` (with labeled transitions and back-edges)
3. Task positions section (if any tasks exist), regardless of workflow assignment

When a custom workflow IS explicitly assigned, behavior is unchanged — the title reads "State Machine" (without "Default").

## Test plan
- [x] All 10 workflow tests pass (`cargo test --lib test_workflow`)
- [x] Updated `test_workflow_returns_no_assignment_when_empty` to verify the default diagram is returned
- [x] Clippy clean (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)