### PR TITLE
fix: Prevent infinite spawn retry loop when worktree is missing [Midtown !2172]

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -1588,6 +1588,20 @@ fn dispatch_owned_pending_tasks(
                     continue;
                 }
 
+                // Skip if a previous spawn failure put this coworker on cooldown.
+                // Without this check, a missing worktree causes an infinite retry
+                // loop every 5s (see !2172).
+                if snap
+                    .spawn_failure_cooldown_names
+                    .contains(&o.to_lowercase())
+                {
+                    debug!(
+                        "Spawn failure cooldown active for {} — skipping pending task !{}",
+                        o, tid
+                    );
+                    continue;
+                }
+
                 info!(
                     "Pending task !{} is assigned to {} but coworker not running - spawning",
                     tid, o
@@ -1651,7 +1665,27 @@ fn dispatch_owned_pending_tasks(
                 effects.push(Effect::SpawnCoworkerWithCallbacks {
                     config,
                     on_success,
-                    on_failure: vec![],
+                    on_failure: vec![
+                        Effect::RecordCooldown {
+                            category: "spawn_failure".to_string(),
+                            key: o.clone(),
+                        },
+                        Effect::PostToChannel {
+                            sender: "midtown".to_string(),
+                            message: format!(
+                                "⚠️ Spawn failed for pending task !{} (coworker {}) — backing off for {}s",
+                                tid, o, SPAWN_FAILURE_COOLDOWN.as_secs()
+                            ),
+                            channel: Some(OPS_CHANNEL.to_string()),
+                            auto_output: false,
+                            message_type: None,
+                            nudge_type: None,
+                            tool_data: None,
+                            provider: None,
+                            tool_use_id: None,
+                            parent_tool_use_id: None,
+                        },
+                    ],
                 });
 
                 coworkers_dispatched_this_tick.insert(o.to_lowercase());

--- a/src/daemon/dispatch_tests.rs
+++ b/src/daemon/dispatch_tests.rs
@@ -4585,3 +4585,103 @@ fn test_build_subject_based_completion_effects_emits_task_completed() {
         panic!("Should emit TaskCompleted with correct fields");
     }
 }
+
+// ============================================================================
+// Bug !2172: daemon repeatedly spawns coworkers into non-existent worktree
+// ============================================================================
+
+#[test]
+fn test_owned_pending_task_skips_spawn_when_spawn_failure_cooldown_active() {
+    // Bug scenario: a pending task with an owner tries to spawn, but the worktree
+    // doesn't exist. The spawn fails, but without a cooldown check, the next tick
+    // (5s later) retries immediately — creating an infinite loop.
+    //
+    // Fix: dispatch_owned_pending_tasks must check spawn_failure_cooldown_names
+    // before attempting to spawn, just like the other dispatch paths do.
+    let snap = snapshot::WorldSnapshot {
+        pending_tasks_with_owners: vec![(
+            "2059".to_string(),
+            "Add new feature".to_string(),
+            "columbus".to_string(),
+        )],
+        // Columbus is on spawn failure cooldown (previous spawn failed)
+        spawn_failure_cooldown_names: ["columbus".to_string()].into_iter().collect(),
+        ..snapshot::minimal_snapshot_for_test()
+    };
+
+    let (state, _tmp, _guard) = make_test_state();
+
+    let effects = spawn_for_pending_tasks(&snap, &state);
+
+    // Must NOT emit any spawn effects when cooldown is active.
+    let spawn_effects: Vec<_> = effects
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                Effect::SpawnCoworkerWithCallbacks { .. }
+                    | Effect::AssignAndSpawn { .. }
+                    | Effect::SpawnSession { .. }
+            )
+        })
+        .collect();
+    assert!(
+        spawn_effects.is_empty(),
+        "Should NOT spawn when spawn_failure_cooldown is active for the owner. \
+         Without this check, the daemon retries every 5s in an infinite loop. Got: {:?}",
+        spawn_effects
+            .iter()
+            .map(|e| format!("{:?}", e))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_owned_pending_task_spawn_failure_records_cooldown() {
+    // Bug scenario: dispatch_owned_pending_tasks has on_failure: vec![] — when
+    // the spawn fails (e.g., missing worktree), no cooldown is recorded and the
+    // task is retried every 5 seconds forever.
+    //
+    // Fix: add RecordCooldown to on_failure so the next tick skips this coworker.
+    let snap = snapshot::WorldSnapshot {
+        pending_tasks_with_owners: vec![(
+            "2059".to_string(),
+            "Add new feature".to_string(),
+            "columbus".to_string(),
+        )],
+        ..snapshot::minimal_snapshot_for_test()
+    };
+
+    let (state, _tmp, _guard) = make_test_state();
+
+    let effects = spawn_for_pending_tasks(&snap, &state);
+
+    // Find the SpawnCoworkerWithCallbacks and check its on_failure
+    let on_failure = effects
+        .iter()
+        .find_map(|e| {
+            if let Effect::SpawnCoworkerWithCallbacks { on_failure, .. } = e {
+                Some(on_failure)
+            } else {
+                None
+            }
+        })
+        .expect("Should emit SpawnCoworkerWithCallbacks for owned pending task");
+
+    // on_failure MUST contain RecordCooldown for spawn_failure
+    let has_cooldown = on_failure.iter().any(|e| {
+        matches!(
+            e,
+            Effect::RecordCooldown { category, .. } if category == "spawn_failure"
+        )
+    });
+    assert!(
+        has_cooldown,
+        "on_failure must include RecordCooldown for 'spawn_failure' to prevent infinite retry loops. \
+         Got on_failure: {:?}",
+        on_failure
+            .iter()
+            .map(|e| format!("{:?}", e))
+            .collect::<Vec<_>>()
+    );
+}

--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -2843,6 +2843,13 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                                 );
                             }
                         }
+                        // Record spawn failure cooldown so the next tick doesn't
+                        // immediately retry this coworker (prevents infinite retry
+                        // loops when worktree creation fails — see !2172).
+                        {
+                            let mut cooldowns = state.cooldowns.lock().unwrap();
+                            cooldowns.record("spawn_failure", &name);
+                        }
                         // Release name back since spawn failed
                         {
                             let mut pool = state.name_pool.lock().unwrap();


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- **Bug**: `dispatch_owned_pending_tasks` had `on_failure: vec![]` and no `spawn_failure_cooldown_names` check, causing 5-second infinite retry loops when a coworker spawn failed (e.g., worktree doesn't exist)
- **Fix 1**: Added `spawn_failure_cooldown_names` check in `dispatch_owned_pending_tasks` before spawning (consistent with other dispatch paths)
- **Fix 2**: Added proper `on_failure` effects with `RecordCooldown` and `PostToChannel` so failed spawns trigger a 60s cooldown
- **Fix 3**: Added spawn failure cooldown recording in `SpawnSession` error handler in effects.rs

## Test plan
- [x] Added `test_owned_pending_task_skips_spawn_when_spawn_failure_cooldown_active` — verifies cooldown check prevents spawn
- [x] Added `test_owned_pending_task_spawn_failure_records_cooldown` — verifies on_failure includes RecordCooldown
- [x] All 132 dispatch tests pass
- [x] Clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)