### PR TITLE
feat: Add --version flag to midtown CLI [Midtown !2196]

### DIFF
--- a/src/bin/midtown/main.rs
+++ b/src/bin/midtown/main.rs
@@ -16,7 +16,7 @@ use cli::{
 use client::DaemonClient;
 
 #[derive(Parser)]
-#[command(name = "midtown")]
+#[command(name = "midtown", version)]
 #[command(about = "Midtown - AI coworker orchestration", long_about = None)]
 struct Cli {
     /// Output format (json or pretty)

--- a/tests/daemon_e2e.rs
+++ b/tests/daemon_e2e.rs
@@ -1335,6 +1335,40 @@ fn test_cli_global_help_no_panic() {
     );
 }
 
+/// Verify `midtown --version` prints the version from Cargo.toml.
+#[test]
+fn test_cli_version_flag() {
+    let binary_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("debug")
+        .join("midtown");
+
+    if !binary_path.exists() {
+        eprintln!("Skipping: debug binary not found at {:?}", binary_path);
+        return;
+    }
+
+    let output = Command::new(&binary_path)
+        .args(["--version"])
+        .output()
+        .expect("Failed to run midtown --version");
+
+    assert!(
+        output.status.success(),
+        "midtown --version should succeed. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let version = env!("CARGO_PKG_VERSION");
+    assert!(
+        stdout.contains(version),
+        "Version output should contain '{}'. Got: {}",
+        version,
+        stdout
+    );
+}
+
 /// Regression test: web assets should not be stale.
 ///
 /// Verifies that built web assets in `web/` are at least as new as


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Add `#[command(version)]` to the `Cli` struct so `midtown --version` and `midtown -V` print the version from Cargo.toml (currently 0.7.0)
- Add test verifying the `--version` flag works correctly

## Test plan
- [x] `midtown --version` prints `midtown 0.7.0`
- [x] `midtown -V` prints `midtown 0.7.0`
- [x] `test_cli_version_flag` passes
- [x] `cargo clippy` clean
- [x] Pre-commit hooks pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)