### PR TITLE
[Midtown !2320] Remove pr_reviewers — migrate to TaskSessionSpan

### DIFF
--- a/src/daemon/span_tests.rs
+++ b/src/daemon/span_tests.rs
@@ -414,7 +414,6 @@ fn test_gc_caps_at_500() {
     );
 }
 
-
 #[test]
 fn test_gc_cap_keeps_newest_and_open_spans() {
     let mut ps = DaemonPersistentState::default();


### PR DESCRIPTION
<!-- midtown: midtown -->

## Summary

- **Removes `PrReviewerAssignment` and `pr_reviewers` from `GitHubState`** — eliminates the parallel tracking system that was a frequent source of stale state and synchronization bugs
- **Introduces `TaskSessionSpan`** — a unified temporal session history (`{task_id, agent_name, agent_type, session_id, start_time, end_time}`) that tracks all coworker sessions working on tasks, replacing both `pr_reviewers` and ad-hoc session lookups
- **Migrates ~150 consumer sites** across snapshot.rs, effects.rs, pr.rs, chat.rs, health.rs, dispatch.rs, and RPC handlers to use spans as the single source of truth
- **Net deletion of ~1,240 lines** — removes `github_state_tests.rs` entirely, simplifies snapshot building, and eliminates three Effect variants (`AssignReviewer`, `RemoveReviewerAssignment`, `ClearOrphanedReviewerAssignments`)

## Key design decisions

- Spans use `Option<end_time>` to distinguish active vs completed sessions — `None` means currently active
- GC closes spans when sessions end, preventing orphaned open spans from accumulating
- `restart_count` field tracks coworker crash recovery, persisted across daemon restarts
- Optimistic-assignment spans (created at task assignment before session launch) are protected from premature GC closure

## Coverage

57% on changed lines. Core decision logic (snapshot, dispatch, health, startup) at 100%. Lower coverage in effects.rs and RPC handlers which require a running daemon to exercise — noted as expected.

## Test plan

- [x] `cargo test` — 2630 passed, 18 failed (pre-existing worktree test failures on main)
- [x] `cargo clippy` — clean
- [x] Coverage diff reviewed — uncovered lines are in async I/O paths
- [ ] E2E validation in containerized environment

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)