### PR TITLE
fix: Include completedTasks in CoworkerStatus task lookup [Midtown !2277]

### DIFF
--- a/web-app/src/lib/CoworkerStatus.svelte
+++ b/web-app/src/lib/CoworkerStatus.svelte
@@ -88,7 +88,7 @@ function getPrUrl(prNumber) {
 }
 
 function openTaskDetail(taskId) {
-	const allTasks = [...$kanbanData.inProgress, ...$kanbanData.backlog];
+	const allTasks = [...$kanbanData.inProgress, ...$kanbanData.backlog, ...($kanbanData.completedTasks || [])];
 	const task = allTasks.find((t) => String(t.id) === String(taskId));
 	if (task) {
 		openTaskThread(task, task.channel || "midtown");


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Fixed `CoworkerStatus.openTaskDetail` to include `completedTasks` in its task lookup, so clicking a completed task from the coworker status panel correctly opens its thread
- The original bug (`openTaskThread` in `api.ts` using `done` (MergedPullRequest[]) instead of `completedTasks` (Task[])) was already fixed by the TypeScript migration in PR #2016 — the type checker caught the mismatch
- This PR fixes the same pattern in `CoworkerStatus.svelte` which was missed

## Test plan
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] All 367 web-app tests pass
- [x] Verified `openTaskThread` in `api.ts` already correctly uses `completedTasks`

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)