### PR TITLE
fix: Refresh channel lead worktree before spawning to prevent crash loops

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -2927,6 +2927,14 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 }
             }
             Effect::RespawnChannelLead { channel_name } => {
+                // Refresh the worktree to origin/<default_branch> BEFORE spawning.
+                // This prevents crash loops caused by stale worktree contents —
+                // if old code crashes the lead on startup, spawning into the same
+                // stale worktree would repeat the crash indefinitely.
+                let worktree_path =
+                    crate::paths::worktrees_dir_for_repo(state.paths.dir_key()).join(&channel_name);
+                refresh_channel_lead_worktree(&worktree_path, &state.default_branch).await;
+
                 let base_dir = state.paths.base_dir().to_path_buf();
                 let project_root = state.all_repo_paths.first().cloned().unwrap_or_default();
                 let dir_key = state.paths.dir_key().to_string();
@@ -3461,6 +3469,12 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                         wf_state_summary,
                     )
                     .await;
+
+                    // Refresh the worktree before spawning/resuming to prevent
+                    // stale code from crashing the channel lead on startup.
+                    let worktree_path = crate::paths::worktrees_dir_for_repo(state.paths.dir_key())
+                        .join(&channel_name);
+                    refresh_channel_lead_worktree(&worktree_path, &state.default_branch).await;
 
                     match (session_id.as_deref(), can_resume_channel_lead) {
                         (Some(id), true) => {
@@ -4896,6 +4910,71 @@ async fn post_insight(state: &DaemonState, agent: &str, insight: &str) {
         },
     };
     Box::pin(execute_effects(vec![nudge_effect], state)).await;
+}
+
+/// Refresh a channel lead worktree to `origin/<default_branch>`.
+///
+/// Runs `git checkout --detach origin/<branch>` in the worktree directory.
+/// The `git fetch` is already done by snapshot collection
+/// (`collect_stale_channel_lead_worktrees`), so we only need the checkout.
+///
+/// This is called BEFORE spawning the channel lead to prevent crash loops
+/// caused by stale worktree contents. If the refresh fails (e.g., worktree
+/// doesn't exist yet), we log and continue — `create_detached_worktree` in
+/// `prepare_spawn` will create a fresh one from `origin/<branch>` anyway.
+async fn refresh_channel_lead_worktree(worktree_path: &std::path::Path, default_branch: &str) {
+    if !worktree_path.exists() {
+        debug!(
+            "Channel lead worktree does not exist yet at {}, skipping refresh",
+            worktree_path.display()
+        );
+        return;
+    }
+
+    let origin_ref = format!("origin/{}", default_branch);
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        tokio::process::Command::new("git")
+            .args(["checkout", "--detach", &origin_ref])
+            .current_dir(worktree_path)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .output(),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(output)) if output.status.success() => {
+            info!(
+                "Refreshed channel lead worktree at {} to {}",
+                worktree_path.display(),
+                origin_ref
+            );
+        }
+        Ok(Ok(output)) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            warn!(
+                "Failed to refresh channel lead worktree at {} to {}: {}",
+                worktree_path.display(),
+                origin_ref,
+                stderr.trim()
+            );
+        }
+        Ok(Err(e)) => {
+            warn!(
+                "Failed to run git checkout in channel lead worktree at {}: {}",
+                worktree_path.display(),
+                e
+            );
+        }
+        Err(_) => {
+            warn!(
+                "Timed out refreshing channel lead worktree at {}",
+                worktree_path.display()
+            );
+        }
+    }
 }
 
 #[path = "effects_tests.rs"]

--- a/src/daemon/effects_tests.rs
+++ b/src/daemon/effects_tests.rs
@@ -3366,3 +3366,177 @@ fi
         log_contents,
     );
 }
