### PR TITLE
fix: Install agent definitions to all auth profile dirs [Midtown !2304]

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -56,6 +56,7 @@ pub const DEFAULT_PROFILE: &str = "default";
 
 /// Claude entries that are shared via symlink across profiles.
 const CLAUDE_SHARED_SYMLINK_ENTRIES: &[&str] = &[
+    "agents",
     "plans",
     "plugins",
     "projects",

--- a/src/bin/midtown/cli/agents_install.rs
+++ b/src/bin/midtown/cli/agents_install.rs
@@ -1,9 +1,9 @@
 //! Agent definition installation.
 //!
-//! Installs compiled-in agent definition files to Claude Code agent directories
-//! so that Claude Code can load them via the `--agent` flag. Definitions are
-//! installed to every auth profile's `agents/` subdir (so profile-scoped sessions
-//! can find them) plus `~/.claude/agents/` as a fallback for non-midtown sessions.
+//! Installs compiled-in agent definition files to `~/.midtown/platforms/claude/agents/`
+//! so that Claude Code can load them via the `--agent` flag. Each auth profile
+//! symlinks `agents/` to this shared directory (via `CLAUDE_SHARED_SYMLINK_ENTRIES`),
+//! so all profile-scoped sessions can find the definitions.
 //!
 //! Called from `midtown start` (first-run install) and `midtown update` (upgrade install).
 
@@ -84,39 +84,18 @@ pub fn check_agent_definitions_outdated(agents_dir: &Path) -> Vec<&'static Agent
         .collect()
 }
 
-/// Return the default Claude Code agents directory (`~/.claude/agents/`).
+/// Return the shared Claude Code agents directory (`~/.midtown/platforms/claude/agents/`).
+///
+/// Agent definitions are installed here once. Each auth profile symlinks its own
+/// `agents/` entry to this shared directory, so definitions are visible to all
+/// profile-scoped sessions without per-profile installation.
 pub fn claude_agents_dir() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
-        .join(".claude")
+        .join(".midtown")
+        .join("platforms")
+        .join("claude")
         .join("agents")
-}
-
-/// Return all Claude agents directories: one per auth profile plus the global fallback.
-///
-/// Each profile at `~/.midtown/auth/<profile>/claude/` gets an `agents/` subdir so
-/// sessions launched with `CLAUDE_CONFIG_DIR` pointing there can find the definitions.
-/// The global `~/.claude/agents/` is included as a fallback for sessions running
-/// outside midtown.
-pub fn all_claude_agents_dirs() -> Vec<PathBuf> {
-    let mut dirs = Vec::new();
-
-    if let Ok(profiles) = midtown::auth::list_profiles_for(midtown::auth::AuthProvider::Claude) {
-        for profile in profiles {
-            dirs.push(
-                midtown::auth::profile_dir_for(midtown::auth::AuthProvider::Claude, &profile)
-                    .join("agents"),
-            );
-        }
-    }
-
-    // Fallback: ~/.claude/agents/ for non-midtown sessions
-    let fallback = claude_agents_dir();
-    if !dirs.contains(&fallback) {
-        dirs.push(fallback);
-    }
-
-    dirs
 }
 
 #[path = "agents_install_tests.rs"]

--- a/src/bin/midtown/cli/agents_install_tests.rs
+++ b/src/bin/midtown/cli/agents_install_tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    AGENT_DEFINITIONS, all_claude_agents_dirs, check_agent_definitions_outdated, claude_agents_dir,
+    AGENT_DEFINITIONS, check_agent_definitions_outdated, claude_agents_dir,
     install_agent_definitions,
 };
 use std::fs;
@@ -172,12 +172,12 @@ fn install_creates_parent_directories() {
 }
 
 #[test]
