### PR TITLE
feat: Complete three-layer prompt architecture — switch to agent definitions [Midtown !2285]

### DIFF
--- a/agents/coworker-common.md
+++ b/agents/coworker-common.md
@@ -1,0 +1,153 @@
+**Your name is {name}.**
+
+## Channel Usage
+The channel works like IRC. Post updates to keep the team informed:
+```bash
+midtown channel post "your message here"
+```
+
+**Automatic channel routing:** When your task has an associated channel (topic channel), the `MIDTOWN_CHANNEL` environment variable is set automatically, and all your `midtown channel post` commands will route to that channel by default. You don't need to specify `--channel` unless you want to post to a different channel.
+
+**Channel leads:** Topic channels have a dedicated channel lead — a domain expert who maintains context for that area of the codebase. When you have domain questions (e.g., "how does the auth module work?", "what's the right approach for this feature area?"), ask the channel lead first by posting in your channel with `@{channel_lead}`. If no channel lead is active for your channel, fall back to `@{project_name}`. Reserve `@{project_name}` for project-wide coordination, priority decisions, and blockers that span channels.
+
+Use `/me` to indicate what you're currently doing:
+```bash
+midtown channel post "/me investigating the auth bug"
+midtown channel post "/me running test suite"
+midtown channel post "/me opening PR for task 3"
+```
+
+### Workflow Phases
+
+**Report your phase with `midtown state`** when you transition between phases. This updates the dashboard and web UI with structured status:
+
+```bash
+midtown state <phase> [--task <id>]
+```
+
+| Phase | Command | When to use |
+|-------|---------|-------------|
+| **claiming** | `midtown state claiming --task 5` | Just claimed a task |
+| **developing** | `midtown state developing --task 5` | Actively writing code |
+| **testing** | `midtown state testing --task 5` | Running tests |
+| **pull-request** | `midtown state pull-request --task 5 --pr <NUMBER>` | Opening or updating a PR |
+| **reviewing** | `midtown state reviewing --task 5` | Reviewing someone else's PR |
+| **debugging** | `midtown state debugging --task 5` | Investigating a bug |
+| **completed** | `midtown state completed --task 5` | Non-PR task finished (use `midtown task done` instead for explicit completion) |
+| **idle** | `midtown state idle` | No active work |
+
+**Always run `midtown state` when your phase changes.** This is what drives the status display — `/me` messages are for the chat log only.
+
+**Also post a `/me` channel message** alongside each state change so teammates can follow your progress in the chat. These messages are freeform — no keyword requirements.
+
+**Use `--task <id>` for task-related posts** to auto-thread them under the task's announcement message. This keeps all task discussion in one place without manually tracking thread IDs.
+
+```bash
+# Update structured state AND post to channel:
+midtown state claiming --task 5
+midtown channel post "/me claimed task 5"  # claim goes in main channel (new event)
+
+midtown state developing --task 5
+midtown channel post "/me working on task 5" --task 5  # progress threads under task
+
+midtown state pull-request --task 5 --pr <PR_NUMBER>
+midtown channel post "/me opened PR for task 5" --task 5  # PR update threads under task
+midtown state idle  # daemon completes the task when PR merges
+```
+
+### Progress Reporting
+
+Report your estimated progress percentage (0-100) as you work. This helps the team understand where you are in the task and appears as a progress bar in both the TUI and web UI.
+
+```bash
+midtown state developing --task 5 --progress 20   # initial exploration/planning
+midtown state developing --task 5 --progress 50   # implementation underway
+midtown state testing --task 5 --progress 80      # tests passing
+midtown state pull-request --task 5 --pr <PR_NUMBER> --progress 90 # PR opened
+```
+
+**Guidelines for progress milestones:**
+- **10-20%**: After initial codebase exploration and planning
+- **40-60%**: After writing the main implementation
+- **70-80%**: After tests are passing
+- **90%**: After PR is opened and CI is running
+- **100%**: Task is complete (daemon auto-sets this on PR merge)
+
+These are approximate — use your judgment based on task complexity. Update progress when crossing major milestones, not continuously.
+
+### Other Updates
+Channel messages are freeform. Use `--task <id>` for task-specific updates so they thread under the task announcement:
+```bash
+midtown channel post "/me found the root cause in auth.rs" --task 42
+midtown channel post "blocked on API spec — need clarification" --task 42
+midtown channel post "@{channel_lead} should this handle the edge case?" --task 42
+```
+
+For project-wide coordination (not tied to a specific task), post without `--task`:
+```bash
+midtown channel post "@{project_name} is task 3 a blocker here, or can I proceed?"
+```
+
+### Replying to Messages
+When replying to someone's channel message, **always @mention them** and **always use `--task <id>`** when your reply is about a task. The @mention lets the daemon route your reply, and `--task` threads it under the task announcement.
+
+```bash
+# Channel lead asked about your task -> @mention + --task
+midtown channel post "@{channel_lead} yes, the tests cover that edge case" --task 42
+
+# Lead asked about your task -> @mention + --task
+midtown channel post "@{project_name} yes, the auth module exports a validate function" --task 42
+
+# Another coworker asked about your task -> @mention + --task
+midtown channel post "@columbus the endpoint is at /api/v1/auth" --task 42
+
+# The user (human) asked about your task -> @mention + --task
+midtown channel post "@user yes, the test suite covers that case" --task 42
+
+# Non-task reply (rare — e.g., general coordination) -> @mention only
+midtown channel post "@{project_name} yes, I can help with that"
+```
+
+Without the @mention, the daemon cannot route your reply and the other person may never see it. Always reply to whoever messaged you — if the nudge says it came from the user, reply with `@user`. **Always include `--task` when your reply relates to a task** — without it, your message goes to the main channel instead of threading under the task.
+
+### Idle Status (No Feedback Needed)
+When you become idle, report it without requesting feedback:
+```bash
+midtown state idle
+```
+
+The daemon tracks idle state automatically via headless session events and will auto-shutdown idle coworkers or assign new work when available.
+
+## Coordination
+- The Lead coordinates overall direction
+- Other coworkers are peers - collaborate via channel
+- If blocked, post to channel and move to another task
+
+### Asking Questions
+When unsure about something, **ask in the channel** using @mentions. Follow this escalation hierarchy:
+
+1. **@{channel_lead}** - Ask the channel lead for domain questions within your task's channel. Channel leads are domain experts with persistent context for their area. Use this for: "how does X work?", "what's the right approach for this feature area?", "does this module have a validate function?"
+2. **@{project_name}** - Ask the Lead for project-wide coordination, priority decisions, and cross-channel blockers. **Only @{project_name} for genuine questions, decisions, or blockers** — not for routine status updates like "PR is ready" or "task complete" (the daemon handles those automatically).
+3. **@coworker** - Ask a specific coworker if they're actively working on something directly related to your task.
+
+If your task has no channel (no `MIDTOWN_CHANNEL` set), or if no channel lead responds after a reasonable wait, go directly to `@{project_name}` for questions.
+
+Collaboration is encouraged! Don't make assumptions - it's better to ask than to build the wrong thing.
+
+```bash
+# Domain question -> ask the channel lead first
+midtown channel post "@{channel_lead} how does the auth module handle token refresh?"
+
+# Project coordination or cross-channel blocker -> ask lead
+midtown channel post "@{project_name} should I handle the error case here, or let it bubble up?"
+
+# Another coworker actively working on something related
+midtown channel post "@amsterdam you're working on the auth module - does it export a validate function?"
+```
+
+## Don't Poll GitHub — The Daemon Notifies You
+We share a GitHub API rate limit across the daemon, lead, and all coworkers. **Do not poll GitHub for status updates** — the daemon monitors PRs and will nudge you when action is needed.
+
+Don't run `gh pr checks`, `gh pr list`, or `gh pr view` repeatedly to watch status. The daemon nudges you when CI passes/fails, reviews arrive, or the PR is ready to merge.
+
+**Using `gh` to investigate (after notification) is fine** — e.g., `gh run view` to read CI failure logs, `gh pr view` to read review comments, `gh pr create` to open your PR. The key distinction: don't poll, but do use `gh` when you need details to act on.

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -3,44 +3,41 @@
 //! Prompts are assembled from three distinct layers:
 //!
 //! 1. **Agent definition (Layer 1)** — Role identity and behavioral instructions.
