### PR TITLE
fix: Bump crashed session stderr log level to WARN

### DIFF
--- a/src/daemon/sessions.rs
+++ b/src/daemon/sessions.rs
@@ -1251,7 +1251,7 @@ impl SessionManager {
 
                         if !stderr_lines.is_empty() {
                             stderr_by_name.insert(name.clone(), stderr_lines.clone());
-                            debug!(
+                            warn!(
                                 "Session '{}' exited (stdout closed) with stderr: {:?}",
                                 name, stderr_lines
                             );
@@ -1500,7 +1500,7 @@ impl SessionManager {
                             name, exit_status, cs.status
                         );
                         if !stderr_lines.is_empty() {
-                            debug!(
+                            warn!(
                                 "Session '{}' reconciled exit with stderr: {:?}",
                                 name, stderr_lines
                             );
@@ -1523,6 +1523,10 @@ impl SessionManager {
                             name, e
                         );
                         if !stderr_lines.is_empty() {
+                            warn!(
+                                "Session '{}' liveness-check failure with stderr: {:?}",
+                                name, stderr_lines
+                            );
                             stderr_by_name.insert(name.clone(), stderr_lines);
                         }
                         cs.status = SessionStatus::Stopped;


### PR DESCRIPTION
<!-- midtown: mercer -->

## Summary

- Promote stderr logging from `debug!` to `warn!` in three session exit paths (`drain_events` stdout-closed, `reconcile_processes` exit detection, and `reconcile_processes` liveness-check failure)
- Add missing stderr log in the liveness-check error path where stderr was captured but never logged

## Motivation

Session stderr from crashed sessions was logged at `debug!` level, which doesn't appear in default INFO-level daemon logs. This made diagnosing channel lead crash loops impossible without custom `RUST_LOG` configuration.

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --lib` passes (18 pre-existing worktree test failures unrelated to this change)
- [ ] Verify stderr appears in daemon logs when a session crashes

Closes !2318

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)