### PR TITLE
feat: Add Settings tab with tool-call display toggle [Midtown !2165]

### DIFF
--- a/web-app/src/App.svelte
+++ b/web-app/src/App.svelte
@@ -21,7 +21,7 @@ import ChannelHeader from "$lib/ChannelHeader.svelte";
 import ChannelList from "$lib/ChannelList.svelte";
 import ChannelNotes from "$lib/ChannelNotes.svelte";
 import ChannelPrList from "$lib/ChannelPrList.svelte";
-import ChannelWorkflow from "$lib/ChannelWorkflow.svelte";
+import ChannelSettings from "$lib/ChannelSettings.svelte";
 import {
 	Sidebar,
 	SidebarContent,
@@ -365,7 +365,7 @@ function selectProject(project) {
               <ChannelHeader />
               {#if !isActiveDm}
                 <div class="channel-tab-bar">
-                  {#each [['messages', 'Messages'], ['prs', 'PRs'], ['notes', 'Notes'], ['workflow', 'Workflow']] as [tab, label]}
+                  {#each [['messages', 'Messages'], ['prs', 'PRs'], ['notes', 'Notes'], ['settings', 'Settings']] as [tab, label]}
                     {@const isActive = ($activeChannelTab[$activeChannel] || 'messages') === tab}
                     <button
                       class="channel-tab"
@@ -382,8 +382,8 @@ function selectProject(project) {
                 <ChannelPrList />
               {:else if ($activeChannelTab[$activeChannel] || 'messages') === 'notes'}
                 <ChannelNotes />
-              {:else if ($activeChannelTab[$activeChannel] || 'messages') === 'workflow'}
-                <ChannelWorkflow />
+              {:else if ($activeChannelTab[$activeChannel] || 'messages') === 'settings'}
+                <ChannelSettings />
               {/if}
             </div>
 

--- a/web-app/src/lib/ChannelSettings.svelte
+++ b/web-app/src/lib/ChannelSettings.svelte
@@ -1,0 +1,151 @@
+<script>
+import ChannelWorkflow from "./ChannelWorkflow.svelte";
+import { activeChannel, channelSettings } from "./store.js";
+
+let inlineToolCalls = $derived($channelSettings[$activeChannel]?.inlineToolCalls ?? false);
+
+function toggleInlineToolCalls() {
+	channelSettings.update((s) => ({
+		...s,
+		[$activeChannel]: {
+			...s[$activeChannel],
+			inlineToolCalls: !inlineToolCalls,
+		},
+	}));
+}
+</script>
+
+<div class="settings-layout">
+  <div class="settings-content">
+    <!-- Tool-call display toggle -->
+    <section class="settings-section">
+      <h2 class="section-title">Tool Call Display</h2>
+      <div class="setting-row">
+        <div class="setting-info">
+          <span class="setting-label">Inline tool calls</span>
+          <span class="setting-description">
+            Show Edit/Write tool calls inline in the message stream instead of grouped at the bottom.
+          </span>
+        </div>
+        <button
+          class="toggle-switch"
+          class:active={inlineToolCalls}
+          onclick={toggleInlineToolCalls}
+          role="switch"
+          aria-checked={inlineToolCalls}
+          aria-label="Toggle inline tool calls"
+        >
+          <span class="toggle-knob"></span>
+        </button>
+      </div>
+    </section>
+
+    <!-- Workflow section (embedded) -->
+    <section class="settings-section workflow-embed">
+      <ChannelWorkflow />
+    </section>
+  </div>
+</div>
+
+<style>
+  .settings-layout {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    height: 100%;
+  }
+
+  .settings-content {
+    padding: 20px 24px;
+    max-width: 800px;
+  }
+
+  .settings-section {
+    margin-bottom: 28px;
+  }
+
+  .section-title {
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: hsl(var(--muted-foreground));
+    margin: 0 0 10px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid hsl(var(--border));
+  }
+
+  .setting-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 8px 0;
+  }
+
+  .setting-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .setting-label {
+    font-size: 0.88rem;
+    font-weight: 500;
+    color: hsl(var(--foreground));
+  }
+
+  .setting-description {
+    font-size: 0.78rem;
+    color: hsl(var(--muted-foreground));
+  }
+
+  .toggle-switch {
+    position: relative;
+    width: 40px;
+    height: 22px;
+    border-radius: 11px;
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--accent));
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: background 0.2s, border-color 0.2s;
+    padding: 0;
+  }
+
+  .toggle-switch.active {
+    background: hsl(var(--primary));
+    border-color: hsl(var(--primary));
+  }
+
+  .toggle-knob {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: hsl(var(--background));
+    transition: transform 0.2s;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  }
+
+  .toggle-switch.active .toggle-knob {
+    transform: translateX(18px);
+  }
+
+  /* The embedded workflow already has its own padding — remove duplicate */
+  .workflow-embed :global(.workflow-layout) {
+    overflow: visible;
+  }
+
+  .workflow-embed :global(.workflow-content) {
+    padding: 0;
+  }
+
+  @media (max-width: 767px) {
+    .settings-content {
+      padding: 16px;
+    }
+  }
+</style>

--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -7,7 +7,7 @@ let prevThreadId = null;
 </script>
 
 <script>
-  import { threadData, agentToolItems, threadToolItems, deepLinkMsgId, threadOwnership, threadForkParents, threadForkOwners, activeProject, channels as channelsStore, activeChannel, daemonStatus, kanbanData, repoStatus, repoStatuses } from './store.js'
+  import { threadData, agentToolItems, threadToolItems, deepLinkMsgId, threadOwnership, threadForkParents, threadForkOwners, activeProject, channels as channelsStore, activeChannel, daemonStatus, kanbanData, repoStatus, repoStatuses, channelSettings } from './store.js'
   import { sendMessage, closeThread, getApiBase, forkThread, unforkThread, openTaskThread, selectDm } from './api.js'
   import { extractPastedFile, updatePreviewUrl, uploadAndSend } from './filePaste.js'
   import { getPrUrl as getPrUrlUtil } from './channelUtils.js'
@@ -259,15 +259,25 @@ let prevThreadId = null;
     }
   })
 
