### PR TITLE
fix: Show reply content in Needs Attention preview instead of thread parent

### DIFF
--- a/web-app/src/lib/api.test.ts
+++ b/web-app/src/lib/api.test.ts
@@ -1034,6 +1034,58 @@ describe("handleUpdate — auto-track threads when someone replies to user messa
 		expect(tracked["ben-msg"]).toBeTruthy();
 		expect(tracked["ben-msg"].subject).toContain("custom name question");
 	});
+
+	it("sets fullText from the reply content, not the parent message", () => {
+		handleUpdate({
+			type: "channel_message",
+			data: {
+				id: "reply-ft-1",
+				from: "coworker",
+				content: "the actual reply text",
+				channel: "web",
+				thread_parent_id: parentId,
+				timestamp: "2026-01-01T00:00:00Z",
+			},
+		});
+
+		const tracked = get(trackedThreads);
+		expect(tracked[parentId]).toBeTruthy();
+		// subject comes from the parent message
+		expect(tracked[parentId].subject).toContain("my question about auth");
+		// fullText comes from the reply, not the parent
+		expect(tracked[parentId].fullText).toBe("the actual reply text");
+	});
+
+	it("updates fullText when a new reply arrives on an already-tracked thread", () => {
+		// First reply — auto-tracks
+		handleUpdate({
+			type: "channel_message",
+			data: {
+				id: "reply-ft-a",
+				from: "coworker",
+				content: "first reply",
+				channel: "web",
+				thread_parent_id: parentId,
+				timestamp: "2026-01-01T00:00:00Z",
+			},
+		});
+
+		// Second reply — should update fullText
+		handleUpdate({
+			type: "channel_message",
+			data: {
+				id: "reply-ft-b",
+				from: "coworker",
+				content: "second reply with more detail",
+				channel: "web",
+				thread_parent_id: parentId,
+				timestamp: "2026-01-01T00:00:01Z",
+			},
+		});
+
+		const tracked = get(trackedThreads);
+		expect(tracked[parentId].fullText).toBe("second reply with more detail");
+	});
 });
 
 describe("forkThread / unforkThread", () => {

--- a/web-app/src/lib/api.ts
+++ b/web-app/src/lib/api.ts
@@ -69,12 +69,13 @@ function trackThread(
 	threadParentId: string,
 	channelName: string,
 	content: string | null | undefined,
-	replyCount?: number,
+	opts?: { replyCount?: number; replyContent?: string | null },
 ): void {
 	const dismissed = get(dismissedThreads);
 	if (dismissed.has(threadParentId)) return;
 	const newSubject = extractThreadSubject(content);
-	const newFullText = extractPlainText(content);
+	// Use reply content for fullText when available, otherwise fall back to parent content
+	const newFullText = extractPlainText(opts?.replyContent ?? content);
 	trackedThreads.update((tracked) => {
 		const existing = tracked[threadParentId];
 		// Keep existing subject/fullText if the new one is just the fallback "Thread"
@@ -88,7 +89,7 @@ function trackThread(
 				fullText,
 				// Only set lastActivity on initial tracking — WS handler updates it on new replies
 				lastActivity: existing?.lastActivity || new Date().toISOString(),
-				replyCount: replyCount ?? (existing?.replyCount || 0),
+				replyCount: opts?.replyCount ?? (existing?.replyCount || 0),
 			},
 		};
 	});
@@ -710,7 +711,7 @@ export function handleUpdate(update: Record<string, unknown>): void {
 					const parentMsg = channelMsgs?.find((m: Message) => m.id === threadParentId);
 					const uName = get(userSenderName);
 					if (parentMsg && (parentMsg.from === "user" || parentMsg.from === uName)) {
-						trackThread(threadParentId, channelName, parentMsg.content);
+						trackThread(threadParentId, channelName, parentMsg.content, { replyContent: msg.content });
 					}
 
 					const tracked = get(trackedThreads);
@@ -724,12 +725,14 @@ export function handleUpdate(update: Record<string, unknown>): void {
 					}
 					// Update lastActivity/replyCount on the tracked entry
 					if (tracked[threadParentId]) {
+						const replyFullText = extractPlainText(msg.content);
 						trackedThreads.update((t) => ({
 							...t,
 							[threadParentId]: {
 								...t[threadParentId],
 								lastActivity: new Date().toISOString(),
 								replyCount: (t[threadParentId]?.replyCount || 0) + 1,
+								...(replyFullText ? { fullText: replyFullText } : {}),
 							},
 						}));
 					}
@@ -1186,7 +1189,7 @@ export function openThread(parentMessage: Message, channelName: string, { pushSt
 		delete next[parentMessage.id];
 		return next;
 	});
-	trackThread(parentMessage.id, channelName, parentMessage.content, parentMessage.reply_count);
+	trackThread(parentMessage.id, channelName, parentMessage.content, { replyCount: parentMessage.reply_count });
 
 	// Show panel immediately with loading state, then populate with replies
 	threadData.set({ parentMessage, channelName, messages: [], tasks });


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Fixed `trackThread()` to use reply content for `fullText` instead of parent message content, so the "Needs Attention" preview shows the actual reply that triggered the notification
- Updated the lastActivity/replyCount update block to also refresh `fullText` with the latest reply content
- Changed `trackThread()` signature from positional `replyCount` param to an options object (`{ replyCount?, replyContent? }`) for cleaner API

## Test plan
- [x] Added test: `sets fullText from the reply content, not the parent message`
- [x] Added test: `updates fullText when a new reply arrives on an already-tracked thread`
- [x] All 61 existing tests pass
- [ ] Manual: verify Needs Attention section shows reply text, not parent text

Fixes Midtown !2292

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)