### PR TITLE
fix: Hide '0 tools used' pill for channel-post-only tool runs [Midtown !2257]

### DIFF
--- a/web-app/src/lib/ToolRunSummary.svelte
+++ b/web-app/src/lib/ToolRunSummary.svelte
@@ -65,7 +65,9 @@ function toggle() {
 }
 </script>
 
-{#if displayState === "collapsed"}
+{#if visibleToolCount === 0}
+	<!-- All tool blocks were filtered (e.g. channel posts) — render nothing -->
+{:else if displayState === "collapsed"}
 	<button
 		class="tool-run-summary"
 		onclick={toggle}


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- When all tool blocks in a tool run are `midtown channel post` commands, `filterChannelPosts()` removes them all, leaving `visibleToolCount` at 0. The component still rendered, showing a "0 tools used" pill.
- Added an early guard in `ToolRunSummary.svelte` to render nothing when `visibleToolCount === 0`.

## Test plan
- [x] Existing `toolRunGrouping.test.js` tests pass (31 tests)
- [x] Pre-commit hooks pass (clippy, fmt, biome)
- [ ] Verify in web UI that channel-post-only tool runs no longer show a pill

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)