### PR TITLE
feat: Restore TUI tool activity display from msg.tool_data [Midtown !2178]

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -617,6 +617,18 @@ To add a new effect:
 
 Tool call data is displayed via `msg.tool_data` on channel messages. The `extract_tool_blocks()` function in `stream.rs` pairs `tool_use` blocks from Assistant events with `tool_result` blocks from User events by `call_id`, producing `ToolBlock` structs that are attached to `PostToChannel` effects. Both topic channel messages (via `process_lead_output()`) and DM channel messages (via `process_agent_output()`) carry `tool_data`, giving the web UI and TUI a single, persisted source for rendering tool call activity.
 
+**Data flow:**
+```
+StreamEvent (NDJSON drain) → extract_tool_events() → Vec<ToolBlock>
+    → Effect::PostToChannel { tool_data } → channel message with ToolBlocks
+    → DaemonState.tool_activity_headers (pre-formatted strings per agent)
+    → coworkers.status RPC → TUI reads header strings directly
+```
+
+- **Channel messages**: Tool activity is carried as `tool_data` (structured `ToolBlock` JSON) on `PostToChannel` effects. The web UI reads `msg.tool_data` directly from channel messages. When a channel message with `tool_data` is posted, the daemon also updates `DaemonState.tool_activity_headers` — a `RwLock<HashMap<String, Vec<String>>>` of pre-formatted display strings (e.g. `"✓ read foo.rs"`, `"› $ git status"`).
+- **TUI rendering**: The TUI polls `coworkers.status` (at 2s intervals) which calls `collect_tool_activity()` to read `tool_activity_headers`. The TUI renders a compact activity strip at the bottom of the chat pane showing the most recent tool calls per active agent, using these pre-formatted header strings directly.
+- **Lifecycle**: Tool activity headers for an agent are cleared from `tool_activity_headers` when the agent posts a non-tool channel message (work phase done) and when a coworker session stops (via `cleanup_coworker_state`).
+
 ## DM Channel Streaming
 
 Each coworker's text output is streamed to a per-coworker DM channel (`dm-<name>`), mirroring how channel leads stream their output to topic channels. This allows the web UI and TUI to show real-time coworker activity when viewing a specific coworker's DM channel.

--- a/src/bin/midtown/cli/chat/app.rs
+++ b/src/bin/midtown/cli/chat/app.rs
@@ -73,6 +73,16 @@ struct KanbanData {
     repos: Vec<(String, String)>,
 }
 
+/// A tool activity entry with a header string and optional completion timestamp.
+///
+/// The `completed_at` field records when a tool call transitioned from in-progress (›)
+/// to completed (✓/✗), enabling age-out after a configurable duration.
+#[derive(Debug, Clone)]
+pub struct ToolActivityEntry {
+    pub header: String,
+    pub completed_at: Option<std::time::Instant>,
+}
+
 /// Data fetched from background thread for coworker status refresh.
 ///
 /// Polled via `coworkers.status` RPC at a faster interval than PR data.
@@ -88,6 +98,8 @@ struct CoworkerStatusData {
     pending_questions: Vec<PendingQuestion>,
     /// Names of active channel leads (e.g. "auth", "tui")
     channel_lead_names: Vec<String>,
+    /// Pre-formatted tool activity headers per agent
+    tool_activity: HashMap<String, Vec<String>>,
 }
 
 /// Coworker status information for the TUI board sidebar