+
+// ── refresh_channel_lead_worktree tests ─────────────────────────────────
+
+/// Create a temporary git repo with one commit and return its path.
+fn create_temp_git_repo() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_path = dir.path().to_path_buf();
+
+    Command::new("git")
+        .args(["init", "--initial-branch=main"])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+
+    // Create initial commit
+    std::fs::write(repo_path.join("file.txt"), "initial").unwrap();
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+
+    (dir, repo_path)
+}
+
+#[tokio::test]
+async fn test_refresh_channel_lead_worktree_updates_to_origin() {
+    let (_dir, repo_path) = create_temp_git_repo();
+
+    // Create a detached worktree
+    let worktree_path = repo_path.join("worktrees").join("ops");
+    std::fs::create_dir_all(worktree_path.parent().unwrap()).unwrap();
+    let output = Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "--detach",
+            worktree_path.to_str().unwrap(),
+            "HEAD",
+        ])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "Failed to create worktree");
+
+    // Record the worktree's current HEAD
+    let old_head = String::from_utf8(
+        Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&worktree_path)
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap()
+    .trim()
+    .to_string();
+
+    // Make a new commit in the main repo
+    std::fs::write(repo_path.join("file.txt"), "updated").unwrap();
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "second commit"])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+
+    let new_head = String::from_utf8(
+        Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&repo_path)
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap()
+    .trim()
+    .to_string();
+    assert_ne!(old_head, new_head, "New commit should have different SHA");
+
+    // Simulate "origin/main" by creating a bare clone as origin.
+    let origin_tmpdir = tempfile::tempdir().unwrap();
+    let origin_dir = origin_tmpdir.path().join("origin.git");
+    let output = Command::new("git")
+        .args([
+            "clone",
+            "--bare",
+            repo_path.to_str().unwrap(),
+            origin_dir.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "Failed to create bare clone: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Add origin remote to the main repo (worktree shares the git config)
+    Command::new("git")
+        .args(["remote", "add", "origin", origin_dir.to_str().unwrap()])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["fetch", "origin"])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+
+    // Verify the worktree is still at the old HEAD
+    let wt_head_before = String::from_utf8(
+        Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&worktree_path)
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap()
+    .trim()
+    .to_string();
+    assert_eq!(
+        wt_head_before, old_head,
+        "Worktree should still be at old HEAD"
+    );
+
+    // Run the refresh
+    super::refresh_channel_lead_worktree(&worktree_path, "main").await;
+
+    // Verify the worktree is now at origin/main
+    let wt_head_after = String::from_utf8(
+        Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&worktree_path)
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap()
+    .trim()
+    .to_string();
+    assert_eq!(
+        wt_head_after, new_head,
+        "Worktree should be updated to origin/main"
+    );
+}
+
+#[tokio::test]
+async fn test_refresh_channel_lead_worktree_nonexistent_path() {
+    // Should be a no-op (not panic) when the worktree doesn't exist
+    let path = std::path::PathBuf::from("/tmp/nonexistent-worktree-test-12345");
+    super::refresh_channel_lead_worktree(&path, "main").await;
+    // No panic = success
+}


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary

- Adds `refresh_channel_lead_worktree()` that runs `git checkout --detach origin/<branch>` before spawning/resuming channel leads
- Applies the refresh in both the `RespawnChannelLead` effect handler (crash recovery path) and the `NudgeChannelLead` handler (idle-shutdown resume path)
- If the worktree doesn't exist yet, the refresh is a safe no-op — `create_detached_worktree` handles creation from `origin/<branch>`

**Root cause:** `create_detached_worktree()` is idempotent — existing worktrees are returned as-is without updating. When stale code crashes the channel lead on startup, the daemon respawns into the same stale worktree indefinitely. The existing `check_channel_lead_worktree_freshness()` only nudges *running* leads, so it can never reach a crash-looping lead.

[Midtown !2319]

## Test plan

- [x] New test: `test_refresh_channel_lead_worktree_updates_to_origin` — creates a real git repo + detached worktree, makes a new commit, verifies the refresh updates the worktree to `origin/main`
- [x] New test: `test_refresh_channel_lead_worktree_nonexistent_path` — confirms no-op for missing paths
- [x] All 67 existing health module tests pass
- [x] `cargo clippy` clean, `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)