### PR TITLE
fix: Reuse existing placeholder comment when re-spawning PR reviewers [Midtown !2186]

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -958,7 +958,7 @@ After `MAX_REVIEWER_RESTARTS` attempts per PR, an escalation warning is posted t
 
 The daemon owns the full lifecycle of placeholder comments — both posting and updating. This avoids prompt-compliance issues (e.g., some Claude models escape `!` characters, producing `<\!--` which breaks tag matching).
 
-**Posting**: When a reviewer spawns, `collect_reviewer_effects_with_source()` chains an `Effect::PostPrComment` in the `on_success` callback of `SpawnCoworkerWithCallbacks`. The effect runs `gh pr comment`, parses the comment ID from the stdout URL, and stores it on `PrReviewerAssignment.placeholder_comment_id`. This ID is also cached in `reviewer_placeholder_cache` to avoid API lookups during snapshot collection.
+**Posting**: When a reviewer spawns, `collect_reviewer_effects_with_source()` chains an `Effect::PostPrComment` in the `on_success` callback of `SpawnCoworkerWithCallbacks`. The effect first checks for an existing placeholder via `lookup_existing_placeholder()` (which reuses the same 3-tier resolution described below). If found, it edits the existing comment via `gh api --method PATCH`; otherwise, it creates a new comment via `gh pr comment` and parses the comment ID from the stdout URL. Either way, the comment ID is stored on `PrReviewerAssignment.placeholder_comment_id` and cached in `reviewer_placeholder_cache`.
 
 **Updating with review findings**: The reviewer agent calls `midtown pr review post --pr <N> --body-file <path>` when its review is complete. The `pr.review-post` RPC handler wraps the body with `<!-- midtown: <name> -->` frontmatter and the Midtown footer, then patches the comment via `gh api --method PATCH`. Errors are surfaced to the caller so the reviewer agent can retry.
 
@@ -982,7 +982,7 @@ When a reviewer is restarted (stuck or dead) and had previously posted a placeho
 - `reviewer_placeholder_cache: Mutex<HashMap<u64, (Option<u64>, Instant)>>` — Cache for `pr_in_progress_placeholder_comment_id()` lookups. Maps PR number to `(comment_id_or_none, checked_at)`. Both positive and negative entries expire after `PLACEHOLDER_CACHE_TTL_SECS` (120s). Cleared when `mark_reviewed_pr()` is called to ensure freshness after a review is posted.
 
 **Effects:**
-- `Effect::PostPrComment { pr_number, reviewer_name, body }` — Posts a new comment on a PR via `gh pr comment`. Parses the comment ID from the stdout URL and stores it on `PrReviewerAssignment.placeholder_comment_id`. Chained as an `on_success` callback when spawning a reviewer.
+- `Effect::PostPrComment { pr_number, reviewer_name, body }` — Posts or reuses a placeholder comment on a PR. Uses `lookup_existing_placeholder()` (3-tier resolution) to check for an existing placeholder; if found, edits it via `gh api --method PATCH`, otherwise creates a new one via `gh pr comment`. Stores the comment ID on `PrReviewerAssignment.placeholder_comment_id`. Chained as an `on_success` callback when spawning a reviewer.
 - `Effect::UpdatePrComment { comment_id, repo_full_name, new_body }` — Patches an existing GitHub issue comment via `gh api --method PATCH`. Used to update stale "Review in progress" placeholder comments when a reviewer is restarted due to being stuck or dead, and by `pr.review-post` to replace the placeholder with final review findings.
 
 ## Reminders

--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -3536,45 +3536,60 @@ async fn rerun_workflow(state: &DaemonState, run_id: u64, check_name: &str, pr_n
     }
 }
 
-/// Find an existing `<!-- midtown-placeholder -->` comment on a PR.
+/// Look up an existing placeholder comment ID for a PR using the 3-tier lookup:
 ///