-  // Extract Edit/Write tool calls for DM channels to render as inline diffs.
-  // Tool items are keyed by channel name in the store; for DM threads we pull
-  // the items for that DM channel and filter for Edit/Write calls.
+  // Extract Edit/Write tool calls to render as inline diffs.
+  // Enabled for DM channels (always) or any channel with inlineToolCalls setting.
+  // Tool items are keyed by channel name in the store; we pull the items for
+  // that channel and filter for Edit/Write calls.
   let isDmChannel = $derived($threadData?.channelName?.startsWith('dm-') ?? false)
+  let showInlineDiffs = $derived(
+    isDmChannel || ($channelSettings[$threadData?.channelName]?.inlineToolCalls ?? false)
+  )
 
   let editDiffs = $derived.by(() => {
-    if (!isDmChannel || !$threadData) return []
+    if (!showInlineDiffs || !$threadData) return []
     const channelName = $threadData.channelName
-    const items = $agentToolItems[channelName] || []
+    const parentId = $threadData.parentMessage?.id
+    // DM channels use channel-keyed tool items; non-DM channels with inline
+    // enabled prefer thread-scoped items (from fork sessions) and fall back
+    // to channel-level items.
+    const threadItems = parentId ? ($threadToolItems[parentId] || []) : []
+    const channelItems = $agentToolItems[channelName] || []
+    const items = isDmChannel ? channelItems : (threadItems.length > 0 ? threadItems : channelItems)
     // Build result status map: call_id → 'error' | 'ok'
     // so we can skip diffs for failed Edit/Write calls.
     const resultStatus = {}
@@ -321,7 +331,7 @@ let prevThreadId = null;
   let mergedTimeline = $derived.by(() => {
     if (!$threadData) return []
     const msgs = ($threadData.messages ?? []).map((m, i) => ({ type: 'message', data: m, timestamp: m.timestamp, msgIndex: i }))
-    if (!isDmChannel || editDiffs.length === 0) return msgs
+    if (!showInlineDiffs || editDiffs.length === 0) return msgs
     const edits = editDiffs.map((d) => ({ type: 'edit', data: d, timestamp: d.timestamp, msgIndex: -1 }))
     const sorted = [...msgs, ...edits].sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''))
     // Recompute message indices after sort — interleaved edits shift positions

--- a/web-app/src/lib/store.js
+++ b/web-app/src/lib/store.js
@@ -184,9 +184,16 @@ export const isWideScreen = writable(false);
 // Whether to show archived channels in the channel list (default: false)
 export const showArchivedChannels = writable(false);
 
-// Active tab per channel: { [channelName]: 'messages' | 'prs' | 'notes' }
+// Active tab per channel: { [channelName]: 'messages' | 'prs' | 'notes' | 'settings' }
 // Keyed by channel name so switching channels preserves tab position.
 export const activeChannelTab = writable({});
+
+// Per-channel settings persisted to localStorage.
+// Format: { [channelName]: { inlineToolCalls: boolean } }
+// inlineToolCalls: when true, Edit/Write tool calls are shown inline in the message
+// stream (like DM threads) instead of grouped in the ThreadActivityDrawer.
+export const channelSettings = writable(loadFromLocalStorage("midtown_channel_settings", {}));
+channelSettings.subscribe((v) => debouncedSaveToLocalStorage("midtown_channel_settings", v));
 
 // Recent tool call activity keyed by channel name.
 // 'midtown' holds the main lead's tool calls; topic channel names hold their channel lead's tool calls.


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Rename the **Workflow** tab to **Settings** and embed the existing workflow UI within it
- Add a **tool-call display toggle** — when enabled, Edit/Write tool calls appear inline in the thread message stream (like DM threads) instead of grouped in the ThreadActivityDrawer
- Setting is stored per-channel in localStorage via a new `channelSettings` store
- For non-DM channels with inline enabled, tool items are sourced from `threadToolItems` (fork sessions) first, falling back to `agentToolItems`

## Screenshots

| Before (Workflow tab) | After (Settings tab) |
|---|---|
| ![before](https://github.com/btucker/midtown/releases/download/untagged-f6419461146b63b1dfb4/before-workflow-tab.png) | ![after](https://github.com/btucker/midtown/releases/download/untagged-f6419461146b63b1dfb4/after-settings-tab.png) |

**Key visual changes:**
- Tab renamed from "Workflow" → "Settings"
- New "Tool Call Display" section with inline tool calls toggle appears above the embedded Workflow section

## Files changed
- `web-app/src/App.svelte` — rename tab, swap component import
- `web-app/src/lib/ChannelSettings.svelte` — new component wrapping workflow + toggle
- `web-app/src/lib/ThreadPanel.svelte` — refactor `isDmChannel` → `showInlineDiffs`
- `web-app/src/lib/store.js` — add `channelSettings` store

## Test plan
- [x] `npx vite build` passes
- [x] `npx biome check` passes on all changed files
- [x] Pre-commit hooks (clippy, fmt, biome) pass
- [ ] Manual: verify Settings tab appears, toggle works, inline diffs render in threads

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)