### PR TITLE
feat: Support clearing plan via empty string in task update [Midtown !2322]

### DIFF
--- a/src/daemon/rpc_task.rs
+++ b/src/daemon/rpc_task.rs
@@ -605,8 +605,12 @@ pub(super) async fn handle_task_update(
 
         // Apply plan mapping
         if let Some(plan_path) = plan {
-            ps.task_plan
-                .insert(task_id.to_string(), plan_path.to_string());
+            if plan_path.is_empty() {
+                ps.task_plan.remove(task_id);
+            } else {
+                ps.task_plan
+                    .insert(task_id.to_string(), plan_path.to_string());
+            }
             needs_save = true;
         }
 


### PR DESCRIPTION
<!-- midtown: houston -->

## Summary
- Adds support for clearing a task's plan by passing `--plan ""` to `midtown task update`
- Empty string removes the plan from `task_plan` HashMap instead of storing an empty entry
- Mirrors the set/clear pattern used elsewhere in persistent state

## Test plan
- [ ] Verify `midtown task update <id> --plan path/to/plan.md` sets the plan
- [ ] Verify `midtown task update <id> --plan ""` clears the plan
- [ ] Verify existing plan behavior on `task create` is unaffected

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)