### PR TITLE
fix: Resolve state_referenced_locally warnings in auto-collapse components [Midtown !2214]

### DIFF
--- a/agents/channel-lead.md
+++ b/agents/channel-lead.md
@@ -80,11 +80,13 @@ The daemon now **automatically forks** your session when a new top-level user me
 
    ```bash
    # Step 1: Instant ack so the user is not left waiting
-   midtown channel post "<brief ack>" --thread <message-id> --channel {channel_name}
+   midtown channel post "<brief ack>" --thread <channel-msg-id> --channel {channel_name}
 
    # Step 2: Fork into a thread-scoped session with context
-   midtown session fork --thread-id <message-id> --initial-message "Brief description of what to investigate"
+   midtown session fork --thread-id <channel-msg-id> --initial-message "Brief description of what to investigate"
    ```
+
+   **IMPORTANT:** Use the **channel message UUID** from the nudge parentheses (e.g., `a1b2c3d4-e5f6-...`), NOT a Claude API message ID (like `msg_01...`).
 
    Always include `--initial-message` when forking manually — it gives the fork precise instructions. Without it, the daemon falls back to the parent message content, but an explicit message is better because you can add context and direction the parent message lacks.
 
@@ -105,7 +107,7 @@ The daemon now **automatically forks** your session when a new top-level user me
 - Quick one-word acks or status updates that are already covered by daemon notifications
 - CI/PR event notifications that need no response (just read and update your context)
 
-**Nudge format:** Nudges include the message ID in the format `sender (message-id): content`. In normal operation (auto-fork), you are already the fork session, so just respond. In the fallback path, use the top-level message ID with `midtown session fork --thread-id <message-id>`.
+**Nudge format:** Nudges include the channel message UUID in the format `sender (channel-msg-id: <uuid>): content`. In normal operation (auto-fork), you are already the fork session, so just respond. In the fallback path, use the channel message UUID (from the parentheses, NOT a Claude API message ID like `msg_01...`) with `midtown session fork --thread-id <uuid>`.
 
 **Embedded thread instructions in nudges:** Some nudges include explicit thread reply instructions appended by the daemon, e.g.:
 
@@ -114,7 +116,7 @@ This is a thread reply. To reply in the thread:
   midtown channel post "..." --thread <parent-id> --channel <channel>
 ```
 
-In the **root session or fallback path** (when you are NOT in an auto-forked session), use these embedded instructions to reply in the correct thread. They take precedence over the `(message-id)` in the sender line — the embedded `--thread` ID points to the thread parent, which is the correct target for your reply. In an auto-forked session, your text output is already posted to the correct thread automatically, so you can ignore these embedded instructions.
+In the **root session or fallback path** (when you are NOT in an auto-forked session), use these embedded instructions to reply in the correct thread. They take precedence over the `(channel-msg-id)` in the sender line — the embedded `--thread` ID points to the thread parent, which is the correct target for your reply. In an auto-forked session, your text output is already posted to the correct thread automatically, so you can ignore these embedded instructions.
 
 ## Posting to the Channel
 

--- a/agents/lead-common.md
+++ b/agents/lead-common.md
@@ -26,11 +26,13 @@ The daemon parses the `!N` pattern and routes to the session working on that tas
 
 ## Thread Replies
 
-When you receive a nudge about a user message or @mention, the message ID is included in the format `sender (message-id): content`. **Always reply in a thread** using this ID:
+When you receive a nudge about a user message or @mention, the channel message UUID is included in the format `sender (channel-msg-id: <uuid>): content`. **Always reply in a thread** using this channel message UUID:
 
 ```bash
-midtown channel post "Your reply" --thread <message-id>
+midtown channel post "Your reply" --thread <channel-msg-id>
 ```
+
+**IMPORTANT:** The `channel-msg-id` in parentheses is a **channel message UUID** (e.g., `a1b2c3d4-e5f6-...`). Do NOT confuse it with Claude API message IDs (which look like `msg_01...`). Always use the UUID from the parentheses.
 
 This keeps the channel organized — top-level posts start conversations, replies continue them. If you don't have a message ID (e.g., daemon-generated nudges), post at the top level as usual.
 
@@ -41,7 +43,7 @@ This is a thread reply. To reply in the thread:
   midtown channel post "..." --thread <parent-id> --channel <channel>
 ```
 
