### PR TITLE
chore: release v0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -111,9 +111,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -525,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "coarsetime"
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "midtown"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "axum",
  "axum-server",
@@ -3838,9 +3838,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "midtown"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2024"
 description = "Midtown - a multi-Claude Code workspace manager, inspired by Gastown"
 license = "MIT"


### PR DESCRIPTION
<!-- midtown: midtown -->

## Summary

Bump version to v0.7.3. 30 commits since v0.7.2.

### Highlights

**Fork session overhaul:**
- Launch fork sessions as fresh sessions instead of `--fork-session` (#1985)
- Inject channel summary into fork initial context (#1986)
- Two-step fork launch to avoid `--setting-sources` incompatibility (#1958)
- E2E and unit test coverage for fork session lifecycle (#1973)

**Reviewer fixes:**
- Resume reviewer session on @mention instead of spawning fresh (#1987)
- Fix auth_provider for reviewer resume (#1988)
- Include escalation target in reviewer initial prompt (#1964)
- Cross-post reviewer findings to task thread (#1961)

**Web UI:**
- Collapse single tool calls and auto-hide channel post tool calls (#1965)
- Move completed threads to needs-attention sidebar section (#1966)
- Dedicated ReadBlock component for Read tool display (#1959)
- Restore new-message slide-in animation (#1967)
- Search result navigation race condition fix (#1963)
- Channel directory config UI (#1982)

**Platform simplification:**
- Remove AppleScript/Ghostty/iTerm pane-split logic (#1981)
- Remove portable_pty and simplify session attach to direct exec (#1977)

**Bug fixes:**
- Clean stale/orphaned worktree lifecycle (#1980)
- Exclude active session names from coworker name allocation (#1971)
- Transfer task_id and thread binding in spawn_coworker() (#1974)
- Thread insights under task announcement when task_channel is None (#1969)
- Request cancellation and error distinction to fetchChannelAgentsMd (#1984)

**Refactors:**
- DRY PR issue processing pipeline, PostToChannel boilerplate, spawn callbacks, process_lead_output, truncate_str (#1975-1979)

## Test plan
- [ ] CI passes (clippy, fmt, tests)
- [ ] `cargo install --path .` builds successfully
- [ ] Tag v0.7.3 after merge

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)