### PR TITLE
[Midtown !2284] feat: Add agent definition installation to start and update

### DIFF
--- a/agents/definitions/midtown-channel-lead.md
+++ b/agents/definitions/midtown-channel-lead.md
@@ -1,0 +1,21 @@
+---
+name: midtown-channel-lead
+description: Midtown channel lead — domain expert for a specific topic channel, tracks work and answers domain questions
+model: sonnet
+---
+
+You are a midtown channel lead — a domain expert responsible for a specific topic channel. You provide deep expertise, track active work in your domain, and help coworkers with domain-specific questions.
+
+## How You Work
+
+1. **Own your domain** — Be the authority on your channel's topic area
+2. **Answer questions** — Help coworkers with domain-specific guidance
+3. **Track work** — Monitor tasks and PRs in your channel
+4. **Curate knowledge** — Maintain notes and document decisions
+
+## Principles
+
+- You advise, you don't implement. Coworkers write the code.
+- Share context proactively when it helps a coworker's task.
+- Only reply to insights when you can add genuine value.
+- Escalate cross-cutting concerns to the project lead.

--- a/agents/definitions/midtown-coworker.md
+++ b/agents/definitions/midtown-coworker.md
@@ -1,0 +1,22 @@
+---
+name: midtown-coworker
+description: Midtown coworker agent — autonomous software engineer that implements features, fixes bugs, and opens PRs
+model: sonnet
+---
+
+You are a midtown coworker — an autonomous software engineer working in an isolated git worktree. You implement features, fix bugs, write tests, and open pull requests.
+
+## How You Work
+
+1. **Claim a task** — Read the task description carefully
+2. **Explore the codebase** — Understand the relevant code before writing anything
+3. **Implement** — Write clean, tested code following project conventions
+4. **Open a PR** — Push your branch and create a pull request
+
+## Principles
+
+- Read before writing. Understand existing patterns before proposing changes.
+- Write tests for new functionality. Follow the project's testing conventions.
+- Keep PRs focused. One logical change per PR.
+- Follow the project's CLAUDE.md conventions exactly.
+- Commit messages should explain *why*, not *what*.

--- a/agents/definitions/midtown-lead.md
+++ b/agents/definitions/midtown-lead.md
@@ -1,0 +1,22 @@
+---
+name: midtown-lead
+description: Midtown project lead — coordinates work, creates tasks, and delegates to coworkers
+model: opus
+---
+
+You are a midtown project lead — the human-facing coordinator for a software project. You plan work, create tasks, delegate to coworkers, and track progress.
+
+## How You Work
+
+1. **Understand requests** — Clarify requirements with the user
+2. **Plan** — Break work into well-scoped tasks
+3. **Delegate** — Create tasks for coworkers to implement
+4. **Track** — Monitor progress and unblock coworkers when needed
+
+## Principles
+
+- You coordinate, you don't implement. Delegate code work to coworkers.
+- Keep tasks well-scoped — one PR per task.
+- Respond to the user promptly. Acknowledge before investigating.
+- When a coworker asks a question, provide clear, actionable answers.
+- Quick fixes (< 10 lines) you can do yourself; anything else, create a task.

--- a/agents/definitions/midtown-reviewer.md
+++ b/agents/definitions/midtown-reviewer.md
@@ -1,0 +1,23 @@
+---
+name: midtown-reviewer
+description: Midtown code reviewer — reviews pull requests for correctness, style, and test coverage
+model: sonnet
+---
+
+You are a midtown reviewer — a dedicated code reviewer. You review pull requests thoroughly and provide actionable feedback.
+
+## Review Process
+
+1. **Understand the PR** — Read the description, linked issues, and all changed files
+2. **Check correctness** — Verify logic, edge cases, and error handling
+3. **Check style** — Ensure code follows project conventions (CLAUDE.md)
+4. **Check tests** — Verify adequate test coverage for new/changed behavior
+5. **Provide feedback** — Comment on specific lines with clear, actionable suggestions
+
+## Principles
+
+- Be specific. Point to exact lines and suggest concrete fixes.
+- Distinguish blocking issues from suggestions.
+- Don't nitpick style that's consistent with the existing codebase.
+- Verify the code does what the PR description claims.
+- Check for security issues (injection, auth bypass, data exposure).

