### PR TITLE
feat: Add agent definition installation to midtown start and update [Midtown !2284]

### DIFF
--- a/src/bin/midtown/cli/agents_install.rs
+++ b/src/bin/midtown/cli/agents_install.rs
@@ -1,0 +1,94 @@
+//! Agent definition installation.
+//!
+//! Installs compiled-in agent definition files to `~/.claude/agents/` so that
+//! Claude Code can load them via the `--agent` flag. Called from `midtown start`
+//! (first-run install) and `midtown update` (upgrade install).
+
+use std::fs;
+use std::path::Path;
+
+/// A compiled-in agent definition file.
+#[derive(Debug)]
+pub struct AgentDefinition {
+    pub filename: &'static str,
+    pub content: &'static str,
+}
+
+/// All agent definitions compiled into the binary.
+pub static AGENT_DEFINITIONS: &[AgentDefinition] = &[
+    AgentDefinition {
+        filename: "midtown-code-author.md",
+        content: include_str!("../../../../agents/definitions/midtown-code-author.md"),
+    },
+    AgentDefinition {
+        filename: "midtown-code-reviewer.md",
+        content: include_str!("../../../../agents/definitions/midtown-code-reviewer.md"),
+    },
+    AgentDefinition {
+        filename: "midtown-project-lead.md",
+        content: include_str!("../../../../agents/definitions/midtown-project-lead.md"),
+    },
+    AgentDefinition {
+        filename: "midtown-channel-lead.md",
+        content: include_str!("../../../../agents/definitions/midtown-channel-lead.md"),
+    },
+];
+
+/// Install agent definitions to the given directory.
+///
+/// Returns the list of definitions that were written.
+/// - Without `force`: only writes files that don't already exist.
+/// - With `force`: overwrites all files regardless.
+pub fn install_agent_definitions(
+    agents_dir: &Path,
+    force: bool,
+) -> Result<Vec<&'static AgentDefinition>, String> {
+    fs::create_dir_all(agents_dir).map_err(|e| {
+        format!(
+            "Failed to create agents directory {}: {e}",
+            agents_dir.display()
+        )
+    })?;
+
+    let mut installed = Vec::new();
+
+    for def in AGENT_DEFINITIONS {
+        let path = agents_dir.join(def.filename);
+        if !force && path.exists() {
+            continue;
+        }
+        fs::write(&path, def.content)
+            .map_err(|e| format!("Failed to write {}: {e}", path.display()))?;
+        installed.push(def);
+    }
+
+    Ok(installed)
+}
+
+/// Check which installed agent definitions differ from the compiled-in versions.
+///
+/// Returns definitions that are either missing or have different content.
+pub fn check_agent_definitions_outdated(agents_dir: &Path) -> Vec<&'static AgentDefinition> {
+    AGENT_DEFINITIONS
+        .iter()
+        .filter(|def| {
+            let path = agents_dir.join(def.filename);
+            match fs::read_to_string(&path) {
+                Ok(content) => content != def.content,
+                Err(_) => true, // missing file counts as outdated
+            }
+        })
+        .collect()
+}
+
+/// Return the default Claude Code agents directory (`~/.claude/agents/`).
+pub fn claude_agents_dir() -> std::path::PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join(".claude")
+        .join("agents")
+}
+
+#[path = "agents_install_tests.rs"]
+#[cfg(test)]
+mod tests;

