### PR TITLE
feat: Render parent-child task grouping in web UI

### DIFF
--- a/src/daemon/rpc_status.rs
+++ b/src/daemon/rpc_status.rs
@@ -52,6 +52,7 @@ pub(super) async fn handle_status(id: RequestId, state: &DaemonState) -> Respons
         task_message_ids,
         task_thread_ids,
         task_plan_map,
+        task_parent_map,
     ) = {
         let ps = state.persistent_state.lock().await;
         let rev_map: std::collections::HashMap<String, u64> = ps
@@ -74,6 +75,7 @@ pub(super) async fn handle_status(id: RequestId, state: &DaemonState) -> Respons
         let msg_ids = ps.task_message_id.clone();
         let thread_ids = ps.task_thread_id.clone();
         let plan_map = ps.task_plan.clone();
+        let parent_map = ps.task_parent.clone();
         (
             rev_map,
             wt_map,
@@ -82,6 +84,7 @@ pub(super) async fn handle_status(id: RequestId, state: &DaemonState) -> Respons
             msg_ids,
             thread_ids,
             plan_map,
+            parent_map,
         )
     };
 
@@ -109,7 +112,12 @@ pub(super) async fn handle_status(id: RequestId, state: &DaemonState) -> Respons
     // Note: get_all_tasks and read_tasks read from Claude Code task storage (local
     // filesystem), not GitHub API, so they're fast and don't cause rate limit timeouts.
     let (tasks, recent_activity, task_pr_map) = match tokio::task::spawn_blocking(move || {
-        let tasks = get_all_tasks(&task_message_ids, &task_thread_ids, &task_plan_map);
+        let tasks = get_all_tasks(
+            &task_message_ids,
+            &task_thread_ids,
+            &task_plan_map,
+            &task_parent_map,
+        );
         let recent_activity = get_recent_channel_activity();
         // Build task -> PR number map from task files with explicit PR associations.
         let task_pr_map: std::collections::HashMap<u32, u64> = crate::tasks::read_tasks()
@@ -242,22 +250,25 @@ fn get_all_tasks(
     task_message_ids: &std::collections::HashMap<String, String>,
     task_thread_ids: &std::collections::HashMap<String, String>,
     task_plan_map: &std::collections::HashMap<String, String>,
+    task_parent_map: &std::collections::HashMap<String, String>,
 ) -> Vec<serde_json::Value> {
     map_tasks_to_json(
         crate::tasks::read_tasks(),
         task_message_ids,
         task_thread_ids,
         task_plan_map,
+        task_parent_map,
     )
 }
 
 /// Map a list of tasks to JSON values, enriching each with message_id, thread_id,
-/// and plan path from the daemon's persistent state maps.
+/// plan path, and parent task ID from the daemon's persistent state maps.
 fn map_tasks_to_json(
     tasks: Vec<crate::tasks::Task>,
     task_message_ids: &std::collections::HashMap<String, String>,
     task_thread_ids: &std::collections::HashMap<String, String>,
     task_plan_map: &std::collections::HashMap<String, String>,
+    task_parent_map: &std::collections::HashMap<String, String>,
 ) -> Vec<serde_json::Value> {
     tasks
         .into_iter()
@@ -270,6 +281,7 @@ fn map_tasks_to_json(
             let message_id = task_message_ids.get(&task.id).cloned();
             let thread_id = task_thread_ids.get(&task.id).cloned();
             let plan = task_plan_map.get(&task.id).cloned();
+            let parent = task_parent_map.get(&task.id).cloned();
             serde_json::json!({
                 "id": task.id,
                 "subject": task.subject,
@@ -279,6 +291,7 @@ fn map_tasks_to_json(
                 "message_id": message_id,
                 "thread_id": thread_id,
                 "plan": plan,
+                "parent": parent,
             })
         })
         .collect()

--- a/src/daemon/rpc_status_tests.rs
+++ b/src/daemon/rpc_status_tests.rs
@@ -330,7 +330,8 @@ fn test_map_tasks_includes_thread_id_and_message_id() {
         .collect();
 
     let plan_map = std::collections::HashMap::new();
-    let result = map_tasks_to_json(tasks, &msg_ids, &thread_ids, &plan_map);
+    let parent_map = std::collections::HashMap::new();
+    let result = map_tasks_to_json(tasks, &msg_ids, &thread_ids, &plan_map, &parent_map);
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0]["id"], "42");
@@ -353,7 +354,8 @@ fn test_map_tasks_thread_id_null_when_absent() {
     let thread_ids = std::collections::HashMap::new();
 
     let plan_map = std::collections::HashMap::new();
-    let result = map_tasks_to_json(tasks, &msg_ids, &thread_ids, &plan_map);
+    let parent_map = std::collections::HashMap::new();
+    let result = map_tasks_to_json(tasks, &msg_ids, &thread_ids, &plan_map, &parent_map);
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0]["message_id"], "msg-only");
@@ -374,10 +376,39 @@ fn test_map_tasks_both_ids_null_when_absent() {
     let thread_ids = std::collections::HashMap::new();
 
     let plan_map = std::collections::HashMap::new();
-    let result = map_tasks_to_json(tasks, &msg_ids, &thread_ids, &plan_map);
+    let parent_map = std::collections::HashMap::new();
+    let result = map_tasks_to_json(tasks, &msg_ids, &thread_ids, &plan_map, &parent_map);
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0]["status"], "completed");
     assert!(result[0]["message_id"].is_null());
     assert!(result[0]["thread_id"].is_null());