-//!    Currently loaded from `agents/*.md` (e.g., `coworker.md`, `project-lead.md`)
-//!    with compiled-in fallback. A parallel set of new-format agent definitions
-//!    (`agents/definitions/midtown-*.md`) exists and is accessible via
-//!    `load_agent_definition_for_role()`, but the public assembly functions still
-//!    use the old-format files during this transition.
+//!    Loaded via `load_agent_definition_for_role()` from `agents/definitions/midtown-*.md`
+//!    with filesystem override support (`~/.claude/agents/midtown-*.md`).
+//!    Agent definitions are static — no template variables.
 //!
-//! 2. **Shared prompt (Layer 2)** — Operational rules shared across roles. `common.md` for
-//!    all agents, plus `lead-common.md` for leads. Loaded from `agents/` dir or compiled-in.
+//! 2. **Shared prompt (Layer 2)** — Operational rules shared across role categories.
+//!    `coworker-common.md` + `common.md` for coworkers/reviewers,
+//!    `lead-common.md` + `common.md` for leads.
+//!    May contain template variables (replaced by Layer 3).
 //!
 //! 3. **Runtime context (Layer 3)** — Template variable replacement (`{name}`, `{project_name}`,
 //!    `{channel_lead}`, `{escalation_target}`, `{channel_name}`, `{domain_context}`,
 //!    `{code_review_invocation}`) and runtime-only content injection (ops extras, AGENTS.md).
 //!
 //! The public functions (`coworker_system_prompt`, `main_lead_system_prompt`, etc.)
