### PR TITLE
fix: Unify fork and lead session launch code paths [Midtown !2179]

### DIFF
--- a/src/daemon/rpc_session.rs
+++ b/src/daemon/rpc_session.rs
@@ -1201,11 +1201,15 @@ pub(super) fn build_fork_config(
         persist_session: true,
         resume_session_id: Some(calling_session_id.to_string()),
         inactivity_timeout: None,
-        settings_path: match crate::settings::write_lead_settings_file() {
-            Ok(path) => Some(path.to_string_lossy().to_string()),
-            Err(e) => {
-                warn!("Failed to write lead settings file for fork session: {e}");
-                None
+        settings_path: if matches!(auth_provider, crate::auth::AuthProvider::Codex) {
+            None
+        } else {
+            match crate::settings::write_lead_settings_file() {
+                Ok(path) => Some(path.to_string_lossy().to_string()),
+                Err(e) => {
+                    warn!("Failed to write lead settings file for fork session: {e}");
+                    None
+                }
             }
         },
         setting_sources: None,

--- a/src/daemon/rpc_session_tests.rs
+++ b/src/daemon/rpc_session_tests.rs
@@ -1506,3 +1506,29 @@ fn test_build_fork_config_sets_lead_settings_path() {
     }
     // Either way, the function should not panic — graceful degradation is the key invariant.
 }
+
+/// Codex sessions reject `settings_path` in `codex_launch_plan_from_config`,
+/// so `build_fork_config` must leave it as `None` for Codex auth provider.
+#[test]
+fn test_build_fork_config_skips_settings_path_for_codex() {
+    let midtown_dir = tempfile::TempDir::new().expect("midtown temp dir");
+    let _guard = crate::paths::set_test_midtown_base_dir(midtown_dir.path().to_path_buf());
+
+    let (_fork_name, headless_config) = build_fork_config(
+        "thread-codex-test",
+        "parent-session-id",
+        Some("web"),
+        None,
+        Some("web"),
+        Some("/tmp/test"),
+        crate::auth::AuthProvider::Codex,
+        false,
+        "test-repo",
+        None,
+    );
+
+    assert!(
+        headless_config.settings_path.is_none(),
+        "Codex forks must have settings_path = None to avoid codex_launch_plan_from_config rejection"
+    );
+}


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Fork sessions (`build_fork_config`) now receive the lead system prompt via `main_lead_system_prompt()` instead of an empty string
- Fork sessions now get the lead settings file via `write_lead_settings_file()` with graceful fallback to `None` on failure
- This fixes the blank-session bug where respawned forks (RespawnFork with `resume_session_id = None`) started with no system prompt, no settings, and no parent context

## How it works

The platform arg builder (`build_claude_headless_args`) has two branches:
- **Resume** (normal forks): system_prompt and settings_path are skipped (inherited from parent session)
- **Fresh** (respawned forks): system_prompt and settings_path ARE used — this is where the fix matters

By always populating both fields in `build_fork_config`, respawned forks now get proper instructions and settings, while normal forks continue to work exactly as before (the fields are ignored for resume sessions).

## Test plan
- [x] Added `test_build_fork_config_sets_lead_system_prompt` — verifies prompt is non-empty and contains project name
- [x] Added `test_build_fork_config_sets_lead_settings_path` — verifies settings_path points to lead settings file (or gracefully degrades in sandboxed environments)
- [x] All 2570 non-sandbox tests pass (`cargo test`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)