### PR TITLE
refactor: Route all lead nudges through NudgeChannelLead effect pipeline [Midtown !2209]

### DIFF
--- a/src/daemon/chat.rs
+++ b/src/daemon/chat.rs
@@ -70,13 +70,16 @@ pub(super) async fn chat_monitor_loop(
                                         let msg_lower = msg.content.to_lowercase();
                                         let lead_mention = format!("@{}", state.project_name).to_lowercase();
                                         if msg_lower.contains("@lead") || msg_lower.contains(&lead_mention) {
-                                            let nudge_text = format!(
-                                                "{} ({}): {}",
-                                                msg.from,
-                                                msg.thread_anchor_id(),
-                                                msg.content
-                                            );
-                                            state.nudge_lead(&nudge_text).await;
+                                            let effect = super::effects::Effect::NudgeChannelLead {
+                                                channel_name: state.default_channel_name().to_string(),
+                                                reason: super::wake_reason::WakeReason::Mention {
+                                                    from: msg.from.clone(),
+                                                    content: msg.content.clone(),
+                                                    msg_id: msg.thread_anchor_id().to_string(),
+                                                    thread_ctx: None,
+                                                },
+                                            };
+                                            super::effects::execute_effects(vec![effect], &state).await;
                                             info!(
                                                 "Nudged lead about @{} mention in {} message",
                                                 state.project_name,
@@ -90,6 +93,7 @@ pub(super) async fn chat_monitor_loop(
                                                     from: msg.from.clone(),
                                                     content: msg.content.clone(),
                                                     msg_id: msg.thread_anchor_id().to_string(),
+                                                    thread_ctx: None,
                                                 },
                                             };
                                             super::effects::execute_effects(vec![effect], &state).await;
@@ -262,7 +266,23 @@ async fn route_at_all(state: &DaemonState, msg: &Message) {
             Duration::from_secs(3600),
         );
         if should_nudge_lead {
-            state.nudge_lead(&nudge_text).await;
+            let thread_ctx =
+                msg.thread_parent_id
+                    .as_ref()
+                    .map(|parent_id| super::wake_reason::ThreadContext {
+                        parent_id: parent_id.clone(),
+                        channel_name: msg.channel_name().to_string(),
+                    });
+            let nudge_effect = super::effects::Effect::NudgeChannelLead {
+                channel_name: state.default_channel_name().to_string(),
+                reason: super::wake_reason::WakeReason::Mention {
+                    from: msg.from.clone(),
+                    content: msg.content.clone(),
+                    msg_id: msg.thread_anchor_id().to_string(),
+                    thread_ctx,
+                },
+            };
+            super::effects::execute_effects(vec![nudge_effect], state).await;
             info!("Nudged lead for @all from {}", msg.from);
         }
     }

--- a/src/daemon/rpc_channel.rs
+++ b/src/daemon/rpc_channel.rs
@@ -523,31 +523,26 @@ pub(super) async fn handle_channel_post(
             // Truncate message for nudge (max 100 chars)
             let summary = truncate_str(&content, 100);
 
-            let nudge_msg = if let Some(parent_id) = thread_parent_id {
-                format!(
-                    "{} mentioned @{} ({}): {}\n\nThis is a thread reply. To reply in the thread:\n  \
-                     midtown channel post \"...\" --thread {parent_id} --channel {channel_name}\n\
-                     To read recent thread context:\n  \
-                     midtown channel read --last 50 --channel {channel_name}",
-                    from,
-                    state.project_name,
-                    msg.thread_anchor_id(),
-                    summary
-                )
-            } else {
-                format!(
-                    "{} mentioned @{} ({}): {}",
-                    from,
-                    state.project_name,
-                    msg.thread_anchor_id(),
-                    summary
-                )
+            let thread_ctx =
+                thread_parent_id.map(|parent_id| crate::daemon::wake_reason::ThreadContext {
+                    parent_id: parent_id.to_string(),
+                    channel_name: channel_name.to_string(),
+                });
+
+            let nudge_effect = crate::daemon::effects::Effect::NudgeChannelLead {
+                channel_name: state.default_channel_name().to_string(),
+                reason: crate::daemon::wake_reason::WakeReason::Mention {
+                    from: from.to_string(),
+                    content: summary.to_string(),
+                    msg_id: msg.thread_anchor_id().to_string(),
+                    thread_ctx,
+                },
             };
             info!(
                 "Nudging Lead about @{} mention from {}",
                 state.project_name, from
             );
-            state.nudge_lead(&nudge_msg).await;
+            crate::daemon::effects::execute_effects(vec![nudge_effect], state).await;
         }
     }
 

--- a/src/daemon/wake_reason.rs
+++ b/src/daemon/wake_reason.rs
@@ -60,6 +60,8 @@ pub enum WakeReason {
         from: String,
         content: String,
         msg_id: String,
+        /// Thread context when the mention is in a thread reply.
+        thread_ctx: Option<ThreadContext>,
     },
     /// Generic nudge (freeform message).
     Nudge { message: String },
@@ -209,8 +211,20 @@ impl WakeReason {
                 from,
                 content,
                 msg_id,
+                thread_ctx,
             } => {
-                format!("{from} mentioned you ({msg_id}): {content}")
+                let base = format!("{from} mentioned you ({msg_id}): {content}");
+                if let Some(ctx) = thread_ctx {
+                    format!(
+                        "{base}\n\nThis is a thread reply. To reply in the thread:\n  \
+                         midtown channel post \"...\" --thread {} --channel {}\n\
+                         To read recent thread context:\n  \
+                         midtown channel read --last 50 --channel {}",
+                        ctx.parent_id, ctx.channel_name, ctx.channel_name
+                    )
+                } else {
+                    base
+                }
             }
             Self::Nudge { message } => message.clone(),
             Self::DmFromUser {

--- a/src/daemon/wake_reason_tests.rs
+++ b/src/daemon/wake_reason_tests.rs
@@ -304,6 +304,7 @@ fn sender_returns_from_for_mention() {
         from: "lexington".to_string(),
         content: "check this".to_string(),
         msg_id: "msg-1".to_string(),
+        thread_ctx: None,
     };
     assert_eq!(reason.sender(), "lexington");
 }
@@ -365,7 +366,8 @@ fn already_in_dm_channel_only_for_dm_from_user() {
         !WakeReason::Mention {
             from: "lex".into(),
             content: "c".into(),
-            msg_id: "m".into()
+            msg_id: "m".into(),
+            thread_ctx: None,
         }
         .already_in_dm_channel()
     );
@@ -399,6 +401,55 @@ fn user_message_thread_reply_nudge_includes_instructions() {
     assert!(
         msg.contains("This is a thread reply"),
         "thread reply nudge should indicate it's a thread reply"
+    );
+}
+
+#[test]
+fn mention_without_thread_ctx_formats_simple_message() {
+    let reason = WakeReason::Mention {
+        from: "broadway".to_string(),
+        content: "check the auth flow".to_string(),
+        msg_id: "msg-mention-001".to_string(),
+        thread_ctx: None,
+    };
+    let msg = reason.to_nudge_message();
+    assert!(
+        msg.contains("broadway mentioned you (msg-mention-001): check the auth flow"),
+        "should format as simple mention"
+    );
+    assert!(
+        !msg.contains("thread reply"),
+        "non-thread mention should not include thread instructions"
+    );
+}
+
+#[test]
+fn mention_with_thread_ctx_includes_thread_instructions() {
+    let reason = WakeReason::Mention {
+        from: "broadway".to_string(),
+        content: "check the auth flow".to_string(),
+        msg_id: "msg-mention-002".to_string(),
+        thread_ctx: Some(ThreadContext {
+            parent_id: "parent-thread-uuid".to_string(),
+            channel_name: "daemon-core".to_string(),
+        }),
+    };
+    let msg = reason.to_nudge_message();
+    assert!(
+        msg.contains("broadway mentioned you"),
+        "should contain mention attribution"
+    );
+    assert!(
+        msg.contains("--thread parent-thread-uuid"),
+        "thread reply mention should include --thread instruction"
+    );
+    assert!(
+        msg.contains("--channel daemon-core"),
+        "thread reply mention should include --channel instruction"
+    );
+    assert!(
+        msg.contains("This is a thread reply"),
+        "thread reply mention should indicate it's a thread reply"
     );
 }
 
@@ -445,7 +496,8 @@ fn nudge_type_returns_correct_variant_names() {
         WakeReason::Mention {
             from: "lex".into(),
             content: "c".into(),
-            msg_id: "m".into()
+            msg_id: "m".into(),
+            thread_ctx: None,
         }
         .nudge_type(),
         "mention"


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Consolidate three separate lead nudge paths into the `NudgeChannelLead` effect pipeline
- Add `thread_ctx: Option<ThreadContext>` to `WakeReason::Mention` for thread reply context
- Replace direct `state.nudge_lead()` calls in `rpc_channel.rs` (coworker @lead mentions) and `chat.rs` (@all broadcasts) with `NudgeChannelLead` effects
- Move thread reply instruction formatting from inline code to `WakeReason::to_nudge_message()`

## Motivation
Previously there were three paths that nudged the lead:
1. `NudgeChannelLead` effect (user messages) — went through the effect system ✓
2. `state.nudge_lead()` in `rpc_channel.rs` — coworker @lead mentions bypassed effects ✗
3. `state.nudge_lead()` in `chat.rs` — @all broadcasts bypassed effects ✗

Now all three go through `NudgeChannelLead` with appropriate `WakeReason::Mention` variants, making lead nudge behavior consistent and testable.

## Test plan
- [x] New unit test: `mention_without_thread_ctx_formats_simple_message`
- [x] New unit test: `mention_with_thread_ctx_includes_thread_instructions`
- [x] Updated existing tests for new `thread_ctx` field
- [x] `cargo clippy` clean
- [x] `cargo build` succeeds

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)