+}
+
+#[test]
+fn test_map_tasks_includes_parent_when_set() {
+    let tasks = vec![
+        make_task(
+            "10",
+            "Implement feature",
+            crate::tasks::TaskStatus::InProgress,
+        ),
+        make_task("11", "Review PR #42", crate::tasks::TaskStatus::InProgress),
+    ];
+    let msg_ids = std::collections::HashMap::new();
+    let thread_ids = std::collections::HashMap::new();
+    let plan_map = std::collections::HashMap::new();
+    let parent_map = [("11".to_string(), "10".to_string())].into_iter().collect();
+
+    let result = map_tasks_to_json(tasks, &msg_ids, &thread_ids, &plan_map, &parent_map);
+
+    assert_eq!(result.len(), 2);
+    assert!(
+        result[0]["parent"].is_null(),
+        "parent task should have no parent"
+    );
+    assert_eq!(
+        result[1]["parent"], "10",
+        "child task should reference parent"
+    );
 }

--- a/web-app/src/lib/TaskList.svelte
+++ b/web-app/src/lib/TaskList.svelte
@@ -3,6 +3,7 @@ import { useSidebar } from "$lib/components/ui/sidebar/context.svelte.ts";
 import { openTaskThread } from "./api.ts";
 import { coworkers, kanbanData } from "./store.ts";
 import TaskRow from "./TaskRow.svelte";
+import { groupTasksByParent } from "./taskGrouping.ts";
 
 const sidebar = useSidebar();
 
@@ -28,13 +29,14 @@ function filterTasksByChannel(tasks, channel) {
 	return tasks.filter((task) => task.channel === channel);
 }
 
