### PR TITLE
fix: Two-step fork launch to avoid --setting-sources incompatibility [Midtown !2227]

### DIFF
--- a/src/daemon/sessions.rs
+++ b/src/daemon/sessions.rs
@@ -534,17 +534,20 @@ impl SessionManager {
 
     /// Spawn a forked session and return its session ID.
     ///
-    /// Two strategies for obtaining the fork's session ID:
+    /// Two strategies depending on the platform:
     ///
-    /// 1. **Pre-assigned** (`config.session_id = Some(uuid)`): The UUID is passed
-    ///    to the CLI as `--session-id`, giving the daemon immediate control. Used
-    ///    for Claude/Zai forks whose `--resume --fork-session` mode does NOT emit
-    ///    `system/init`. A 2-second health check catches immediate startup failures.
+    /// 1. **Two-step fork** (Claude/Zai, `config.session_id = Some(uuid)`):
+    ///    - Step 1: Launch with `--resume <parent> --fork-session --session-id <uuid>`
+    ///      using minimal args (no `--setting-sources`) to create the fork on disk.
+    ///    - Step 2: Kill the fork process, then re-launch as a normal
+    ///      `--resume <new-session-id>` with full args (`--setting-sources`, etc.).
     ///
-    /// 2. **Init-event discovery** (`config.session_id = None`): The daemon waits
-    ///    up to 30 seconds for the process to emit a `system/init` event containing
-    ///    the session/thread ID. Used for Codex forks, where the thread/start
-    ///    response generates a synthetic init event.
+    ///    This avoids the incompatibility between `--setting-sources` and `--fork-session`.
+    ///
+    /// 2. **Init-event discovery** (Codex, `config.session_id = None`): The daemon
+    ///    waits up to 30 seconds for the process to emit a `system/init` event
+    ///    containing the session/thread ID. Used for Codex forks, where the
+    ///    thread/start response generates a synthetic init event.
     ///
     /// **Architectural invariant:** Fork sessions are NOT registered in
     /// `CoworkerManager`. They bypass `spawn_coworker()` entirely. This means they
@@ -576,12 +579,12 @@ impl SessionManager {
         }
 
         let fork_session_id = if let Some(sid) = preassigned_session_id {
-            // Claude/Zai path: session_id was pre-assigned via --session-id flag.
-            // Forked sessions (--resume --fork-session) don't emit system/init,
-            // so we register immediately using the pre-assigned ID. A non-blocking
-            // try_wait() catches processes that crash during startup without
-            // penalizing healthy spawns with a fixed sleep. The event loop's
-            // dead-session detection handles later exits (same pattern as spawn_coworker).
+            // Claude/Zai path: two-step fork process.
+            //
+            // Step 1: The fork process (--resume <parent> --fork-session --session-id <uuid>)
+            // was launched with minimal args to create the forked session file. We verify
+            // it didn't crash, then kill it immediately — the fork step's only job is to
+            // create the session on disk.
             if let Ok(Some(status)) = session.try_wait() {
                 let stderr = session.drain_stderr().await;
                 let stderr_summary = if stderr.is_empty() {
@@ -597,6 +600,57 @@ impl SessionManager {
                     ),
                 });
             }
+
+            // Step 2: Kill the fork process and re-launch as a normal resume of the
+            // new session. This second launch can safely include --setting-sources,
+            // --settings, and other flags that are incompatible with --fork-session.
+            let _ = session.kill().await;
+
+            let mut resume_config = config.clone();
+            resume_config.resume_session_id = Some(sid.clone());
+            resume_config.fork_session = false;
+            resume_config.session_id = None; // not needed for resume of a known session
+
+            session =
+                HeadlessSession::spawn(&resume_config)
+                    .await
+                    .map_err(|e| crate::Error::Rpc {
+                        code: -32603,
+                        message: format!(
+                            "Failed to respawn fork session for '{}' (step 2): {}",
+                            name, e
+                        ),
+                    })?;
+
+            if let Err(e) = session.ensure_ready().await {
+                let _ = session.kill().await;
+                return Err(crate::Error::Rpc {
+                    code: -32603,
+                    message: format!("Fork session resume failed for '{}' (step 2): {}", name, e),
+                });
+            }
+
+            // Verify the resumed process didn't crash immediately
+            if let Ok(Some(status)) = session.try_wait() {
+                let stderr = session.drain_stderr().await;
+                let stderr_summary = if stderr.is_empty() {
+                    String::new()
+                } else {
+                    format!(" (stderr: {})", stderr.join("; "))
+                };
+                return Err(crate::Error::Rpc {
+                    code: -32603,
+                    message: format!(
+                        "Fork session for '{}' exited immediately after resume with {}{}",
+                        name, status, stderr_summary
+                    ),
+                });
+            }
+
+            info!(
+                "Two-step fork for '{}': forked session {} created, now resumed",
+                name, sid
+            );
             sid
         } else {
             // Codex path: wait for the init event to discover the thread ID.

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -57,10 +57,13 @@ impl Platform {
 /// Always produces:
 /// - `--dangerously-skip-permissions`
 /// - `--model <model>`
-/// - `--setting-sources project,local`
 ///
 /// Conditionally adds:
 /// - `--add-dir` (for each additional directory)
+///
+/// Note: `--setting-sources` is NOT included here. It must be added by callers
+/// that need it. Fork sessions (`--resume --fork-session`) are incompatible with
+/// `--setting-sources`, so callers must decide based on their session type.
 fn build_claude_common_args(model: &str, additional_dirs: &[PathBuf]) -> Vec<String> {
     let mut args = vec!["--dangerously-skip-permissions".to_string()];
 
@@ -71,10 +74,6 @@ fn build_claude_common_args(model: &str, additional_dirs: &[PathBuf]) -> Vec<Str
             args.push(d.to_string());
         }
     }
-
-    // Setting sources — unconditional for all sessions
-    args.push("--setting-sources".to_string());
-    args.push("project,local".to_string());
 
     // Model selection
     args.push("--model".to_string());
@@ -113,11 +112,15 @@ fn build_codex_common_args(model: Option<&str>, additional_dirs: &[PathBuf]) -> 
 /// handles sandbox prefix + binary separately.
 ///
 /// Fresh sessions get: `-p`, `--append-system-prompt`, `--json-schema`,
-///   `--session-id` (when pre-assigned), `--settings`, `--setting-sources` (from common).
+///   `--session-id` (when pre-assigned), `--settings`, `--setting-sources`.
 ///
-/// Resume sessions get: `--resume <id>` and skip `--settings`/`--setting-sources`
-///   to avoid "Tool names must be unique" errors. Fork-resume sessions additionally
-///   get `--session-id <uuid>` so the daemon can register them without waiting for init.
+/// Resume sessions get: `--resume <id>`, `--setting-sources`, and skip `--settings`
+///   to avoid "Tool names must be unique" errors.
+///
+/// Fork-resume sessions get: `--resume <id>`, `--fork-session`, `--session-id <uuid>`,
+///   and skip both `--settings` and `--setting-sources` (the latter is incompatible
+///   with `--fork-session`). The two-step fork in `spawn_fork()` handles re-launching
+///   with full args after the fork is created.
 ///
 /// Both modes may include `--disallowedTools` (comma-separated) for hard tool
 /// restrictions that the LLM cannot bypass (e.g., channel lead code-edit blocks).
@@ -145,11 +148,21 @@ pub fn build_claude_headless_args(config: &HeadlessConfig) -> Vec<String> {
     } = config;
 
     let is_resume = resume_session_id.is_some();
+    let is_fork = is_resume && *fork_session;
 
     let mut args = build_claude_common_args(
         model,
         &[], // headless sessions don't use additional_dirs
     );
+
+    // Setting sources — skip for fork sessions because --setting-sources is
+    // incompatible with --resume --fork-session in the Claude CLI. The two-step
+    // fork process in spawn_fork() handles this: fork first with minimal args,
+    // then respawn as a normal resume where --setting-sources is safe.
+    if !is_fork {
+        args.push("--setting-sources".to_string());
+        args.push("project,local".to_string());
+    }
 
     if is_resume {
         // Resume mode: --resume <id>, no -p flag, no system prompt/schema
@@ -250,6 +263,10 @@ pub fn build_claude_headed_args(
         &config.model,
         &config.additional_dirs,
     ));
+
+    // Setting sources — always included for headed (interactive) sessions
+    args.push("--setting-sources".to_string());
+    args.push("project,local".to_string());
 
     // Session mode — exactly one of these
     let session_id = match &config.session_mode {

--- a/src/platform_tests.rs
+++ b/src/platform_tests.rs
@@ -67,16 +67,14 @@ fn test_claude_common_args_always_has_model() {
     assert!(args.contains(&"opus".to_string()));
 }
 
+/// `--setting-sources` is NOT in common args — it's added by callers conditionally
+/// because fork sessions (`--resume --fork-session`) are incompatible with it.
 #[test]
-fn test_claude_common_args_always_has_setting_sources() {
+fn test_claude_common_args_does_not_include_setting_sources() {
     let args = build_claude_common_args("sonnet", &[]);
     assert!(
-        args.contains(&"--setting-sources".to_string()),
-        "Common args must always include --setting-sources"
-    );
-    assert!(
-        args.contains(&"project,local".to_string()),
-        "Setting sources must be project,local"
+        !args.contains(&"--setting-sources".to_string()),
+        "Common args must NOT include --setting-sources (callers add it conditionally)"
     );
 }
 
@@ -307,6 +305,7 @@ fn test_claude_headless_args_has_common_flags() {
     // Common flags should be present
     assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
     assert!(args.contains(&"--model".to_string()));
+    // --setting-sources is added by build_claude_headless_args (not common), verified here
     assert!(args.contains(&"--setting-sources".to_string()));
 }
 
@@ -610,6 +609,39 @@ fn test_claude_headless_args_no_fork_session_without_flag() {
     assert!(
         !args.contains(&"--fork-session".to_string()),
         "--fork-session should NOT be present when fork_session is false"
+    );
+}
+
+/// Verify that fork sessions do NOT include `--setting-sources`, which is
+/// incompatible with `--resume --fork-session` in the Claude CLI.
+#[test]
+fn test_claude_headless_args_fork_session_skips_setting_sources() {
+    let config = HeadlessConfig {
+        resume_session_id: Some("session-abc".to_string()),
+        persist_session: true,
+        fork_session: true,
+        ..test_headless_config()
+    };
+    let args = build_claude_headless_args(&config);
+    assert!(
+        !args.contains(&"--setting-sources".to_string()),
+        "Fork sessions must NOT include --setting-sources (incompatible with --fork-session)"
+    );
+}
+
+/// Verify that normal (non-fork) resume sessions still include `--setting-sources`.
+#[test]
+fn test_claude_headless_args_normal_resume_has_setting_sources() {
+    let config = HeadlessConfig {
+        resume_session_id: Some("session-abc".to_string()),
+        persist_session: true,
+        fork_session: false,
+        ..test_headless_config()
+    };
+    let args = build_claude_headless_args(&config);
+    assert!(
+        args.contains(&"--setting-sources".to_string()),
+        "Normal resume sessions should include --setting-sources"
     );
 }
 


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Fork sessions were dying immediately because `--setting-sources project,local` is incompatible with `--resume --fork-session` in the Claude CLI
- Implements a two-step fork process: (1) fork with minimal args to create the session on disk, (2) kill and re-launch as a normal resume with full args
- Moves `--setting-sources` out of `build_claude_common_args()` into callers so fork sessions can skip it

## Changes
- **`src/platform.rs`**: `build_claude_common_args()` no longer adds `--setting-sources`; `build_claude_headless_args()` adds it conditionally (skipped for fork sessions); `build_claude_headed_args()` always adds it
- **`src/daemon/sessions.rs`**: `spawn_fork()` now implements two-step fork for Claude/Zai: fork → kill → resume
- **`src/platform_tests.rs`**: Updated existing tests, added `test_claude_headless_args_fork_session_skips_setting_sources` and `test_claude_headless_args_normal_resume_has_setting_sources`

## Test plan
- [x] New test verifies fork session args exclude `--setting-sources`
- [x] New test verifies normal resume args include `--setting-sources`
- [x] All 41 platform tests pass
- [x] `cargo clippy` passes with `-D warnings`
- [x] `cargo fmt` passes
- [ ] E2E: verify fork sessions launch successfully (requires running daemon)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)