### PR TITLE
fix: Match sidebar background to header color in light mode

### DIFF
--- a/web-app/src/app.css
+++ b/web-app/src/app.css
@@ -32,7 +32,7 @@
   --ring: 240 5.9% 10%;
   --radius: 0.5rem;
   --header-height: 45px;
-  --sidebar-background: 42.5 48% 90.2%;
+  --sidebar-background: 48 45% 97.8%;
   --sidebar-foreground: 240 5.3% 26.1%;
   --sidebar-primary: 240 5.9% 10%;
   --sidebar-primary-foreground: 0 0% 98%;


### PR DESCRIPTION
<!-- midtown: midtown -->

## Summary

- Changes light mode `--sidebar-background` from warm tan (`42.5 48% 90.2%`) to near-white warm (`48 45% 97.8%` / `#FCFBF7`) to match the header color
- Dark mode sidebar is unchanged

## Test plan

- [ ] Open the web app in light mode and verify the sidebar background matches the header
- [ ] Verify dark mode sidebar appearance is unchanged
- [ ] Check sidebar text/icons remain readable against the lighter background

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)