### PR TITLE
fix: Remove stale reviewer assignments when session never started

### DIFF
--- a/src/github_state.rs
+++ b/src/github_state.rs
@@ -17,6 +17,13 @@ use tracing::{debug, warn};
 /// Mirrors PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS from the in-memory tracker.
 pub const PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS: u64 = 600;
 
+/// Grace period (in seconds) for the optimistic assignment window. Assignments
+/// younger than this are never pruned, even if the reviewer isn't running yet,
+/// because the spawn may still be in progress. After this window, assignments
+/// where the session never started (no `reviewer_session_id`) and the reviewer
+/// is not running are considered orphaned and removed.
+pub const OPTIMISTIC_ASSIGNMENT_GRACE_SECS: u64 = 60;
+
 /// Persistent state for GitHub-related data.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct GitHubState {
@@ -382,10 +389,18 @@ impl GitHubState {
     /// of a reviewer just because the review is taking longer than the timeout.
     /// Running coworkers' assignments are preserved regardless of timeout.
     ///
-    /// **Optimistic assignment safety**: Assignments younger than `timeout` (600s)
-    /// are never pruned, even if the reviewer doesn't appear in `running_coworkers`.
-    /// This protects against the window between optimistic assignment (before spawn)
-    /// and worktree creation (after spawn completes).
+    /// **Optimistic assignment safety**: Assignments younger than
+    /// `OPTIMISTIC_ASSIGNMENT_GRACE_SECS` (60s) are never pruned, even if the
+    /// reviewer doesn't appear in `running_coworkers`. This protects against
+    /// the window between optimistic assignment (before spawn) and worktree
+    /// creation (after spawn completes).
+    ///
+    /// **Orphaned assignment cleanup**: Assignments older than the grace period
+    /// but younger than `timeout` (600s) are removed if the reviewer is not
+    /// running AND the session never started (`reviewer_session_id` is `None`).
+    /// This handles the case where a coworker was repurposed before the review
+    /// session started — without this, the stale assignment blocks re-spawning
+    /// for the full 600-second timeout.
     ///
     /// When `running_session_ids` is provided, assignments with a known
     /// `reviewer_session_id` are matched by session ID instead of name. This
@@ -398,6 +413,7 @@ impl GitHubState {
     ) {
         let now = Utc::now();
         let timeout = chrono::Duration::seconds(PR_REVIEW_ASSIGNMENT_TIMEOUT_SECS as i64);
+        let grace = chrono::Duration::seconds(OPTIMISTIC_ASSIGNMENT_GRACE_SECS as i64);
 
         let is_reviewer_running = |a: &PrReviewerAssignment| -> bool {
             // If we have session IDs and the assignment has one, prefer session-based matching
@@ -412,17 +428,30 @@ impl GitHubState {
             .pr_reviewers
             .iter()
             .filter(|(_, a)| {
-                now.signed_duration_since(a.assigned_at) > timeout && !is_reviewer_running(a)
+                let elapsed = now.signed_duration_since(a.assigned_at);
+                if is_reviewer_running(a) {
+                    return false;
+                }
+                // Case 1: Assignment expired by timeout (original behavior)
+                if elapsed > timeout {
+                    return true;
+                }
+                // Case 2: Assignment past grace period, session never started
+                // (coworker was repurposed before the review session began)
+                if elapsed > grace && a.reviewer_session_id.is_none() {
+                    return true;
+                }
+                false
             })
             .map(|(pr, _)| *pr)
             .collect();
 
-        for pr in to_remove {
+        for pr in &to_remove {
             debug!(
-                "Cleaning up expired reviewer assignment for PR #{} (timed out, coworker not running)",
+                "Cleaning up stale reviewer assignment for PR #{} (coworker not running)",
                 pr
             );
-            self.pr_reviewers.remove(&pr);
+            self.pr_reviewers.remove(pr);
         }
 
         // Refresh timestamps for running coworkers whose assignments would have expired

--- a/src/github_state_tests.rs
+++ b/src/github_state_tests.rs
@@ -657,6 +657,103 @@ fn test_expired_assignment_removed_when_reviewer_not_running_enables_respawn() {
     );
 }
 
+/// Regression test for !2303: When a reviewer assignment exists but the session
+/// never started (e.g., the coworker was repurposed as a developer), the
+/// assignment blocks re-spawning for the full 600-second timeout. The fix:
+/// `cleanup_expired_preserving` should remove assignments where the reviewer
+/// is not running AND the session never started (no `reviewer_session_id`),
+/// after a grace period for the optimistic assignment window.
+#[test]
+fn test_stale_assignment_removed_when_session_never_started() {
+    let mut state = GitHubState::default();
+    state.assign_reviewer(2001, "lexington", AssignmentSource::PollingFallback);
+
+    // Backdate assignment past the grace period (120s) but within the 600s timeout.
+    // This simulates a coworker that was assigned ~2 minutes ago but never started
+    // a review session (e.g., was repurposed as a developer).
+    if let Some(a) = state.pr_reviewers.get_mut(&2001) {
+        a.assigned_at = Utc::now() - chrono::Duration::seconds(120);
+    }
+
+    // Precondition: `is_assigned()` still returns true (within 600s timeout).
+    assert!(
+        state.is_assigned(2001),
+        "assignment should still be within timeout window"
+    );
+
+    // Precondition: no reviewer_session_id (session never started).
+    assert!(
+        state
+            .pr_reviewers
+            .get(&2001)
+            .unwrap()
+            .reviewer_session_id
+            .is_none(),
+        "session was never started, so reviewer_session_id should be None"
+    );
+
+    // Lexington is NOT in running coworkers (was repurposed).
+    let running: std::collections::HashSet<String> = std::collections::HashSet::new();
+    state.cleanup_expired_preserving(&running, None);
+
+    // The assignment should be removed because the reviewer is not running
+    // and the session never started, even though it's within the 600s timeout.
+    assert!(
+        !state.pr_reviewers.contains_key(&2001),
+        "stale assignment for repurposed reviewer (no session started) must be \
+         removed by cleanup_expired_preserving to unblock re-spawning"
+    );
+}
+
+/// Verify that fresh assignments within the grace period are NOT removed,
+/// even if the reviewer isn't running yet (optimistic assignment window).
+#[test]
+fn test_fresh_optimistic_assignment_preserved_during_grace_period() {
+    let mut state = GitHubState::default();
+    state.assign_reviewer(2002, "park", AssignmentSource::PollingFallback);
+
+    // Assignment is only 30 seconds old — within the grace period for spawn.
+    if let Some(a) = state.pr_reviewers.get_mut(&2002) {
+        a.assigned_at = Utc::now() - chrono::Duration::seconds(30);
+    }
+
+    // Park is NOT running yet (spawn in progress).
+    let running: std::collections::HashSet<String> = std::collections::HashSet::new();
+    state.cleanup_expired_preserving(&running, None);
+
+    // The assignment should be preserved — it's within the grace period.
+    assert!(
+        state.pr_reviewers.contains_key(&2002),
+        "fresh optimistic assignment should be preserved during grace period"
+    );
+}
+
+/// Verify that assignments with a backfilled session_id are preserved even
+/// past the grace period, as long as the session might still be running.
+#[test]
+fn test_assignment_with_session_id_preserved_when_session_running() {
+    let mut state = GitHubState::default();
+    state.assign_reviewer(2003, "broadway", AssignmentSource::PollingFallback);
+
+    // Assignment is 120s old with a backfilled session_id (session did start).
+    if let Some(a) = state.pr_reviewers.get_mut(&2003) {
+        a.assigned_at = Utc::now() - chrono::Duration::seconds(120);
+        a.reviewer_session_id = Some("sess-abc".to_string());
+    }
+
+    // Broadway IS running.
+    let running: std::collections::HashSet<String> = ["broadway".to_string()].into_iter().collect();
+    let sessions: std::collections::HashSet<String> =
+        ["sess-abc".to_string()].into_iter().collect();
+    state.cleanup_expired_preserving(&running, Some(&sessions));
+
+    // Should be preserved — session is actively running.
+    assert!(
+        state.pr_reviewers.contains_key(&2003),
+        "assignment with active session should be preserved"
+    );
+}
+
 #[test]
 fn test_add_review_comment_id() {
     let mut state = GitHubState::default();


### PR DESCRIPTION
<!-- midtown: bleecker -->

## Summary

- Fix stale reviewer assignments blocking re-spawning when a coworker is repurposed before the review session starts (!2303)
- Add `OPTIMISTIC_ASSIGNMENT_GRACE_SECS` (60s) grace period for the optimistic assignment window
- After grace period, `cleanup_expired_preserving` removes assignments where the reviewer is not running AND the session never started (`reviewer_session_id` is `None`)
- Unblocks re-spawning within ~60s instead of waiting the full 10-minute timeout

## Test plan

- [x] Added regression test `test_stale_assignment_removed_when_session_never_started` — verifies orphaned assignments are cleaned up
- [x] Added `test_fresh_optimistic_assignment_preserved_during_grace_period` — verifies fresh assignments are not prematurely removed
- [x] Added `test_assignment_with_session_id_preserved_when_session_running` — verifies active sessions are preserved
- [x] All 9 existing cleanup tests continue to pass
- [x] `cargo clippy` and `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)