-When these instructions are present, **always use them** to reply in the correct thread. They take precedence over the `(message-id)` in the sender line — the embedded `--thread` ID points to the thread parent, which is the correct target for your reply.
+When these instructions are present, **always use them** to reply in the correct thread. They take precedence over the `(channel-msg-id)` in the sender line — the embedded `--thread` ID points to the thread parent, which is the correct target for your reply.
 
 <EXTREMELY_IMPORTANT>
 Thread replies require the CLI tool call above — but your text output is still auto-posted as a top-level message. This means writing text alongside a `--thread` reply produces a duplicate: once in the thread, once at the top level. When replying in a thread, keep your text output brief (e.g., status notes unrelated to the thread) or omit it entirely when the thread reply covers everything.
@@ -69,13 +71,15 @@ When a user message requires **multi-turn research** — code exploration, debug
 
 1. Reply in the thread with a brief acknowledgment:
    ```bash
-   midtown channel post "<brief ack>" --thread <message-id>
+   midtown channel post "<brief ack>" --thread <channel-msg-id>
    ```
 
 2. Fork yourself into the thread, **always including `--initial-message`** with a brief description of what the fork should do:
    ```bash
-   midtown session fork --thread-id <message-id> --initial-message "Investigate why auth tokens expire early — check the token refresh logic and expiry calculation"
+   midtown session fork --thread-id <channel-msg-id> --initial-message "Investigate why auth tokens expire early — check the token refresh logic and expiry calculation"
    ```
+
+   **IMPORTANT:** The `--thread-id` must be the **channel message UUID** from the nudge parentheses (e.g., `user (a1b2c3d4-...): content`). Do NOT use Claude API message IDs (which look like `msg_01...`) — those are internal conversation IDs and will cause the fork to bind to a non-existent thread.
 
    The `--initial-message` gives the fork clear instructions so it can start working immediately. Without it, the daemon falls back to the parent message content, but an explicit message is always better because you can add context the parent message lacks.
 

--- a/src/daemon/rpc_channel_tests.rs
+++ b/src/daemon/rpc_channel_tests.rs
@@ -168,9 +168,9 @@ async fn test_user_message_queues_headed_lead_nudge() {
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0].kind, "nudge_text");
     assert!(
-        messages[0].text.starts_with("user (")
+        messages[0].text.starts_with("user (channel-msg-id: ")
             && messages[0].text.ends_with("): please check this"),
-        "nudge text should be 'user (<id>): please check this', got: {}",
+        "nudge text should be 'user (channel-msg-id: <id>): please check this', got: {}",
         messages[0].text
     );
     assert!(messages[0].submit);
@@ -205,7 +205,7 @@ async fn test_user_at_project_name_queues_single_nudge() {
     );
     assert_eq!(messages[0].kind, "nudge_text");
     assert!(
-        messages[0].text.starts_with("user ("),
+        messages[0].text.starts_with("user (channel-msg-id: "),
         "expected user-message nudge format, got: {}",
         messages[0].text
     );
@@ -354,8 +354,9 @@ async fn test_user_message_to_main_channel_nudges_lead() {
         "Main lead should be nudged for main channel user messages"
     );
     assert!(
-        messages[0].text.starts_with("user (") && messages[0].text.ends_with("): hello main"),
-        "nudge text should be 'user (<id>): hello main', got: {}",
+        messages[0].text.starts_with("user (channel-msg-id: ")
+            && messages[0].text.ends_with("): hello main"),
+        "nudge text should be 'user (channel-msg-id: <id>): hello main', got: {}",
         messages[0].text
     );
 }
@@ -397,9 +398,9 @@ async fn test_user_message_with_coworker_mention_still_nudges_lead() {
         "Lead should be nudged even when user @mentions a coworker"
     );
     assert!(
-        messages[0].text.starts_with("user (")
+        messages[0].text.starts_with("user (channel-msg-id: ")
             && messages[0].text.ends_with("): @york can you check this?"),
-        "nudge text should be 'user (<id>): @york can you check this?', got: {}",
+        "nudge text should be 'user (channel-msg-id: <id>): @york can you check this?', got: {}",
         messages[0].text
     );
 }