-fn all_claude_agents_dirs_includes_fallback() {
-    let dirs = all_claude_agents_dirs();
-    assert!(!dirs.is_empty(), "should return at least one directory");
+fn claude_agents_dir_points_to_shared_platform_dir() {
+    let dir = claude_agents_dir();
+    let path_str = dir.to_string_lossy();
     assert!(
-        dirs.contains(&claude_agents_dir()),
-        "should include ~/.claude/agents/ fallback"
+        path_str.contains(".midtown/platforms/claude/agents"),
+        "should point to shared platform dir, got: {path_str}"
     );
 }
 

--- a/src/bin/midtown/cli/daemon.rs
+++ b/src/bin/midtown/cli/daemon.rs
@@ -679,23 +679,15 @@ pub fn handle_start(project: Option<String>, repos: Vec<PathBuf>) -> Result<Resp
     // Check and install required plugins before starting daemon
     ensure_required_plugins();
 
-    // Install agent definitions to all profile dirs + ~/.claude/agents/ fallback
-    for agents_dir in super::agents_install::all_claude_agents_dirs() {
-        match super::agents_install::install_agent_definitions(&agents_dir, false) {
-            Ok(installed) if !installed.is_empty() => {
-                let names: Vec<&str> = installed.iter().map(|d| d.filename).collect();
-                eprintln!(
-                    "Installed agent definitions to {}: {}",
-                    agents_dir.display(),
-                    names.join(", ")
-                );
-            }
-            Err(e) => eprintln!(
-                "Warning: Failed to install agent definitions to {}: {e}",
-                agents_dir.display()
-            ),
-            _ => {}
+    // Install agent definitions to shared dir (~/.midtown/platforms/claude/agents/)
+    let agents_dir = super::agents_install::claude_agents_dir();
+    match super::agents_install::install_agent_definitions(&agents_dir, false) {
+        Ok(installed) if !installed.is_empty() => {
+            let names: Vec<&str> = installed.iter().map(|d| d.filename).collect();
+            eprintln!("Installed agent definitions: {}", names.join(", "));
         }
+        Err(e) => eprintln!("Warning: Failed to install agent definitions: {e}"),
+        _ => {}
     }
 
     // Build web-app if source is available and dist is stale

--- a/src/bin/midtown/cli/update.rs
+++ b/src/bin/midtown/cli/update.rs
@@ -78,7 +78,7 @@ pub fn handle_update(check_only: bool, force: bool) -> Result<Response, String> 
         }
     }
 
-    // Update agent definitions in all profile dirs + ~/.claude/agents/ fallback
+    // Update agent definitions in shared dir (~/.midtown/platforms/claude/agents/)
     update_agent_definitions(force)?;
 
     Ok(Response::Message {
@@ -387,22 +387,15 @@ fn write_last_check_timestamp() -> Result<(), String> {
 /// With `force`: overwrites all definitions without prompting.
 /// Without `force`: checks for outdated definitions and prompts the user.
 fn update_agent_definitions(force: bool) -> Result<(), String> {
-    let agents_dirs = super::agents_install::all_claude_agents_dirs();
-
-    // Check outdated against the first directory (definitions are identical across dirs)
-    let outdated = agents_dirs
-        .first()
-        .map(|d| super::agents_install::check_agent_definitions_outdated(d))
-        .unwrap_or_default();
+    let agents_dir = super::agents_install::claude_agents_dir();
+    let outdated = super::agents_install::check_agent_definitions_outdated(&agents_dir);
 
     if outdated.is_empty() {
         return Ok(());
     }
 
     if force {
-        for agents_dir in &agents_dirs {
-            super::agents_install::install_agent_definitions(agents_dir, true)?;
-        }
+        super::agents_install::install_agent_definitions(&agents_dir, true)?;
         let names: Vec<&str> = outdated.iter().map(|d| d.filename).collect();
         eprintln!("Updated agent definitions: {}", names.join(", "));
         return Ok(());
@@ -410,14 +403,12 @@ fn update_agent_definitions(force: bool) -> Result<(), String> {
 
     // Print summary and prompt
     eprintln!("\nAgent definitions have changed:");
-    if let Some(first_dir) = agents_dirs.first() {
-        for def in &outdated {
-            let path = first_dir.join(def.filename);
-            if path.exists() {
-                eprintln!("  {} (modified)", def.filename);
-            } else {
-                eprintln!("  {} (new)", def.filename);
-            }
+    for def in &outdated {
+        let path = agents_dir.join(def.filename);
+        if path.exists() {
+            eprintln!("  {} (modified)", def.filename);
+        } else {
+            eprintln!("  {} (new)", def.filename);
         }
     }
 
@@ -426,9 +417,7 @@ fn update_agent_definitions(force: bool) -> Result<(), String> {
 
     let mut input = String::new();
     if std::io::stdin().read_line(&mut input).is_ok() && input.trim().eq_ignore_ascii_case("y") {
-        for agents_dir in &agents_dirs {
-            super::agents_install::install_agent_definitions(agents_dir, true)?;
-        }
+        super::agents_install::install_agent_definitions(&agents_dir, true)?;
         eprintln!("Updated agent definitions");
     } else {
         eprintln!("Skipped agent definition update (use --force to overwrite)");


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary

- **Bug:** `agents_install.rs` installed agent definitions to `~/.claude/agents/`, but Claude Code sessions use `CLAUDE_CONFIG_DIR=~/.midtown/auth/<profile>/claude/` — installed agents were invisible to profile-scoped sessions
- **Fix:** Add `"agents"` to `CLAUDE_SHARED_SYMLINK_ENTRIES` and install to `~/.midtown/platforms/claude/agents/` — each profile symlinks to the shared dir automatically (same pattern as plans, plugins, projects, etc.)
- Simplifies daemon start and update paths: single-dir install, no profile iteration

## Test plan

- [x] All 9 agent install tests pass (`cargo test --bin midtown agents_install`)
- [x] `cargo clippy` clean, `cargo fmt` clean
- [ ] Manual: `midtown start` — verify agent definitions appear in `~/.midtown/platforms/claude/agents/`
- [ ] Manual: verify profile `agents/` is a symlink to the shared dir

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)