### PR TITLE
fix: Drain stderr in process reconciliation path

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3821,7 +3821,7 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
                     state.plugin_daemon.ensure_running().await;
                 }
 
-                let (events, stopped, stderr_by_name) = state.session_manager.drain_events().await;
+                let (events, stopped, mut stderr_by_name) = state.session_manager.drain_events().await;
 
                 // Update health state from SessionManager (used by snapshot for decision functions)
                 let health = state.session_manager.collect_health().await;
@@ -3985,7 +3985,8 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
                 // Defense-in-depth: check process liveness via try_wait() to catch
                 // sessions where the process exited but drain_events didn't detect it
                 // (e.g., pipe buffering issues, partial reads, timing races).
-                let reconciled = state.session_manager.reconcile_process_health().await;
+                let (reconciled, reconciled_stderr) =
+                    state.session_manager.reconcile_process_health().await;
                 let mut all_stopped: Vec<String> = stopped;
                 if !reconciled.is_empty() {
                     warn!(
@@ -3994,6 +3995,9 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
                         reconciled
                     );
                     all_stopped.extend(reconciled);
+                    // Merge reconciled stderr into the main stderr map so crash
+                    // diagnostics are included in exit messages.
+                    stderr_by_name.extend(reconciled_stderr);
                 }
 
                 // Handle stopped sessions: deregister, record stop time, post to channel

--- a/src/daemon/sessions.rs
+++ b/src/daemon/sessions.rs
@@ -1451,9 +1451,10 @@ impl SessionManager {
     /// app-server process), checks whether the event channel is still open.
     ///
     /// Returns the names of sessions that were discovered to be dead.
-    pub async fn reconcile_process_health(&self) -> Vec<String> {
+    pub async fn reconcile_process_health(&self) -> (Vec<String>, HashMap<String, Vec<String>>) {
         let mut sessions = self.sessions.write().await;
         let mut newly_stopped = Vec::new();
+        let mut stderr_by_name: HashMap<String, Vec<String>> = HashMap::new();
 
         for (_slot_id, cs) in sessions.iter_mut() {
             // Only check sessions that we think are alive
@@ -1490,11 +1491,21 @@ impl SessionManager {
             } else {
                 match session.try_wait() {
                     Ok(Some(exit_status)) => {
-                        // Process has exited but drain_events didn't catch it
+                        // Process has exited but drain_events didn't catch it.
+                        // Drain stderr before dropping the session handle so crash
+                        // diagnostics are preserved.
+                        let stderr_lines = session.drain_stderr_final().await;
                         warn!(
                             "Session '{}' process exited (status={}) but was still tracked as {:?} — forcing cleanup",
                             name, exit_status, cs.status
                         );
+                        if !stderr_lines.is_empty() {
+                            debug!(
+                                "Session '{}' reconciled exit with stderr: {:?}",
+                                name, stderr_lines
+                            );
+                            stderr_by_name.insert(name.clone(), stderr_lines);
+                        }
                         cs.status = SessionStatus::Stopped;
                         cs.session = None;
                         newly_stopped.push(name.clone());
@@ -1503,11 +1514,17 @@ impl SessionManager {
                         // Process is still running — all good
                     }
                     Err(e) => {
-                        // Error checking process status — treat as dead
+                        // Error checking process status — treat as dead.
+                        // Drain stderr before dropping — even on error, there
+                        // may be useful output buffered.
+                        let stderr_lines = session.drain_stderr_final().await;
                         warn!(
                             "Failed to check process liveness for session '{}': {} — marking as stopped",
                             name, e
                         );
+                        if !stderr_lines.is_empty() {
+                            stderr_by_name.insert(name.clone(), stderr_lines);
+                        }
                         cs.status = SessionStatus::Stopped;
                         cs.session = None;
                         newly_stopped.push(name.clone());
@@ -1516,7 +1533,7 @@ impl SessionManager {
             }
         }
 
-        newly_stopped
+        (newly_stopped, stderr_by_name)
     }
 
     /// Check if a session was a failed resume attempt.

--- a/src/daemon/sessions_tests.rs
+++ b/src/daemon/sessions_tests.rs
@@ -200,11 +200,15 @@ async fn test_reconcile_catches_no_handle_sessions() {
     // This simulates the inconsistent state where a session handle is lost
     insert_test_session(&sm, "madison", SessionStatus::Running).await;
 
-    let stopped = sm.reconcile_process_health().await;
+    let (stopped, stderr_map) = sm.reconcile_process_health().await;
     assert_eq!(
         stopped,
         vec!["madison"],
         "Should detect handle-less Running session"
+    );
+    assert!(
+        stderr_map.is_empty(),
+        "No stderr expected for handle-less session"
     );
 
     // Verify the session is now marked as Stopped
@@ -221,7 +225,7 @@ async fn test_reconcile_skips_already_stopped() {
 
     insert_test_session(&sm, "park", SessionStatus::Stopped).await;
 
-    let stopped = sm.reconcile_process_health().await;
+    let (stopped, _stderr_map) = sm.reconcile_process_health().await;
     assert!(
         stopped.is_empty(),
         "Should not flag already-stopped sessions"
@@ -231,7 +235,7 @@ async fn test_reconcile_skips_already_stopped() {
 #[tokio::test]
 async fn test_reconcile_empty() {
     let sm = SessionManager::new("test-repo".to_string());
-    let stopped = sm.reconcile_process_health().await;
+    let (stopped, _stderr_map) = sm.reconcile_process_health().await;
     assert!(stopped.is_empty());
 }
 


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary

- Drain stderr via `drain_stderr_final()` in `reconcile_process_health()` before dropping the session handle, so crash diagnostics from sessions caught by the defense-in-depth `try_wait()` path are preserved
- Return the collected stderr map alongside stopped names so the caller in the event loop can include stderr in exit messages (matching the existing `drain_events` behavior)
- Also drain stderr in the `Err(e)` branch (process status check failed) since useful output may still be buffered

Fixes Midtown !2317

## Test plan

- [x] Existing `test_reconcile_catches_no_handle_sessions` updated to verify empty stderr map for handle-less sessions
- [x] `test_reconcile_skips_already_stopped` and `test_reconcile_empty` updated for new return type
- [x] `cargo test` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)