--- a/src/bin/midtown/cli/agents_install.rs
+++ b/src/bin/midtown/cli/agents_install.rs
@@ -1,0 +1,91 @@
+//! Agent definition installation.
+//!
+//! Installs compiled-in agent definitions to `~/.claude/agents/` so Claude Code
+//! can load them via the `--agent` flag (e.g., `claude --agent midtown-coworker`).
+
+use std::fs;
+use std::path::Path;
+
+/// Compiled-in agent definitions: (filename, content).
+pub const AGENT_DEFINITIONS: &[(&str, &str)] = &[
+    (
+        "midtown-coworker.md",
+        include_str!("../../../../agents/definitions/midtown-coworker.md"),
+    ),
+    (
+        "midtown-reviewer.md",
+        include_str!("../../../../agents/definitions/midtown-reviewer.md"),
+    ),
+    (
+        "midtown-lead.md",
+        include_str!("../../../../agents/definitions/midtown-lead.md"),
+    ),
+    (
+        "midtown-channel-lead.md",
+        include_str!("../../../../agents/definitions/midtown-channel-lead.md"),
+    ),
+];
+
+/// Install agent definitions to `~/.claude/agents/`.
+///
+/// If `force` is false, existing files are not overwritten (preserving user customizations).
+/// If `force` is true, all files are overwritten with compiled-in defaults.
+pub fn install_agent_definitions(force: bool) -> Result<(), String> {
+    let agents_dir = dirs::home_dir()
+        .ok_or("Cannot determine home directory")?
+        .join(".claude")
+        .join("agents");
+    install_agent_definitions_to(&agents_dir, force)
+}
+
+/// Install agent definitions to a specific directory (testable).
+pub fn install_agent_definitions_to(agents_dir: &Path, force: bool) -> Result<(), String> {
+    fs::create_dir_all(agents_dir)
+        .map_err(|e| format!("Failed to create {}: {}", agents_dir.display(), e))?;
+
+    for (filename, content) in AGENT_DEFINITIONS {
+        let path = agents_dir.join(filename);
+        if !force && path.exists() {
+            continue;
+        }
+        fs::write(&path, content)
+            .map_err(|e| format!("Failed to write {}: {}", path.display(), e))?;
+    }
+
+    Ok(())
+}
+
+/// Check which agent definitions differ from compiled-in versions.
+///
+/// Returns filenames that are missing or differ from the compiled-in defaults.
+pub fn check_agent_definitions_outdated() -> Vec<String> {
+    let agents_dir = match dirs::home_dir() {
+        Some(home) => home.join(".claude").join("agents"),
+        None => {
+            return AGENT_DEFINITIONS
+                .iter()
+                .map(|(f, _)| f.to_string())
+                .collect();
+        }
+    };
+    check_agent_definitions_outdated_in(&agents_dir)
+}
+
+/// Check which agent definitions differ (testable with custom directory).
+pub fn check_agent_definitions_outdated_in(agents_dir: &Path) -> Vec<String> {
+    AGENT_DEFINITIONS
+        .iter()
+        .filter(|(filename, expected)| {
+            let path = agents_dir.join(filename);
+            match fs::read_to_string(&path) {
+                Ok(content) => content != *expected,
+                Err(_) => true, // missing file = outdated
+            }
+        })
+        .map(|(filename, _)| filename.to_string())
+        .collect()
+}
+
+#[path = "agents_install_tests.rs"]
+#[cfg(test)]
+mod tests;

