### PR TITLE
feat: Add checkmark to completed tasks and improve green color [Midtown !2197]

### DIFF
--- a/web-app/src/app.css
+++ b/web-app/src/app.css
@@ -42,6 +42,7 @@
   --sidebar-ring: 217.2 91.2% 59.8%;
   --insight: 300 50% 35%;
   --accent-teal: 188 45% 32%;
+  --accent-green: 145 40% 38%;
   --chip-foreground: 0 0% 10%;
   /* Status indicator colors — visible on light backgrounds */
   --status-green: 120 45% 38%;
@@ -86,6 +87,7 @@
   --sidebar-ring: 180 29.4% 52.9%;
   --insight: 300 29.4% 52.9%;
   --accent-teal: 188 45% 65%;
+  --accent-green: 145 35% 55%;
   --chip-foreground: 0 0% 96%;
   /* Status indicator colors — match terminal palette on dark backgrounds */
   --status-green: 120 43% 53%;
@@ -132,6 +134,7 @@
   --color-sidebar-ring: hsl(var(--sidebar-ring));
   --color-insight: hsl(var(--insight));
   --color-accent-teal: hsl(var(--accent-teal));
+  --color-accent-green: hsl(var(--accent-green));
   --color-chip-foreground: hsl(var(--chip-foreground));
   --color-status-green: hsl(var(--status-green));
   --color-status-amber: hsl(var(--status-amber));

--- a/web-app/src/lib/ChannelSettings.svelte
+++ b/web-app/src/lib/ChannelSettings.svelte
@@ -364,7 +364,7 @@ $effect(() => {
   }
 
   .agents-status.success {
-    color: hsl(142 71% 45%);
+    color: hsl(var(--accent-green));
   }
 
   .agents-buttons {

--- a/web-app/src/lib/TaskRow.svelte
+++ b/web-app/src/lib/TaskRow.svelte
@@ -31,7 +31,7 @@ const prUrl = $derived(
 const descriptionHtml = $derived(isCard && task.description ? renderContent(task.description) : "");
 
 function statusBarColor(task) {
-	if (task.status === "done") return "hsl(var(--accent-green, 142 71% 45%))";
+	if (task.status === "done") return "hsl(var(--accent-green, 145 40% 38%))";
 	if (task.status !== "in_progress") return "hsl(var(--muted-foreground) / 0.3)";
 	if (task.owner) return getSenderColor(task.owner);
 	return "hsl(var(--accent-teal))";
@@ -83,11 +83,11 @@ function handleDescriptionClick(e) {
   <div class="flex-1 min-w-0 flex flex-col gap-[3px]">
     {#if isCard}
       <span class="shrink-0 font-semibold text-[0.65rem] {isActive ? 'opacity-80' : 'opacity-60'}">!{task.id}</span>
-      <span>{task.subject}</span>
+      <span>{#if task.status === 'done'}<span class="text-[hsl(var(--accent-green))]">✓ </span>{/if}{task.subject}</span>
     {:else}
       <div class="flex items-center gap-1.5">
         <span class="shrink-0 font-semibold {isActive ? 'opacity-80' : 'opacity-60'}">!{task.id}</span>
-        <span class="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">{task.subject}</span>
+        <span class="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">{#if task.status === 'done'}<span class="text-[hsl(var(--accent-green))]">✓ </span>{/if}{task.subject}</span>
         {#if isBlocked}
           <span class="shrink-0 text-[0.62rem] text-[hsl(var(--status-amber))] opacity-85" title="Blocked by !{task.blocked_by[0]}">⧗ !{task.blocked_by[0]}</span>
         {/if}
@@ -143,7 +143,7 @@ function handleDescriptionClick(e) {
             class="inline-flex items-center gap-1 text-[hsl(var(--link-default))] text-[0.72rem] no-underline hover:underline"
           ><span class="inline-flex items-center justify-center size-4 rounded-full bg-[hsl(var(--muted))]"><Github size={10} /></span>PR #{relatedPr.number}</a>
           {#if relatedPr.ci_status === 'passed'}
-            <CircleCheck size={13} class="text-[hsl(var(--accent-green,142_71%_45%))]" />
+            <CircleCheck size={13} class="text-[hsl(var(--accent-green,145_40%_38%))]" />
           {:else if relatedPr.ci_status === 'failed'}
             <CircleX size={13} class="text-[hsl(var(--status-red,0_84%_60%))]" />
           {:else if relatedPr.ci_status === 'running'}

--- a/web-app/src/lib/ThreadList.svelte
+++ b/web-app/src/lib/ThreadList.svelte
@@ -124,7 +124,7 @@ function handleDismiss(e, threadId) {
   }
 
   .thread-row.completed {
-    color: hsl(var(--accent-green, 142 71% 45%) / 0.8);
+    color: hsl(var(--accent-green, 145 40% 38%) / 0.8);
   }
 
   .accent-line {
@@ -145,7 +145,7 @@ function handleDismiss(e, threadId) {
     display: flex;
     align-items: center;
     justify-content: center;
-    color: hsl(var(--accent-green, 142 71% 45%));
+    color: hsl(var(--accent-green, 145 40% 38%));
   }
 
   .thread-content {


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Added ✓ unicode checkmark before completed task subject text in both sidebar row and card variants of `TaskRow.svelte`
- Defined `--accent-green` as a proper CSS variable with theme-appropriate values:
  - Light: `145 40% 38%` (desaturated, darker green)
  - Dark: `145 35% 55%` (slightly lighter, lower saturation for dark backgrounds)
- Updated all 4 files that referenced the old hardcoded `142 71% 45%` green to use the new CSS variable
- Added Tailwind `--color-accent-green` mapping for utility class usage

## Key files changed
- `web-app/src/app.css` — new `--accent-green` variable in both light/dark themes + Tailwind mapping
- `web-app/src/lib/TaskRow.svelte` — checkmark character + updated green references
- `web-app/src/lib/ThreadList.svelte` — updated fallback values
- `web-app/src/lib/ChannelSettings.svelte` — migrated hardcoded green to use CSS variable

## Test plan
- [x] `vite build` passes
- [x] `biome check` passes
- [x] Pre-commit hooks pass (clippy, fmt, biome)
- [ ] Visual verification: completed tasks show ✓ in sidebar
- [ ] Visual verification: green is comfortable in both light and dark themes

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)