### PR TITLE
fix: Route task completion messages to task channel instead of main [Midtown !2215]

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -159,7 +159,7 @@ fn task_completed_effects(
         Effect::PostToChannel {
             sender: "midtown".to_string(),
             message: channel_message,
-            channel: None,
+            channel: channel.clone(),
             auto_output: false,
             message_type: None,
             nudge_type: None,

--- a/src/daemon/dispatch_tests.rs
+++ b/src/daemon/dispatch_tests.rs
@@ -4502,6 +4502,33 @@ fn test_build_task_completion_effects_falls_back_to_pr_title() {
 }
 
 #[test]
+fn test_build_task_completion_effects_routes_to_task_channel() {
+    let effects = build_task_completion_effects(
+        "feat: Add auth endpoint [Midtown #42]",
+        123,
+        "myrepo",
+        Some("proj-auth".to_string()),
+        None,
+    );
+
+    // PostToChannel should carry the task's channel
+    let post = effects
+        .iter()
+        .find(|e| matches!(e, Effect::PostToChannel { .. }))
+        .expect("Should have a PostToChannel effect");
+    match post {
+        Effect::PostToChannel { channel, .. } => {
+            assert_eq!(
+                channel.as_deref(),
+                Some("proj-auth"),
+                "PostToChannel should route to the task's channel"
+            );
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn test_build_task_completion_effects_no_workflow_event_without_channel() {
     let effects = build_task_completion_effects(
         "feat: Add auth endpoint [Midtown #42]",


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Fixed `task_completed_effects()` in `dispatch.rs` which accepted a `channel` parameter but hardcoded `channel: None` for `PostToChannel`, causing task completion messages to go through fallback message-text parsing instead of using the explicit task channel
- Added test verifying `PostToChannel` carries the task's channel when one is provided

## Context
The effect executor has a 3-step channel resolution for `PostToChannel`:
1. Use explicit `channel` if provided
2. Extract task ID from message content (e.g., "!42") and look up its channel
3. Fall back to default project channel

Previously, `task_completed_effects()` always used step 2-3 (implicit resolution via message text) even though the caller already passed the correct channel. This change makes it use step 1 (explicit routing).

## Test plan
- [x] New test `test_build_task_completion_effects_routes_to_task_channel` verifies PostToChannel carries the task channel
- [x] All existing dispatch tests pass (7 + 1 new)
- [x] `cargo clippy` clean
- [x] Full `cargo test` passes

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)