### PR TITLE
fix: Set explicit channel name on main lead auto-output [Midtown !2263]

### DIFF
--- a/src/daemon/stream.rs
+++ b/src/daemon/stream.rs
@@ -101,7 +101,7 @@ pub fn extract_assistant_text(events: &[StreamEvent]) -> String {
 /// tool data (`ToolBlock`s) from tool_use/tool_result pairs and attaches them
 /// to the posted channel messages for client-side rendering.
 ///
-/// - The main lead's text and tool data are posted to the main channel (`channel: None`).
+/// - The main lead's text and tool data are posted to the main channel (project name).
 /// - Each channel lead's text and tool data are posted to its respective topic channel.
 /// - Fork sessions' text and tool data are posted to their bound topic channels.
 /// - Coworker text is handled separately by [`process_agent_output()`].
@@ -115,13 +115,13 @@ pub fn process_lead_output(
 ) -> Vec<Effect> {
     let mut effects = Vec::new();
 
-    // Main lead → posts to main channel.
+    // Main lead → posts to main channel (project name = default channel name).
     if let Some(lead_events) = events.get(main_lead_session_name) {
         push_lead_output_effects(
             &mut effects,
             lead_events,
             main_lead_session_name.to_string(),
-            None,
+            Some(main_lead_session_name.to_string()),
         );
     }
 

--- a/src/daemon/stream_tests.rs
+++ b/src/daemon/stream_tests.rs
@@ -348,7 +348,7 @@ fn test_process_lead_output_returns_post_effect() {
         } => {
             assert_eq!(sender, "myproject");
             assert_eq!(message, "Hello from lead");
-            assert!(channel.is_none());
+            assert_eq!(channel.as_deref(), Some("myproject"));
             assert!(auto_output, "stream output should be auto_output");
         }
         _ => panic!("Expected PostToChannel effect"),
@@ -413,6 +413,84 @@ fn test_process_lead_output_empty_text_posts_tool_data_only() {
             assert!(tool_data.is_some(), "should have tool_data");
         }
         _ => panic!("Expected PostToChannel with tool_data"),
+    }
+}
+
+// ── main lead channel name tests ────────────────────────────────────
+
+#[test]
+fn test_process_lead_output_main_lead_sets_channel_to_project_name() {
+    // Bug regression: main lead auto-output was posted with channel: None,
+    // causing Message::channel_name() to default to hardcoded "midtown".
+    // For projects NOT named "midtown", WebSocket broadcasts sent the wrong
+    // channel name, so real-time messages disappeared in the frontend.
+    let mut events = HashMap::new();
+    events.insert(
+        "myproject".to_string(),
+        vec![StreamEvent::Assistant {
+            message: json!({
+                "content": [{"type": "text", "text": "Hello from lead"}]
+            }),
+            session_id: None,
+            extra: json!(null),
+        }],
+    );
+
+    let effects = process_lead_output(&events, &HashMap::new(), "myproject", &HashMap::new());
+    assert_eq!(effects.len(), 1);
+
+    match &effects[0] {
+        Effect::PostToChannel {
+            sender,
+            message,
+            channel,
+            auto_output,
+            ..
+        } => {
+            assert_eq!(sender, "myproject");
+            assert_eq!(message, "Hello from lead");
+            assert_eq!(
+                channel.as_deref(),
+                Some("myproject"),
+                "Main lead channel should be set to project name, not None"
+            );
+            assert!(auto_output, "stream output should be auto_output");
+        }
+        _ => panic!("Expected PostToChannel effect"),
+    }
+}
+
+#[test]
+fn test_process_lead_output_main_lead_tool_data_sets_channel() {
+    // Tool-data-only effects for the main lead should also have the channel set.
+    let mut events = HashMap::new();
+    events.insert(
+        "myproject".to_string(),
+        vec![StreamEvent::Assistant {
+            message: json!({
+                "content": [{
+                    "type": "tool_use",
+                    "id": "tc_1",
+                    "name": "Read",
+                    "input": {"file_path": "src/main.rs"}
+                }]
+            }),
+            session_id: None,
+            extra: json!(null),
+        }],
+    );
+
+    let effects = process_lead_output(&events, &HashMap::new(), "myproject", &HashMap::new());
+    assert_eq!(effects.len(), 1);
+    match &effects[0] {
+        Effect::PostToChannel { channel, .. } => {
+            assert_eq!(
+                channel.as_deref(),
+                Some("myproject"),
+                "Main lead tool_data channel should also be set"
+            );
+        }
+        _ => panic!("Expected PostToChannel effect"),
     }
 }
 
@@ -593,7 +671,11 @@ fn test_process_lead_output_main_and_channel_lead_both_post() {
         .find(|e| matches!(e, Effect::PostToChannel { sender, .. } if sender == "lead"));
     assert!(main_effect.is_some());
     if let Some(Effect::PostToChannel { channel, .. }) = main_effect {
-        assert!(channel.is_none(), "Main lead posts to main channel");
+        assert_eq!(
+            channel.as_deref(),
+            Some("lead"),
+            "Main lead posts to main channel"
+        );
     }
 
     let cl_effect = effects
@@ -712,7 +794,11 @@ fn test_process_lead_output_tool_data_populated_for_main_lead() {
         } => {
             assert_eq!(sender, "lead");
             assert_eq!(message, "");
-            assert!(channel.is_none(), "Main lead posts to main channel");
+            assert_eq!(
+                channel.as_deref(),
+                Some("lead"),
+                "Main lead posts to main channel"
+            );
             assert!(*auto_output);
             let blocks = tool_data.as_ref().expect("should have tool_data");
             assert_eq!(blocks.len(), 1);


### PR DESCRIPTION
<!-- midtown: mercer -->

## Summary
- Main lead auto-output was created with `channel: None` in `push_lead_output_effects` (stream.rs:124)
- The channel router wrote to disk correctly (defaulting to project name), but the WebSocket broadcast sent the original Message with `channel: None`
- `Message::channel_name()` falls back to hardcoded `"midtown"` — wrong for projects not named "midtown"
- Fix: pass `Some(main_lead_session_name)` as the channel, matching the pattern already used by channel leads and fork sessions

## Changes
- **stream.rs**: Pass explicit channel name (`Some(main_lead_session_name)`) for main lead auto-output instead of `None`
- **stream_tests.rs**: Added 2 regression tests verifying channel is set; updated 3 existing tests that asserted the old buggy `None` behavior

## Test plan
- [x] 2 new regression tests pass (text + tool_data channel verification)
- [x] All 85 stream tests pass
- [x] Full test suite passes (2663 tests, 19 pre-existing sandbox failures unrelated)
- [x] Clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)