### PR TITLE
fix: Invert RPC cache from skip-list to whitelist of cacheable methods [Midtown !2266]

### DIFF
--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -204,30 +204,45 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
     let request_id_for_cache = request.id.clone();
     let request_method = request.method.clone();
 
-    // Methods that must bypass the RPC idempotency cache fall into two categories:
+    // Whitelist of methods eligible for RPC idempotency caching.
     //
-    // 1. Read methods with their own domain-specific caching (prs.status,
-    //    coworkers.status) — the idempotency cache would shadow their own TTL caches
-    //    because the web server reuses id=1 for repeated polls.
+    // Only pure read-only methods that do NOT have their own domain-specific
+    // caching belong here. Everything else (mutating methods, methods with
+    // their own cache) must be excluded to avoid two problems:
     //
-    // 2. Mutating methods (auth.switch, auth.pool-toggle) — the web layer sends id=1
-    //    for every call, so two successive requests with different params (e.g., enable
-    //    then disable within 60s) would share the same cache key and the second call
-    //    would incorrectly return the first call's cached response without executing.
-    let skip_rpc_cache = matches!(
+    // 1. The web layer sends id=1 for every call, so two successive mutating
+    //    requests within 60s would share the same cache key and the second
+    //    call would return a stale cached response instead of executing.
+    //
+    // 2. Methods with domain-specific caching (prs.status, coworkers.status)
+    //    would have their own TTL logic shadowed by this cache.
+    //
+    // Using a whitelist (rather than a skip-list) ensures new methods default
+    // to uncached, which is always safe.
+    let use_rpc_cache = matches!(
         request_method.as_str(),
-        "prs.status"
-            | "coworkers.status"
-            | "auth.switch"
-            | "auth.pool-toggle"
-            | "pr.review"
-            | "pr.review-post"
-            | "pr.merge"
-            | "pr.allow"
+        "ping"
+            | "version"
+            | "status"
+            | "snapshot"
+            | "channel.read"
+            | "channel.list"
+            | "task.metadata"
+            | "reminder.list"
+            | "workflow.list"
+            | "workflow.get_state"
+            | "session.resolve"
+            | "session.list"
+            | "session.view"
+            | "session.thread_ownership"
+            | "coworker.list"
+            | "coworker.view"
+            | "coworker.questions"
+            | "pr.list-external"
     );
 
     // Check cache for idempotent response (within 60 second TTL)
-    if !skip_rpc_cache {
+    if use_rpc_cache {
         let now = std::time::Instant::now();
         let cache = state.rpc_response_cache.lock().await;
         if let Some((cached_response, timestamp)) = cache.get(&request_id_for_cache)
@@ -249,7 +264,7 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
     // failures (e.g., invalid params due to race conditions) without getting
     // a stale cached error.
     // Methods with domain-specific caching (e.g., prs.status) are excluded.
-    if !skip_rpc_cache && !response.is_error() {
+    if use_rpc_cache && !response.is_error() {
         let mut cache = state.rpc_response_cache.lock().await;
         cache.insert(
             request_id_for_cache,

--- a/src/daemon/rpc_tests.rs
+++ b/src/daemon/rpc_tests.rs
@@ -268,3 +268,105 @@ fn test_rpc_cache_numeric_id_collision() {
         "PID-prefixed string IDs from different processes should NOT collide"
     );
 }
+
+/// Verify that known mutating methods are NOT in the RPC cache whitelist.
+///
+/// The `use_rpc_cache` whitelist in `handle_request` must exclude all mutating
+/// methods. If a mutating method were cached, the web layer (which sends id=1
+/// for every call) could return stale responses instead of executing the mutation.
+/// This test guards against regressions where a new mutating method is
+/// accidentally added to the whitelist.
+#[test]
+fn test_mutating_methods_excluded_from_rpc_cache() {
+    // Helper that mirrors the use_rpc_cache logic in handle_request
+    fn is_cacheable(method: &str) -> bool {
+        matches!(
+            method,
+            "ping"
+                | "version"
+                | "status"
+                | "snapshot"
+                | "channel.read"
+                | "channel.list"
+                | "task.metadata"
+                | "reminder.list"
+                | "workflow.list"
+                | "workflow.get_state"
+                | "session.resolve"
+                | "session.list"
+                | "session.view"
+                | "session.thread_ownership"
+                | "coworker.list"
+                | "coworker.view"
+                | "coworker.questions"
+                | "pr.list-external"
+        )
+    }
+
+    let mutating_methods = [
+        "shutdown",
+        "daemon.exec-restart",
+        "daemon.set-draining",
+        "daemon.check-pending",
+        "coworker.stop_all",
+        "coworker.spawn",
+        "coworker.break",
+        "coworker.report-state",
+        "coworker.nudge",
+        "coworker.asking",
+        "lead.spawn",
+        "oneshot.execute",
+        "channel.post",
+        "channel.create",
+        "channel.archive",
+        "channel.unarchive",
+        "channel.rename",
+        "task.create",
+        "task.update",
+        "task.done",
+        "task.request",
+        "task.claim",
+        "reminder.create",
+        "reminder.cancel",
+        "workflow.assign",
+        "workflow.unassign",
+        "workflow.set_state",
+        "auth.switch",
+        "auth.pool-toggle",
+        "pr.review",
+        "pr.review-post",
+        "pr.merge",
+        "pr.auto-merge",
+        "pr.allow",
+        "session.attach",
+        "session.detach",
+        "session.clear",
+        "session.fork",
+        "session.fork_thread",
+        "session.unfork_thread",
+        "headed.register",
+        "headed.unregister",
+        "headed.heartbeat",
+        "headed.ack",
+        "headed.output",
+        "headed.enqueue",
+    ];
+
+    for method in &mutating_methods {
+        assert!(
+            !is_cacheable(method),
+            "Mutating method '{}' must NOT be in the RPC cache whitelist",
+            method
+        );
+    }
+
+    // Also verify read-only methods with their own caching are excluded
+    let domain_cached_methods = ["prs.status", "coworkers.status"];
+    for method in &domain_cached_methods {
+        assert!(
+            !is_cacheable(method),
+            "Domain-cached method '{}' must NOT be in the RPC cache whitelist",
+            method
+        );
+    }
+}


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Inverted the RPC idempotency cache from a blacklist (`skip_rpc_cache`) to a whitelist (`use_rpc_cache`) of cacheable read-only methods
- The previous skip-list only covered 8 methods but missed 30+ mutating methods (`coworker.spawn`, `task.create`, `channel.post`, `session.fork`, etc.)
- Since the web layer sends `id=1` for every RPC call, uncovered mutating methods could return stale cached responses instead of executing
- The whitelist approach ensures new methods default to uncached, which is always safe — no more regressions when adding new RPC methods

## Coverage note
The changed lines in `handle_request` are in an async function requiring full `DaemonState`, which can't be unit-tested directly. The whitelist logic is validated by a mirrored `matches!` in the new `test_mutating_methods_excluded_from_rpc_cache` test, and end-to-end cache behavior is covered by `tests/rpc_idempotency_e2e.rs`.

## Test plan
- [x] New unit test `test_mutating_methods_excluded_from_rpc_cache` verifies all 46 mutating methods are excluded from the cache whitelist
- [x] Existing cache unit tests pass (TTL, cleanup, success-only caching, numeric ID collision)
- [x] `cargo clippy` passes clean
- [x] `cargo fmt` passes

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)