### PR TITLE
fix: Add project-level autoCompact setting for fork sessions [Midtown !2177]

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "autoCompact": true
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -250,4 +250,33 @@ mod tests {
             "settings should not contain unreplaced {{bin}} placeholders"
         );
     }
+
+    /// `.claude/settings.json` must exist and contain `autoCompact: true`.
+    ///
+    /// Fork sessions don't receive `--settings <file>` (they use `--resume --fork-session`
+    /// which skips the explicit settings file to avoid duplicate tool registrations).
+    /// However, ALL sessions get `--setting-sources project,local`, so they read
+    /// `.claude/settings.json`. This project-level file is the only way fork sessions
+    /// receive `autoCompact: true` — without it, forks hit "Prompt is too long" errors
+    /// when conversations grow beyond the context window.
+    ///
+    /// Regression test for !2177.
+    #[test]
+    fn test_project_settings_has_auto_compact() {
+        let project_settings_path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(".claude/settings.json");
+        assert!(
+            project_settings_path.exists(),
+            ".claude/settings.json must exist so fork sessions get autoCompact \
+             (forks don't receive --settings, only --setting-sources project,local)"
+        );
+        let content = std::fs::read_to_string(&project_settings_path)
+            .expect("should be able to read .claude/settings.json");
+        let settings: serde_json::Value =
+            serde_json::from_str(&content).expect(".claude/settings.json should be valid JSON");
+        assert_eq!(
+            settings["autoCompact"], true,
+            ".claude/settings.json must have autoCompact: true for fork sessions"
+        );
+    }
 }


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Fork sessions don't receive `--settings <file>` (they use `--resume --fork-session` which skips the explicit settings file to avoid duplicate tool registrations)
- All sessions get `--setting-sources project,local`, so they read `.claude/settings.json`
- Created `.claude/settings.json` with `autoCompact: true` so fork sessions auto-compact instead of hitting "Prompt is too long" errors
- Added regression test that validates the project-level settings file exists with the correct setting

## Test plan
- [x] New test `test_project_settings_has_auto_compact` passes — validates `.claude/settings.json` exists and has `autoCompact: true`
- [x] All existing tests pass (5 pre-existing failures in `coworker::tests::test_*_worktree*` are unrelated)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)