### PR TITLE
fix: Pass channelName to getSenderColor in thread reply indicators [Midtown !2275]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -910,7 +910,7 @@ function getToolCallStatusIcon(entry) {
                       {#each participants as p}
                         <span
                           class="thread-avatar-chip"
-                          style="background-color: {getSenderColor(p)}"
+                          style="background-color: {getSenderColor(p, undefined, $activeChannel)}"
                           title={p}
                         >{p[0].toUpperCase()}</span>
                       {/each}


### PR DESCRIPTION
<!-- midtown: spring -->

## Summary

- Thread participant avatar chips in `Channel.svelte` called `getSenderColor(p)` without the `channelName` argument, causing channel leads to render with the default gray (`#d0d0d0`) instead of the mustard lead color
- Added `$activeChannel` as the third argument to match how `MessageRow.svelte` already calls `getSenderColor`

## Visual change

Fixes channel lead avatar color in thread reply indicators (gray → mustard). Screenshots not available from headless worktree — the change is a single argument addition matching an established pattern.

## Test plan

- [ ] Verify channel lead avatars in thread reply indicators show mustard instead of gray
- [ ] Verify non-lead coworker avatars remain their assigned colors

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)