### PR TITLE
[Midtown !2263] fix: Use resolved channel name in WebSocket broadcast for main lead

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -2392,7 +2392,17 @@ impl DaemonState {
             ));
         }
 
-        self.broadcast_web_update(web::channel_message_update(message));
+        // Broadcast with the resolved channel name so WebSocket clients route
+        // the message to the correct frontend channel bucket.  The channel
+        // router already resolved `None` → the project's main channel name,
+        // but `message.channel` may still be `None` (main lead auto-output).
+        if message.channel.is_none() {
+            let mut resolved = message.clone();
+            resolved.channel = Some(send_result.channel_name.clone());
+            self.broadcast_web_update(web::channel_message_update(&resolved));
+        } else {
+            self.broadcast_web_update(web::channel_message_update(message));
+        }
 
         Ok(())
     }

--- a/src/web_tests.rs
+++ b/src/web_tests.rs
@@ -1848,3 +1848,37 @@ async fn test_channel_directory_rejects_nonexistent_directory() {
     .await;
     assert_eq!(result.unwrap_err(), StatusCode::BAD_REQUEST);
 }
+
+/// Regression test: main lead auto-output messages have `channel: None`, and
+/// `channel_name()` falls back to hardcoded "midtown".  Before the fix in
+/// `send_and_broadcast_async`, the WebSocket broadcast would always send
+/// "midtown" regardless of the actual project name.  The fix sets
+/// `message.channel` to the resolved name from the channel router before
+/// broadcasting.  This test verifies the contract: when a caller resolves
+/// the channel and sets it on the message, the broadcast carries the
+/// correct project-specific channel name.
+#[test]
+fn test_channel_message_update_resolved_channel_overrides_default() {
+    // Simulate what send_and_broadcast_async now does: resolve None → actual project name
+    let mut msg = crate::message::Message::text("midtown", "lead output");
+    assert!(
+        msg.channel.is_none(),
+        "main lead messages start with channel: None"
+    );
+
+    // Before fix: channel_name() returns "midtown" regardless of project
+    assert_eq!(msg.channel_name(), "midtown");
+
+    // After fix: send_and_broadcast_async sets the resolved channel
+    msg.channel = Some("my-custom-project".to_string());
+    let update = channel_message_update(&msg);
+    match update {
+        WebUpdate::ChannelMessage(data) => {
+            assert_eq!(
+                data.channel, "my-custom-project",
+                "WebSocket broadcast must use the resolved channel name, not the hardcoded default"
+            );
+        }
+        _ => panic!("Expected ChannelMessage update"),
+    }
+}


### PR DESCRIPTION
<!-- midtown: mercer -->

## Summary

- Main lead auto-output creates `PostToChannel` effects with `channel: None`. The channel router writes to disk correctly, but the WebSocket broadcast via `channel_message_update` calls `message.channel_name()` which defaults to hardcoded `"midtown"`. For projects not named "midtown", real-time messages go to the wrong frontend channel bucket — messages appear on refresh but not in real-time.
- Fix: In `send_and_broadcast_async`, when the message's channel is `None`, clone the message and set the channel to the resolved name from the channel router's `SendResult` before broadcasting.
- Added regression test verifying that resolved channel names propagate through `channel_message_update`.

## Test plan

- [x] Unit test `test_channel_message_update_resolved_channel_overrides_default` passes
- [x] `cargo clippy` clean
- [ ] Verify in a non-"midtown" project that main lead messages appear in real-time via WebSocket

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)