### PR TITLE
refactor: Remove last pr_author_sessions remnant [Midtown !2306]

### DIFF
--- a/src/daemon/effects_tests.rs
+++ b/src/daemon/effects_tests.rs
@@ -3262,33 +3262,6 @@ fn link_pr_to_session_backfills_branch_on_session_record() {
     );
 }
 
-#[test]
-fn store_pr_author_session_does_not_overwrite_existing_branch() {
-    let mut ps = crate::daemon::state::DaemonPersistentState::default();
-    let session = crate::daemon::state::SessionRecord {
-        session_id: "session-abc".to_string(),
-        task_id: Some("42".to_string()),
-        branch: Some("existing-branch".to_string()), // Already has a branch
-        ..Default::default()
-    };
-    ps.sessions.insert("session-abc".to_string(), session);
-
-    // Simulate backfill — should NOT overwrite
-    let branch = "feature-branch".to_string();
-    let session_id = "session-abc";
-    if let Some(record) = ps.sessions.get_mut(session_id)
-        && record.branch.is_none()
-    {
-        record.branch = Some(branch.clone());
-    }
-
-    // Should keep the original branch
-    assert_eq!(
-        ps.sessions.get("session-abc").unwrap().branch,
-        Some("existing-branch".to_string())
-    );
-}
-
 // ============================================================================
 // lookup_existing_placeholder — task_reviewer_metadata tier-1 path
 // ============================================================================


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary

- Remove `store_pr_author_session_does_not_overwrite_existing_branch` test from `effects_tests.rs` — the last code reference to the legacy `pr_author_sessions` system
- All production code (`Effect::StorePrAuthorSession`, `pr_author_sessions` HashMap, fallback reads in `pr.rs`) was already cleaned up in prior PRs (#2073, #2075)
- The ~36 fixture JSON files contain `pr_author_sessions` only in historical task description text, not as data structure fields — no fixture changes needed

## Test plan

- [x] `cargo build` — passes
- [x] `cargo clippy` — passes with `-D warnings`
- [x] `cargo test` — 2665 passed, 18 pre-existing worktree test failures (unrelated)
- [x] Verified removed test no longer runs (`cargo test -- store_pr_author_session` → 0 tests)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)