### PR TITLE
refactor: DRY PR issue processing pipeline in pr.rs [Midtown !2246]

### DIFF
--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -881,6 +881,44 @@ async fn decide_and_build_pr_issue_effects(
     new_effects
 }
 
+#[allow(clippy::too_many_arguments)]
+/// Shared single-issue pipeline gate: cooldown check + decision/effect build.
+///
+/// `process_pr_issue_nudges` and `collect_green_with_feedback_effects` both
+/// run this same sequence once they identify an owner + issue for a PR.
+async fn maybe_decide_pr_issue_effects(
+    owner: &str,
+    pf: &PrFields<'_>,
+    issue_type: PrIssueType,
+    review_content: Option<&str>,
+    snap: &WorldSnapshot,
+    state: &DaemonState,
+    active_coworkers: &[String],
+    idle_coworkers: &[String],
+) -> Vec<Effect> {
+    let should_nudge = {
+        let tracker = state.pr_issue_tracker.lock().await;
+        tracker.should_nudge(pf.number, issue_type)
+    };
+
+    if !should_nudge {
+        return Vec::new();
+    }
+
+    decide_and_build_pr_issue_effects(
+        owner,
+        pf.number,
+        pf.title,
+        issue_type,
+        review_content,
+        snap,
+        state,
+        active_coworkers,
+        idle_coworkers,
+    )
+    .await
+}
+
 /// Process per-PR issue detection and generate nudge effects.
 ///
 /// For each non-draft PR: resolves the owner, detects actionable issues (merge
@@ -943,15 +981,6 @@ async fn process_pr_issue_nudges(
         };
 
         for issue_type in issues {
-            let should_nudge = {
-                let tracker = state.pr_issue_tracker.lock().await;
-                tracker.should_nudge(pf.number, issue_type)
-            };
-
-            if !should_nudge {
-                continue;
-            }
-
             let review_content = match issue_type {
                 PrIssueType::ChangesRequested | PrIssueType::Approved => {
                     fetch_review_content(pf.number).await
@@ -960,10 +989,9 @@ async fn process_pr_issue_nudges(
             };
 
             effects.extend(
-                decide_and_build_pr_issue_effects(
+                maybe_decide_pr_issue_effects(
                     &owner,
-                    pf.number,
-                    pf.title,
+                    &pf,
                     issue_type,
                     review_content.as_deref(),
                     snap,
@@ -1424,15 +1452,6 @@ async fn collect_green_with_feedback_effects(
             }
         }
 
-        // Check cooldown to avoid spamming
-        let should_nudge = {
-            let tracker = state.pr_issue_tracker.lock().await;
-            tracker.should_nudge(pr_number, PrIssueType::GreenWithFeedback)
-        };
-        if !should_nudge {
-            continue;
-        }
-
         // Use pre-fetched review content (fetched at the top of poll_prs_for_issues
         // to keep this function free of I/O — CLAUDE.md: "Decision functions are pure").
         let review_content = pre_fetched_review_content
@@ -1440,10 +1459,9 @@ async fn collect_green_with_feedback_effects(
             .map(|s| s.as_str());
 
         effects.extend(
-            decide_and_build_pr_issue_effects(
+            maybe_decide_pr_issue_effects(
                 &owner,
-                pr_number,
-                pf.title,
+                &pf,
                 PrIssueType::GreenWithFeedback,
                 review_content,
                 snap,

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -820,6 +820,101 @@ async fn test_orphaned_pr_with_task_branch_and_merge_conflict_is_ignored() {
     );
 }
 
+#[tokio::test]
+async fn test_maybe_decide_pr_issue_effects_skips_when_cooldown_active() {
+    use super::super::snapshot::minimal_snapshot_for_test;
+
+    let snap = minimal_snapshot_for_test();
+    let (state, _tmp, _guard) = make_test_state("test-repo");
+    let pr = json!({
+        "number": 4242,
+        "headRefName": "york/fix-auth",
+        "title": "Fix auth bug",
+        "body": "<!-- midtown: york -->",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": null,
+        "reviewDecision": null,
+        "isDraft": false,
+    });
+    let pf = PrFields::from_json(&pr);
+
+    {
+        let mut tracker = state.pr_issue_tracker.lock().await;
+        tracker.record_nudge(pf.number, PrIssueType::CiFailed);
+    }
+
+    let effects = maybe_decide_pr_issue_effects(
+        "york",
+        &pf,
+        PrIssueType::CiFailed,
+        None,
+        &snap,
+        &state,
+        &[],
+        &[],
+    )
+    .await;
+
+    assert!(
+        effects.is_empty(),
+        "Cooldown gate should skip decision/effect build when nudge is still active"
+    );
+}
+
+#[tokio::test]
+async fn test_collect_green_with_feedback_clears_cooldown_for_inactive_owner() {
+    use super::super::snapshot::minimal_snapshot_for_test;
+    use std::collections::{HashMap, HashSet};
+
+    let pr_number = 5151u64;
+    let pr = json!({
+        "number": pr_number,
+        "headRefName": "york/fix-ci",
+        "title": "Fix CI flake [Midtown !5151]",
+        "body": "<!-- midtown: york -->",
+        "isDraft": false,
+        "statusCheckRollup": [{"conclusion": "SUCCESS"}],
+        "reviewDecision": "CHANGES_REQUESTED",
+    });
+
+    let snap = minimal_snapshot_for_test();
+    let (state, _tmp, _guard) = make_test_state("test-repo");
+
+    {
+        let mut tracker = state.pr_issue_tracker.lock().await;
+        tracker.record_nudge(pr_number, PrIssueType::GreenWithFeedback);
+        assert!(
+            tracker.has_nudge(pr_number, PrIssueType::GreenWithFeedback),
+            "Precondition: GreenWithFeedback nudge should exist before collection"
+        );
+    }
+
+    let reviewed_prs: HashSet<u64> = [pr_number].into_iter().collect();
+    let effects = collect_green_with_feedback_effects(
+        &snap,
+        &state,
+        &[pr],
+        &reviewed_prs,
+        &[], // owner is inactive
+        &["york".to_string()],
+        &HashMap::new(),
+    )
+    .await;
+
+    {
+        let tracker = state.pr_issue_tracker.lock().await;
+        assert!(
+            !tracker.has_nudge(pr_number, PrIssueType::GreenWithFeedback),
+            "Collector should clear stale GreenWithFeedback cooldown when owner is inactive"
+        );
+    }
+
+    assert!(
+        !effects.is_empty(),
+        "After cooldown clear, green-with-feedback PR should proceed through shared decision pipeline"
+    );
+}
+
 /// Bug: After a daemon restart, worktree_branch_owners is empty because
 /// current_coworker is None for all worktree assignments. This causes
 /// collect_reviewer_effects_with_source to skip all PRs as "orphaned"


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- extracted a shared maybe_decide_pr_issue_effects helper to centralize the cooldown gate + issue decision/effect pipeline
- updated both process_pr_issue_nudges and collect_green_with_feedback_effects to use the shared helper, leaving them as thin filters/data-source wrappers
- added focused tests for the new cooldown gate helper and inactive-owner GreenWithFeedback cooldown clearing path

## Test plan
- cargo test test_maybe_decide_pr_issue_effects_skips_when_cooldown_active -- --nocapture
- cargo test test_collect_green_with_feedback_clears_cooldown_for_inactive_owner -- --nocapture
- cargo test test_poll_prs_session_based_owner_resolution -- --nocapture
- ./scripts/coverage-diff.sh

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)
