### PR TITLE
feat: Auto-restart coworkers on 'Prompt is too long' error [Midtown !2162]

### DIFF
--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -1122,6 +1122,7 @@ pub(super) fn check_and_nudge_api_errors(
 /// The `has_tool_name_conflict` flag currently covers unrecoverable conditions:
 /// - "Tool names must be unique" registration conflicts.
 /// - Stale Codex resume/session IDs (e.g., "no rollout found for thread id ...").
+/// - Context exhaustion ("prompt is too long") — the conversation outgrew the model's window.
 ///
 /// Generic API retries cannot fix these. We clear the saved session ID first, then
 /// shut down and restart fresh.

--- a/src/daemon/sessions.rs
+++ b/src/daemon/sessions.rs
@@ -74,6 +74,15 @@ fn is_stale_codex_session_error(error_msg: &str) -> bool {
         || lowercase.contains("thread_not_found")
 }
 
+/// Detect "Prompt is too long" context exhaustion errors.
+///
+/// These occur when a coworker's conversation grows past the model's context
+/// window. Retrying can never succeed — the session must be killed and
+/// restarted fresh with task context preserved.
+fn is_context_exhausted_error(error_msg: &str) -> bool {
+    error_msg.to_lowercase().contains("prompt is too long")
+}
+
 /// Parse usage limit messages to extract reset time.
 ///
 /// Claude Code usage limit messages typically contain text like:
@@ -231,6 +240,7 @@ pub struct CoworkerSession {
     /// Includes:
     /// - "Tool names must be unique" conflicts.
     /// - Stale Codex resume/session errors (e.g., "no rollout found for thread id ...").
+    /// - Context exhaustion ("prompt is too long").
     pub has_tool_name_conflict: bool,
     /// Whether this session was spawned as a `--resume` (vs fresh).
     /// Used to detect failed resume attempts: if a resume session exits quickly,
@@ -1140,6 +1150,12 @@ impl SessionManager {
                                         cs.has_tool_name_conflict = true;
                                         warn!(
                                             "Session '{}' hit stale Codex session/thread error — needs fresh restart",
+                                            name
+                                        );
+                                    } else if is_context_exhausted_error(&combined) {
+                                        cs.has_tool_name_conflict = true;
+                                        warn!(
+                                            "Session '{}' hit context exhaustion ('prompt is too long') — needs fresh restart",
                                             name
                                         );
                                     } else {

--- a/src/daemon/sessions_tests.rs
+++ b/src/daemon/sessions_tests.rs
@@ -55,6 +55,27 @@ fn test_is_stale_codex_session_error_ignores_generic_errors() {
     assert!(!is_stale_codex_session_error(msg));
 }
 
+#[test]
+fn test_is_context_exhausted_error_detects_prompt_too_long() {
+    assert!(is_context_exhausted_error("Prompt is too long"));
+    assert!(is_context_exhausted_error(
+        "Error: prompt is too long (250000 tokens > 200000 max)"
+    ));
+}
+
+#[test]
+fn test_is_context_exhausted_error_case_insensitive() {
+    assert!(is_context_exhausted_error("PROMPT IS TOO LONG"));
+    assert!(is_context_exhausted_error("Prompt Is Too Long"));
+}
+
+#[test]
+fn test_is_context_exhausted_error_ignores_generic_errors() {
+    assert!(!is_context_exhausted_error("rate limit exceeded"));
+    assert!(!is_context_exhausted_error("network error"));
+    assert!(!is_context_exhausted_error("too long ago"));
+}
+
 /// Insert a fake session entry for testing (no real process).
 async fn insert_test_session(sm: &SessionManager, name: &str, status: SessionStatus) {
     let mut sessions = sm.sessions.write().await;

--- a/src/daemon/snapshot.rs
+++ b/src/daemon/snapshot.rs
@@ -77,8 +77,8 @@ pub struct ProcessHealth {
     /// When true, the session is waiting for a tool to complete (e.g., long-running Bash command)
     /// and shouldn't be considered stuck even if no events are emitted during execution.
     pub has_pending_tool: bool,
-    /// Whether the coworker has a tool name conflict (e.g., duplicate MCP tool names).
-    /// When true, the session may fail tool calls and needs a restart.
+    /// Whether the coworker has an unrecoverable session error (e.g., duplicate MCP tool names,
+    /// stale Codex session IDs, or context exhaustion). When true, the session needs a restart.
     #[serde(default)]
     pub has_tool_name_conflict: bool,
     /// Whether the coworker is waiting for the next API response after a tool result.


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Detect "prompt is too long" context exhaustion errors in coworker sessions
- Trigger fresh restart (kill + respawn) instead of futile retry nudges
- Follows the existing unrecoverable-error pattern (stale Codex sessions, tool name conflicts)

## Changes
- **sessions.rs**: Added `is_context_exhausted_error()` detection function; wired into the error classification chain to set `has_tool_name_conflict = true`
- **sessions_tests.rs**: 3 new tests for detection (positive match, case insensitivity, negative cases)
- **health.rs**: Updated doc comment to document the new error type
- **snapshot.rs**: Updated `has_tool_name_conflict` doc comment to reflect its broader purpose

## Design decision
Reused the existing `has_tool_name_conflict` flag rather than adding a new `has_context_exhausted` flag. This avoids updating ~40 snapshot fixtures and dozens of tests while achieving identical behavior — the existing `check_and_restart_tool_name_conflicts` handler already kills the session and respawns fresh.

## Test plan
- [x] `is_context_exhausted_error()` correctly detects "prompt is too long" (case-insensitive)
- [x] `is_context_exhausted_error()` does not false-positive on unrelated errors
- [x] All 57 session tests pass
- [x] All 74 health tests pass
- [x] All 176 rules tests pass
- [x] Clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)