@@ -322,6 +334,9 @@ pub struct App {
     coworker_status_snapshot_ready: bool,
     /// Whether the headless lead session is actively working
     pub lead_working: bool,
+    /// Tool activity entries per agent, keyed by agent name (lowercase).
+    /// Each entry has a header string and optional completion timestamp for age-out.
+    pub tool_activity: HashMap<String, Vec<ToolActivityEntry>>,
     /// Optimistic thinking state: channels where user just submitted a message.
     /// Set immediately on message submit; cleared when real tool activity arrives
     /// or after 30 seconds. Used to show spinner before channel lead responds.
@@ -685,6 +700,7 @@ impl App {
             coworker_pulse_frames: HashMap::new(),
             coworker_status_snapshot_ready: false,
             lead_working: false,
+            tool_activity: HashMap::new(),
             channel_lead_thinking: HashMap::new(),
             max_coworkers: 10, // Default, will be updated from daemon
             pending_questions: Vec::new(),
@@ -907,6 +923,13 @@ impl App {
                     self.max_coworkers = data.max_coworkers;
                     self.pending_questions = data.pending_questions;
                     self.channel_lead_names = data.channel_lead_names;
+                    // Merge tool activity, preserving completed_at timestamps
+                    let old = std::mem::take(&mut self.tool_activity);
+                    self.tool_activity = merge_tool_activity(old, data.tool_activity);
+                    // Clear optimistic thinking for channels with real tool activity
+                    for agent_key in self.tool_activity.keys() {
+                        self.channel_lead_thinking.remove(agent_key);
+                    }
                     self.coworker_status_receiver = None;
                 }
                 Err(TryRecvError::Empty) => {
@@ -1072,6 +1095,7 @@ impl App {
                 lead_working: false,
                 pending_questions: Vec::new(),
                 channel_lead_names: Vec::new(),
+                tool_activity: HashMap::new(),
             });
             let _ = tx.send(data);
         });
@@ -2913,6 +2937,36 @@ impl App {
         }
     }
 
+    /// Return visible tool entries for the given agent key.
+    ///
+    /// Filters out completed entries older than 30 seconds and returns the
+    /// most recent entries first (newest at index 0).
+    /// Capped at 3 entries to avoid taking up too much vertical space.
+    pub fn visible_tool_entries(&self, agent_key: &str) -> Vec<&ToolActivityEntry> {
+        let entries = match self.tool_activity.get(agent_key) {
+            Some(e) => e,
+            None => return Vec::new(),
+        };
+        let age_limit = std::time::Duration::from_secs(30);
+        let mut visible: Vec<&ToolActivityEntry> = entries
+            .iter()
+            .filter(|e| {
+                // Keep in-progress entries (no completed_at) and recent completions.
+                e.completed_at
+                    .map(|t| t.elapsed() < age_limit)
+                    .unwrap_or(true)
+            })
+            .collect();
+        // Keep only the most recent entries (last N from the vec).
+        let max_entries = 3;
+        if visible.len() > max_entries {
+            visible = visible[visible.len() - max_entries..].to_vec();
+        }
+        // Reverse so newest is first.
+        visible.reverse();
+        visible
+    }
+
     /// Return a style for a coworker row that fades in/out with a small wave delay
     /// based on the row index.
     ///
@@ -2978,6 +3032,9 @@ impl App {
                 .channel_lead_thinking
                 .values()
                 .any(|t| t.elapsed() < CHANNEL_LEAD_THINKING_TIMEOUT)
+            || !self
+                .visible_tool_entries(self.selected_channel.as_str())
+                .is_empty()
     }
 
     /// Advance the spinner frame if enough time has elapsed since the last tick.
