### PR TITLE
fix: Clear onNextError callback on fork/unfork success [Midtown !2224]

### DIFF
--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -8,7 +8,7 @@ let prevThreadId = null;
 
 <script>
   import { threadData, deepLinkMsgId, threadOwnership, threadForkParents, threadForkOwners, activeProject, channels as channelsStore, activeChannel, daemonStatus, kanbanData, repoStatus, repoStatuses, channelSettings } from './store.js'
-  import { sendMessage, closeThread, forkThread, unforkThread, openTaskThread, selectDm } from './api.js'
+  import { sendMessage, closeThread, forkThread, unforkThread, clearErrorCallback, openTaskThread, selectDm } from './api.js'
   import { handleCodePaste } from './codePaste.js'
   import { extractPastedFile, updatePreviewUrl, uploadAndSend } from './filePaste.js'
   import { getPrUrl as getPrUrlUtil } from './channelUtils.js'
@@ -141,14 +141,21 @@ let prevThreadId = null;
       : null
   )
   let forkPending = $state(false)
+  let forkErrorCallbackId = $state(null)
 
-  // Clear forkPending when ownership state updates.
+  // Clear forkPending and stale error callback when ownership state updates (success path).
   $effect(() => {
     if ($threadData?.parentMessage?.id) {
       const _ownership = $threadOwnership[$threadData.parentMessage.id]
       untrack(() => {
         forkPending = false
         if (forkTimeout) { clearTimeout(forkTimeout); forkTimeout = null }
+        // Clear the error callback registered by forkThread/unforkThread so it
+        // doesn't fire on the next unrelated server error.
+        if (forkErrorCallbackId != null) {
+          clearErrorCallback(forkErrorCallbackId)
+          forkErrorCallbackId = null
+        }
       })
     }
   })
@@ -165,6 +172,7 @@ let prevThreadId = null;
       if (!forkPending) return // Timeout already handled this request
       if (forkTimeout) { clearTimeout(forkTimeout); forkTimeout = null }
       forkPending = false
+      forkErrorCallbackId = null
       forkError = msg
       // Auto-clear error after 5 seconds
       setTimeout(() => { forkError = null }, 5000)
@@ -179,9 +187,9 @@ let prevThreadId = null;
       }
     }, 10000)
     if (hasDedicatedSession) {
-      unforkThread($threadData.parentMessage.id, $threadData.channelName, onError)
+      forkErrorCallbackId = unforkThread($threadData.parentMessage.id, $threadData.channelName, onError)
     } else {
-      forkThread($threadData.parentMessage.id, $threadData.channelName, onError)
+      forkErrorCallbackId = forkThread($threadData.parentMessage.id, $threadData.channelName, onError)
     }
   }
 

--- a/web-app/src/lib/api.js
+++ b/web-app/src/lib/api.js
@@ -876,9 +876,10 @@ export function sendAnswer(coworkerName, answer) {
 
 // Create a dedicated session for a thread (fork).
 // If onError is provided, it will be called with the error message on failure.
+// Returns the error callback ID (or undefined) so callers can clear it on success.
 export function forkThread(threadParentId, channelName, onError) {
 	if (ws && ws.readyState === WebSocket.OPEN) {
-		if (onError) onNextError(onError);
+		const errorId = onError ? onNextError(onError) : undefined;
 		ws.send(
 			JSON.stringify({
 				type: "fork_thread",
@@ -886,6 +887,7 @@ export function forkThread(threadParentId, channelName, onError) {
 				channel: channelName,
 			}),
 		);
+		return errorId;
 	} else if (onError) {
 		onError("Not connected");
 	}
@@ -893,9 +895,10 @@ export function forkThread(threadParentId, channelName, onError) {
 
 // Return a thread to the channel lead (kill dedicated session).
 // If onError is provided, it will be called with the error message on failure.
+// Returns the error callback ID (or undefined) so callers can clear it on success.
 export function unforkThread(threadParentId, channelName, onError) {
 	if (ws && ws.readyState === WebSocket.OPEN) {
-		if (onError) onNextError(onError);
+		const errorId = onError ? onNextError(onError) : undefined;
 		ws.send(
 			JSON.stringify({
 				type: "unfork_thread",
@@ -903,6 +906,7 @@ export function unforkThread(threadParentId, channelName, onError) {
 				channel: channelName,
 			}),
 		);
+		return errorId;
 	} else if (onError) {
 		onError("Not connected");
 	}

--- a/web-app/src/lib/api.test.js
+++ b/web-app/src/lib/api.test.js
@@ -1,11 +1,13 @@
 import { get } from "svelte/store";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	clearErrorCallback,
 	closeThread,
 	fetchChannels,
 	fetchHistory,
 	forkThread,
 	handleUpdate,
+	onNextError,
 	pushNavState,
 	selectDm,
 	switchProject,
@@ -1014,5 +1016,63 @@ describe("forkThread / unforkThread", () => {
 
 	it("unforkThread does not throw when no onError provided and WS disconnected", () => {
 		expect(() => unforkThread("thread-123", "web")).not.toThrow();
+	});
+});
+
+describe("onNextError callback leak on success path", () => {
+	it("caller can clear error callback on success to prevent stale firing", () => {
+		// Simulates the fixed flow: forkThread registers an onError callback
+		// via onNextError. When the fork succeeds (thread_ownership update arrives),
+		// the caller clears the callback using the returned ID.
+		const onError = vi.fn();
+		const callbackId = onNextError(onError);
+
+		// Simulate success: thread_ownership update arrives
+		handleUpdate({
+			type: "thread_ownership",
+			data: { thread_parent_id: "thread-1", has_dedicated_session: true, owner: "web-discuss-ab12" },
+		});
+
+		// Caller clears the callback on success (this is what ThreadPanel now does)
+		clearErrorCallback(callbackId);
+
+		// An unrelated error arrives — the stale callback must NOT fire
+		handleUpdate({
+			type: "error",
+			data: { message: "unrelated error from different operation" },
+		});
+
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it("clearErrorCallback prevents a registered callback from firing on subsequent errors", () => {
+		// Test the lower-level API: onNextError returns an ID,
+		// clearErrorCallback removes it, so a subsequent error doesn't fire the callback.
+		const onError = vi.fn();
+		const id = onNextError(onError);
+
+		// Simulate success — caller clears the callback
+		clearErrorCallback(id);
+
+		// Now an unrelated error arrives
+		handleUpdate({
+			type: "error",
+			data: { message: "some error" },
+		});
+
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it("error callback fires correctly when an actual error occurs (no success)", () => {
+		const onError = vi.fn();
+		onNextError(onError);
+
+		// Error arrives before any success — callback should fire
+		handleUpdate({
+			type: "error",
+			data: { message: "fork failed: no channel lead" },
+		});
+
+		expect(onError).toHaveBeenCalledWith("fork failed: no channel lead");
 	});
 });


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- **Bug:** When `forkThread()`/`unforkThread()` succeeded, the `onError` callback registered via `onNextError()` was never removed from the `errorCallbacks` map. The next unrelated server error would fire the stale callback, showing a misleading fork error in the ThreadPanel.
- **Fix:** `forkThread`/`unforkThread` now return the error callback ID. `ThreadPanel` captures it and calls `clearErrorCallback()` when the `threadOwnership` update arrives (success signal).
- Added 3 tests covering: callback cleanup on success, `clearErrorCallback` API, and error callback normal firing.

## Test plan
- [x] All 323 web-app tests pass (12 test files)
- [x] 3 new tests specifically cover the onNextError leak fix
- [x] `cargo clippy` and `biome check` pass clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)