### PR TITLE
fix: Mobile sidebar stays open on first channel tap to show tasks/threads

### DIFF
--- a/web-app/src/lib/ChannelList.svelte
+++ b/web-app/src/lib/ChannelList.svelte
@@ -132,13 +132,8 @@ function selectChannel(channelName) {
 	// feel sluggish on desktop. Now the channel switches instantly and messages
 	// appear when the fetch completes.
 
-	// Close mobile sidebar overlay when navigating to a channel
-	sidebar.setOpenMobile(false);
-
-	// Close thread panel when switching channels — thread context is
-	// channel-scoped and should not carry over to a different channel.
-	// pushState: false because we push our own entry below with the new channel.
-	closeThread({ pushState: false });
+	const isAlreadyActive = $activeChannel === channelName;
+	const isAlreadyExpanded = expandedChannels.has(channelName);
 
 	// Compute and apply the new expanded state for this channel.
 	// computeExpandedAfterChannelNameClick handles two cases:
@@ -149,11 +144,30 @@ function selectChannel(channelName) {
 		taskThreadIds,
 		completedTaskThreadIds,
 	});
-	if (next.has(channelName)) {
+	const willExpand = next.has(channelName);
+	if (willExpand) {
 		expandedChannels.add(channelName);
 	} else {
 		expandedChannels.delete(channelName);
 	}
+
+	// On mobile, first tap expands the channel to show tasks/threads — keep the
+	// sidebar open so the user can see them. Only close on the second tap (channel
+	// is already active and expanded) or when tapping a channel with nothing to expand.
+	// On desktop, setOpenMobile is a no-op so we always call it.
+	if (sidebar.isMobile) {
+		const shouldKeepOpen = !isAlreadyActive && willExpand;
+		if (!shouldKeepOpen) {
+			sidebar.setOpenMobile(false);
+		}
+	} else {
+		sidebar.setOpenMobile(false);
+	}
+
+	// Close thread panel when switching channels — thread context is
+	// channel-scoped and should not carry over to a different channel.
+	// pushState: false because we push our own entry below with the new channel.
+	closeThread({ pushState: false });
 
 	activeChannel.set(channelName);
 	pushNavState({ channel: channelName });


### PR DESCRIPTION
<!-- midtown: york -->

## Summary

- On mobile, tapping a channel in the sidebar now expands it first (to show tasks/threads) instead of immediately closing the sidebar
- Second tap on the already-active, already-expanded channel navigates and closes the sidebar as before
- Channels with no tasks/threads to expand still close immediately on first tap
- Desktop behavior is unchanged (`setOpenMobile` is a no-op on non-mobile)

## Test plan

- [ ] On mobile (or responsive mode), tap a channel that has active tasks — sidebar should stay open showing the expanded task list
- [ ] Tap the same channel again — sidebar should close and navigate to the channel
- [ ] Tap a channel with no tasks/threads — sidebar should close immediately
- [ ] On desktop, verify channel switching behavior is unchanged

[Midtown !2312]

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)