### PR TITLE
feat: Smart paste — auto-wrap pasted code in markdown fences [Midtown !2200]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -618,7 +618,7 @@ function handlePaste(e) {
 		pendingFile = file;
 		return;
 	}
-	handleCodePaste(
+	const cursorPos = handleCodePaste(
 		e,
 		textareaElement,
 		() => inputText,
@@ -626,6 +626,12 @@ function handlePaste(e) {
 			inputText = t;
 		},
 	);
+	if (cursorPos !== false) {
+		tick().then(() => {
+			textareaElement.selectionStart = cursorPos;
+			textareaElement.selectionEnd = cursorPos;
+		});
+	}
 }
 
 function clearPendingFile() {

--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -439,7 +439,13 @@ let prevThreadId = null;
       pendingFile = file
       return
     }
-    handleCodePaste(e, textareaEl, () => replyText, (t) => { replyText = t })
+    const cursorPos = handleCodePaste(e, textareaEl, () => replyText, (t) => { replyText = t })
+    if (cursorPos !== false) {
+      tick().then(() => {
+        textareaEl.selectionStart = cursorPos
+        textareaEl.selectionEnd = cursorPos
+      })
+    }
   }
 
   function clearPendingFile() {

--- a/web-app/src/lib/codePaste.js
+++ b/web-app/src/lib/codePaste.js
@@ -86,7 +86,7 @@ export function detectCode(text) {
 		if (score >= 4) {
 			return { isCode: true, language: hljsLanguage };
 		}
-	} else if (nonEmptyLines.length <= 2) {
+	} else {
 		// Short text: require strong signal or single-line pattern match
 		if (STRONG_SINGLE_LINE.test(text) || score >= 6) {
 			return { isCode: true, language: hljsLanguage };
@@ -116,7 +116,8 @@ export function wrapInFences(text, language) {
  * @param {HTMLTextAreaElement} textareaElement - The textarea element
  * @param {() => string} getCurrentText - Returns the current textarea value
  * @param {(text: string) => void} setText - Sets the textarea value
- * @returns {boolean} Whether the paste was handled
+ * @returns {false | number} `false` if the paste was not handled, or the
+ *   cursor position that should be set after the DOM updates.
  */
 export function handleCodePaste(e, textareaElement, getCurrentText, setText) {
 	const text = e.clipboardData?.getData("text/plain");
@@ -135,12 +136,5 @@ export function handleCodePaste(e, textareaElement, getCurrentText, setText) {
 	const newText = current.slice(0, start) + fenced + current.slice(end);
 	setText(newText);
 
-	// Reposition cursor after the inserted fenced block.
-	const cursorPos = start + fenced.length;
-	queueMicrotask(() => {
-		textareaElement.selectionStart = cursorPos;
-		textareaElement.selectionEnd = cursorPos;
-	});
-
-	return true;
+	return start + fenced.length;
 }

--- a/web-app/src/lib/codePaste.test.js
+++ b/web-app/src/lib/codePaste.test.js
@@ -179,7 +179,7 @@ describe("handleCodePaste", () => {
 		expect(setText).not.toHaveBeenCalled();
 	});
 
-	test("returns true and calls preventDefault + setText for code", () => {
+	test("returns cursor position and calls preventDefault + setText for code", () => {
 		const code = `function greet(name) {
 	const msg = "Hello, " + name;
 	return msg;
@@ -190,7 +190,8 @@ describe("handleCodePaste", () => {
 		const setText = vi.fn();
 
 		const result = handleCodePaste(e, textarea, getText, setText);
-		expect(result).toBe(true);
+		expect(result).not.toBe(false);
+		expect(typeof result).toBe("number");
 		expect(e.preventDefault).toHaveBeenCalled();
 		expect(setText).toHaveBeenCalledTimes(1);
 		const newText = setText.mock.calls[0][0];
@@ -241,10 +242,37 @@ describe("handleCodePaste", () => {
 		const setText = vi.fn();
 
 		const result = handleCodePaste(e, textarea, getText, setText);
-		expect(result).toBe(true);
+		expect(result).not.toBe(false);
 		const newText = setText.mock.calls[0][0];
 		expect(newText.startsWith("before ")).toBe(true);
 		expect(newText.endsWith(" after")).toBe(true);
 		expect(newText).toContain("```");
+	});
+
+	test("returns correct cursor position after fenced block", () => {
+		const code = "const x = 1;";
+		const e = makeEvent(code);
+		const textarea = makeTextarea("", 0, 0);
+		const getText = () => "";
+		const setText = vi.fn();
+
+		const cursorPos = handleCodePaste(e, textarea, getText, setText);
+		const newText = setText.mock.calls[0][0];
+		// Cursor should be at end of the inserted fenced block
+		expect(cursorPos).toBe(newText.length);
+	});
+
+	test("returns correct cursor position when inserting mid-text", () => {
+		const code = "const x = 1;";
+		const e = makeEvent(code);
+		const existing = "before  after";
+		const textarea = makeTextarea(existing, 7, 7);
+		const getText = () => existing;
+		const setText = vi.fn();
+
+		const cursorPos = handleCodePaste(e, textarea, getText, setText);
+		const fenced = wrapInFences(code, null);
+		// Cursor should be at start offset + fenced block length
+		expect(cursorPos).toBe(7 + fenced.length);
 	});
 });


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Add `codePaste.js` with scoring-based heuristics to detect pasted code (keywords, syntax chars, indentation, highlight.js relevance) and wrap in markdown fences
- Integrate into `Channel.svelte` and `ThreadPanel.svelte` paste handlers
- 25 unit tests covering detection, wrapping, and paste handler behavior

## How it works
When a user pastes text into the chat input, the new `handleCodePaste()` function:
1. Gets the plain text from the clipboard
2. Runs `detectCode()` which scores the text using 6 heuristic signals (shebang, keywords, syntax chars, indentation, trailing semicolons, highlight.js relevance)
3. Multi-line text (3+ lines) needs score >= 4; short text needs score >= 6 or a strong single-line pattern match
4. If detected as code, wraps in markdown fences with auto-detected language and inserts at cursor position
5. Repositions cursor after the inserted block

Edge cases handled: already-fenced text (no double-wrap), URLs/paths (not code), prose (not code), single-line needs strong signals.

## Test plan
- [x] All 25 new unit tests pass (detectCode, wrapInFences, handleCodePaste)
- [x] All 313 existing tests pass
- [x] Biome lint/format passes
- [x] Cargo clippy passes
- [ ] Manual test: paste a code snippet into chat — should auto-wrap in fences
- [ ] Manual test: paste normal text — should NOT wrap
- [ ] Manual test: paste already-fenced code — should NOT double-wrap

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)