### PR TITLE
fix(web): widen completed-check container so checkmark icon is visible [Midtown !2229]

### DIFF
--- a/web-app/src/lib/ThreadList.svelte
+++ b/web-app/src/lib/ThreadList.svelte
@@ -140,7 +140,7 @@ function handleDismiss(e, threadId) {
   }
 
   .completed-check {
-    width: 2px;
+    width: 14px;
     flex-shrink: 0;
     display: flex;
     align-items: center;


### PR DESCRIPTION
<!-- midtown: web -->

## Summary

- Fixed `.completed-check` CSS width from `2px` to `14px` in `ThreadList.svelte` — the narrow width (copied from `.accent-line` which is intentionally a thin vertical bar) was clipping the `Check` icon to an invisible green sliver

## Test plan

- [ ] Open the web UI with completed task threads in the sidebar
- [ ] Verify the checkmark glyph is visible (not just a green line)
- [ ] Verify alignment with non-completed thread accent lines

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)