--- a/src/bin/midtown/cli/agents_install_tests.rs
+++ b/src/bin/midtown/cli/agents_install_tests.rs
@@ -1,0 +1,114 @@
+use super::*;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn install_writes_files_when_missing() {
+    let tmp = TempDir::new().unwrap();
+    let agents_dir = tmp.path().join("agents");
+
+    install_agent_definitions_to(&agents_dir, false).unwrap();
+
+    for (filename, _) in AGENT_DEFINITIONS {
+        let path = agents_dir.join(filename);
+        assert!(path.exists(), "Expected {} to be installed", filename);
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("---"),
+            "Expected YAML frontmatter in {}",
+            filename
+        );
+    }
+}
+
+#[test]
+fn install_does_not_overwrite_existing_without_force() {
+    let tmp = TempDir::new().unwrap();
+    let agents_dir = tmp.path().join("agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+
+    // Pre-create one file with custom content
+    let custom = "custom user content";
+    fs::write(agents_dir.join("midtown-coworker.md"), custom).unwrap();
+
+    install_agent_definitions_to(&agents_dir, false).unwrap();
+
+    // Custom file should be preserved
+    let content = fs::read_to_string(agents_dir.join("midtown-coworker.md")).unwrap();
+    assert_eq!(
+        content, custom,
+        "Should not overwrite existing file without force"
+    );
+
+    // Other files should be installed
+    assert!(agents_dir.join("midtown-reviewer.md").exists());
+}
+
+#[test]
+fn install_overwrites_with_force() {
+    let tmp = TempDir::new().unwrap();
+    let agents_dir = tmp.path().join("agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+
+    // Pre-create one file with custom content
+    fs::write(agents_dir.join("midtown-coworker.md"), "custom").unwrap();
+
+    install_agent_definitions_to(&agents_dir, true).unwrap();
+
+    // Custom file should be overwritten
+    let content = fs::read_to_string(agents_dir.join("midtown-coworker.md")).unwrap();
+    assert_ne!(content, "custom", "Should overwrite with force=true");
+    assert!(
+        content.contains("midtown-coworker"),
+        "Should contain agent definition"
+    );
+}
+
+#[test]
+fn check_outdated_detects_differences() {
+    let tmp = TempDir::new().unwrap();
+    let agents_dir = tmp.path().join("agents");
+    fs::create_dir_all(&agents_dir).unwrap();
+
+    // Install current versions
+    install_agent_definitions_to(&agents_dir, true).unwrap();
+
+    // No files should be outdated
+    let outdated = check_agent_definitions_outdated_in(&agents_dir);
+    assert!(
+        outdated.is_empty(),
+        "Freshly installed should not be outdated"
+    );
+
+    // Modify one file
+    fs::write(agents_dir.join("midtown-coworker.md"), "modified content").unwrap();
+
+    let outdated = check_agent_definitions_outdated_in(&agents_dir);
+    assert_eq!(outdated.len(), 1);
+    assert_eq!(outdated[0], "midtown-coworker.md");
+}
+
+#[test]
+fn check_outdated_returns_empty_when_all_match() {
+    let tmp = TempDir::new().unwrap();
+    let agents_dir = tmp.path().join("agents");
+
+    install_agent_definitions_to(&agents_dir, true).unwrap();
+
+    let outdated = check_agent_definitions_outdated_in(&agents_dir);
+    assert!(outdated.is_empty());
+}
+
+#[test]
+fn check_outdated_includes_missing_files() {
+    let tmp = TempDir::new().unwrap();
+    let agents_dir = tmp.path().join("agents");
+    // Don't install anything — all files are missing
+
+    let outdated = check_agent_definitions_outdated_in(&agents_dir);
+    assert_eq!(
+        outdated.len(),
+        AGENT_DEFINITIONS.len(),
+        "All missing files should be reported as outdated"
+    );
+}

--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -679,6 +679,11 @@ pub fn handle_start(project: Option<String>, repos: Vec<PathBuf>) -> Result<Resp
     // Check and install required plugins before starting daemon
     ensure_required_plugins();
 
+    // Install agent definitions (first-run: writes missing files, never overwrites)
+    if let Err(e) = crate::cli::agents_install::install_agent_definitions(false) {
+        eprintln!("Warning: Failed to install agent definitions: {}", e);
+    }
+
     // Build web-app if source is available and dist is stale
     build_web_app_if_needed();
 

--- a/src/bin/midtown/cli/mod.rs
+++ b/src/bin/midtown/cli/mod.rs
@@ -1,3 +1,4 @@
+pub mod agents_install;
 mod auth;
 mod channel;
 mod chat;
@@ -250,8 +251,8 @@ pub fn handle_notes(cmd: &NotesCommand) -> Result<Response, String> {
 }
 
 /// Handle `midtown update` — check for and install the latest release.
-pub fn handle_update(check_only: bool) -> Result<Response, String> {
-    update::handle_update(check_only)
+pub fn handle_update(check_only: bool, force: bool) -> Result<Response, String> {
+    update::handle_update(check_only, force)
 }
 
 /// Handle `midtown webserver stop` command

--- a/src/bin/midtown/cli/update.rs
+++ b/src/bin/midtown/cli/update.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
+use super::agents_install;
 use super::response::Response;
 
 const GITHUB_REPO: &str = "btucker/midtown";
@@ -10,7 +11,7 @@ const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const CHECK_INTERVAL: Duration = Duration::from_secs(3600); // 1 hour
 
 /// Handle `midtown update` — download and install the latest release.
-pub fn handle_update(check_only: bool) -> Result<Response, String> {
+pub fn handle_update(check_only: bool, force: bool) -> Result<Response, String> {
     let latest = fetch_latest_version()?;
     let latest_bare = latest.strip_prefix('v').unwrap_or(&latest);
 
@@ -75,6 +76,31 @@ pub fn handle_update(check_only: bool) -> Result<Response, String> {
         let legacy_web_app = install_dir.join("web-app");
         if legacy_web_app.is_dir() {
             let _ = fs::remove_dir_all(&legacy_web_app);
+        }
+    }
+
+    // Update agent definitions
+    let outdated = agents_install::check_agent_definitions_outdated();
+    if !outdated.is_empty() {
+        if force {
+            agents_install::install_agent_definitions(true)?;
+            eprintln!("Updated agent definitions: {}", outdated.join(", "));
+        } else {
+            eprintln!("\nAgent definitions have changed:");
+            for f in &outdated {
+                eprintln!("  - {}", f);
+            }
+            eprint!("Overwrite with updated versions? [y/N] ");
+            let _ = std::io::stderr().flush();
+            let mut input = String::new();
+            if std::io::stdin().read_line(&mut input).is_ok()
+                && input.trim().eq_ignore_ascii_case("y")
+            {
+                agents_install::install_agent_definitions(true)?;
+                eprintln!("Updated agent definitions.");
+            } else {
+                eprintln!("Skipped agent definition update.");
+            }
         }
     }
 

--- a/src/bin/midtown/main.rs
+++ b/src/bin/midtown/main.rs
@@ -264,6 +264,9 @@ enum Commands {
         /// Only check for updates, don't install
         #[arg(long)]
         check: bool,
+        /// Force overwrite agent definitions without prompting
+        #[arg(long)]
+        force: bool,
     },
     /// Run a one-shot Claude Code session via the daemon (JSON streaming)
     #[command(hide = true)]
@@ -699,8 +702,8 @@ fn main() {
     }
 
     // Update command (no daemon required - checks GitHub releases)
-    if let Commands::Update { check } = &command {
-        let result = cli::handle_update(*check);
+    if let Commands::Update { check, force } = &command {
+        let result = cli::handle_update(*check, *force);
         handle_result(format, result);
         return;
     }


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary

- Adds 4 Claude Code agent definition files (`midtown-coworker`, `midtown-reviewer`, `midtown-lead`, `midtown-channel-lead`) compiled into the binary
- `midtown start`: installs missing agent definitions to `~/.claude/agents/` (first-run, never overwrites)
- `midtown update`: detects changed definitions, prompts user to overwrite
- `midtown update --force`: overwrites agent definitions without prompting

## New files
- `agents/definitions/midtown-*.md` — 4 Claude Code agent definition files with YAML frontmatter
- `src/bin/midtown/cli/agents_install.rs` — install/check logic with `_to()` variants for testability
- `src/bin/midtown/cli/agents_install_tests.rs` — 6 unit tests covering install, force, and outdated detection

## Test plan
- [x] 6 unit tests pass (`cargo test agents_install`)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] Manual: `midtown start` installs files to `~/.claude/agents/`
- [ ] Manual: `midtown update --force` overwrites agent definitions

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)