-// Derived: tasks for this channel
-const channelTasks = $derived.by(() => {
+// Derived: tasks for this channel, grouped by parent-child hierarchy
+const groupedTasks = $derived.by(() => {
 	const allTasks = [
 		...$kanbanData.inProgress.map((t) => ({ ...t, status: "in_progress" })),
 		...$kanbanData.backlog.map((t) => ({ ...t, status: "pending" })),
 	];
-	return filterTasksByChannel(allTasks, channelName);
+	const filtered = filterTasksByChannel(allTasks, channelName);
+	return groupTasksByParent(filtered);
 });
 
 // Map coworker name → coworker object for progress/phase lookup
@@ -58,19 +60,20 @@ function handleTaskClick(task) {
 </script>
 
 <div class="flex flex-col gap-0.5 py-1 pb-1.5">
-  {#each channelTasks as task}
+  {#each groupedTasks as { task, depth }}
     {@const cw = task.owner ? cwMap.get(task.owner) : null}
     {@const reviewInfo = taskReviewerMap.get(String(task.id))}
     <TaskRow
       {task}
       {cw}
+      {depth}
       reviewer={reviewInfo?.reviewer}
       reviewPosted={reviewInfo?.reviewPosted ?? false}
       onclick={() => handleTaskClick(task)}
     />
   {/each}
 
-  {#if channelTasks.length === 0}
+  {#if groupedTasks.length === 0}
     <div class="px-3 py-2 text-[0.72rem] text-muted-foreground italic text-center">No active tasks</div>
   {/if}
 </div>

--- a/web-app/src/lib/TaskRow.svelte
+++ b/web-app/src/lib/TaskRow.svelte
@@ -11,7 +11,7 @@ import { renderContent } from "./markdown.ts";
 import { getSenderColor } from "./messageUtils.ts";
 import { activeChannel, channels, coworkers, daemonStatus, kanbanData, repoStatus, repoStatuses } from "./store.ts";
 
-let { task, cw = null, reviewer = null, reviewPosted = false, onclick = null, variant = "row" } = $props();
+let { task, cw = null, depth = 0, reviewer = null, reviewPosted = false, onclick = null, variant = "row" } = $props();
 
 const isCard = $derived(variant === "card");
 const isActive = $derived(task.status === "in_progress");
@@ -75,10 +75,11 @@ function handleDescriptionClick(e) {
 </script>
 
 <button
-  class="task-row w-full overflow-visible flex items-stretch gap-1.5 py-[5px] cursor-pointer transition-[background] duration-100 text-left font-mono text-[0.72rem] leading-[1.3] text-muted-foreground {isCard ? 'border border-[hsl(var(--border))] bg-[hsl(var(--card))] mb-2 hover:bg-[hsl(var(--accent)_/_0.3)] pr-3 rounded-md' : 'border-none bg-transparent rounded-[5px] hover:bg-sidebar-accent'} {isActive ? 'text-sidebar-foreground' : ''} {isBlocked ? 'opacity-65' : ''}"
+  class="task-row w-full overflow-visible flex items-stretch gap-1.5 py-[5px] cursor-pointer transition-[background] duration-100 text-left font-mono text-[0.72rem] leading-[1.3] text-muted-foreground {isCard ? 'border border-[hsl(var(--border))] bg-[hsl(var(--card))] mb-2 hover:bg-[hsl(var(--accent)_/_0.3)] pr-3 rounded-md' : 'border-none bg-transparent rounded-[5px] hover:bg-sidebar-accent'} {isActive ? 'text-sidebar-foreground' : ''} {isBlocked ? 'opacity-65' : ''} {depth > 0 ? 'pl-3' : ''}"
   onclick={isCard ? undefined : onclick}
   data-testid={isCard ? 'task-card' : undefined}
 >
+  {#if depth > 0}<span class="shrink-0 text-muted-foreground/30 text-[0.6rem] self-center mr-[-2px]">└</span>{/if}
   <span class="w-[3px] rounded-sm shrink-0 self-stretch" style="background: {statusBarColor(task)}"></span>
   <div class="flex-1 min-w-0 flex flex-col gap-[3px]">
     {#if isCard}

--- a/web-app/src/lib/taskGrouping.test.ts
+++ b/web-app/src/lib/taskGrouping.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { groupTasksByParent } from "./taskGrouping.ts";
+import type { Task } from "./types.ts";
+
+function makeTask(id: number, subject: string, parent?: string): Task {
+	return { id, subject, status: "in_progress", parent };
+}
+
+describe("groupTasksByParent", () => {
+	it("returns empty array for empty input", () => {
+		expect(groupTasksByParent([])).toEqual([]);
+	});
+
+	it("returns tasks at depth 0 when no parent relationships", () => {
+		const tasks = [makeTask(1, "Task A"), makeTask(2, "Task B")];
+		const result = groupTasksByParent(tasks);
+		expect(result).toEqual([
+			{ task: tasks[0], depth: 0 },
+			{ task: tasks[1], depth: 0 },
+		]);
+	});
+
+	it("nests child under its parent at depth 1", () => {
+		const parent = makeTask(10, "Implement feature");
+		const child = makeTask(11, "Review PR #42", "10");
+		const result = groupTasksByParent([parent, child]);
+		expect(result).toEqual([
+			{ task: parent, depth: 0 },
+			{ task: child, depth: 1 },
+		]);
+	});
+
+	it("shows child at depth 0 when parent is not in list", () => {
+		const child = makeTask(11, "Review PR #42", "10");
+		const result = groupTasksByParent([child]);
+		expect(result).toEqual([{ task: child, depth: 0 }]);
+	});
+
+	it("groups multiple children under same parent", () => {
+		const parent = makeTask(10, "Implement feature");
+		const child1 = makeTask(11, "Review PR", "10");
+		const child2 = makeTask(12, "Address feedback", "10");
+		const result = groupTasksByParent([parent, child1, child2]);
+		expect(result).toEqual([
+			{ task: parent, depth: 0 },
+			{ task: child1, depth: 1 },
+			{ task: child2, depth: 1 },
+		]);
+	});
+
+	it("handles mixed parent and standalone tasks", () => {
+		const standalone = makeTask(5, "Standalone");
+		const parent = makeTask(10, "Feature");
+		const child = makeTask(11, "Review", "10");
+		const result = groupTasksByParent([standalone, parent, child]);
+		expect(result).toEqual([
+			{ task: standalone, depth: 0 },
+			{ task: parent, depth: 0 },
+			{ task: child, depth: 1 },
+		]);
+	});
+
+	it("preserves input order for children listed before parent", () => {
+		const child = makeTask(11, "Review", "10");
+		const parent = makeTask(10, "Feature");
+		// Child appears before parent in input — child should nest under parent
+		const result = groupTasksByParent([child, parent]);
+		expect(result).toEqual([
+			{ task: parent, depth: 0 },
+			{ task: child, depth: 1 },
+		]);
+	});
+
+	it("handles self-parent by treating as top-level", () => {
+		const task = makeTask(5, "Self-referencing", "5");
+		const result = groupTasksByParent([task]);
+		expect(result).toEqual([{ task, depth: 0 }]);
+	});
+
+	it("handles circular parent refs without losing tasks", () => {
+		const a = makeTask(1, "Task A", "2");
+		const b = makeTask(2, "Task B", "1");
+		const result = groupTasksByParent([a, b]);
+		// Both should appear — neither can be properly nested
+		expect(result).toHaveLength(2);
+		expect(result.every((r) => r.depth === 0)).toBe(true);
+	});
+
+	it("does not duplicate tasks in any scenario", () => {
+		const parent = makeTask(10, "Feature");
+		const child = makeTask(11, "Review", "10");
+		const orphan = makeTask(12, "Orphan", "99");
+		const selfRef = makeTask(13, "Self", "13");
+		const result = groupTasksByParent([parent, child, orphan, selfRef]);
+		const ids = result.map((r) => r.task.id);
+		expect(ids).toHaveLength(new Set(ids).size);
+		expect(ids).toContain(10);
+		expect(ids).toContain(11);
+		expect(ids).toContain(12);
+		expect(ids).toContain(13);
+	});
+});

--- a/web-app/src/lib/taskGrouping.ts
+++ b/web-app/src/lib/taskGrouping.ts
@@ -1,0 +1,65 @@
+import type { Task } from "./types.ts";
+
+export interface GroupedTask {
+	task: Task;
+	depth: number;
+}
+
+/**
+ * Arrange tasks into parent-child groups for display.
+ *
+ * Returns a flat list with depth annotations:
+ * - Top-level tasks (no parent, or parent not in the list) get depth 0
+ * - Children are placed immediately after their parent with depth 1
+ *
+ * Children whose parent is not in the visible list are shown at depth 0
+ * to avoid orphaned invisible tasks.
+ */
+export function groupTasksByParent(tasks: Task[]): GroupedTask[] {
+	const taskIds = new Set(tasks.map((t) => String(t.id)));
+	const topLevelIds = new Set<string>();
+
+	// Separate into parents/top-level and children-with-visible-parent.
+	// A task is only treated as a child if its parent is in the list AND
+	// is not itself a child (prevents cycles and limits nesting to 1 level).
+	const childrenByParent = new Map<string, Task[]>();
+	const topLevel: Task[] = [];
+
+	// First pass: identify which tasks are top-level (no parent or parent not in list)
+	for (const task of tasks) {
+		const parentId = task.parent;
+		if (!parentId || !taskIds.has(parentId) || parentId === String(task.id)) {
+			topLevel.push(task);
+			topLevelIds.add(String(task.id));
+		}
+	}
+
+	// Second pass: classify remaining tasks as children only if their parent is top-level
+	for (const task of tasks) {
+		const parentId = task.parent;
+		if (parentId && parentId !== String(task.id) && taskIds.has(parentId)) {
+			if (topLevelIds.has(parentId)) {
+				const siblings = childrenByParent.get(parentId) || [];
+				siblings.push(task);
+				childrenByParent.set(parentId, siblings);
+			} else {
+				// Parent is itself a child or in a cycle — promote to top level
+				topLevel.push(task);
+			}
+		}
+	}
+
+	// Build flat list: each top-level task followed by its children
+	const result: GroupedTask[] = [];
+	for (const task of topLevel) {
+		result.push({ task, depth: 0 });
+		const children = childrenByParent.get(String(task.id));
+		if (children) {
+			for (const child of children) {
+				result.push({ task: child, depth: 1 });
+			}
+		}
+	}
+
+	return result;
+}

--- a/web-app/src/lib/types.ts
+++ b/web-app/src/lib/types.ts
@@ -63,6 +63,7 @@ export interface Task {
 	channel?: string;
 	thread_id?: string;
 	message_id?: string;
+	parent?: string;
 }
 
 // ── Pull requests ────────────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- midtown: mercer -->

## Summary

- Thread `task_parent` map from daemon persistent state through the status API, adding a `"parent"` field to each task JSON object
- Add `groupTasksByParent()` utility with cycle-safe grouping logic — handles orphaned children, self-parent refs, and circular parent chains
- Render child tasks indented with a `└` connector under their parent in the sidebar task list
- 10 unit tests for grouping logic, 1 new Rust test for parent field serialization

Implements Phase 1 (Web UI component) from the task-centric PR lifecycle plan.

[Midtown !2301]

## Test plan

- [x] `cargo test --lib rpc_status` — 17/17 pass (includes new `test_map_tasks_includes_parent_when_set`)
- [x] `cargo clippy` — clean, no warnings
- [x] `vitest run` — 389/389 pass (includes 10 new grouping tests)
- [x] `vite build` — succeeds
- [x] Biome check — only pre-existing warnings, no new errors

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)