### PR TITLE
fix: Replace hardcoded 'midtown' channel refs with {project_name} placeholder [Midtown !2168]

### DIFF
--- a/agents/channel-lead.md
+++ b/agents/channel-lead.md
@@ -129,7 +129,7 @@ midtown channel post "reply text" --thread <message-id> --channel {channel_name}
 
 **2. Posting to a different channel** (e.g., escalation to main):
 ```bash
-midtown channel post "@{project_name} <situation and what you need>" --channel midtown
+midtown channel post "@{project_name} <situation and what you need>" --channel {project_name}
 ```
 
 **In the root session, always reply in a thread** when responding to user messages or @mentions — this keeps the channel organized. Note: your text output is still auto-posted as a top-level message, so writing text alongside a `--thread` reply produces a duplicate. Keep your text output brief or omit it when the thread reply covers everything. (Forked sessions auto-tag posts with their bound thread — no `--thread` needed.)
@@ -187,7 +187,7 @@ Keep your text output brief or omit it entirely when the thread reply covers eve
 
 **Escalation format** (post to main channel):
 ```bash
-midtown channel post "@{project_name} <situation and what you need>" --channel midtown
+midtown channel post "@{project_name} <situation and what you need>" --channel {project_name}
 ```
 
 Keep domain questions in #{channel_name}. Reserve escalations for things that genuinely require project-wide coordination.

--- a/agents/ops-channel-lead.md
+++ b/agents/ops-channel-lead.md
@@ -15,7 +15,7 @@ As the **#ops channel lead**, you receive daemon operational alerts addressed to
 When the daemon posts an alert like `@ops PR #N has been stuck...`:
 
 1. **Read the alert** — understand what's stuck and for how long
-2. **Check channel context** — read recent activity in #ops and #midtown to understand the situation
+2. **Check channel context** — read recent activity in #ops and #{project_name} to understand the situation
 3. **Take action** — post in the relevant channel to unblock the situation (nudge the stuck coworker, provide context, etc.)
 4. **Escalate if needed** — if you can't resolve it, escalate to the Project Lead (`@{project_name}`)
 
@@ -27,9 +27,9 @@ Escalate when the situation requires something only the Project Lead can do:
 - **Genuine daemon bug** — stuck condition persists despite your intervention (use `midtown e2e capture`)
 - **Architectural guidance** — CI failure or merge conflict needs project-level context
 
-**Escalation format** (post to #midtown):
+**Escalation format** (post to #{project_name}):
 ```bash
-midtown channel post "@{project_name} PR #N is stuck — coworker hasn't responded to nudges for X minutes. Needs reassignment." --channel midtown
+midtown channel post "@{project_name} PR #N is stuck — coworker hasn't responded to nudges for X minutes. Needs reassignment." --channel {project_name}
 ```
 
 ### What You Do NOT Own

--- a/agents/project-lead.md
+++ b/agents/project-lead.md
@@ -98,7 +98,7 @@ Prefer combining tightly coupled work into a single task rather than splitting a
 
 Topic channels have dedicated **channel leads** — domain experts with persistent context for their area. Channel leads brainstorm, answer domain questions, and track active work in their channel. They do not implement code or open PRs.
 
-**Insight ownership:** When a coworker posts an insight in a topic channel, the channel lead for that channel decides whether to engage — not you. You only respond to insights posted in the main channel (#midtown). If a channel lead has started a thread on an insight, that thread is their responsibility.
+**Insight ownership:** When a coworker posts an insight in a topic channel, the channel lead for that channel decides whether to engage — not you. You only respond to insights posted in the main channel (#{project_name}). If a channel lead has started a thread on an insight, that thread is their responsibility.
 
 **The #ops channel lead** owns the operational layer:
 - Handles all `@ops` daemon alerts (stuck PRs, orphaned worktrees, coworker health)

--- a/src/agents_tests.rs
+++ b/src/agents_tests.rs
@@ -667,6 +667,52 @@ fn test_reviewer_launch_prompt_codex_invocation() {
     );
 }
 
+// ── Hardcoded channel name regression tests ─────────────────────
+
+#[test]
+fn test_channel_lead_no_hardcoded_midtown_channel() {
+    // When project_name is NOT "midtown", `--channel midtown` and `#midtown`
+    // (as channel refs) should not appear. These indicate hardcoded channel
+    // names that should use {project_name}.
+    let prompt = channel_lead_system_prompt("daemon-core", "No context.", "ravioli", None);
+    assert!(
+        !prompt.contains("--channel midtown"),
+        "Channel lead prompt should not contain hardcoded '--channel midtown'"
+    );
+    assert!(
+        !prompt.contains("#midtown"),
+        "Channel lead prompt should not contain hardcoded '#midtown' channel reference"
+    );
+}
+
+#[test]
+fn test_ops_channel_lead_no_hardcoded_midtown_channel() {
+    // The ops channel lead gets extra content from ops-channel-lead.md.
+    // Verify that content also uses {project_name} not literal "midtown".
+    let prompt = channel_lead_system_prompt("ops", "No context.", "ravioli", None);
+    assert!(
+        !prompt.contains("--channel midtown"),
+        "Ops channel lead prompt should not contain hardcoded '--channel midtown'"
+    );
+    assert!(
+        !prompt.contains("#midtown"),
+        "Ops channel lead prompt should not contain hardcoded '#midtown' channel reference"
+    );
+}
+
+#[test]
+fn test_main_lead_no_hardcoded_midtown_channel() {
+    let prompt = main_lead_system_prompt("ravioli");
+    assert!(
+        !prompt.contains("--channel midtown"),
+        "Main lead prompt should not contain hardcoded '--channel midtown'"
+    );
+    assert!(
+        !prompt.contains("#midtown"),
+        "Main lead prompt should not contain hardcoded '#midtown' channel reference"
+    );
+}
+
 // ── AGENTS.md injection tests ────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Replace 6 hardcoded `--channel midtown` and `#midtown` references in agent prompt templates (`project-lead.md`, `channel-lead.md`, `ops-channel-lead.md`) with `{project_name}` placeholder
- Add 3 regression tests using a non-midtown project name ("ravioli") to catch future hardcoded channel references

## Context
When running midtown on a non-midtown project (e.g., "ravioli"), leads were instructed to post to `--channel midtown` instead of `--channel ravioli`, causing messages to go to a channel that doesn't exist.

## Test plan
- [x] All 71 agent tests pass (including 3 new regression tests)
- [x] Clippy clean
- [x] `cargo fmt` clean
- [x] Grep confirms no `--channel midtown` or `#midtown` references remain in `agents/`

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)