### PR TITLE
fix: Resolve auth_provider from agent definition model override [Midtown !2264]

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -262,6 +262,10 @@ Review source strategy is controlled separately by `execution.review_mode`:
 
 This means `lead_provider` acts as a shared fallback for both the Project Lead and Channel Leads. Setting `project_lead_provider` overrides only the Project Lead's provider without affecting channel leads, and vice versa for `channel_lead_provider`. The resolved provider is stored in `LaunchConfig.auth_provider` and is also used to derive the default model via `default_model_for_provider_role()`.
 
+**Agent definition model overrides:** When `coworker call-in --agent <name>` specifies an agent definition with a `model` field, the call-in handler (`rpc_coworker.rs`) resolves the auth_provider from the model alias via `provider_for_model_alias()` before building the `LaunchConfig`. This ensures the model and provider are consistent — without it, `spawn_coworker()` would silently normalize the model to match the caller's provider via `normalize_model_for_provider_role()`, defeating the agent definition's model intent.
+
+**Agent definitions** (`src/agent_definition.rs`): Markdown files with YAML frontmatter (name, description, model) and a system prompt body. Searched in `.claude/agents/{name}.md` (project-level) then `~/.claude/agents/{name}.md` (user-level). The parsed `AgentDefinition.model` feeds into provider resolution, and the body becomes the coworker's system prompt.
+
 ## Channel Leads
 
 Channel leads are headless Claude Code sessions attached to individual topic channels. They are on-demand domain experts — spawned when triggered, shut down when idle, and resumed within a daemon run.

--- a/src/agent_definition.rs
+++ b/src/agent_definition.rs
@@ -93,6 +93,17 @@ pub fn parse_agent_file(path: &Path) -> Result<AgentDefinition, String> {
     parse_agent_content(&content, path)
 }
 
+/// Strip surrounding YAML quotes (`"` or `'`) from a value string.
+fn strip_yaml_quotes(s: &str) -> String {
+    if s.len() >= 2
+        && ((s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')))
+    {
+        s[1..s.len() - 1].to_string()
+    } else {
+        s.to_string()
+    }
+}
+
 /// Parse agent definition content (testable without filesystem).
 fn parse_agent_content(content: &str, source_path: &Path) -> Result<AgentDefinition, String> {
     let trimmed = content.trim_start();
@@ -140,7 +151,7 @@ fn parse_agent_content(content: &str, source_path: &Path) -> Result<AgentDefinit
         }
         if let Some((key, value)) = line.split_once(':') {
             let key = key.trim();
-            let value = value.trim();
+            let value = strip_yaml_quotes(value.trim());
             match key {
                 "name" => name = Some(value.to_string()),
                 "description" => description = Some(value.to_string()),

--- a/src/agent_definition_tests.rs
+++ b/src/agent_definition_tests.rs
@@ -142,3 +142,63 @@ Review the code carefully."#;
     assert!(def.description.unwrap().contains("reviewing pull requests"));
     assert_eq!(def.model.as_deref(), Some("sonnet"));
 }
+
+#[test]
+fn test_body_with_horizontal_rules_preserved() {
+    let content = r#"---
+name: test-agent
+---
+
+First paragraph.
+
+---
+
+Second paragraph after horizontal rule.
+
+---
+
+Third paragraph."#;
+
+    let def = parse_agent_content(content, Path::new("/tmp/test-agent.md")).unwrap();
+    assert!(
+        def.system_prompt.contains("Second paragraph"),
+        "Body should preserve content after horizontal rules"
+    );
+    assert!(
+        def.system_prompt.contains("Third paragraph"),
+        "Body should preserve all content after multiple horizontal rules"
+    );
+}
+
+#[test]
+fn test_quoted_model_value_stripped() {
+    let content = r#"---
+name: test
+model: "opus"
+---
+
+Prompt."#;
+
+    let def = parse_agent_content(content, Path::new("/tmp/test.md")).unwrap();
+    assert_eq!(
+        def.model.as_deref(),
+        Some("opus"),
+        "Quoted model value should have quotes stripped"
+    );
+}
+
+#[test]
+fn test_single_quoted_values_stripped() {
+    let content = r#"---
+name: 'my-agent'
+description: 'A test agent'
+model: 'sonnet'
+---
+
+Prompt."#;
+
+    let def = parse_agent_content(content, Path::new("/tmp/test.md")).unwrap();
+    assert_eq!(def.name, "my-agent");
+    assert_eq!(def.description.as_deref(), Some("A test agent"));
+    assert_eq!(def.model.as_deref(), Some("sonnet"));
+}

--- a/src/daemon/rpc_coworker.rs
+++ b/src/daemon/rpc_coworker.rs
@@ -157,7 +157,15 @@ pub(super) async fn handle_coworker_spawn(
 
             // Register thread binding so the coworker's channel posts
             // are automatically routed to the specified thread.
+            // Note: DM channels skip fork_bound_threads (see rpc_channel.rs and effects.rs),
+            // so thread binding is silently ignored for dm-* channels.
             if let Some(ref tid) = thread {
+                if channel.as_deref().is_some_and(|c| c.starts_with("dm-")) {
+                    warn!(
+                        "Thread binding for {} ignored: DM channels do not use fork_bound_threads",
+                        config.name
+                    );
+                }
                 // In-memory binding for immediate routing
                 state
                     .fork_bound_threads


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- When an agent definition specifies a model (e.g., `model: opus`), the coworker call-in path now resolves the correct `auth_provider` from the model alias before building the `LaunchConfig`
- Adds `provider_for_model_alias()` helper that maps model aliases to their provider (opus/sonnet/haiku → Claude, gpt-*/o3/o4 → Codex)
- Size aliases (small/medium/large) are provider-agnostic and preserve the passed-in provider
- Same fix pattern as PR #1988 (reviewer resume auth_provider resolution)

**Note:** This PR includes a cherry-pick of the agent definition code from PR #1993 (!2262) as a base, since the auth_provider fix applies to that code path.

Found during review of PR #1993 by amsterdam.

## Test plan
- [x] `provider_for_model_alias` unit tests for Claude models (opus, sonnet, haiku)
- [x] `provider_for_model_alias` unit tests for Codex models (gpt-5-codex, o3, o4-mini)
- [x] `provider_for_model_alias` returns None for size aliases (small/medium/large)
- [x] `provider_for_model_alias` returns None for unknown models
- [x] Integration test: agent with `model: opus` resolves to Claude provider
- [x] Integration test: agent with `model: large` keeps passed-in provider
- [x] Integration test: no agent model keeps passed-in provider
- [x] All existing helpers tests pass (122/122)
- [x] Clippy clean, fmt check passes

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)