### PR TITLE
fix: Mobile sidebar stays open on first channel tap to show tasks/threads [Midtown !2312]

### DIFF
--- a/web-app/src/lib/ChannelList.svelte
+++ b/web-app/src/lib/ChannelList.svelte
@@ -132,13 +132,8 @@ function selectChannel(channelName) {
 	// feel sluggish on desktop. Now the channel switches instantly and messages
 	// appear when the fetch completes.
 
-	// Close mobile sidebar overlay when navigating to a channel
-	sidebar.setOpenMobile(false);
-
-	// Close thread panel when switching channels — thread context is
-	// channel-scoped and should not carry over to a different channel.
-	// pushState: false because we push our own entry below with the new channel.
-	closeThread({ pushState: false });
+	const isAlreadyActive = $activeChannel === channelName;
+	const isAlreadyExpanded = expandedChannels.has(channelName);
 
 	// Compute and apply the new expanded state for this channel.
 	// computeExpandedAfterChannelNameClick handles two cases:
@@ -149,11 +144,30 @@ function selectChannel(channelName) {
 		taskThreadIds,
 		completedTaskThreadIds,
 	});
-	if (next.has(channelName)) {
+	const willExpand = next.has(channelName);
+	if (willExpand) {
 		expandedChannels.add(channelName);
 	} else {
 		expandedChannels.delete(channelName);
 	}
+
+	// On mobile, first tap expands the channel to show tasks/threads — keep the
+	// sidebar open so the user can see them. Only close on the second tap (channel
+	// is already active and expanded) or when tapping a channel with nothing to expand.
+	// On desktop, setOpenMobile is a no-op so we always call it.
+	if (sidebar.isMobile) {
+		const shouldKeepOpen = !isAlreadyActive && willExpand;
+		if (!shouldKeepOpen) {
+			sidebar.setOpenMobile(false);
+		}
+	} else {
+		sidebar.setOpenMobile(false);
+	}
+
+	// Close thread panel when switching channels — thread context is
+	// channel-scoped and should not carry over to a different channel.
+	// pushState: false because we push our own entry below with the new channel.
+	closeThread({ pushState: false });
 
 	activeChannel.set(channelName);
 	pushNavState({ channel: channelName });


### PR DESCRIPTION
<!-- midtown: midtown -->

## Summary

- On mobile, tapping a channel in the sidebar now expands it first to show tasks/threads instead of immediately closing the sidebar
- Second tap (already active + expanded) navigates and closes the sidebar as before
- Channels with nothing to expand still close immediately on first tap
- Desktop behavior unchanged (`setOpenMobile` is a no-op)

## Root Cause

`selectChannel()` called `sidebar.setOpenMobile(false)` unconditionally at the top, closing the sidebar before the user could see the expanded task/thread list.

## Fix

Moved the `setOpenMobile(false)` call after the expand logic. On mobile, checks whether the channel is being expanded for the first time — if so, keeps the sidebar open. Otherwise closes normally.

## Test plan

- [ ] On mobile/PWA: tap a channel with tasks/threads — sidebar stays open showing expanded content
- [ ] On mobile/PWA: tap the same channel again — sidebar closes and navigates
- [ ] On mobile/PWA: tap a channel with no tasks/threads — sidebar closes immediately
- [ ] On desktop: verify no behavior change (setOpenMobile is a no-op)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)