### PR TITLE
feat: Render parent-child task grouping in web UI

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -1075,6 +1075,7 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
             };
             let message_id = persistent_state.task_message_id.get(&task.id).cloned();
             let thread_id = persistent_state.task_thread_id.get(&task.id).cloned();
+            let parent = persistent_state.task_parent.get(&task.id).cloned();
             serde_json::json!({
                 "id": task.id,
                 "subject": task.subject,
@@ -1085,6 +1086,7 @@ async fn api_status(State(state): State<Arc<WebState>>) -> Result<impl IntoRespo
                 "blocked_by": task.blocked_by,
                 "message_id": message_id,
                 "thread_id": thread_id,
+                "parent": parent,
             })
         })
         .collect();

--- a/web-app/src/lib/TaskList.svelte
+++ b/web-app/src/lib/TaskList.svelte
@@ -28,13 +28,54 @@ function filterTasksByChannel(tasks, channel) {
 	return tasks.filter((task) => task.channel === channel);
 }
 
-// Derived: tasks for this channel
+/**
+ * Group tasks so children appear immediately after their parent, indented.
+ * Tasks without a parent (or whose parent isn't in the list) appear at the top level.
+ * Returns { task, isChild }[] for rendering.
+ */
+function groupByParent(tasks) {
+	const childrenOf = new Map(); // parent id → child tasks[]
+	const topLevel = [];
+	const taskIds = new Set(tasks.map((t) => String(t.id)));
+
+	for (const task of tasks) {
+		if (task.parent && taskIds.has(String(task.parent))) {
+			const key = String(task.parent);
+			if (!childrenOf.has(key)) childrenOf.set(key, []);
+			childrenOf.get(key).push(task);
+		} else {
+			topLevel.push(task);
+		}
+	}
+
+	// Promote children whose parent is also a child (circular refs) to top level
+	const topLevelIds = new Set(topLevel.map((t) => String(t.id)));
+	for (const [parentId, children] of childrenOf) {
+		if (!topLevelIds.has(parentId)) {
+			topLevel.push(...children);
+		}
+	}
+
+	const result = [];
+	for (const task of topLevel) {
+		result.push({ task, isChild: false });
+		const children = childrenOf.get(String(task.id));
+		if (children) {
+			for (const child of children) {
+				result.push({ task: child, isChild: true });
+			}
+		}
+	}
+	return result;
+}
+
+// Derived: tasks for this channel, grouped by parent-child relationship
 const channelTasks = $derived.by(() => {
 	const allTasks = [
 		...$kanbanData.inProgress.map((t) => ({ ...t, status: "in_progress" })),
 		...$kanbanData.backlog.map((t) => ({ ...t, status: "pending" })),
 	];
-	return filterTasksByChannel(allTasks, channelName);
+	return groupByParent(filterTasksByChannel(allTasks, channelName));
 });
 
 // Map coworker name → coworker object for progress/phase lookup
@@ -58,12 +99,13 @@ function handleTaskClick(task) {
 </script>
 
 <div class="flex flex-col gap-0.5 py-1 pb-1.5">
-  {#each channelTasks as task}
+  {#each channelTasks as { task, isChild }}
     {@const cw = task.owner ? cwMap.get(task.owner) : null}
     {@const reviewInfo = taskReviewerMap.get(String(task.id))}
     <TaskRow
       {task}
       {cw}
+      {isChild}
       reviewer={reviewInfo?.reviewer}
       reviewPosted={reviewInfo?.reviewPosted ?? false}
       onclick={() => handleTaskClick(task)}

--- a/web-app/src/lib/TaskRow.svelte
+++ b/web-app/src/lib/TaskRow.svelte
@@ -11,7 +11,15 @@ import { renderContent } from "./markdown.ts";
 import { getSenderColor } from "./messageUtils.ts";
 import { activeChannel, channels, coworkers, daemonStatus, kanbanData, repoStatus, repoStatuses } from "./store.ts";
 
-let { task, cw = null, reviewer = null, reviewPosted = false, onclick = null, variant = "row" } = $props();
+let {
+	task,
+	cw = null,
+	isChild = false,
+	reviewer = null,
+	reviewPosted = false,
+	onclick = null,
+	variant = "row",
+} = $props();
 
 const isCard = $derived(variant === "card");
 const isActive = $derived(task.status === "in_progress");
@@ -75,7 +83,7 @@ function handleDescriptionClick(e) {
 </script>
 
 <button
-  class="task-row w-full overflow-visible flex items-stretch gap-1.5 py-[5px] cursor-pointer transition-[background] duration-100 text-left font-mono text-[0.72rem] leading-[1.3] text-muted-foreground {isCard ? 'border border-[hsl(var(--border))] bg-[hsl(var(--card))] mb-2 hover:bg-[hsl(var(--accent)_/_0.3)] pr-3 rounded-md' : 'border-none bg-transparent rounded-[5px] hover:bg-sidebar-accent'} {isActive ? 'text-sidebar-foreground' : ''} {isBlocked ? 'opacity-65' : ''}"
+  class="task-row w-full overflow-visible flex items-stretch gap-1.5 py-[5px] cursor-pointer transition-[background] duration-100 text-left font-mono text-[0.72rem] leading-[1.3] text-muted-foreground {isCard ? 'border border-[hsl(var(--border))] bg-[hsl(var(--card))] mb-2 hover:bg-[hsl(var(--accent)_/_0.3)] pr-3 rounded-md' : 'border-none bg-transparent rounded-[5px] hover:bg-sidebar-accent'} {isActive ? 'text-sidebar-foreground' : ''} {isBlocked ? 'opacity-65' : ''} {isChild && !isCard ? 'pl-3' : ''}"
   onclick={isCard ? undefined : onclick}
   data-testid={isCard ? 'task-card' : undefined}
 >

--- a/web-app/src/lib/types.ts
+++ b/web-app/src/lib/types.ts
@@ -63,6 +63,8 @@ export interface Task {
 	channel?: string;
 	thread_id?: string;
 	message_id?: string;
+	parent?: string;
+	blocked_by?: string[];
 }
 
 // ── Pull requests ────────────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- midtown: mercer -->

## Summary
- Wire `parent` field from `DaemonPersistentState.task_parent` through the `/api/status` endpoint to the frontend
- Add `groupByParent()` in `TaskList.svelte` to order child tasks immediately after their parent
- Indent child task rows with `pl-3` padding in `TaskRow.svelte`
- Add `parent` and `blocked_by` fields to the TypeScript `Task` interface
- Handle edge cases: orphaned children promoted to top-level, circular parent references detected and surfaced

## Test plan
- [x] Rust build passes (`cargo build`)
- [x] Clippy clean (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Web app Vite build passes
- [x] All 377 web-app tests pass (`vitest run`)
- [x] Biome lint clean on all changed files
- [ ] Manual: verify child tasks appear indented under parent in sidebar task list
- [ ] Manual: verify tasks with no parent render normally (no regression)
- [ ] Manual: verify tasks whose parent is in a different channel appear at top level

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)