### PR TITLE
fix: Update stale `midtown coworker upload-image` ref in code-author prompt [Midtown !2289]

### DIFF
--- a/agents/definitions/midtown-code-author.md
+++ b/agents/definitions/midtown-code-author.md
@@ -102,7 +102,7 @@ When your PR includes visual changes, use the **Playwright MCP tools** to captur
 **Workflow:**
 
 1. **Navigate and interact** — use MCP tools to browse to the right page and click into the desired UI state
-2. **Upload for GitHub** — use `midtown coworker upload-image` to get a GitHub-embeddable URL
+2. **Upload for GitHub** — use `midtown agent upload-image` to get a GitHub-embeddable URL
 3. **Embed in PR description** — include the returned markdown in your PR body
 
 ## Requesting PR Reviews


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Fixes a stale `midtown coworker upload-image` reference in `agents/definitions/midtown-code-author.md` that was missed during the CLI unification (PR #2031)
- Updates to `midtown agent upload-image` to match the new unified CLI namespace

## Test plan
- [x] Verified the change is a single-line text fix in an agent definition markdown file
- [x] No code changes — clippy/fmt not affected

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)