### PR TITLE
fix: Channel lead avatar color in reply indicators [Midtown !2275]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -910,7 +910,7 @@ function getToolCallStatusIcon(entry) {
                       {#each participants as p}
                         <span
                           class="thread-avatar-chip"
-                          style="background-color: {getSenderColor(p)}"
+                          style="background-color: {getSenderColor(p, undefined, $activeChannel)}"
                           title={p}
                         >{p[0].toUpperCase()}</span>
                       {/each}


### PR DESCRIPTION
<!-- midtown: spring -->

## Summary

- Thread participant avatars called `getSenderColor(p)` without the `channelName` parameter, so channel leads fell through to the gray default (`#d0d0d0`) instead of getting their mustard color (`AVENUE_COLORS.lead`)
- Fix: pass `$activeChannel` as the third argument so channel lead names are matched correctly

## Test plan

- [ ] Open a channel with a channel lead (e.g., #ops)
- [ ] Find a thread with replies from the channel lead
- [ ] Verify the thread reply indicator shows the lead's avatar in mustard, not gray

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)