-/// Queries the GitHub REST API for issue comments and returns the database ID
-/// of the first comment containing the placeholder marker. Returns `None` if
-/// no placeholder exists or if the API call fails.
-async fn find_existing_placeholder(state: &DaemonState, pr_number: u64) -> Option<u64> {
-    let repo_path = state.all_repo_paths.first()?;
-    let repo_full_name = state.get_repo_full_name(repo_path);
-    if repo_full_name.is_empty() {
-        return None;
-    }
-
-    let endpoint = format!("repos/{}/issues/{}/comments", repo_full_name, pr_number);
-    let output = tokio::process::Command::new("gh")
-        .args(["api", &endpoint])
-        .output()
-        .await
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let comments: Vec<serde_json::Value> = serde_json::from_str(&stdout).ok()?;
-
-    // Find the last placeholder comment (most recent)
-    for comment in comments.iter().rev() {
-        let body = comment.get("body")?.as_str()?;
-        if body.contains("<!-- midtown-placeholder -->") && !body.contains("<!-- midtown:") {
-            return comment.get("id")?.as_u64();
+/// 1. **Persistent state** — `PrReviewerAssignment.placeholder_comment_id`
+/// 2. **In-memory cache** — `reviewer_placeholder_cache` (TTL-based)
+/// 3. **GitHub API fallback** — `pr_in_progress_placeholder_comment_id` via `spawn_blocking`
+///
+/// This reuses the same lookup infrastructure as `collect_world_snapshot` in
+/// `snapshot.rs`, avoiding divergent detection criteria and pagination issues.
+async fn lookup_existing_placeholder(state: &DaemonState, pr_number: u64) -> Option<u64> {
+    // Tier 1: Check stored placeholder_comment_id from the assignment
+    {
+        let ps = state.persistent_state.lock().await;
+        if let Some(assignment) = ps.github.pr_reviewers.get(&pr_number)
+            && let Some(id) = assignment.placeholder_comment_id
+        {
+            return Some(id);
         }
     }
-    None
+
+    // Tier 2: Check in-memory cache
+    const PLACEHOLDER_CACHE_TTL_SECS: u64 = 120;
+    let cached = {
+        let cache = state.reviewer_placeholder_cache.lock().unwrap();
+        cache.get(&pr_number).copied()
+    };
+
+    match cached {
+        Some((id, checked_at)) if checked_at.elapsed().as_secs() < PLACEHOLDER_CACHE_TTL_SECS => {
+            return id; // Use cached result within TTL
+        }
+        _ => {}
+    }
+
+    // Tier 3: Cache miss or expired — fetch from GitHub via spawn_blocking
+    let id = tokio::task::spawn_blocking(move || {
+        super::pr::pr_in_progress_placeholder_comment_id(pr_number)
+    })
+    .await
+    .ok()
+    .flatten();
+
+    // Update cache with result
+    {
+        let mut cache = state.reviewer_placeholder_cache.lock().unwrap();
+        cache.insert(pr_number, (id, std::time::Instant::now()));
+    }
+
+    id
 }
 
-/// Post a "Review in progress" placeholder comment on a PR via `gh pr comment`.
+/// Post a "Review in progress" placeholder comment on a PR.
 ///
-/// Parses the comment ID from the stdout URL and stores it on the
+/// Uses `gh api --method PATCH` to edit an existing placeholder or
+/// `gh pr comment` to create a new one. Stores the comment ID on the
 /// `PrReviewerAssignment` so the daemon can later update the placeholder
 /// with the final review via `pr.review-post`.
 ///
@@ -3586,7 +3601,7 @@ async fn post_pr_comment(state: &DaemonState, pr_number: u64, reviewer_name: &st
 
     // Check for an existing placeholder comment on the PR to reuse.
     // This prevents placeholder accumulation when reviewers are re-spawned after timeout.
-    let existing_placeholder_id = find_existing_placeholder(state, pr_number).await;
+    let existing_placeholder_id = lookup_existing_placeholder(state, pr_number).await;
 
     let comment_id = if let Some(existing_id) = existing_placeholder_id {
         // Edit the existing placeholder comment via gh api PATCH

--- a/src/daemon/effects_tests.rs
+++ b/src/daemon/effects_tests.rs
@@ -1713,10 +1713,12 @@ async fn test_post_pr_comment_parses_bare_numeric_url() {
     }
 }
 
-/// Verify that when a placeholder comment already exists on a PR,
-/// `post_pr_comment` edits the existing comment (PATCH) instead of creating
-/// a new one (`gh pr comment`). This prevents placeholder accumulation when
-/// reviewers are re-spawned after timeout.
+/// Verify that when a placeholder comment ID is already stored on the
+/// `PrReviewerAssignment` (from a previous reviewer cycle), `post_pr_comment`
+/// edits the existing comment (PATCH) instead of creating a new one.
+///
+/// Uses the 3-tier lookup: tier 1 (persistent state) returns the stored ID,
+/// so no GitHub API call is needed for discovery — only for the PATCH update.
 #[allow(clippy::await_holding_lock)] // Intentionally hold PATH_LOCK across await.
 #[tokio::test]
 async fn test_post_pr_comment_reuses_existing_placeholder() {
@@ -1727,27 +1729,28 @@ async fn test_post_pr_comment_reuses_existing_placeholder() {
     let (state, _project_dir, _guard) = make_workflow_test_state("post-pr-reuse");
 
     let pr_number = 77u64;
+    let existing_comment_id = 55555u64;
     {
         let mut ps = state.persistent_state.lock().await;
         ps.github
             .assign_reviewer(pr_number, "riverside", AssignmentSource::Webhook);
+        // Pre-populate the placeholder_comment_id (as if a previous reviewer
+        // cycle posted it before timing out). This is the tier 1 lookup path.
+        if let Some(assignment) = ps.github.pr_reviewers.get_mut(&pr_number) {
+            assignment.placeholder_comment_id = Some(existing_comment_id);
+        }
     }
 
     // Mock `gh` to:
-    // 1. Return an existing placeholder comment when listing PR comments
-    // 2. Accept the PATCH request to update it
-    // 3. Log which commands were called for verification
+    // 1. Accept the PATCH request to update the existing comment
+    // 2. Log which commands were called for verification
+    // Note: no "issues/.../comments" mock needed — tier 1 lookup finds the ID
     let temp_dir = tempfile::tempdir().unwrap();
     let mock_gh_dir = temp_dir.path().join("bin");
     std::fs::create_dir_all(&mock_gh_dir).unwrap();
     let log_file = temp_dir.path().join("gh_calls.log");
     let mock_gh_script = mock_gh_dir.join("gh");
 
-    // The mock script routes based on arguments:
-    // - "repo view ..." → returns repo full name (needed by get_repo_full_name)
-    // - "api ... /issues/.../comments" (GET) → returns JSON with existing placeholder
-    // - "api --method PATCH ..." → logs and returns success
-    // - "pr comment ..." → logs (should NOT be called)
     std::fs::write(
         &mock_gh_script,
         format!(
@@ -1756,14 +1759,13 @@ echo "$@" >> "{log}"
 if echo "$@" | grep -q "repo view"; then
   echo 'test/repo'
 elif echo "$@" | grep -q "PATCH"; then
-  echo '{{"id": 55555}}'
-elif echo "$@" | grep -q "issues/.*/comments"; then
-  echo '[{{"id": 55555, "body": "<!-- midtown-placeholder -->\n## Review Status\n\n🔍 Review in progress by pleasant..."}}]'
+  echo '{{"id": {existing_comment_id}}}'
 elif echo "$@" | grep -q "pr comment"; then
   echo 'https://github.com/test/repo/pull/77#issuecomment-99999'
 fi
 "#,
-            log = log_file.display()
+            log = log_file.display(),
+            existing_comment_id = existing_comment_id,
         ),
     )
     .unwrap();
@@ -1804,7 +1806,7 @@ fi
         log_contents,
     );
 
-    // Verify: the existing comment ID (55555) was stored on the assignment
+    // Verify: the existing comment ID is still stored on the assignment
     {
         let ps = state.persistent_state.lock().await;
         let assignment = ps
@@ -1814,8 +1816,8 @@ fi
             .expect("assignment should still exist");
         assert_eq!(
             assignment.placeholder_comment_id,
-            Some(55555),
-            "Should store the existing comment ID 55555 on the assignment"
+            Some(existing_comment_id),
+            "Should preserve the existing comment ID on the assignment"
         );
     }
 
@@ -1827,9 +1829,116 @@ fi
             .expect("placeholder cache should be populated");
         assert_eq!(
             *cached_id,
-            Some(55555),
+            Some(existing_comment_id),
             "Placeholder cache should contain the existing comment ID"
         );
+    }
+}
+
+/// Verify that `lookup_existing_placeholder` falls back to the GitHub API
+/// (tier 3) when the assignment has no stored placeholder_comment_id and
+/// the cache is empty. This covers the re-spawn scenario where the daemon
+/// restarted and lost in-memory state.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn test_post_pr_comment_reuses_placeholder_via_api_fallback() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _path_guard = crate::daemon::PATH_LOCK.lock().unwrap();
+
+    let (state, _project_dir, _guard) = make_workflow_test_state("post-pr-reuse-api");
+
+    let pr_number = 88u64;
+    let existing_comment_id = 66666u64;
+    {
+        let mut ps = state.persistent_state.lock().await;
+        ps.github
+            .assign_reviewer(pr_number, "madison", AssignmentSource::Webhook);
+        // Do NOT set placeholder_comment_id — simulates daemon restart
+    }
+
+    // Mock `gh` to:
+    // 1. Return placeholder via `gh pr view --json comments` (tier 3 fallback)
+    // 2. Accept the PATCH request
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mock_gh_dir = temp_dir.path().join("bin");
+    std::fs::create_dir_all(&mock_gh_dir).unwrap();
+    let log_file = temp_dir.path().join("gh_calls.log");
+    let mock_gh_script = mock_gh_dir.join("gh");
+
+    std::fs::write(
+        &mock_gh_script,
+        format!(
+            r#"#!/bin/bash
+echo "$@" >> "{log}"
+if echo "$@" | grep -q "repo view"; then
+  echo 'test/repo'
+elif echo "$@" | grep -q "pr view.*--json comments"; then
+  echo '{{"comments": [{{"body": "<!-- midtown-placeholder -->\n## Review Status\n\n🔍 Review in progress by pleasant...", "url": "https://github.com/test/repo/pull/88#issuecomment-{existing_comment_id}"}}]}}'
+elif echo "$@" | grep -q "PATCH"; then
+  echo '{{"id": {existing_comment_id}}}'
+elif echo "$@" | grep -q "pr comment"; then
+  echo 'https://github.com/test/repo/pull/88#issuecomment-99999'
+fi
+"#,
+            log = log_file.display(),
+            existing_comment_id = existing_comment_id,
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(&mock_gh_script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    unsafe {
+        std::env::set_var(
+            "PATH",
+            format!("{}:{}", mock_gh_dir.display(), original_path),
+        );
+    }
+
+    let effects = vec![Effect::PostPrComment {
+        pr_number,
+        reviewer_name: "madison".to_string(),
+        body:
+            "<!-- midtown-placeholder -->\n## Review Status\n\n🔍 Review in progress by madison..."
+                .to_string(),
+    }];
+    execute_effects(effects, &state).await;
+
+    unsafe {
+        std::env::set_var("PATH", &original_path);
+    }
+
+    let log_contents = std::fs::read_to_string(&log_file).unwrap();
+
+    // Verify: tier 3 API fallback was called
+    assert!(
+        log_contents.contains("pr view"),
+        "Should have called `gh pr view --json comments` as tier 3 fallback, got: {}",
+        log_contents,
+    );
+
+    // Verify: PATCH was called (not `gh pr comment`)
+    assert!(
+        log_contents.contains("PATCH"),
+        "Should have called gh api --method PATCH to edit existing placeholder, got: {}",
+        log_contents,
+    );
+    assert!(
+        !log_contents.contains("pr comment"),
+        "Should NOT have called `gh pr comment` when placeholder exists, got: {}",
+        log_contents,
+    );
+
+    // Verify: the placeholder ID was stored on the assignment
+    {
+        let ps = state.persistent_state.lock().await;
+        let assignment = ps
+            .github
+            .pr_reviewers
+            .get(&pr_number)
+            .expect("assignment should still exist");
+        assert_eq!(assignment.placeholder_comment_id, Some(existing_comment_id),);
     }
 }
 


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- When a reviewer times out and is re-spawned, `post_pr_comment` now checks for an existing `<!-- midtown-placeholder -->` comment on the PR and edits it via `gh api --method PATCH` instead of creating a new one
- Adds `find_existing_placeholder()` helper that queries the GitHub REST API for existing placeholder comments
- Prevents accumulation of multiple "Review in progress by ..." comments on a single PR when reviewers cycle through timeouts

## Test plan
- [x] New test `test_post_pr_comment_reuses_existing_placeholder` verifies PATCH is called (not `gh pr comment`) when a placeholder exists
- [x] Existing tests `test_post_pr_comment_stores_comment_id_on_assignment` and `test_post_pr_comment_parses_bare_numeric_url` still pass (no regression)
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)