### PR TITLE
fix: Pass channelName to getSenderColor in thread reply avatars [Midtown !2275]

### DIFF
--- a/web-app/src/lib/Channel.svelte
+++ b/web-app/src/lib/Channel.svelte
@@ -910,7 +910,7 @@ function getToolCallStatusIcon(entry) {
                       {#each participants as p}
                         <span
                           class="thread-avatar-chip"
-                          style="background-color: {getSenderColor(p)}"
+                          style="background-color: {getSenderColor(p, undefined, $activeChannel)}"
                           title={p}
                         >{p[0].toUpperCase()}</span>
                       {/each}


### PR DESCRIPTION
<!-- midtown: spring -->

## Summary

- Thread participant avatar chips in reply indicators called `getSenderColor(p)` without the `channelName` argument, so channel leads displayed gray instead of their mustard color
- Added `$activeChannel` as third arg, matching the pattern already used in `MessageRow.svelte`

## Visual change

This fixes channel lead avatar color in thread reply indicators (gray → mustard). Screenshots not available from headless worktree — the change is a single argument addition matching an established pattern.

## Test plan

- [ ] Open a channel where the channel lead has posted thread replies
- [ ] Verify the reply indicator avatar chip shows mustard (not gray) for the channel lead
- [ ] Verify coworker avatar colors are unaffected

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)