@@ -850,7 +851,9 @@ async fn test_user_thread_reply_nudge_uses_parent_id() {
     // would cause the lead to create a nested reply invisible to the user.
     // The nudge also includes --thread/--channel instructions after the message preview.
     assert!(
-        messages[0].text.contains(&format!("user ({})", parent_id)),
+        messages[0]
+            .text
+            .contains(&format!("user (channel-msg-id: {})", parent_id)),
         "nudge for thread reply should use parent_id, got: {}",
         messages[0].text
     );
@@ -1478,7 +1481,7 @@ async fn test_thread_routing_with_topic_session_routes_to_fork() {
 async fn test_topic_sessions_dedup_returns_existing() {
     let (state, _tmp, _guard) = make_test_state("midtown-test-topic-sessions-dedup");
 
-    let thread_id = "thread-dedup-uuid";
+    let thread_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
     let first_fork = "fork-session-first";
 
     // Pre-populate topic_sessions as if a fork already exists for this thread.

--- a/src/daemon/rpc_session.rs
+++ b/src/daemon/rpc_session.rs
@@ -1521,6 +1521,24 @@ pub(super) async fn handle_session_fork(
     initial_message: Option<&str>,
     state: &DaemonState,
 ) -> crate::rpc::Response {
+    // Validate thread_parent_id is a UUID — reject Claude API message IDs
+    // (e.g., "msg_01...") which would silently create a fork bound to a
+    // non-existent thread.
+    if uuid::Uuid::parse_str(thread_parent_id).is_err() {
+        return crate::rpc::Response::error(
+            id,
+            crate::rpc::RpcError::new(
+                -32602,
+                format!(
+                    "Invalid thread_parent_id '{}': expected a channel message UUID \
+                     (e.g., 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'). \
+                     This looks like a Claude API message ID — use the channel message UUID \
+                     from the nudge parentheses instead.",
+                    thread_parent_id
+                ),
+            ),
+        );
+    }
     match create_fork_session(
         thread_parent_id,
         calling_session_id,
@@ -1708,6 +1726,19 @@ pub(super) async fn handle_session_fork_thread(
     channel: &str,
     state: &DaemonState,
 ) -> Response {
+    // Validate thread_parent_id is a UUID
+    if uuid::Uuid::parse_str(thread_parent_id).is_err() {
+        return Response::error(
+            id,
+            crate::rpc::RpcError::new(
+                -32602,
+                format!(
+                    "Invalid thread_parent_id '{}': expected a channel message UUID.",
+                    thread_parent_id
+                ),
+            ),
+        );
+    }
     // Resolve channel lead session ID from persistent state
     let lead_session_id = {
         let ps = state.persistent_state.lock().await;

--- a/src/daemon/rpc_session_tests.rs
+++ b/src/daemon/rpc_session_tests.rs
@@ -749,7 +749,7 @@ async fn test_create_fork_session_with_channel_hint_reaches_spawn() {
 async fn test_handle_session_fork_already_exists_response() {
     let (state, _tmp, _guard) = make_test_state();
 
-    let thread_id = "thread-rpc-already-exists";
+    let thread_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
     let existing_sid = "rpc-existing-session-xyz".to_string();
     state
         .topic_sessions
@@ -787,7 +787,7 @@ async fn test_handle_session_fork_already_exists_response() {
 async fn test_handle_session_fork_returns_pending_during_spawn_window() {
     let (state, _tmp, _guard) = make_test_state();
 
-    let thread_id = "thread-rpc-pending-fork";
+    let thread_id = "b2c3d4e5-f6a7-8901-bcde-f12345678901";
     state
         .topic_sessions
         .lock()
@@ -889,7 +889,7 @@ async fn test_create_fork_session_falls_back_to_repo_name() {
 async fn test_handle_session_fork_existing_does_not_nudge() {
     let (state, _tmp, _guard) = make_test_state();
 
-    let thread_id = "thread-existing-no-nudge";
+    let thread_id = "c3d4e5f6-a7b8-9012-cdef-123456789012";
     let existing_sid = "existing-session-no-nudge".to_string();
     state
         .topic_sessions
@@ -924,7 +924,7 @@ async fn test_handle_session_fork_existing_does_not_nudge() {
 async fn test_handle_session_fork_with_initial_message() {
     let (state, _tmp, _guard) = make_test_state();
 
-    let thread_id = "thread-initial-msg-test";
+    let thread_id = "d4e5f6a7-b8c9-0123-defa-234567890123";
     let calling_session_id = "lead-session-for-initial-msg";
 
     // Insert a channel lead session so the fork attempt goes through
@@ -1298,7 +1298,13 @@ async fn test_fork_thread_stale_session_self_heals() {
     }
 
     // First call: should detect stale session and clean up the mapping
-    let resp1 = handle_session_fork_thread(1_i64.into(), "thread-1", channel, &state).await;
+    let resp1 = handle_session_fork_thread(
+        1_i64.into(),
+        "e5f6a7b8-c9d0-1234-efab-345678901234",
+        channel,
+        &state,
+    )
+    .await;
     let json1: serde_json::Value = serde_json::to_value(&resp1).unwrap();
     assert!(
         json1.get("error").is_some(),
@@ -1312,7 +1318,13 @@ async fn test_fork_thread_stale_session_self_heals() {
     );
 
     // Second call: should return "No channel lead session" (self-healed)
-    let resp2 = handle_session_fork_thread(2_i64.into(), "thread-1", channel, &state).await;
+    let resp2 = handle_session_fork_thread(
+        2_i64.into(),
+        "e5f6a7b8-c9d0-1234-efab-345678901234",
+        channel,
+        &state,
+    )
+    .await;
     let json2: serde_json::Value = serde_json::to_value(&resp2).unwrap();
     assert!(
         json2.get("error").is_some(),
@@ -1332,7 +1344,13 @@ async fn test_fork_thread_stale_session_self_heals() {
 async fn test_fork_thread_no_channel_lead() {
     let (state, _tmp, _guard) = make_test_state();
 
-    let resp = handle_session_fork_thread(1_i64.into(), "thread-1", "nonexistent", &state).await;
+    let resp = handle_session_fork_thread(
+        1_i64.into(),
+        "f6a7b8c9-d0e1-2345-fabc-456789012345",
+        "nonexistent",
+        &state,
+    )
+    .await;
     let json: serde_json::Value = serde_json::to_value(&resp).unwrap();
     assert!(json.get("error").is_some());
     let msg = json["error"]["message"].as_str().unwrap_or("");
@@ -1530,5 +1548,131 @@ fn test_build_fork_config_skips_settings_path_for_codex() {
     assert!(
         headless_config.settings_path.is_none(),
         "Codex forks must have settings_path = None to avoid codex_launch_plan_from_config rejection"
+    );
+}
+
+// ============================================================================
+// Fork thread_parent_id UUID validation tests
+// ============================================================================
+
+/// `handle_session_fork` rejects Claude API message IDs (non-UUID strings).
+/// This prevents leads from accidentally creating forks bound to non-existent
+/// threads when they confuse Claude API IDs with channel message UUIDs.
+#[tokio::test]
+async fn test_handle_session_fork_rejects_non_uuid_thread_id() {
+    let (state, _tmp, _guard) = make_test_state();
+
+    // Claude API message ID format
+    let resp = handle_session_fork(
+        RequestId::Number(100),
+        "msg_01JPxyz123abc",
+        "any-caller",
+        None,
+        None,
+        &state,
+    )
+    .await;
+    let json = serde_json::to_value(&resp).unwrap();
+    assert!(
+        json.get("error").is_some(),
+        "Should reject Claude API message ID"
+    );
+    let msg = json["error"]["message"].as_str().unwrap();
+    assert!(
+        msg.contains("Invalid thread_parent_id"),
+        "Error should mention invalid thread_parent_id, got: {}",
+        msg
+    );
+    assert!(
+        msg.contains("channel message UUID"),
+        "Error should suggest using channel message UUID, got: {}",
+        msg
+    );
+}
+
+/// `handle_session_fork` accepts valid UUID thread IDs.
+#[tokio::test]
+async fn test_handle_session_fork_accepts_valid_uuid() {
+    let (state, _tmp, _guard) = make_test_state();
+
+    let valid_uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+    // Pre-populate topic_sessions so the fork returns "already exists"
+    // without needing to spawn a real session.
+    state
+        .topic_sessions
+        .lock()
+        .unwrap()
+        .insert(valid_uuid.to_string(), "existing-session".to_string());
+
+    let resp = handle_session_fork(
+        RequestId::Number(101),
+        valid_uuid,
+        "any-caller",
+        None,
+        None,
+        &state,
+    )
+    .await;
+    let json = serde_json::to_value(&resp).unwrap();
+    assert!(
+        json.get("error").is_none(),
+        "Should accept valid UUID thread ID, got error: {:?}",
+        json.get("error")
+    );
+}
+
+/// `handle_session_fork` rejects various non-UUID strings.
+#[tokio::test]
+async fn test_handle_session_fork_rejects_various_non_uuid_formats() {
+    let (state, _tmp, _guard) = make_test_state();
+
+    let invalid_ids = [
+        "msg_01JPxyz123abc", // Claude API message ID
+        "not-a-uuid",        // arbitrary string
+        "12345",             // numeric
+        "",                  // empty (won't reach here due to require_str! but defensive)
+        "tool_use_abc123",   // tool use ID
+    ];
+
+    for invalid_id in &invalid_ids {
+        if invalid_id.is_empty() {
+            continue; // skip empty — handled by require_str!
+        }
+        let resp = handle_session_fork(
+            RequestId::Number(200),
+            invalid_id,
+            "any-caller",
+            None,
+            None,
+            &state,
+        )
+        .await;
+        let json = serde_json::to_value(&resp).unwrap();
+        assert!(
+            json.get("error").is_some(),
+            "Should reject non-UUID '{}', got: {:?}",
+            invalid_id,
+            json.get("result")
+        );
+    }
+}
+
+/// `handle_session_fork_thread` rejects non-UUID thread IDs.
+#[tokio::test]
+async fn test_handle_session_fork_thread_rejects_non_uuid() {
+    let (state, _tmp, _guard) = make_test_state();
+
+    let resp = handle_session_fork_thread(1_i64.into(), "msg_01JPxyz123abc", "web", &state).await;
+    let json: serde_json::Value = serde_json::to_value(&resp).unwrap();
+    assert!(
+        json.get("error").is_some(),
+        "Should reject Claude API message ID in fork_thread"
+    );
+    let msg = json["error"]["message"].as_str().unwrap();
+    assert!(
+        msg.contains("Invalid thread_parent_id"),
+        "Error should mention invalid thread_parent_id, got: {}",
+        msg
     );
 }

--- a/src/daemon/wake_reason.rs
+++ b/src/daemon/wake_reason.rs
@@ -158,9 +158,12 @@ impl WakeReason {
                 thread_ctx,
             } => {
                 if let Some(ctx) = thread_ctx {
-                    format!("user ({msg_id}): {content}\n\n{}", ctx.reply_instructions())
+                    format!(
+                        "user (channel-msg-id: {msg_id}): {content}\n\n{}",
+                        ctx.reply_instructions()
+                    )
                 } else {
-                    format!("user ({msg_id}): {content}")
+                    format!("user (channel-msg-id: {msg_id}): {content}")
                 }
             }
             Self::InsightPosted {
@@ -224,7 +227,7 @@ impl WakeReason {
                 msg_id,
                 thread_ctx,
             } => {
-                let base = format!("{from} mentioned you ({msg_id}): {content}");
+                let base = format!("{from} mentioned you (channel-msg-id: {msg_id}): {content}");
                 if let Some(ctx) = thread_ctx {
                     format!("{base}\n\n{}", ctx.reply_instructions())
                 } else {
@@ -238,7 +241,7 @@ impl WakeReason {
                 coworker_name,
             } => {
                 format!(
-                    "user ({msg_id}): {content}\n\n\
+                    "user (channel-msg-id: {msg_id}): {content}\n\n\
                      Reply with: midtown channel post \"...\" --channel dm-{coworker_name}"
                 )
             }

--- a/src/daemon/wake_reason_tests.rs
+++ b/src/daemon/wake_reason_tests.rs
@@ -422,7 +422,9 @@ fn mention_without_thread_ctx_formats_simple_message() {
     };
     let msg = reason.to_nudge_message();
     assert!(
-        msg.contains("broadway mentioned you (msg-mention-001): check the auth flow"),
+        msg.contains(
+            "broadway mentioned you (channel-msg-id: msg-mention-001): check the auth flow"
+        ),
         "should format as simple mention"
     );
     assert!(


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Fixed Svelte 5 `state_referenced_locally` warnings in five auto-collapse components by wrapping `createAutoCollapse()` in `$derived.by()` and moving initial state assignment into `$effect.pre()`
- Fixed timer leak: captured `ac` reference in a local `currentAc` variable inside `$effect` closures to prevent stale closure references when `timestamp` changes
- Restored `clearTimer()` in the `$effect` cleanup and updated JSDoc in `useAutoCollapse.js` to reflect the new usage pattern

## Test plan
- [x] Svelte `state_referenced_locally` warnings no longer appear in console
- [x] Auto-collapse behavior works correctly (blocks expand on render, collapse after delay)
- [x] User override (manual expand/collapse) is preserved across re-renders

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)