### PR TITLE
feat: Add --plan option to `midtown task update` [Midtown !cli-quickfix]

### DIFF
--- a/src/bin/midtown/cli/task.rs
+++ b/src/bin/midtown/cli/task.rs
@@ -71,6 +71,9 @@ pub enum TaskCommand {
         /// Set explicit PR number associated with this task
         #[arg(long)]
         pr: Option<u64>,
+        /// Path to an implementation plan file (recommended: ~/.midtown/projects/<project>/plans/)
+        #[arg(long)]
+        plan: Option<String>,
     },
     /// Mark a task as done
     Done {
@@ -168,6 +171,7 @@ pub fn handle(cmd: &TaskCommand, client: &DaemonClient) -> Result<Response, Stri
             channel,
             model,
             pr,
+            plan,
         } => client.task_update(
             id,
             owner.as_deref(),
@@ -177,6 +181,7 @@ pub fn handle(cmd: &TaskCommand, client: &DaemonClient) -> Result<Response, Stri
             channel.as_deref(),
             model.as_deref(),
             *pr,
+            plan.as_deref(),
         ),
         TaskCommand::Claim { id } => client.task_claim(id),
         TaskCommand::Done { id } => client.task_done(id),

--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -549,6 +549,7 @@ impl DaemonClient {
         channel: Option<&str>,
         model: Option<&str>,
         pr: Option<u64>,
+        plan: Option<&str>,
     ) -> Result<Response, String> {
         let mut params = serde_json::json!({ "id": id });
         if let Some(o) = owner {
@@ -571,6 +572,9 @@ impl DaemonClient {
         }
         if let Some(pr_num) = pr {
             params["pr"] = serde_json::json!(pr_num);
+        }
+        if let Some(p) = plan {
+            params["plan"] = serde_json::json!(p);
         }
         self.send("task.update", Some(params))
     }

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -562,6 +562,7 @@ async fn dispatch_request(request: Request, state: &DaemonState) -> Response {
             let channel = params.str_param("channel");
             let model = params.str_param("model");
             let pr = params.u64_param("pr");
+            let plan = params.str_param("plan");
             super::rpc_task::handle_task_update(
                 request.id,
                 task_id,
@@ -572,6 +573,7 @@ async fn dispatch_request(request: Request, state: &DaemonState) -> Response {
                 channel,
                 model,
                 pr,
+                plan,
                 state,
             )
             .await

--- a/src/daemon/rpc_task.rs
+++ b/src/daemon/rpc_task.rs
@@ -494,6 +494,7 @@ pub(super) async fn handle_task_update(
     channel: Option<&str>,
     model: Option<&str>,
     pr: Option<u64>,
+    plan: Option<&str>,
     state: &DaemonState,
 ) -> Response {
     // Validate status if provided
@@ -577,6 +578,13 @@ pub(super) async fn handle_task_update(
                 // Model format validation failed - return error
                 return Response::error(id, RpcError::new(-32602, e));
             }
+        }
+
+        // Apply plan mapping
+        if let Some(plan_path) = plan {
+            ps.task_plan
+                .insert(task_id.to_string(), plan_path.to_string());
+            needs_save = true;
         }
 
         // Save if any mapping changed


### PR DESCRIPTION
<!-- midtown: cli -->

## Summary

- Adds `--plan` option to `midtown task update`, matching the existing `--plan` support on `task create`
- Plumbs the option through CLI → client → RPC dispatcher → handler → daemon persistent state (`task_plan` mapping)
- Help text encourages storing plans in `~/.midtown/projects/<project>/plans/`

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy` passes
- [x] `cargo fmt --check` passes
- [x] Existing `task_update` tests pass
- [ ] Manual: `midtown task update <id> --plan path/to/plan.md` stores the plan path and `midtown task view <id>` displays it

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)