### PR TITLE
Fix mobile sidebar: thread rows require double-tap

### DIFF
--- a/web-app/src/lib/ChannelList.svelte
+++ b/web-app/src/lib/ChannelList.svelte
@@ -328,30 +328,28 @@ function handleKeyDown(event) {
     </div>
     <div class="needs-attention-list">
       {#each completedThreads as thread}
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <div
+        <button
           class="completed-thread-row"
-          role="button"
-          tabindex="0"
           title={thread.fullText}
           data-testid="needs-attention-thread"
           onclick={() => handleCompletedThreadClick(thread)}
-          onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleCompletedThreadClick(thread) }}
         >
           <span class="completed-check-icon"><Check size={10} /></span>
           <div class="completed-thread-content">
             <span class="completed-thread-subject">{thread.subject}</span>
             <span class="completed-thread-channel">#{thread.channelName}</span>
           </div>
-          <button
+          <span
             class="completed-dismiss-btn"
+            role="button"
+            tabindex="-1"
             title="Dismiss"
             data-testid="needs-attention-dismiss"
             onclick={(e) => handleCompletedThreadDismiss(e, thread.id)}
           >
             <X size={10} />
-          </button>
-        </div>
+          </span>
+        </button>
       {/each}
     </div>
   {/if}
@@ -546,6 +544,7 @@ function handleKeyDown(event) {
     align-items: center;
     gap: 6px;
     padding: 3px 6px 3px 0;
+    width: 100%;
     border: none;
     background: transparent;
     cursor: pointer;

--- a/web-app/src/lib/ThreadList.svelte
+++ b/web-app/src/lib/ThreadList.svelte
@@ -51,17 +51,13 @@ function handleDismiss(e, threadId) {
 <div class="thread-list" data-testid="thread-list">
   {#each channelThreads as thread}
     {@const hasUnread = thread.unread > 0}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
+    <button
       class="thread-row"
       class:unread={hasUnread}
-      role="button"
-      tabindex="0"
       data-testid="sidebar-thread-row"
       data-thread-id={thread.id}
       title={thread.fullText}
       onclick={() => handleClick(thread)}
-      onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleClick(thread) }}
     >
       <span class="accent-line" class:accent-unread={hasUnread}></span>
       <div class="thread-content">
@@ -70,15 +66,17 @@ function handleDismiss(e, threadId) {
           <span class="unread-badge" data-testid="sidebar-thread-unread-badge">{thread.unread}</span>
         {/if}
       </div>
-      <button
+      <span
         class="dismiss-btn"
+        role="button"
+        tabindex="-1"
         data-testid="sidebar-thread-dismiss"
         title="Stop tracking this thread"
         onclick={(e) => handleDismiss(e, thread.id)}
       >
         <X size={10} />
-      </button>
-    </div>
+      </span>
+    </button>
   {/each}
 </div>
 
@@ -95,6 +93,7 @@ function handleDismiss(e, threadId) {
     align-items: center;
     gap: 6px;
     padding: 3px 6px 3px 0;
+    width: 100%;
     border: none;
     background: transparent;
     cursor: pointer;


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Changed thread rows from `<div role="button">` to native `<button>` elements in `ThreadList.svelte` and `ChannelList.svelte`
- iOS Safari PWA mode doesn't reliably fire `click` on single tap for non-native interactive elements — native `<button>` fixes the double-tap issue
- Inner dismiss buttons changed from `<button>` to `<span>` to avoid invalid nested `<button>` HTML

## Test plan
- [x] Vite build passes
- [x] All 6 Playwright E2E sidebar-thread tests pass
- [x] Biome lint clean (no new warnings)
- [ ] Manual verification on iOS Safari PWA: single tap navigates to thread

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)