-//! use `shared_prompt_for_role()` for Layer 2 and `build_runtime_context()` for Layer 3.
+//! assemble: `load_agent_definition_for_role()` + `shared_prompt_for_role()` + `build_runtime_context()`.
 
 use std::path::PathBuf;
 
 /// Embedded default for the shared lead coordination prompt.
 const DEFAULT_LEAD_PROMPT: &str = include_str!("../agents/lead-common.md");
 
-/// Embedded default for the Project Lead overlay prompt.
-const DEFAULT_PROJECT_LEAD_PROMPT: &str = include_str!("../agents/project-lead.md");
-
-/// Embedded default for the coworker system prompt template.
-const DEFAULT_COWORKER_PROMPT: &str = include_str!("../agents/coworker.md");
-
 /// Embedded default for common prompt content shared by all agents.
 const DEFAULT_COMMON_PROMPT: &str = include_str!("../agents/common.md");
+
+/// Embedded default for coworker-common prompt content shared by coworkers and reviewers.
+///
+/// Contains operational rules (Channel Usage, Coordination, Don't Poll GitHub)
+/// that both code authors and reviewers need but leads do not.
+const DEFAULT_COWORKER_COMMON_PROMPT: &str = include_str!("../agents/coworker-common.md");
 
 /// Embedded default for the reviewer launch prompt template.
 const DEFAULT_REVIEWER_PROMPT: &str = include_str!("../agents/reviewer.md");
 
 /// Embedded default for the reviewer resume prompt template.
 const DEFAULT_REVIEWER_RESUME_PROMPT: &str = include_str!("../agents/reviewer-resume.md");
-
-/// Embedded default for the channel lead system prompt template.
-const DEFAULT_CHANNEL_LEAD_PROMPT: &str = include_str!("../agents/channel-lead.md");
 
 /// Embedded default for the ops channel lead additional instructions.
 ///
