### PR TITLE
fix: Skip tool-only messages in senderChanged() to preserve author attribution

### DIFF
--- a/web-app/src/lib/messageUtils.test.ts
+++ b/web-app/src/lib/messageUtils.test.ts
@@ -224,4 +224,14 @@ describe("senderChanged", () => {
 		const msgs = [msg("park", "", [{ tool_name: "Bash", input: {} }]), msg("park", "hello")];
 		expect(senderChanged(msgs, 1)).toBe(true);
 	});
+
+	it("returns false for consecutive tool-only messages from the same sender (expanded tool run)", () => {
+		// Inside expanded ToolRunSummary, tool-only messages are visible and should
+		// use normal adjacent comparison to preserve sender grouping.
+		const msgs = [
+			msg("park", "", [{ tool_name: "Read", input: {} }]),
+			msg("park", "", [{ tool_name: "Bash", input: {} }]),
+		];
+		expect(senderChanged(msgs, 1)).toBe(false);
+	});
 });

--- a/web-app/src/lib/messageUtils.ts
+++ b/web-app/src/lib/messageUtils.ts
@@ -114,8 +114,13 @@ export function formatTimeCompact(timestamp: string): string {
 // Returns true if the sender changed from the previous *visible* message.
 // Tool-only messages are collapsed into ToolRunSummary and never render an avatar,
 // so we skip them when walking backward to find the last visually-rendered message.
+// Exception: when the current message is itself tool-only (inside an expanded
+// ToolRunSummary), use normal adjacent comparison to preserve sender grouping.
 export function senderChanged(msgs: Message[], index: number): boolean {
 	if (index === 0) return true;
+	if (isToolOnly(msgs[index])) {
+		return msgs[index].from !== msgs[index - 1].from;
+	}
 	for (let i = index - 1; i >= 0; i--) {
 		if (!isToolOnly(msgs[i])) {
 			return msgs[index].from !== msgs[i].from;


### PR DESCRIPTION
<!-- midtown: mercer -->

## Summary

- Fix author attribution (avatar + name) disappearing when an agent's first message is tool-only
- Update `senderChanged()` in `messageUtils.ts` to walk backward past tool-only messages when finding the last visually-rendered predecessor
- Add 7 test cases covering tool-only predecessor scenarios

## Details

**Bug**: When an agent's first message has `tool_data` but no text content, it gets collapsed into a `ToolRunSummary` button with no avatar. The next text message from the same agent then renders in continuation style (no avatar/name) because `senderChanged()` only compared adjacent messages — it saw same sender and returned `false`, unaware the predecessor was never visually rendered.

**Fix**: `senderChanged()` now walks backward through the message array, skipping tool-only messages (via `isToolOnly()` from `toolRunGrouping.ts`), to find the last message that was actually rendered with attribution. If all predecessors are tool-only, it returns `true` (show attribution).

Affects both `Channel.svelte` and `ThreadPanel.svelte` since both pass the full message array to `MessageRow`.

## Test plan

- [x] Added test: returns true when previous message is tool-only from same sender
- [x] Added test: returns true with multiple tool-only predecessors from same sender
- [x] Added test: returns false when tool-only predecessor is from different sender (continuation preserved)
- [x] Added test: returns true when all predecessors are tool-only (first visible message)
- [x] Existing senderChanged behavior preserved (first message, same sender, different sender)
- [x] Full web-app test suite passes (375 tests)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)