### PR TITLE
fix: Remove dead toolCount prop from ToolRunSummary [Midtown !2258]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -820,7 +820,6 @@ function getToolCallStatusIcon(entry) {
           {#if segment.type === 'tool-run'}
             <ToolRunSummary
               messages={segment.messages}
-              toolCount={segment.toolCount}
               lastTimestamp={segment.lastTimestamp}
               allMessages={channelMessages}
               startIndex={renderStartIndex + segment._offset}

--- a/web-app/src/lib/ThreadPanel.svelte
+++ b/web-app/src/lib/ThreadPanel.svelte
@@ -682,7 +682,6 @@ let prevThreadId = null;
         {#if entry.type === 'tool-run'}
           <ToolRunSummary
             messages={entry.entries.map(e => e.data)}
-            toolCount={entry.toolCount}
             lastTimestamp={entry.lastTimestamp}
             allMessages={timelineMessages}
             startIndex={entry.entries[0].msgIndex}
@@ -842,7 +841,6 @@ let prevThreadId = null;
         {#if entry.type === 'tool-run'}
           <ToolRunSummary
             messages={entry.entries.map(e => e.data)}
-            toolCount={entry.toolCount}
             lastTimestamp={entry.lastTimestamp}
             allMessages={timelineMessages}
             startIndex={entry.entries[0].msgIndex}

--- a/web-app/src/lib/ToolRunSummary.svelte
+++ b/web-app/src/lib/ToolRunSummary.svelte
@@ -8,7 +8,6 @@ const TOOL_RUN_DELAY_MS = 10_000;
 
 let {
 	messages,
-	toolCount,
 	lastTimestamp,
 	allMessages = [],
 	startIndex = 0,
@@ -55,7 +54,7 @@ let visibleEntries = $derived.by(() =>
 		.filter(Boolean),
 );
 
-// Use visible tool count (after filtering channel posts) instead of raw toolCount
+// Count visible tools (after filtering channel posts like 'midtown channel post')
 let visibleToolCount = $derived(visibleEntries.reduce((sum, entry) => sum + (entry.msg.tool_data?.length || 0), 0));
 
 function toggle() {

--- a/web-app/src/lib/toolRunGrouping.js
+++ b/web-app/src/lib/toolRunGrouping.js
@@ -31,7 +31,7 @@ export function filterChannelPosts(toolData) {
  *
  * Returns an array of segments:
  *   { type: 'message', message }           — a normal message
- *   { type: 'tool-run', messages, toolCount, lastTimestamp } — 1+ consecutive tool-only messages
+ *   { type: 'tool-run', messages, lastTimestamp } — 1+ consecutive tool-only messages
  */
 export function groupToolRuns(messages) {
 	const segments = [];
@@ -39,11 +39,9 @@ export function groupToolRuns(messages) {
 
 	function flushRun() {
 		if (currentRun.length >= 1) {
-			const toolCount = currentRun.reduce((sum, m) => sum + (m.tool_data?.length || 0), 0);
 			segments.push({
 				type: "tool-run",
 				messages: currentRun,
-				toolCount,
 				lastTimestamp: currentRun[currentRun.length - 1].timestamp,
 			});
 		}
@@ -75,11 +73,9 @@ export function groupTimelineToolRuns(timeline) {
 
 	function flushRun() {
 		if (currentRun.length >= 1) {
-			const toolCount = currentRun.reduce((sum, e) => sum + (e.data.tool_data?.length || 0), 0);
 			segments.push({
 				type: "tool-run",
 				entries: currentRun,
-				toolCount,
 				lastTimestamp: currentRun[currentRun.length - 1].data.timestamp,
 			});
 		}

--- a/web-app/src/lib/toolRunGrouping.test.js
+++ b/web-app/src/lib/toolRunGrouping.test.js
@@ -138,7 +138,6 @@ describe("groupToolRuns", () => {
 		expect(groups).toHaveLength(1);
 		expect(groups[0].type).toBe("tool-run");
 		expect(groups[0].messages).toEqual(msgs);
-		expect(groups[0].toolCount).toBe(4);
 	});
 
 	it("creates a run from a single tool message", () => {
@@ -147,7 +146,6 @@ describe("groupToolRuns", () => {
 		expect(groups).toHaveLength(1);
 		expect(groups[0].type).toBe("tool-run");
 		expect(groups[0].messages).toEqual(msgs);
-		expect(groups[0].toolCount).toBe(1);
 	});
 
 	it("breaks runs on text messages", () => {
@@ -161,11 +159,9 @@ describe("groupToolRuns", () => {
 		const groups = groupToolRuns(msgs);
 		expect(groups).toHaveLength(3);
 		expect(groups[0].type).toBe("tool-run");
-		expect(groups[0].toolCount).toBe(2);
 		expect(groups[1].type).toBe("message");
 		expect(groups[1].message.id).toBe("3");
 		expect(groups[2].type).toBe("tool-run");
-		expect(groups[2].toolCount).toBe(2);
 	});
 
 	it("treats whitespace-only content as tool-only", () => {
@@ -200,9 +196,8 @@ describe("filterChannelPosts — visible tool count", () => {
 			},
 		];
 
-		// Raw toolCount from groupToolRuns includes the channel post
-		const groups = groupToolRuns(messages);
-		expect(groups[0].toolCount).toBe(2);
+		// groupToolRuns produces a valid group; visible count is computed in the component
+		groupToolRuns(messages);
 
 		// Visible count after filtering should be 1
 		const visibleToolCount = messages.reduce((sum, m) => sum + filterChannelPosts(m.tool_data).length, 0);
@@ -267,7 +262,6 @@ describe("groupTimelineToolRuns", () => {
 		const groups = groupTimelineToolRuns(entries);
 		expect(groups).toHaveLength(1);
 		expect(groups[0].type).toBe("tool-run");
-		expect(groups[0].toolCount).toBe(3);
 		expect(groups[0].entries).toEqual(entries);
 	});
 
@@ -276,7 +270,6 @@ describe("groupTimelineToolRuns", () => {
 		const groups = groupTimelineToolRuns(entries);
 		expect(groups).toHaveLength(1);
 		expect(groups[0].type).toBe("tool-run");
-		expect(groups[0].toolCount).toBe(1);
 		expect(groups[0].entries).toEqual(entries);
 	});
 
@@ -285,10 +278,8 @@ describe("groupTimelineToolRuns", () => {
 		const groups = groupTimelineToolRuns(entries);
 		expect(groups).toHaveLength(3);
 		expect(groups[0].type).toBe("tool-run"); // single tool, still grouped
-		expect(groups[0].toolCount).toBe(1);
 		expect(groups[1].type).toBe("edit");
 		expect(groups[2].type).toBe("tool-run"); // single tool, still grouped
-		expect(groups[2].toolCount).toBe(1);
 	});
 
 	it("text messages break tool runs", () => {
@@ -302,10 +293,8 @@ describe("groupTimelineToolRuns", () => {
 		const groups = groupTimelineToolRuns(entries);
 		expect(groups).toHaveLength(3);
 		expect(groups[0].type).toBe("tool-run");
-		expect(groups[0].toolCount).toBe(2);
 		expect(groups[1].type).toBe("message");
 		expect(groups[1].data.id).toBe("3");
 		expect(groups[2].type).toBe("tool-run");
-		expect(groups[2].toolCount).toBe(2);
 	});
 });


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Removed the unused `toolCount` prop from `ToolRunSummary.svelte` — it was superseded by the derived `visibleToolCount` (which counts tools after filtering channel-post blocks)
- Removed `toolCount` computation from `groupToolRuns()` and `groupTimelineToolRuns()` in `toolRunGrouping.js`
- Removed `toolCount={...}` pass-through from `Channel.svelte` and `ThreadPanel.svelte`
- Updated tests to no longer assert on the removed field

## Test plan
- [x] All 31 `toolRunGrouping.test.js` tests pass
- [x] Pre-commit hooks pass (clippy, fmt, biome)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)