### PR TITLE
feat: Add --plan option to task update command

### DIFF
--- a/src/daemon/rpc_task.rs
+++ b/src/daemon/rpc_task.rs
@@ -582,8 +582,12 @@ pub(super) async fn handle_task_update(
 
         // Apply plan mapping
         if let Some(plan_path) = plan {
-            ps.task_plan
-                .insert(task_id.to_string(), plan_path.to_string());
+            if plan_path.is_empty() {
+                ps.task_plan.remove(task_id);
+            } else {
+                ps.task_plan
+                    .insert(task_id.to_string(), plan_path.to_string());
+            }
             needs_save = true;
         }
 


### PR DESCRIPTION
<!-- midtown: houston -->

## Summary
- Threads `--plan` option through `task update`, mirroring the existing `task create` flow
- Touches all 4 layers: CLI args, client method, RPC dispatch, and RPC handler
- Supports clearing a plan by passing an empty string (update semantics)

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` — all task-related tests pass (18 pre-existing worktree failures unrelated)
- [ ] Manual: `midtown task update <id> --plan path/to/plan.md` sets plan
- [ ] Manual: `midtown task update <id> --plan ""` clears plan
- [ ] Manual: `midtown task view <id>` shows updated plan path

Closes !2322

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)