### PR TITLE
fix: Show reply content in Needs Attention preview [Midtown !2292]

### DIFF
--- a/web-app/src/lib/api.test.ts
+++ b/web-app/src/lib/api.test.ts
@@ -1012,6 +1012,58 @@ describe("handleUpdate — auto-track threads when someone replies to user messa
 		expect(tracked[parentId]).toBeUndefined();
 	});
 
+	it("sets fullText from the reply content, not the parent message", () => {
+		handleUpdate({
+			type: "channel_message",
+			data: {
+				id: "reply-ft-1",
+				from: "coworker",
+				content: "here is the detailed answer to your question",
+				channel: "web",
+				thread_parent_id: parentId,
+				timestamp: "2026-01-01T00:00:00Z",
+			},
+		});
+
+		const tracked = get(trackedThreads);
+		expect(tracked[parentId]).toBeTruthy();
+		// subject comes from parent (thread topic)
+		expect(tracked[parentId].subject).toContain("my question about auth");
+		// fullText should be the reply content, not the parent
+		expect(tracked[parentId].fullText).toBe("here is the detailed answer to your question");
+	});
+
+	it("updates fullText when a new reply arrives on an already-tracked thread", () => {
+		// First reply auto-tracks
+		handleUpdate({
+			type: "channel_message",
+			data: {
+				id: "reply-ft-2a",
+				from: "coworker",
+				content: "first answer",
+				channel: "web",
+				thread_parent_id: parentId,
+				timestamp: "2026-01-01T00:00:00Z",
+			},
+		});
+
+		// Second reply should update fullText
+		handleUpdate({
+			type: "channel_message",
+			data: {
+				id: "reply-ft-2b",
+				from: "coworker",
+				content: "actually, here is a better answer",
+				channel: "web",
+				thread_parent_id: parentId,
+				timestamp: "2026-01-01T00:00:01Z",
+			},
+		});
+
+		const tracked = get(trackedThreads);
+		expect(tracked[parentId].fullText).toBe("actually, here is a better answer");
+	});
+
 	it("auto-tracks when parent from matches userSenderName (custom display name)", () => {
 		userSenderName.set("ben");
 		messagesByChannel.set({

--- a/web-app/src/lib/api.ts
+++ b/web-app/src/lib/api.ts
@@ -70,11 +70,12 @@ function trackThread(
 	channelName: string,
 	content: string | null | undefined,
 	replyCount?: number,
+	replyContent?: string | null,
 ): void {
 	const dismissed = get(dismissedThreads);
 	if (dismissed.has(threadParentId)) return;
 	const newSubject = extractThreadSubject(content);
-	const newFullText = extractPlainText(content);
+	const newFullText = replyContent ? extractPlainText(replyContent) : extractPlainText(content);
 	trackedThreads.update((tracked) => {
 		const existing = tracked[threadParentId];
 		// Keep existing subject/fullText if the new one is just the fallback "Thread"
@@ -710,7 +711,7 @@ export function handleUpdate(update: Record<string, unknown>): void {
 					const parentMsg = channelMsgs?.find((m: Message) => m.id === threadParentId);
 					const uName = get(userSenderName);
 					if (parentMsg && (parentMsg.from === "user" || parentMsg.from === uName)) {
-						trackThread(threadParentId, channelName, parentMsg.content);
+						trackThread(threadParentId, channelName, parentMsg.content, undefined, msg.content);
 					}
 
 					const tracked = get(trackedThreads);
@@ -724,12 +725,14 @@ export function handleUpdate(update: Record<string, unknown>): void {
 					}
 					// Update lastActivity/replyCount on the tracked entry
 					if (tracked[threadParentId]) {
+						const replyFullText = extractPlainText(msg.content);
 						trackedThreads.update((t) => ({
 							...t,
 							[threadParentId]: {
 								...t[threadParentId],
 								lastActivity: new Date().toISOString(),
 								replyCount: (t[threadParentId]?.replyCount || 0) + 1,
+								...(replyFullText ? { fullText: replyFullText } : {}),
 							},
 						}));
 					}


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary

- **Bug**: "Needs Attention" thread preview showed the thread parent message text instead of the reply that actually @mentioned the user
- **Fix**: `trackThread()` now accepts an optional `replyContent` parameter so `fullText` is derived from the reply, while `subject` still comes from the parent (thread topic identifier)
- **Also fixed**: The WS handler update block (for subsequent replies on already-tracked threads) now updates `fullText` with each new reply, keeping the preview current

## Test plan

- [x] Added test: `sets fullText from the reply content, not the parent message`
- [x] Added test: `updates fullText when a new reply arrives on an already-tracked thread`
- [x] All 61 existing tests continue to pass
- [ ] Manual: verify Needs Attention section shows reply text in the web UI

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)