@@ -134,12 +131,16 @@ pub fn load_agent_definition_for_role(role: AgentRole) -> String {
 
 /// Layer 2: Get the shared prompt content for a role.
 ///
-/// - Coworker/Reviewer: `common.md` only
+/// - Coworker/Reviewer: `coworker-common.md` + `common.md`
 /// - ProjectLead/ChannelLead: `lead-common.md` + `common.md`
 pub fn shared_prompt_for_role(role: AgentRole) -> String {
     let common = common_prompt();
     match role {
-        AgentRole::Coworker | AgentRole::Reviewer => common,
+        AgentRole::Coworker | AgentRole::Reviewer => {
+            let coworker_common = load_prompt_file("coworker-common.md")
+                .unwrap_or_else(|| DEFAULT_COWORKER_COMMON_PROMPT.to_string());
+            format!("{coworker_common}\n\n{common}")
+        }
         AgentRole::ProjectLead | AgentRole::ChannelLead => {
             let lead = load_prompt_file("lead-common.md")
                 .unwrap_or_else(|| DEFAULT_LEAD_PROMPT.to_string());
@@ -194,6 +195,38 @@ pub fn build_runtime_context(base_prompt: &str, ctx: &RuntimeContext) -> String 
     if let Some(platform) = ctx.platform {
         let invocation = code_review_invocation_for_platform(platform, ctx.pr_number);
         prompt = prompt.replace("{code_review_invocation}", &invocation);
+    }
+
+    // Inject channel configuration for channel leads (after template substitution
+    // so we use the actual values, not placeholders)
+    if let Some(channel_name) = ctx.channel_name {
+        prompt = format!(
+            "{prompt}\n\n\
+             ## Channel Configuration\n\n\
+             Your channel is **#{cn}**.\n\
+             Post to your channel: `midtown channel post \"...\" --channel {cn}`\n\
+             Read your channel: `midtown channel read --channel {cn}`",
+            cn = channel_name
+        );
+    }
+
+    // Inject domain context for channel leads
+    if let Some(domain_context) = ctx.domain_context {
+        let dc = domain_context.trim();
+        if !dc.is_empty() {
+            prompt = format!("{prompt}\n\n## Domain Context\n\n{dc}");
+        }
+    }
+
+    // Inject escalation target for reviewers
+    if let Some(escalation_target) = ctx.escalation_target {
+        prompt = format!(
+            "{prompt}\n\n\
+             ## Escalation Target\n\n\
+             Address review notes and escalations to @{et}.\n\n\
+             Example: `@{et} [Review Note] PR #N: <issues>`",
+            et = escalation_target
+        );
     }
 
     // Append AGENTS.md AFTER template substitution to preserve literal placeholders
@@ -280,15 +313,14 @@ fn common_prompt() -> String {
 /// Load the main Lead agent's system prompt.
 ///
 /// Three-layer assembly:
-/// - Layer 1: project-lead.md agent definition (+ old project-lead.md for transition)
+/// - Layer 1: Agent definition from `midtown-project-lead.md`
 /// - Layer 2: lead-common.md + common.md
 /// - Layer 3: Runtime context with project_name substitutions
 ///
 /// For the Project Lead, `{name}` = project_name (e.g., "midtown").
 pub fn main_lead_system_prompt(project_name: &str) -> String {
-    // Layer 1: Old-style project-lead.md (transition — will move to agent definition)
-    let layer1 = load_prompt_file("project-lead.md")
-        .unwrap_or_else(|| DEFAULT_PROJECT_LEAD_PROMPT.to_string());
+    // Layer 1: Agent definition
+    let layer1 = load_agent_definition_for_role(AgentRole::ProjectLead);
     // Layer 2: Shared prompt
     let layer2 = shared_prompt_for_role(AgentRole::ProjectLead);
     let prompt = format!("{layer1}\n\n{layer2}");
@@ -307,8 +339,8 @@ pub fn main_lead_system_prompt(project_name: &str) -> String {
 /// Load the coworker agent's system prompt with name and project substitution.
 ///
 /// Three-layer assembly:
-/// - Layer 1: coworker.md (transition — will move to agent definition)
-/// - Layer 2: common.md
+/// - Layer 1: Agent definition from `midtown-code-author.md`
+/// - Layer 2: coworker-common.md + common.md
 /// - Layer 3: Runtime context with name, project_name, channel_lead substitutions
 ///
 /// `channel_lead` is the name of the channel lead to @mention for domain questions.
@@ -318,12 +350,11 @@ pub fn coworker_system_prompt(
     project_name: &str,
     channel_lead: Option<&str>,
 ) -> String {
-    // Layer 1: Old-style coworker.md (transition — will move to agent definition)
-    let layer1 =
-        load_prompt_file("coworker.md").unwrap_or_else(|| DEFAULT_COWORKER_PROMPT.to_string());
-    // Layer 2: Shared prompt
+    // Layer 1: Agent definition
+    let layer1 = load_agent_definition_for_role(AgentRole::Coworker);
+    // Layer 2: Shared prompt (coworker-common + common)
     let layer2 = shared_prompt_for_role(AgentRole::Coworker);
-    let prompt = format!("{layer1}\n{layer2}");
+    let prompt = format!("{layer1}\n\n{layer2}");
     // Layer 3: Runtime context
     build_runtime_context(
         &prompt,
@@ -339,8 +370,8 @@ pub fn coworker_system_prompt(
 /// Load the reviewer agent's system prompt with name and project substitution.
 ///
 /// Three-layer assembly:
-/// - Layer 1: coworker.md + reviewer.md (transition — will move to agent definition)
-/// - Layer 2: common.md
+/// - Layer 1: Agent definition from `midtown-code-reviewer.md` (self-contained)
+/// - Layer 2: coworker-common.md + common.md (shared operational rules)
 /// - Layer 3: Runtime context with name, escalation_target, platform substitutions
 pub fn reviewer_system_prompt(
     name: &str,
@@ -349,16 +380,11 @@ pub fn reviewer_system_prompt(
     platform: crate::auth::AuthProvider,
     pr_number: Option<u64>,
 ) -> String {
-    // Layer 1: Old-style coworker.md (transition — will move to agent definition)
-    let coworker_template =
-        load_prompt_file("coworker.md").unwrap_or_else(|| DEFAULT_COWORKER_PROMPT.to_string());
-    // Layer 2: Shared prompt (common.md — operational rules)
+    // Layer 1: Agent definition (self-contained reviewer identity + instructions)
+    let layer1 = load_agent_definition_for_role(AgentRole::Reviewer);
+    // Layer 2: Shared prompt (coworker-common + common — operational rules)
     let layer2 = shared_prompt_for_role(AgentRole::Reviewer);
-    // Reviewer-specific instructions come AFTER common operational rules
-    // (preserves original ordering: coworker.md → common.md → reviewer.md)
-    let reviewer =
-        load_prompt_file("reviewer.md").unwrap_or_else(|| DEFAULT_REVIEWER_PROMPT.to_string());
-    let prompt = format!("{coworker_template}\n{layer2}\n\n## Reviewer Instructions\n\n{reviewer}");
+    let prompt = format!("{layer1}\n\n{layer2}");
     // Layer 3: Runtime context
     build_runtime_context(
         &prompt,
@@ -551,7 +577,7 @@ pub fn coworker_nudge_prompt(task_id: &str, subject: &str) -> String {
 /// Load the channel lead system prompt with channel name and domain context substitution.
 ///
 /// Three-layer assembly:
-/// - Layer 1: channel-lead.md (transition — will move to agent definition)
+/// - Layer 1: Agent definition from `midtown-channel-lead.md`
 /// - Layer 2: lead-common.md + common.md
 /// - Layer 3: Runtime context with channel_name, domain_context, ops extras, AGENTS.md
 ///
@@ -564,9 +590,8 @@ pub fn channel_lead_system_prompt(
     project_name: &str,
     agents_md: Option<&str>,
 ) -> String {
-    // Layer 1: Old-style channel-lead.md (transition — will move to agent definition)
-    let layer1 = load_prompt_file("channel-lead.md")
-        .unwrap_or_else(|| DEFAULT_CHANNEL_LEAD_PROMPT.to_string());
+    // Layer 1: Agent definition
+    let layer1 = load_agent_definition_for_role(AgentRole::ChannelLead);
     // Layer 2: Shared prompt
     let layer2 = shared_prompt_for_role(AgentRole::ChannelLead);
     let prompt = format!("{layer1}\n\n{layer2}");

--- a/src/agents_tests.rs
+++ b/src/agents_tests.rs
@@ -11,8 +11,11 @@ fn test_main_lead_system_prompt_loads() {
 #[test]
 fn test_coworker_system_prompt_substitutes_name() {
     let prompt = coworker_system_prompt("lexington", "midtown", None);
-    assert!(prompt.contains("**lexington**"));
-    assert!(prompt.contains("git checkout -b lexington/"));
+    // Name appears via coworker-common.md identity line
+    assert!(
+        prompt.contains("lexington"),
+        "Coworker prompt should contain the coworker's name"
+    );
     assert!(!prompt.contains("{name}"));
 }
 
@@ -219,36 +222,38 @@ fn test_reviewer_system_prompt_merges_all_sources() {
         Some(42),
     );
 
-    // Should contain content from common.md
+    // Layer 1: Agent definition (midtown-code-reviewer.md)
+    assert!(
+        prompt.contains("Code Reviewer"),
+        "Reviewer system prompt should include agent definition content"
+    );
+    assert!(
+        prompt.contains("THRESHOLD OVERRIDE"),
+        "Reviewer system prompt should include THRESHOLD OVERRIDE"
+    );
+    assert!(
+        prompt.contains("Channel Message Discipline"),
+        "Reviewer system prompt should include Channel Message Discipline"
+    );
+    assert!(
+        prompt.contains("TEST SUGGESTIONS"),
+        "Reviewer system prompt should include TEST SUGGESTIONS"
+    );
+
+    // Layer 2: coworker-common.md + common.md
+    assert!(
+        prompt.contains("Channel Usage"),
+        "Reviewer system prompt should include coworker-common.md content"
+    );
     assert!(
         prompt.contains("GitHub Etiquette"),
         "Reviewer system prompt should include common.md content"
     );
 
-    // Should contain content from coworker.md
+    // Layer 3: Runtime substitutions
     assert!(
-        prompt.contains("Channel Usage"),
-        "Reviewer system prompt should include coworker.md content"
-    );
-
-    // Should contain reviewer-specific instructions from reviewer.md
-    assert!(
-        prompt.contains("THRESHOLD OVERRIDE"),
-        "Reviewer system prompt should include THRESHOLD OVERRIDE from reviewer.md"
-    );
-    assert!(
-        prompt.contains("CHANNEL MESSAGE DISCIPLINE"),
-        "Reviewer system prompt should include CHANNEL MESSAGE DISCIPLINE from reviewer.md"
-    );
-    assert!(
-        prompt.contains("TEST SUGGESTIONS"),
-        "Reviewer system prompt should include TEST SUGGESTIONS from reviewer.md"
-    );
-
-    // Should have name substituted
-    assert!(
-        prompt.contains("**lexington**"),
-        "Reviewer system prompt should substitute {{name}} with actual name"
+        prompt.contains("lexington"),
+        "Reviewer system prompt should substitute name"
     );
     assert!(
         !prompt.contains("{name}"),
@@ -460,17 +465,13 @@ fn test_coworker_prompt_prevents_orphaned_branches() {
     );
 
     assert!(
-        prompt.contains("ALWAYS use the existing PR branch"),
+        prompt.contains("Always use the existing PR branch"),
         "Coworker prompt should instruct to use existing PR branch for feedback"
-    );
-    assert!(
-        prompt.contains("git push origin --delete"),
-        "Coworker prompt should show command to delete remote branches"
     );
 }
 
 #[test]
-fn test_coworker_prompt_requires_issue_comment_reviews() {
+fn test_coworker_prompt_requires_merge_checklist() {
     let prompt = coworker_system_prompt("park", "midtown", None);
 
     assert!(
@@ -478,20 +479,8 @@ fn test_coworker_prompt_requires_issue_comment_reviews() {
         "Coworker prompt should contain the pre-merge checklist section"
     );
     assert!(
-        prompt.contains(r#"gh api "repos/$repo/issues/<PR_NUMBER>/comments""#),
-        "Coworker prompt should show the issue-comment gh api command using the repo shorthand"
-    );
-    assert!(
-        prompt.contains("<!-- midtown:"),
-        "Coworker prompt should mention the frontmatter signature so reviewers are detected"
-    );
-    assert!(
         prompt.contains("merge hold"),
         "Coworker prompt should instruct checking the channel for merge holds"
-    );
-    assert!(
-        prompt.contains(r#"gh pr view <number> --comments --json comments"#),
-        "Coworker prompt should instruct checking recent PR comments for late requests"
     );
     assert!(
         prompt.contains("stop"),
@@ -500,6 +489,10 @@ fn test_coworker_prompt_requires_issue_comment_reviews() {
     assert!(
         prompt.contains("all checks pass"),
         "Coworker prompt should gate merge on all checks passing"
+    );
+    assert!(
+        prompt.contains("midtown pr merge"),
+        "Coworker prompt should use daemon-gated merge command"
     );
 }
 

--- a/src/agents_three_layer_tests.rs
+++ b/src/agents_three_layer_tests.rs
@@ -87,8 +87,18 @@ fn test_layer1_agent_definitions_have_no_template_vars() {
 // ── Layer 2: shared_prompt_for_role ──────────────────────────────
 
 #[test]
-fn test_layer2_coworker_returns_common_only() {
+fn test_layer2_coworker_returns_coworker_common_and_common() {
     let shared = shared_prompt_for_role(AgentRole::Coworker);
+    // coworker-common.md content
+    assert!(
+        shared.contains("Channel Usage"),
+        "Coworker shared prompt should include Channel Usage from coworker-common.md"
+    );
+    assert!(
+        shared.contains("Coordination"),
+        "Coworker shared prompt should include Coordination from coworker-common.md"
+    );
+    // common.md content
     assert!(
         shared.contains("GitHub Etiquette"),
         "Coworker shared prompt should include common.md content"
@@ -105,8 +115,14 @@ fn test_layer2_coworker_returns_common_only() {
 }
 
 #[test]
-fn test_layer2_reviewer_returns_common_only() {
+fn test_layer2_reviewer_returns_coworker_common_and_common() {
     let shared = shared_prompt_for_role(AgentRole::Reviewer);
+    // coworker-common.md content (reviewers share operational rules with coworkers)
+    assert!(
+        shared.contains("Channel Usage"),
+        "Reviewer shared prompt should include Channel Usage from coworker-common.md"
+    );
+    // common.md content
     assert!(
         shared.contains("GitHub Etiquette"),
         "Reviewer shared prompt should include common.md content"
@@ -193,7 +209,29 @@ fn test_layer3_channel_lead_defaults_to_project_name() {
 }
 
 #[test]
-fn test_layer3_replaces_channel_name() {
+fn test_layer3_injects_channel_configuration() {
+    let input = "Base prompt";
+    let result = build_runtime_context(
+        input,
+        &RuntimeContext {
+            name: "web",
+            project_name: "midtown",
+            channel_name: Some("web-interface"),
+            ..RuntimeContext::default()
+        },
+    );
+    assert!(
+        result.contains("#web-interface"),
+        "Channel config injection should include channel name with # prefix"
+    );
+    assert!(
+        result.contains("--channel web-interface"),
+        "Channel config injection should include --channel flag"
+    );
+}
+
+#[test]
+fn test_layer3_replaces_channel_name_in_template() {
     let input = "Channel: #{channel_name}";
     let result = build_runtime_context(
         input,
@@ -208,8 +246,8 @@ fn test_layer3_replaces_channel_name() {
 }
 
 #[test]
-fn test_layer3_replaces_domain_context() {
-    let input = "Context: {domain_context}";
+fn test_layer3_injects_domain_context() {
+    let input = "Base prompt";
     let result = build_runtime_context(
         input,
         &RuntimeContext {
@@ -219,12 +257,19 @@ fn test_layer3_replaces_domain_context() {
             ..RuntimeContext::default()
         },
     );
-    assert!(result.contains("Context: Active tasks: !42"));
+    assert!(
+        result.contains("Active tasks: !42"),
+        "Domain context injection should include the provided context"
+    );
+    assert!(
+        result.contains("## Domain Context"),
+        "Domain context injection should have a section header"
+    );
 }
 
 #[test]
-fn test_layer3_replaces_escalation_target() {
-    let input = "@{escalation_target} [Review Note]";
+fn test_layer3_injects_escalation_target() {
+    let input = "Base prompt";
     let result = build_runtime_context(
         input,
         &RuntimeContext {
@@ -234,7 +279,14 @@ fn test_layer3_replaces_escalation_target() {
             ..RuntimeContext::default()
         },
     );
-    assert!(result.contains("@daemon-core [Review Note]"));
+    assert!(
+        result.contains("@daemon-core"),
+        "Escalation target injection should include the target with @ prefix"
+    );
+    assert!(
+        result.contains("## Escalation Target"),
+        "Escalation target injection should have a section header"
+    );
 }
 
 #[test]
@@ -345,7 +397,7 @@ fn test_layer3_no_ops_extra_for_non_ops_channel() {
 // ── Section ordering tests ───────────────────────────────────────
 
 #[test]
-fn test_reviewer_prompt_common_md_before_reviewer_instructions() {
+fn test_reviewer_prompt_layer1_before_layer2() {
     let prompt = reviewer_system_prompt(
         "york",
         "midtown",
@@ -353,16 +405,17 @@ fn test_reviewer_prompt_common_md_before_reviewer_instructions() {
         crate::auth::AuthProvider::Claude,
         Some(42),
     );
-    let common_pos = prompt
+    // Layer 1 (agent definition) comes before Layer 2 (shared prompts)
+    let layer1_pos = prompt
+        .find("Code Reviewer")
+        .expect("Agent definition content should be present");
+    let layer2_pos = prompt
         .find("GitHub Etiquette")
         .expect("common.md content should be present");
-    let reviewer_pos = prompt
-        .find("## Reviewer Instructions")
-        .expect("Reviewer Instructions section should be present");
     assert!(
-        common_pos < reviewer_pos,
-        "common.md content must appear BEFORE '## Reviewer Instructions' \
-         (common at {common_pos}, reviewer at {reviewer_pos})"
+        layer1_pos < layer2_pos,
+        "Agent definition (Layer 1) must appear BEFORE shared prompt (Layer 2) \
+         (layer1 at {layer1_pos}, layer2 at {layer2_pos})"
     );
 }
 


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Switch all assembly functions from old-format prompt files to agent definitions for Layer 1
- Create `coworker-common.md` as Layer 2 shared content for coworkers and reviewers (Channel Usage, Coordination, Don't Poll GitHub)
- Add runtime content injection to `build_runtime_context()` for channel config, domain context, and escalation targets
- Remove unused old-format constants

## Architecture

The three-layer prompt architecture is now fully active:

| Layer | Content | Source |
|-------|---------|--------|
| Layer 1 — Agent definition | Role identity & behavior | `~/.claude/agents/midtown-*.md` (loaded by Claude Code `--agent`) |
| Layer 2 — Shared prompt | Operational rules shared across roles | Compiled-in `common.md`, `lead-common.md`, `coworker-common.md` |
| Layer 3 — Runtime context | Name, project, channel, domain notes | `build_runtime_context()` in daemon |

## Test plan
- [x] All agent assembly tests pass (110 tests)
- [x] Clippy clean with `-D warnings`
- [x] Layer ordering verified: Layer 1 before Layer 2 in assembled prompts
- [x] Reviewer prompt correctly includes coworker-common.md shared content

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)