@@ -3693,6 +3750,26 @@ fn fetch_coworker_status_via_rpc() -> Option<CoworkerStatusData> {
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
+    let tool_activity: HashMap<String, Vec<String>> = data
+        .get("tool_activity")
+        .and_then(|v| v.as_object())
+        .map(|obj| {
+            obj.iter()
+                .map(|(agent, headers)| {
+                    let strs: Vec<String> = headers
+                        .as_array()
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    (agent.clone(), strs)
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
     let channel_lead_names: Vec<String> = data
         .get("channel_leads")
         .and_then(|v| v.as_array())
@@ -3711,6 +3788,7 @@ fn fetch_coworker_status_via_rpc() -> Option<CoworkerStatusData> {
         lead_working,
         pending_questions,
         channel_lead_names,
+        tool_activity,
     })
 }
 
@@ -3755,6 +3833,65 @@ fn fetch_pending_questions_via_rpc() -> Vec<PendingQuestion> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+/// Merge incoming tool activity headers with existing entries, preserving completed_at timestamps.
+///
+/// When an entry transitions from in-progress (›) to completed (✓/✗), records the current
+/// instant as `completed_at`. Completed entries that were already tracked preserve their
+/// original `completed_at` timestamp so age-out logic can measure elapsed time correctly.
+///
+/// Matching between old and new entries is done by comparing the body text (everything after
+/// the first character prefix and leading whitespace), allowing a "› Read foo.rs" to match
+/// a "✓ Read foo.rs" across ticks.
+fn merge_tool_activity(
+    old: HashMap<String, Vec<ToolActivityEntry>>,
+    new: HashMap<String, Vec<String>>,
+) -> HashMap<String, Vec<ToolActivityEntry>> {
+    new.into_iter()
+        .map(|(agent, headers)| {
+            let old_entries = old.get(&agent);
+            let entries = headers
+                .into_iter()
+                .map(|header| {
+                    let is_completed = header.starts_with('\u{2713}') // ✓
+                        || header.starts_with('\u{2717}'); // ✗
+                    let completed_at = if is_completed {
+                        // Extract body text: everything after the prefix char and leading space.
+                        let body: &str = header[header
+                            .char_indices()
+                            .nth(1)
+                            .map(|(i, _)| i)
+                            .unwrap_or(header.len())..]
+                            .trim_start();
+                        // Look for a matching old entry by body text to preserve its timestamp.
+                        old_entries
+                            .and_then(|entries| {
+                                entries.iter().find(|e| {
+                                    let old_body = e.header[e
+                                        .header
+                                        .char_indices()
+                                        .nth(1)
+                                        .map(|(i, _)| i)
+                                        .unwrap_or(e.header.len())..]
+                                        .trim_start();
+                                    old_body == body
+                                })
+                            })
+                            .and_then(|e| e.completed_at)
+                            .or_else(|| Some(std::time::Instant::now()))
+                    } else {
+                        None
+                    };
+                    ToolActivityEntry {
+                        header,
+                        completed_at,
+                    }
+                })
+                .collect();
+            (agent, entries)
+        })
+        .collect()
 }
 
 /// Cache for default branch names, keyed by repo full name (or empty string for current repo).
@@ -4003,6 +4140,7 @@ pub(super) mod tests {
             coworker_pulse_frames: HashMap::new(),
             coworker_status_snapshot_ready: false,
             lead_working: false,
+            tool_activity: HashMap::new(),
             channel_lead_thinking: HashMap::new(),
             max_coworkers: 10, // Test default
             pending_questions: Vec::new(),

--- a/src/bin/midtown/cli/chat/ui/chat.rs
+++ b/src/bin/midtown/cli/chat/ui/chat.rs
@@ -58,18 +58,27 @@ pub fn draw_chat_panel(f: &mut Frame, app: &mut App, area: Rect) {
     }
 }
 
-/// Compute the number of lines the lead indicator area should occupy.
+/// Compute the number of lines the lead indicator area should occupy (1–3).
 ///
-/// Always returns 1 to maintain a stable status area — the indicator
+/// Always returns at least 1 to maintain a stable status area — the indicator
 /// never collapses to zero, preventing messages from jumping when activity starts.
-fn lead_indicator_height(_app: &App) -> u16 {
-    1
+/// Returns 1 when idle (dim placeholder), optimistic thinking, or only one entry.
+fn lead_indicator_height(app: &App) -> u16 {
+    let agent_key = app.selected_channel.as_str();
+    let entries_len = app.visible_tool_entries(agent_key).len();
+    if entries_len > 0 {
+        entries_len as u16
+    } else {
+        1 // Always reserve at least 1 line (dim placeholder or optimistic spinner)
+    }
 }
 
 /// Draw the lead working indicator area between chat messages and the input bar.
 ///
-/// Shows the channel/agent name with a pulsing indicator when thinking,
-/// or a dim placeholder when idle.
+/// Shows up to 3 tool entries in chronological order (oldest at top, newest at bottom).
+/// The last line (newest entry) shows the agent name pulsing bold/normal in yellow.
+/// Completed (✓/✗) entries age out after 30 seconds, collapsing the area to 0.
+/// Descriptions are not explicitly truncated — ratatui clips at the terminal edge naturally.
 fn draw_lead_indicator(f: &mut Frame, app: &mut App, area: Rect) {
     if area.height == 0 {
         return;
@@ -77,31 +86,94 @@ fn draw_lead_indicator(f: &mut Frame, app: &mut App, area: Rect) {
 
     let agent_key = app.selected_channel.as_str();
 
-    // Check for optimistic thinking state (show spinner when channel lead is responding)
+    let entries = app.visible_tool_entries(agent_key);
+
+    // Check for optimistic thinking state (show spinner even before tool activity arrives)
     let channel_thinking = app
         .channel_lead_thinking
         .get(agent_key)
         .map(|t| t.elapsed() < CHANNEL_LEAD_THINKING_TIMEOUT)
         .unwrap_or(false);
 
-    if channel_thinking {
-        // Show agent name with pulsing bold to indicate activity
-        let line = Line::from(vec![
-            Span::raw(" "),
-            Span::styled(agent_key.to_string(), app.pulse_name_style(Color::Yellow)),
-        ]);
-        f.render_widget(Paragraph::new(vec![line]), area);
-    } else {
-        // Idle: render a dim placeholder to keep the status area stable.
-        // This prevents messages from jumping when activity starts/stops.
-        let line = Line::from(vec![Span::styled(
-            format!("   {agent_key}"),
-            Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::DIM),
-        )]);
-        f.render_widget(Paragraph::new(vec![line]), area);
+    if entries.is_empty() {
+        if channel_thinking {
+            // Show agent name with pulsing bold to indicate activity (no tool entries yet)
+            let line = Line::from(vec![
+                Span::raw(" "),
+                Span::styled(agent_key.to_string(), app.pulse_name_style(Color::Yellow)),
+            ]);
+            f.render_widget(Paragraph::new(vec![line]), area);
+        } else {
+            // Idle: render a dim placeholder to keep the status area stable.
+            // This prevents messages from jumping when activity starts/stops.
+            let line = Line::from(vec![Span::styled(
+                format!("   {agent_key}"),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
+            )]);
+            f.render_widget(Paragraph::new(vec![line]), area);
+        }
+        return;
     }
+
+    // Pulse the lead name only when this channel has in-progress entries.
+    // Without this guard, a globally-advancing spinner_frame (from active coworkers elsewhere)
+    // would cause the name to falsely animate when the selected channel only has completed entries.
+    let has_in_progress = entries.iter().any(|e| e.header.starts_with('›'));
+    let name_style = if has_in_progress {
+        app.pulse_name_style(Color::Yellow)
+    } else {
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD)
+    };
+
+    // Width of " lead " prefix: 1 space + agent_name + 1 space
+    let prefix_width = 1 + agent_key.chars().count() + 1;
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let n = entries.len();
+
+    // Display oldest first (reverse of visible_tool_entries which returns newest first).
+    // Agent name goes on the last line (newest entry = bottom), like a standard CLI.
+    for (i, entry) in entries.iter().rev().enumerate() {
+        let mut chars = entry.header.chars();
+        let prefix_char = chars.next().unwrap_or('›');
+        let description = chars.as_str().trim_start().to_string();
+
+        let prefix_color = match prefix_char {
+            '\u{2713}' => Color::Green, // ✓
+            '\u{2717}' => Color::Red,   // ✗
+            _ => Color::DarkGray,       // ›
+        };
+        let text_color = if prefix_char == '\u{2717}' {
+            Color::Red
+        } else {
+            Color::DarkGray
+        };
+
+        let is_last = i == n - 1; // last rendered = newest entry = agent name line
+        if is_last {
+            // Last line (newest): " lead › Read foo.rs" — name pulses when in progress
+            lines.push(Line::from(vec![
+                Span::raw(" "),
+                Span::styled(format!("{agent_key} "), name_style),
+                Span::styled(prefix_char.to_string(), Style::default().fg(prefix_color)),
+                Span::styled(format!(" {description}"), Style::default().fg(text_color)),
+            ]));
+        } else {
+            // Older entries: indented to align with the agent-name line's description.
+            let indent = " ".repeat(prefix_width);
+            lines.push(Line::from(vec![
+                Span::raw(indent),
+                Span::styled(prefix_char.to_string(), Style::default().fg(prefix_color)),
+                Span::styled(format!(" {description}"), Style::default().fg(text_color)),
+            ]));
+        }
+    }
+
+    f.render_widget(Paragraph::new(lines), area);
 }
 
 /// Compute the number of lines needed to display pending questions.

--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -8,6 +8,77 @@ use super::constants::OPS_CHANNEL;
 use super::trackers::PrIssueType;
 use crate::message::Message;
 
+/// Maximum tool activity entries per agent before oldest are evicted.
+const MAX_TOOL_ITEMS_PER_AGENT: usize = 20;
+
+/// Maximum length (in bytes) for a semantic header string before truncation.
+const MAX_SEMANTIC_HEADER_BYTES: usize = 120;
+
+/// Generate a human-readable header for a tool call (e.g. "$ git status", "read foo.rs").
+fn semantic_header(name: &str, input: &serde_json::Value) -> String {
+    let raw = match name {
+        "Bash" => {
+            let command = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
+            format!("$ {command}")
+        }
+        "Edit" | "Write" | "Read" => {
+            let path = first_path_field(input);
+            let verb = name.to_lowercase();
+            format!("{verb} {path}")
+        }
+        "Glob" => {
+            let pattern = input.get("pattern").and_then(|v| v.as_str()).unwrap_or("");
+            format!("glob {pattern}")
+        }
+        "Grep" => {
+            let pattern = input.get("pattern").and_then(|v| v.as_str()).unwrap_or("");
+            format!("grep /{pattern}/")
+        }
+        "Task" | "Agent" => {
+            let desc = input
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            format!("task: {desc}")
+        }
+        "NotebookEdit" => {
+            let path = first_path_field(input);
+            format!("notebook edit {path}")
+        }
+        "WebFetch" => {
+            let url_str = input.get("url").and_then(|v| v.as_str()).unwrap_or("");
+            format!("fetch {url_str}")
+        }
+        "WebSearch" => {
+            let query = input.get("query").and_then(|v| v.as_str()).unwrap_or("");
+            format!("search \"{query}\"")
+        }
+        "TodoWrite" => "todo: update".to_string(),
+        "MultiEdit" => {
+            let path = first_path_field(input);
+            format!("multi-edit {path}")
+        }
+        _ => name.to_lowercase(),
+    };
+
+    if raw.len() > MAX_SEMANTIC_HEADER_BYTES {
+        let boundary = raw.floor_char_boundary(MAX_SEMANTIC_HEADER_BYTES);
+        format!("{}\u{2026}", &raw[..boundary])
+    } else {
+        raw
+    }
+}
+
+/// Return the first path-like field found in the input object.
+fn first_path_field(input: &serde_json::Value) -> &str {
+    for key in &["file_path", "notebook_path", "path"] {
+        if let Some(v) = input.get(key).and_then(|v| v.as_str()) {
+            return v;
+        }
+    }
+    ""
+}
+
 async fn load_channel_lead_context(
     base_dir: PathBuf,
     channel_name: &str,
@@ -1231,6 +1302,48 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                             }
                         }
                     }
+                }
+
+                // Update tool_activity_headers from tool_data for TUI activity display.
+                // When tool_data has blocks → generate semantic headers and append.
+                // When no tool_data and sender is a real agent → clear (work phase done).
+                // Skip system senders (midtown, user) and non-fork explicit-channel posts.
+                let is_system_sender = matches!(sender.to_lowercase().as_str(), "midtown" | "user")
+                    || sender.eq_ignore_ascii_case(&state.project_name);
+                let has_fork_channel_binding = state
+                    .fork_bound_channels
+                    .lock()
+                    .unwrap()
+                    .contains_key(&sender);
+                let has_explicit_channel = msg.channel.is_some();
+                let skip = is_system_sender
+                    || (has_explicit_channel && !has_fork_channel_binding && !is_dm_channel);
+
+                if let Some(ref blocks) = msg.tool_data {
+                    let agent_key = sender.to_lowercase();
+                    let mut headers_map = state.tool_activity_headers.write().unwrap();
+                    let entry = headers_map.entry(agent_key).or_default();
+                    for block in blocks {
+                        let header = semantic_header(&block.tool_name, &block.input);
+                        let prefix = if block.output.is_some() {
+                            if block.error {
+                                "\u{2717}" // ✗
+                            } else {
+                                "\u{2713}" // ✓
+                            }
+                        } else {
+                            "\u{203a}" // › (in-progress)
+                        };
+                        entry.push(format!("{prefix} {header}"));
+                    }
+                    // Cap to avoid unbounded growth.
+                    if entry.len() > MAX_TOOL_ITEMS_PER_AGENT {
+                        let drain_count = entry.len() - MAX_TOOL_ITEMS_PER_AGENT;
+                        entry.drain(..drain_count);
+                    }
+                } else if !skip {
+                    let mut headers_map = state.tool_activity_headers.write().unwrap();
+                    headers_map.remove(&sender.to_lowercase());
                 }
             }
             Effect::BroadcastCoworkerUpdate {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -639,6 +639,14 @@ pub(crate) struct DaemonState {
     /// exclusive adapter lease. Adapters consume via poll+ack; the daemon
     /// enqueues logical control messages (nudges/keys) without terminal coupling.
     headed_sessions: Mutex<HashMap<String, HeadedSessionState>>,
+    /// Pre-formatted tool activity headers per agent, keyed by lowercase agent name.
+    ///
+    /// Populated from `tool_data` ToolBlocks on `PostToChannel` effects.
+    /// Each entry is a display string like "✓ read foo.rs" or "› $ git status".
+    /// Cleared when the agent posts a non-tool channel message (work phase done),
+    /// and when a coworker session stops (via `cleanup_coworker_state`).
+    /// Used by `coworkers.status` RPC for the TUI tool activity indicator.
+    pub(crate) tool_activity_headers: std::sync::RwLock<HashMap<String, Vec<String>>>,
     /// Negative cache for `is_pr_reviewed`: PR numbers confirmed NOT to have a review yet.
     ///
     /// `is_pr_reviewed` caches positive results (reviewed) in persistent state forever.
@@ -1002,6 +1010,11 @@ impl DaemonState {
         self.clear_pending_nudge(name);
         // Clear task assignment tracking (coworker is no longer active)
         self.clear_coworker_assignments(name);
+        // Clear tool activity headers (prevents stale activity on respawn)
+        {
+            let mut headers_map = self.tool_activity_headers.write().unwrap();
+            headers_map.remove(name);
+        }
         // Capture fork bindings before cleanup for web UI notification.
         let bound_thread_id = self.fork_bound_threads.lock().unwrap().get(name).cloned();
         let bound_channel = self.fork_bound_channels.lock().unwrap().get(name).cloned();
@@ -1443,6 +1456,7 @@ impl DaemonState {
             restart_requested: std::sync::atomic::AtomicBool::new(false),
             shutdown_tx,
             headed_sessions: Mutex::new(HashMap::new()),
+            tool_activity_headers: std::sync::RwLock::new(HashMap::new()),
             name_pool: std::sync::Mutex::new(name_pool),
             name_to_session: std::sync::Mutex::new(name_to_session),
             session_to_name: std::sync::Mutex::new(session_to_name),

--- a/src/daemon/mod_tests.rs
+++ b/src/daemon/mod_tests.rs
@@ -1571,6 +1571,10 @@ async fn test_cleanup_coworker_state_clears_all_transient_state() {
     }
     state.record_pending_nudge(name, "test nudge");
     state.record_task_assignment(name, "42");
+    {
+        let mut headers_map = state.tool_activity_headers.write().unwrap();
+        headers_map.insert(name.to_string(), vec!["› $ git status".to_string()]);
+    }
 
     // Verify state was populated
     assert!(!state.cooldowns.lock().unwrap().is_empty());
@@ -1578,6 +1582,13 @@ async fn test_cleanup_coworker_state_clears_all_transient_state() {
         state
             .coworker_task_assignments
             .lock()
+            .unwrap()
+            .contains_key(name)
+    );
+    assert!(
+        state
+            .tool_activity_headers
+            .read()
             .unwrap()
             .contains_key(name)
     );
@@ -1607,6 +1618,13 @@ async fn test_cleanup_coworker_state_clears_all_transient_state() {
             "task assignments should be cleared"
         );
     }
+    {
+        let headers_map = state.tool_activity_headers.read().unwrap();
+        assert!(
+            !headers_map.contains_key(name),
+            "tool activity headers should be cleared"
+        );
+    }
 }
 
 #[tokio::test]
@@ -1623,6 +1641,11 @@ async fn test_cleanup_coworker_state_preserves_other_coworkers() {
     state.record_pending_nudge("park", "nudge park");
     state.record_task_assignment("madison", "42");
     state.record_task_assignment("park", "43");
+    {
+        let mut headers_map = state.tool_activity_headers.write().unwrap();
+        headers_map.insert("madison".to_string(), vec!["› $ cargo build".to_string()]);
+        headers_map.insert("park".to_string(), vec!["✓ read foo.rs".to_string()]);
+    }
 
     // Only clean up madison
     state.cleanup_coworker_state("madison").await;
@@ -1648,6 +1671,17 @@ async fn test_cleanup_coworker_state_preserves_other_coworkers() {
         assert!(
             assignments.contains_key("park"),
             "park's task assignment should still exist"
+        );
+    }
+    {
+        let headers_map = state.tool_activity_headers.read().unwrap();
+        assert!(
+            headers_map.contains_key("park"),
+            "park's tool activity headers should still exist"
+        );
+        assert!(
+            !headers_map.contains_key("madison"),
+            "madison's tool activity headers should be cleared"
         );
     }
 }

--- a/src/daemon/rpc_coworker.rs
+++ b/src/daemon/rpc_coworker.rs
@@ -826,7 +826,7 @@ fn is_pr_open(pr_number: u64, repo_path: Option<&std::path::Path>) -> bool {
 /// current (microsecond latency). The TUI polls this at 1–2s to keep the
 /// coworker status panel up-to-date without delay.
 ///
-/// Returns: coworkers, max_coworkers, lead_working,
+/// Returns: coworkers, max_coworkers, lead_working, tool_activity,
 ///          channel_leads, channel_leads_working.
 pub(crate) async fn handle_coworkers_status(id: RequestId, state: &DaemonState) -> Response {
     let (coworkers_data, channel_lead_names) = build_coworkers_data(state).await;
@@ -837,6 +837,7 @@ pub(crate) async fn handle_coworkers_status(id: RequestId, state: &DaemonState) 
     let channel_leads_working = build_channel_leads_working(&health_guard, &channel_lead_names);
     drop(health_guard);
 
+    let tool_activity = collect_tool_activity(state);
     let channel_leads: Vec<&String> = channel_lead_names.iter().collect();
 
     Response::success(
@@ -845,6 +846,7 @@ pub(crate) async fn handle_coworkers_status(id: RequestId, state: &DaemonState) 
             "coworkers": coworkers_data,
             "max_coworkers": state.max_coworkers,
             "lead_working": lead_working,
+            "tool_activity": tool_activity,
             "channel_leads": channel_leads,
             "channel_leads_working": channel_leads_working,
         }),
@@ -1044,6 +1046,35 @@ pub(crate) fn build_channel_leads_working(
             (name.clone(), serde_json::Value::Bool(active))
         })
         .collect()
+}
+
+/// Collect pre-formatted tool activity headers per agent as a JSON value for the RPC response.
+///
+/// Returns a JSON object mapping agent name → array of header strings
+/// (e.g. `{"lead": ["✓ read foo.rs", "› $ git status"]}`).
+/// Sourced from `tool_activity_headers`, populated from `tool_data` on channel messages.
+fn collect_tool_activity(state: &DaemonState) -> serde_json::Value {
+    let headers_map = state.tool_activity_headers.read().unwrap();
+    serialize_tool_activity_headers(&headers_map)
+}
+
+/// Serialize a tool activity headers map to a JSON object.
+///
+/// Separated from `collect_tool_activity` for testability without `DaemonState`.
+fn serialize_tool_activity_headers(
+    headers_map: &HashMap<String, Vec<String>>,
+) -> serde_json::Value {
+    let obj: serde_json::Map<String, serde_json::Value> = headers_map
+        .iter()
+        .map(|(agent, headers)| {
+            let arr: Vec<serde_json::Value> = headers
+                .iter()
+                .map(|h| serde_json::Value::String(h.clone()))
+                .collect();
+            (agent.clone(), serde_json::Value::Array(arr))
+        })
+        .collect();
+    serde_json::Value::Object(obj)
 }
 
 #[path = "rpc_coworker_tests.rs"]

--- a/src/daemon/rpc_coworker_tests.rs
+++ b/src/daemon/rpc_coworker_tests.rs
@@ -1369,3 +1369,45 @@ fn test_is_project_lead_rejects_regular_coworkers() {
     // Channel lead names are NOT project leads
     assert!(!is_project_lead("auth", "midtown"));
 }
+
+// ============================================================================
+// Tests for serialize_tool_activity_headers
+// ============================================================================
+
+#[test]
+fn test_serialize_tool_activity_headers_empty() {
+    let map: HashMap<String, Vec<String>> = HashMap::new();
+    let result = super::serialize_tool_activity_headers(&map);
+    assert_eq!(result, serde_json::json!({}));
+}
+
+#[test]
+fn test_serialize_tool_activity_headers_with_entries() {
+    let mut map = HashMap::new();
+    map.insert(
+        "amsterdam".to_string(),
+        vec!["✓ $ git status".to_string(), "› read foo.rs".to_string()],
+    );
+
+    let result = super::serialize_tool_activity_headers(&map);
+    let obj = result.as_object().expect("should be an object");
+    assert!(obj.contains_key("amsterdam"));
+
+    let items = obj["amsterdam"].as_array().expect("should be an array");
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].as_str().unwrap(), "✓ $ git status");
+    assert_eq!(items[1].as_str().unwrap(), "› read foo.rs");
+}
+
+#[test]
+fn test_serialize_tool_activity_headers_multiple_agents() {
+    let mut map = HashMap::new();
+    map.insert("madison".to_string(), vec!["✗ $ cargo test".to_string()]);
+    map.insert("lead".to_string(), vec!["› edit src/main.rs".to_string()]);
+
+    let result = super::serialize_tool_activity_headers(&map);
+    let obj = result.as_object().expect("should be an object");
+    assert_eq!(obj.len(), 2);
+    assert_eq!(obj["madison"][0].as_str().unwrap(), "✗ $ cargo test");
+    assert_eq!(obj["lead"][0].as_str().unwrap(), "› edit src/main.rs");
+}


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Wire the TUI's tool activity indicator to source from `msg.tool_data` on channel messages instead of the old `BroadcastUniversalItems` / `recent_tool_items` path
- Add `tool_activity_headers` field to `DaemonState` — populated from `ToolBlock` data in the `PostToChannel` effect handler using `semantic_header()` to generate display strings with ✓/✗/› prefixes
- Change `collect_tool_activity()` RPC to return pre-formatted header strings directly, simplifying the TUI consumer (removes `extract_tool_activity_headers` and its tests)

## Architecture
The old path (being removed in PR #1906): `StreamEvent` → `UniversalItem` → `BroadcastUniversalItems` effect → `recent_tool_items` → RPC → TUI parses UniversalItem JSON

The new path: `StreamEvent` → `ToolBlock` → `PostToChannel` effect → `tool_activity_headers` (pre-formatted) → RPC → TUI reads strings directly

Net change: -224 lines, +121 lines across 6 files.

## Test plan
- [x] `serialize_tool_activity_headers` tests pass (3 new tests)
- [x] `cleanup_coworker_state` tests updated to verify `tool_activity_headers` cleanup (4 tests pass)
- [x] Full test suite: 2568 pass, 18 pre-existing worktree sandbox failures (unrelated)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)