### PR TITLE
refactor: Route all exit messages to #ops and remove tail output [Midtown !2183]

### DIFF
--- a/src/daemon/helpers.rs
+++ b/src/daemon/helpers.rs
@@ -992,20 +992,17 @@ pub fn format_task_prompt(task_id: &str, context_message: &str) -> String {
 
 /// Format the ops message for an unexpected session exit.
 ///
-/// Combines the session role/name header with optional stderr tail and
-/// optional formatted session output (from JSONL event log).
+/// Combines the session role/name header with optional stderr tail.
 pub fn format_unexpected_exit_message(
     session_role: &str,
     name: &str,
     stderr_lines: Option<&[String]>,
-    tail_output: Option<&str>,
 ) -> String {
     let header = format!("⚠️ {} {} session exited unexpectedly", session_role, name);
 
     let has_stderr = stderr_lines.is_some_and(|lines| !lines.is_empty());
-    let has_tail = tail_output.is_some_and(|t| !t.trim().is_empty());
 
-    if !has_stderr && !has_tail {
+    if !has_stderr {
         return header;
     }
 
@@ -1026,12 +1023,6 @@ pub fn format_unexpected_exit_message(
             stderr.len(),
             last_n.join("\n")
         ));
-    }
-
-    if let Some(tail) = tail_output
-        && !tail.trim().is_empty()
-    {
-        parts.push(format!("Session tail:\n{}", tail));
     }
 
     parts.join("\n\n")

--- a/src/daemon/helpers_tests.rs
+++ b/src/daemon/helpers_tests.rs
@@ -1494,25 +1494,25 @@ fn get_merged_task_pr_returns_none_for_unknown_task() {
 // ============================================================================
 
 #[test]
-fn test_unexpected_exit_message_no_stderr_no_tail() {
-    let msg = format_unexpected_exit_message("Coworker", "park", None, None);
+fn test_unexpected_exit_message_no_stderr() {
+    let msg = format_unexpected_exit_message("Coworker", "park", None);
     assert_eq!(msg, "⚠️ Coworker park session exited unexpectedly");
 }
 
 #[test]
-fn test_unexpected_exit_message_empty_stderr_no_tail() {
+fn test_unexpected_exit_message_empty_stderr() {
     let empty: Vec<String> = vec![];
-    let msg = format_unexpected_exit_message("Coworker", "park", Some(&empty), None);
+    let msg = format_unexpected_exit_message("Coworker", "park", Some(&empty));
     assert_eq!(msg, "⚠️ Coworker park session exited unexpectedly");
 }
 
 #[test]
-fn test_unexpected_exit_message_with_stderr_no_tail() {
+fn test_unexpected_exit_message_with_stderr() {
     let stderr = vec![
         "error: something went wrong".to_string(),
         "panic at line 42".to_string(),
     ];
-    let msg = format_unexpected_exit_message("Coworker", "park", Some(&stderr), None);
+    let msg = format_unexpected_exit_message("Coworker", "park", Some(&stderr));
     assert!(msg.contains("⚠️ Coworker park session exited unexpectedly"));
     assert!(msg.contains("Stderr (2 lines)"));
     assert!(msg.contains("error: something went wrong"));
@@ -1520,31 +1520,9 @@ fn test_unexpected_exit_message_with_stderr_no_tail() {
 }
 
 #[test]
-fn test_unexpected_exit_message_with_stderr_and_tail() {
-    let stderr = vec!["error: crash".to_string()];
-    let tail = "Let me check that file.\n**[Read]**\n```json\n{}\n```";
-    let msg = format_unexpected_exit_message("Coworker", "madison", Some(&stderr), Some(tail));
-    assert!(msg.contains("⚠️ Coworker madison session exited unexpectedly"));
-    assert!(msg.contains("Stderr (1 lines)"));
-    assert!(msg.contains("error: crash"));
-    assert!(msg.contains("Session tail"));
-    assert!(msg.contains("Let me check that file."));
-}
-
-#[test]
-fn test_unexpected_exit_message_tail_only_no_stderr() {
-    let tail = "Running cargo build...";
-    let msg = format_unexpected_exit_message("Channel lead", "park", None, Some(tail));
-    assert!(msg.contains("⚠️ Channel lead park session exited unexpectedly"));
-    assert!(msg.contains("Session tail"));
-    assert!(msg.contains("Running cargo build..."));
-    assert!(!msg.contains("Stderr"));
-}
-
-#[test]
 fn test_unexpected_exit_message_stderr_truncated_to_10() {
     let stderr: Vec<String> = (0..20).map(|i| format!("line {}", i)).collect();
-    let msg = format_unexpected_exit_message("Coworker", "park", Some(&stderr), None);
+    let msg = format_unexpected_exit_message("Coworker", "park", Some(&stderr));
     assert!(msg.contains("Stderr (20 lines)"));
     // Should contain last 10 lines (10-19), not first 10 (0-9)
     assert!(msg.contains("line 19"));
@@ -1554,6 +1532,6 @@ fn test_unexpected_exit_message_stderr_truncated_to_10() {
 
 #[test]
 fn test_unexpected_exit_message_lead_role() {
-    let msg = format_unexpected_exit_message("Lead", "midtown", None, None);
+    let msg = format_unexpected_exit_message("Lead", "midtown", None);
     assert_eq!(msg, "⚠️ Lead midtown session exited unexpectedly");
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3814,9 +3814,6 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
                     let fork_thread_id = state.fork_bound_threads.lock().unwrap().get(&name).cloned();
                     let fork_channel = state.fork_bound_channels.lock().unwrap().get(&name).cloned();
 
-                    // Capture tail output BEFORE remove (remove deletes the log file).
-                    let tail_output = state.session_manager.get_tail_output(&name, 20).await;
-
                     // Remove from session manager tracking (session-death-specific:
                     // shutdown path uses session_manager.shutdown() instead)
                     state.session_manager.remove(&name).await;
@@ -4078,31 +4075,22 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
                             "Coworker"
                         };
 
-                        // Format message with stderr and tail output (captured above)
+                        // Format message with stderr
                         let message_text = helpers::format_unexpected_exit_message(
                             session_role,
                             &name,
                             stderr_by_name.get(&name).map(|v| v.as_slice()),
-                            tail_output.as_deref(),
                         );
 
-                        // Lead exits go to main channel (user needs to see them).
-                        // Coworker/channel-lead exits go to #ops (operational noise).
-                        if is_lead {
-                            let msg = crate::message::Message::text("midtown", message_text);
-                            if let Err(e) = state.send_and_broadcast_async(&msg).await {
-                                warn!("Failed to post session exit message for {}: {}", name, e);
-                            }
-                        } else {
-                            let msg = crate::message::Message::for_channel(
-                                constants::OPS_CHANNEL,
-                                "midtown",
-                                message_text,
-                                crate::message::MessageType::Text,
-                            );
-                            if let Err(e) = state.send_and_broadcast_async(&msg).await {
-                                warn!("Failed to post session exit message for {}: {}", name, e);
-                            }
+                        // All exit messages go to #ops (operational noise).
+                        let msg = crate::message::Message::for_channel(
+                            constants::OPS_CHANNEL,
+                            "midtown",
+                            message_text,
+                            crate::message::MessageType::Text,
+                        );
+                        if let Err(e) = state.send_and_broadcast_async(&msg).await {
+                            warn!("Failed to post session exit message for {}: {}", name, e);
                         }
                     }
                 }

--- a/src/daemon/sessions.rs
+++ b/src/daemon/sessions.rs
@@ -1538,44 +1538,6 @@ impl SessionManager {
             .map(|(output, _, _)| output)
     }
 
-    /// Get a short tail of recent session output for diagnostics (e.g., crash messages).
-    ///
-    /// Like `get_output` but reads only the last `max_lines` JSONL events instead
-    /// of 200, producing a compact summary suitable for ops messages.
-    pub async fn get_tail_output(&self, name: &str, max_lines: usize) -> Option<String> {
-        let log_path = {
-            let sessions = self.sessions.read().await;
-            sessions
-                .values()
-                .find(|cs| cs.name == name)
-                .map(|cs| cs.output_log_path.clone())
-                .unwrap_or_else(|| crate::paths::headless_output_file(&self.repo_name, name))
-        };
-
-        let content = tokio::task::spawn_blocking(move || std::fs::read_to_string(log_path))
-            .await
-            .ok()?
-            .ok()?;
-
-        if content.is_empty() {
-            return None;
-        }
-
-        let lines: Vec<String> = content
-            .lines()
-            .rev()
-            .take(max_lines)
-            .map(|s| s.to_string())
-            .collect();
-
-        let output = format_events_as_rich_text(lines.iter().rev().map(|s| s.as_str()));
-        if output == "(no output yet)" {
-            None
-        } else {
-            Some(output)
-        }
-    }
-
     /// Get recent output for a coworker alongside the log file path and byte offset.
     ///
     /// Returns a rich formatted string that includes:


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Route lead session "exited unexpectedly" messages to #ops (previously went to main channel), matching coworker/channel-lead exit behavior
- Remove `tail_output` parameter from `format_unexpected_exit_message()` — the JSONL event log tail was noisy and not actionable
- Remove `get_tail_output()` from `SessionManager` (now dead code)
- Only stderr (actual CLI errors) is kept for diagnostics

Net result: -81 lines across 4 files.

## Test plan
- [x] All 5 `test_unexpected_exit_message_*` tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)