### PR TITLE
chore: Bump version to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "midtown"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "axum",
  "axum-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "midtown"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 description = "Midtown - a multi-Claude Code workspace manager, inspired by Gastown"
 license = "MIT"


### PR DESCRIPTION
<!-- midtown: midtown -->

## Summary

- Bump version from 0.7.0 to 0.7.1 for patch release

32 commits since v0.7.0 including:
- `--version` CLI flag
- Smart paste (auto-wrap pasted code in markdown fences)
- Auto-collapse tool blocks after 30s
- Sidebar checkmarks for completed tasks
- Post-rebase context staleness prevention
- External/fork PR blocking
- Tool data visibility gating
- Newline rendering fix
- Web-app rebuild on restart
- Dispatch cooldowns and spawn retry fixes

## Test plan

- [ ] `cargo check` passes with new version
- [ ] `midtown --version` shows 0.7.1 after install

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)