### PR TITLE
fix(web): skip ThreadActivityDrawer age-out effects in inlineMode [Midtown !2213]

### DIFF
--- a/web-app/src/lib/ThreadActivityDrawer.svelte
+++ b/web-app/src/lib/ThreadActivityDrawer.svelte
@@ -78,8 +78,10 @@ let merged = $derived.by(() => {
 	return out;
 });
 
-// Phase 1: stamp newly completed items reactively (runs before DOM update when merged changes)
+// Phase 1: stamp newly completed items reactively (runs before DOM update when merged changes).
+// Skip when inlineMode — the drawer doesn't render tool items, so age-out is a no-op.
 $effect.pre(() => {
+	if (inlineMode) return;
 	const now = Date.now();
 	let changed = false;
 	const current = untrack(() => completedAt);
@@ -93,9 +95,9 @@ $effect.pre(() => {
 	if (changed) completedAt = newCompleted;
 });
 
-// Phase 2: expire completed items after AGE_OUT_MS (skip when expanded)
+// Phase 2: expire completed items after AGE_OUT_MS (skip when expanded or inlineMode)
 $effect(() => {
-	if (expanded) return;
+	if (expanded || inlineMode) return;
 
 	const currentCompleted = completedAt;
 	if (currentCompleted.size === 0) return;


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Verified that inline tool blocks' `createAutoCollapse` pattern is correctly wired — Svelte 5 `$state` writes from `setTimeout` callbacks work correctly since signals are proxy-based
- Added `inlineMode` guards to ThreadActivityDrawer's Phase 1 (`$effect.pre`) and Phase 2 (`$effect`) age-out effects to skip wasted computation when `inlineMode=true` (the default since PR #1937)
- The drawer only shows typing dots in inline mode — the `completedAt`/`expired` reactive effects were running on every message change but their results were never rendered

## Investigation findings

Two separate auto-collapse systems coexist:
1. **Inline tool blocks** (BashBlock, EditBlock, etc.) — `createAutoCollapse` from `useAutoCollapse.js`, collapses preview→header after 30s. Correctly wired.
2. **ThreadActivityDrawer** — own `completedAt`/`expired` mechanism, ages out items after 3s. Only active when `inlineMode=false`.

The drawer's age-out code was dead in the default mode (`inlineMode=true`) but still running effects. This PR adds early returns to skip that computation.

## Test plan
- [x] All 319 web-app vitest tests pass
- [x] Pre-commit hooks pass (clippy, fmt, biome)
- [x] Static analysis confirms `createAutoCollapse` timer pattern works correctly with Svelte 5 reactivity

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)