### PR TITLE
fix(web): Restore new-message slide-in animation [Midtown !2235]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -109,6 +109,11 @@ let initialMessageCounts = $state.raw({});
 // `ch in initialMessageCounts` stays false, causing each new message to
 // schedule another microtask with a higher len — so isNewMessage() returns
 // false for genuinely new messages (the animation bug).
+//
+// Note: Unlike the sibling renderStartIndex effect (which uses a version
+// counter to allow re-scheduling on channel switch), this effect uses a
+// simple synchronous guard because we only ever need the *first* snapshot
+// per channel — subsequent runs should be ignored entirely, not re-queued.
 let pendingInitialCounts = {};
 
 $effect(() => {

--- a/web-app/src/lib/deferredState.test.js
+++ b/web-app/src/lib/deferredState.test.js
@@ -182,6 +182,50 @@ describe("initialMessageCounts — synchronous guard prevents race condition", (
 		expect(counts.web).toBe(100);
 	});
 
+	it("isNewMessage returns false during microtask window via Infinity fallback", async () => {
+		const counts = {}; // initialMessageCounts (async)
+		const pendingCounts = {}; // synchronous shadow
+
+		function fixedEffectRun(ch, len) {
+			if (!(ch in pendingCounts) && len > 0) {
+				pendingCounts[ch] = len;
+				const snapshotLen = len;
+				queueMicrotask(() => {
+					counts[ch] = snapshotLen;
+				});
+			}
+		}
+
+		// Mirrors Channel.svelte's isNewMessage()
+		function isNewMessage(channelName, index) {
+			const threshold = counts[channelName] ?? Infinity;
+			return index >= threshold;
+		}
+
+		// Before any effect runs: no entry → Infinity fallback → all "old"
+		expect(isNewMessage("web", 0)).toBe(false);
+		expect(isNewMessage("web", 999)).toBe(false);
+
+		// History loads with 100 messages — guard fires, microtask queued
+		fixedEffectRun("web", 100);
+
+		// During microtask window: counts["web"] is still undefined
+		// isNewMessage should return false (Infinity fallback)
+		expect(isNewMessage("web", 100)).toBe(false);
+		expect(isNewMessage("web", 101)).toBe(false);
+
+		// New message arrives — guard blocks, snapshot stays at 100
+		fixedEffectRun("web", 101);
+
+		// After microtask drains: counts["web"] = 100
+		await new Promise((r) => queueMicrotask(r));
+
+		// Now messages at index >= 100 are "new" and should animate
+		expect(isNewMessage("web", 99)).toBe(false);
+		expect(isNewMessage("web", 100)).toBe(true);
+		expect(isNewMessage("web", 101)).toBe(true);
+	});
+
 	it("synchronous guard works correctly across channel switches", async () => {
 		const counts = {};
 		const pendingCounts = {};


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Fix race condition in `initialMessageCounts` snapshotting that silently broke the slide-in animation for new messages
- Root cause: `queueMicrotask()` added in 4b531b4e (to fix `state_unsafe_mutation`) deferred the guard check, allowing re-entrant effect runs to bump the snapshot count higher when messages arrived during the microtask gap
- Add `pendingInitialCounts` synchronous shadow variable — same pattern as `pendingRenderStartIndex` in the sibling effect
- Add 4 tests documenting the race condition and verifying the fix

## Root Cause

The `initialMessageCounts` effect used `ch in initialMessageCounts` as its once-only guard, but the write was deferred via `queueMicrotask()`. When new messages arrived before the microtask fired:

1. History loads (100 msgs) → effect schedules microtask to set count=100
2. New message arrives → guard still passes (deferred write hasn't fired) → schedules count=101
3. Another message → schedules count=102
4. All microtasks fire → final count=102
5. `isNewMessage(ch, 100)` → `100 >= 102` → false → **no animation**

## Visual Changes

This PR restores a 180ms `fly` slide-in animation for new messages. The before/after difference is temporal (messages appear instantly vs sliding up), which cannot be captured in static screenshots.

## Test plan
- [x] New test: "BUG: without synchronous guard, new messages bump the snapshot count" — documents broken pattern
- [x] New test: "FIXED: synchronous guard captures first snapshot, ignores subsequent runs"
- [x] New test: "isNewMessage returns false during microtask window via Infinity fallback" — validates full chain
- [x] New test: "synchronous guard works correctly across channel switches"
- [x] All existing tests pass
- [x] Pre-commit hooks pass (clippy, fmt, biome)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)