--- a/src/bin/midtown/cli/agents_install_tests.rs
+++ b/src/bin/midtown/cli/agents_install_tests.rs
@@ -1,0 +1,178 @@
+use super::{AGENT_DEFINITIONS, check_agent_definitions_outdated, install_agent_definitions};
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn install_writes_files_when_they_dont_exist() {
+    let tmp = TempDir::new().unwrap();
+    let agents_dir = tmp.path().join("agents");
+
+    let result = install_agent_definitions(&agents_dir, false);
+    assert!(result.is_ok(), "install should succeed: {:?}", result);
+
+    let installed = result.unwrap();
+    assert_eq!(
+        installed.len(),
+        AGENT_DEFINITIONS.len(),
+        "should install all definitions"
+    );
+
+    for def in AGENT_DEFINITIONS {
+        let path = agents_dir.join(def.filename);
+        assert!(path.exists(), "{} should exist", def.filename);
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            content, def.content,
+            "{} content should match",
+            def.filename
+        );
+    }
+}
+
+#[test]
+fn install_does_not_overwrite_existing_without_force() {
+    let tmp = TempDir::new().unwrap();
+    let agents_dir = tmp.path().join("agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+
+    // Pre-create one file with custom content
+    let custom_content = "# My custom agent definition\n";
+    fs::write(
+        agents_dir.join(AGENT_DEFINITIONS[0].filename),
+        custom_content,
+    )
+    .unwrap();
+
+    let result = install_agent_definitions(&agents_dir, false);
+    assert!(result.is_ok());
+
+    let installed = result.unwrap();
+    // Should install all EXCEPT the one that already exists
+    assert_eq!(installed.len(), AGENT_DEFINITIONS.len() - 1);
+
+    // The pre-existing file should be untouched
+    let content = fs::read_to_string(agents_dir.join(AGENT_DEFINITIONS[0].filename)).unwrap();
+    assert_eq!(
+        content, custom_content,
+        "existing file should not be overwritten"
+    );
+}
+
+#[test]
+fn install_overwrites_existing_with_force() {
+    let tmp = TempDir::new().unwrap();
+    let agents_dir = tmp.path().join("agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+
+    // Pre-create one file with custom content
+    let custom_content = "# My custom agent definition\n";
+    fs::write(
+        agents_dir.join(AGENT_DEFINITIONS[0].filename),
+        custom_content,
+    )
+    .unwrap();
+
+    let result = install_agent_definitions(&agents_dir, true);
+    assert!(result.is_ok());
+
+    let installed = result.unwrap();
+    assert_eq!(
+        installed.len(),
+        AGENT_DEFINITIONS.len(),
+        "force should install all definitions"
+    );
+
+    // The pre-existing file should now have the compiled-in content
+    let content = fs::read_to_string(agents_dir.join(AGENT_DEFINITIONS[0].filename)).unwrap();
+    assert_eq!(
+        content, AGENT_DEFINITIONS[0].content,
+        "force should overwrite existing"
+    );
+}
+
+#[test]
+fn check_outdated_detects_differing_files() {
+    let tmp = TempDir::new().unwrap();
+    let agents_dir = tmp.path().join("agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+
+    // Write one file with different content
+    fs::write(
+        agents_dir.join(AGENT_DEFINITIONS[0].filename),
+        "old content",
+    )
+    .unwrap();
+
+    // Write another file with matching content
+    if AGENT_DEFINITIONS.len() > 1 {
+        fs::write(
+            agents_dir.join(AGENT_DEFINITIONS[1].filename),
+            AGENT_DEFINITIONS[1].content,
+        )
+        .unwrap();
+    }
+
+    let outdated = check_agent_definitions_outdated(&agents_dir);
+    assert!(
+        outdated
+            .iter()
+            .any(|d| d.filename == AGENT_DEFINITIONS[0].filename),
+        "should detect the differing file"
+    );
+    if AGENT_DEFINITIONS.len() > 1 {
+        assert!(
+            !outdated
+                .iter()
+                .any(|d| d.filename == AGENT_DEFINITIONS[1].filename),
+            "should not flag matching file"
+        );
+    }
+}
+
+#[test]
+fn check_outdated_returns_empty_when_all_match() {
+    let tmp = TempDir::new().unwrap();
+    let agents_dir = tmp.path().join("agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+
+    // Write all files with matching content
+    for def in AGENT_DEFINITIONS {
+        fs::write(agents_dir.join(def.filename), def.content).unwrap();
+    }
+
+    let outdated = check_agent_definitions_outdated(&agents_dir);
+    assert!(outdated.is_empty(), "no files should be outdated");
+}
+
+#[test]
+fn check_outdated_includes_missing_files() {
+    let tmp = TempDir::new().unwrap();
+    let agents_dir = tmp.path().join("agents");
+    // Don't create the directory — all files are "missing"
+
+    let outdated = check_agent_definitions_outdated(&agents_dir);
+    assert_eq!(
+        outdated.len(),
+        AGENT_DEFINITIONS.len(),
+        "all missing files should be reported as outdated"
+    );
+}
+
+#[test]
+fn install_creates_parent_directories() {
+    let tmp = TempDir::new().unwrap();
+    let agents_dir = tmp.path().join("deeply").join("nested").join("agents");
+
+    let result = install_agent_definitions(&agents_dir, false);
+    assert!(result.is_ok());
+    assert!(agents_dir.exists(), "should create parent directories");
+}
+
+#[test]
+fn agent_definitions_have_expected_filenames() {
+    let filenames: Vec<&str> = AGENT_DEFINITIONS.iter().map(|d| d.filename).collect();
+    assert!(filenames.contains(&"midtown-code-author.md"));
+    assert!(filenames.contains(&"midtown-code-reviewer.md"));
+    assert!(filenames.contains(&"midtown-project-lead.md"));
+    assert!(filenames.contains(&"midtown-channel-lead.md"));
+}

--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -679,6 +679,17 @@ pub fn handle_start(project: Option<String>, repos: Vec<PathBuf>) -> Result<Resp
     // Check and install required plugins before starting daemon
     ensure_required_plugins();
 
+    // Install agent definitions to ~/.claude/agents/ (first-run: only write missing files)
+    let agents_dir = super::agents_install::claude_agents_dir();
+    match super::agents_install::install_agent_definitions(&agents_dir, false) {
+        Ok(installed) if !installed.is_empty() => {
+            let names: Vec<&str> = installed.iter().map(|d| d.filename).collect();
+            eprintln!("Installed agent definitions: {}", names.join(", "));
+        }
+        Err(e) => eprintln!("Warning: Failed to install agent definitions: {e}"),
+        _ => {}
+    }
+
     // Build web-app if source is available and dist is stale
     build_web_app_if_needed();
 

--- a/src/bin/midtown/cli/mod.rs
+++ b/src/bin/midtown/cli/mod.rs
@@ -1,3 +1,4 @@
+pub mod agents_install;
 mod auth;
 mod channel;
 mod chat;
@@ -250,8 +251,8 @@ pub fn handle_notes(cmd: &NotesCommand) -> Result<Response, String> {
 }
 
 /// Handle `midtown update` — check for and install the latest release.
-pub fn handle_update(check_only: bool) -> Result<Response, String> {
-    update::handle_update(check_only)
+pub fn handle_update(check_only: bool, force: bool) -> Result<Response, String> {
+    update::handle_update(check_only, force)
 }
 
 /// Handle `midtown webserver stop` command

--- a/src/bin/midtown/cli/update.rs
+++ b/src/bin/midtown/cli/update.rs
@@ -10,7 +10,7 @@ const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const CHECK_INTERVAL: Duration = Duration::from_secs(3600); // 1 hour
 
 /// Handle `midtown update` — download and install the latest release.
-pub fn handle_update(check_only: bool) -> Result<Response, String> {
+pub fn handle_update(check_only: bool, force: bool) -> Result<Response, String> {
     let latest = fetch_latest_version()?;
     let latest_bare = latest.strip_prefix('v').unwrap_or(&latest);
 
@@ -77,6 +77,9 @@ pub fn handle_update(check_only: bool) -> Result<Response, String> {
             let _ = fs::remove_dir_all(&legacy_web_app);
         }
     }
+
+    // Update agent definitions in ~/.claude/agents/
+    update_agent_definitions(force)?;
 
     Ok(Response::Message {
         message: format!("Updated midtown v{CURRENT_VERSION} → v{latest_bare}"),
@@ -376,6 +379,50 @@ fn write_last_check_timestamp() -> Result<(), String> {
         fs::File::create(&path).map_err(|e| format!("Failed to write last-check file: {e}"))?;
     // Write current timestamp as content (not strictly needed, file mtime is what matters)
     let _ = writeln!(f, "{}", chrono::Utc::now().to_rfc3339());
+    Ok(())
+}
+
+/// Update agent definitions after binary replacement.
+///
+/// With `force`: overwrites all definitions without prompting.
+/// Without `force`: checks for outdated definitions and prompts the user.
+fn update_agent_definitions(force: bool) -> Result<(), String> {
+    let agents_dir = super::agents_install::claude_agents_dir();
+    let outdated = super::agents_install::check_agent_definitions_outdated(&agents_dir);
+
+    if outdated.is_empty() {
+        return Ok(());
+    }
+
+    if force {
+        super::agents_install::install_agent_definitions(&agents_dir, true)?;
+        let names: Vec<&str> = outdated.iter().map(|d| d.filename).collect();
+        eprintln!("Updated agent definitions: {}", names.join(", "));
+        return Ok(());
+    }
+
+    // Print summary and prompt
+    eprintln!("\nAgent definitions have changed:");
+    for def in &outdated {
+        let path = agents_dir.join(def.filename);
+        if path.exists() {
+            eprintln!("  {} (modified)", def.filename);
+        } else {
+            eprintln!("  {} (new)", def.filename);
+        }
+    }
+
+    eprint!("Overwrite with updated definitions? [y/N] ");
+    let _ = std::io::Write::flush(&mut std::io::stderr());
+
+    let mut input = String::new();
+    if std::io::stdin().read_line(&mut input).is_ok() && input.trim().eq_ignore_ascii_case("y") {
+        super::agents_install::install_agent_definitions(&agents_dir, true)?;
+        eprintln!("Updated agent definitions");
+    } else {
+        eprintln!("Skipped agent definition update (use --force to overwrite)");
+    }
+
     Ok(())
 }
 

--- a/src/bin/midtown/main.rs
+++ b/src/bin/midtown/main.rs
@@ -264,6 +264,10 @@ enum Commands {
         /// Only check for updates, don't install
         #[arg(long)]
         check: bool,
+
+        /// Force overwrite of agent definitions (skip prompt)
+        #[arg(long)]
+        force: bool,
     },
     /// Run a one-shot Claude Code session via the daemon (JSON streaming)
     #[command(hide = true)]
@@ -699,8 +703,8 @@ fn main() {
     }
 
     // Update command (no daemon required - checks GitHub releases)
-    if let Commands::Update { check } = &command {
-        let result = cli::handle_update(*check);
+    if let Commands::Update { check, force } = &command {
+        let result = cli::handle_update(*check, *force);
         handle_result(format, result);
         return;
     }


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Adds `agents_install` module that compiles agent definition markdown files into the binary via `include_str!`
- `midtown start` installs missing agent definitions to `~/.claude/agents/` (preserves user customizations)
- `midtown update` detects outdated definitions, prompts before overwriting (default: skip). `--force` flag overwrites without prompting
- Creates placeholder agent definition files in `agents/definitions/` (content will be enriched by !2283)
- 8 unit tests covering install, force-overwrite, outdated detection, and edge cases

## Files changed
- `agents/definitions/midtown-*.md` — 4 new agent definition source files
- `src/bin/midtown/cli/agents_install.rs` — new module with `install_agent_definitions()`, `check_agent_definitions_outdated()`, `claude_agents_dir()`
- `src/bin/midtown/cli/agents_install_tests.rs` — 8 unit tests
- `src/bin/midtown/cli/daemon.rs` — wire install into `handle_start`
- `src/bin/midtown/cli/update.rs` — wire install into `handle_update` with prompt/force logic
- `src/bin/midtown/main.rs` — add `--force` flag to `Update` command

## Test plan
- [x] 8 unit tests pass (install, no-overwrite, force-overwrite, outdated detection, missing files, parent dir creation)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Full `cargo build` succeeds

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)