### PR TITLE
[Midtown !2330] Collapse parent-child tasks into single sidebar row

### DIFF
--- a/web-app/src/lib/TaskList.svelte
+++ b/web-app/src/lib/TaskList.svelte
@@ -60,14 +60,17 @@ function handleTaskClick(task) {
 </script>
 
 <div class="flex flex-col gap-0.5 py-1 pb-1.5">
-  {#each groupedTasks as { task, depth }}
+  {#each groupedTasks as { task, children }}
     {@const cw = task.owner ? cwMap.get(task.owner) : null}
     {@const reviewInfo = taskReviewerMap.get(String(task.id))}
+    {@const childReviewer = !reviewInfo && children.length > 0
+      ? children.find((c) => /review/i.test(c.subject))?.owner ?? null
+      : null}
     <TaskRow
       {task}
       {cw}
-      {depth}
-      reviewer={reviewInfo?.reviewer}
+      {children}
+      reviewer={reviewInfo?.reviewer ?? childReviewer}
       reviewPosted={reviewInfo?.reviewPosted ?? false}
       onclick={() => handleTaskClick(task)}
     />

--- a/web-app/src/lib/TaskRow.svelte
+++ b/web-app/src/lib/TaskRow.svelte
@@ -10,18 +10,43 @@ import { getPrUrl as getPrUrlUtil } from "./channelUtils.ts";
 import { renderContent } from "./markdown.ts";
 import { getSenderColor } from "./messageUtils.ts";
 import { activeChannel, channels, coworkers, daemonStatus, kanbanData, repoStatus, repoStatuses } from "./store.ts";
+import type { Task } from "./types.ts";
 
-let { task, cw = null, depth = 0, reviewer = null, reviewPosted = false, onclick = null, variant = "row" } = $props();
+let {
+	task,
+	cw = null,
+	children = [] as Task[],
+	reviewer = null,
+	reviewPosted = false,
+	onclick = null,
+	variant = "row",
+} = $props();
 
 const isCard = $derived(variant === "card");
-const isActive = $derived(task.status === "in_progress");
+
+// Status rollup for row variant: in_progress if any child is in_progress,
+// done only when parent + all children are done
+const rolledUpStatus = $derived.by(() => {
+	if (isCard || children.length === 0) return task.status;
+	const allTasks = [task, ...children];
+	if (allTasks.some((t) => t.status === "in_progress")) return "in_progress";
+	if (allTasks.every((t) => t.status === "done")) return "done";
+	return task.status;
+});
+
+const isActive = $derived(rolledUpStatus === "in_progress");
 const isBlocked = $derived(task.blocked_by?.length > 0);
 
 // Card-only: auto-derive coworker/reviewer from stores
 const cwMap = $derived(isCard ? new Map($coworkers.map((c) => [c.name, c])) : null);
 const relatedPr = $derived(isCard ? $kanbanData.review.find((pr) => String(pr.task_id) === String(task.id)) : null);
 const effectiveCw = $derived(isCard ? (task.owner ? (cwMap?.get(task.owner) ?? null) : null) : cw);
-const effectiveReviewer = $derived(isCard ? (relatedPr?.reviewer ?? null) : reviewer);
+const childDerivedReviewer = $derived(
+	!reviewer && children.length > 0 ? (children.find((c) => /review/i.test(c.subject))?.owner ?? null) : null,
+);
+const effectiveReviewer = $derived(
+	isCard ? (relatedPr?.reviewer ?? childDerivedReviewer) : (reviewer ?? childDerivedReviewer),
+);
 const effectiveReviewPosted = $derived(isCard ? relatedPr?.review_posted || false : reviewPosted);
 const hasProgress = $derived(effectiveCw?.progress != null);
 
@@ -30,10 +55,10 @@ const prUrl = $derived(
 );
 const descriptionHtml = $derived(isCard && task.description ? renderContent(task.description) : "");
 
-function statusBarColor(task) {
-	if (task.status === "done") return "hsl(var(--accent-green, 145 40% 38%))";
-	if (task.status !== "in_progress") return "hsl(var(--muted-foreground) / 0.3)";
-	if (task.owner) return getSenderColor(task.owner);
+function statusBarColor(status, owner) {
+	if (status === "done") return "hsl(var(--accent-green, 145 40% 38%))";
+	if (status !== "in_progress") return "hsl(var(--muted-foreground) / 0.3)";
+	if (owner) return getSenderColor(owner);
 	return "hsl(var(--accent-teal))";
 }
 
@@ -75,12 +100,11 @@ function handleDescriptionClick(e) {
 </script>
 
 <button
-  class="task-row w-full overflow-visible flex items-stretch gap-1.5 py-[5px] cursor-pointer transition-[background] duration-100 text-left font-mono text-[0.72rem] leading-[1.3] text-muted-foreground {isCard ? 'border border-[hsl(var(--border))] bg-[hsl(var(--card))] mb-2 hover:bg-[hsl(var(--accent)_/_0.3)] pr-3 rounded-md' : 'border-none bg-transparent rounded-[5px] hover:bg-sidebar-accent'} {isActive ? 'text-sidebar-foreground' : ''} {isBlocked ? 'opacity-65' : ''} {depth > 0 ? 'pl-3' : ''}"
+  class="task-row w-full overflow-visible flex items-stretch gap-1.5 py-[5px] cursor-pointer transition-[background] duration-100 text-left font-mono text-[0.72rem] leading-[1.3] text-muted-foreground {isCard ? 'border border-[hsl(var(--border))] bg-[hsl(var(--card))] mb-2 hover:bg-[hsl(var(--accent)_/_0.3)] pr-3 rounded-md' : 'border-none bg-transparent rounded-[5px] hover:bg-sidebar-accent'} {isActive ? 'text-sidebar-foreground' : ''} {isBlocked ? 'opacity-65' : ''}"
   onclick={isCard ? undefined : onclick}
   data-testid={isCard ? 'task-card' : undefined}
 >
-  {#if depth > 0}<span class="shrink-0 text-muted-foreground/30 text-[0.6rem] self-center mr-[-2px]">└</span>{/if}
-  <span class="w-[3px] rounded-sm shrink-0 self-stretch" style="background: {statusBarColor(task)}"></span>
+  <span class="w-[3px] rounded-sm shrink-0 self-stretch" style="background: {statusBarColor(rolledUpStatus, task.owner)}"></span>
   <div class="flex-1 min-w-0 flex flex-col gap-[3px]">
     {#if isCard}
       <span class="shrink-0 font-semibold text-[0.65rem] {isActive ? 'opacity-80' : 'opacity-60'}">!{task.id}</span>
@@ -88,7 +112,7 @@ function handleDescriptionClick(e) {
     {:else}
       <div class="flex items-center gap-1.5">
         <span class="shrink-0 font-semibold {isActive ? 'opacity-80' : 'opacity-60'}">!{task.id}</span>
-        <span class="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">{#if task.status === 'done'}<span class="text-[hsl(var(--accent-green))]">✓ </span>{/if}{task.subject}</span>
+        <span class="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">{#if rolledUpStatus === 'done'}<span class="text-[hsl(var(--accent-green))]">✓ </span>{/if}{task.subject}</span>
         {#if isBlocked}
           <span class="shrink-0 text-[0.62rem] text-[hsl(var(--status-amber))] opacity-85" title="Blocked by !{task.blocked_by[0]}">⧗ !{task.blocked_by[0]}</span>
         {/if}

--- a/web-app/src/lib/taskGrouping.test.ts
+++ b/web-app/src/lib/taskGrouping.test.ts
@@ -11,29 +11,26 @@ describe("groupTasksByParent", () => {
 		expect(groupTasksByParent([])).toEqual([]);
 	});
 
-	it("returns tasks at depth 0 when no parent relationships", () => {
+	it("returns tasks with empty children when no parent relationships", () => {
 		const tasks = [makeTask(1, "Task A"), makeTask(2, "Task B")];
 		const result = groupTasksByParent(tasks);
 		expect(result).toEqual([
-			{ task: tasks[0], depth: 0 },
-			{ task: tasks[1], depth: 0 },
+			{ task: tasks[0], children: [] },
+			{ task: tasks[1], children: [] },
 		]);
 	});
 
-	it("nests child under its parent at depth 1", () => {
+	it("nests child under its parent", () => {
 		const parent = makeTask(10, "Implement feature");
 		const child = makeTask(11, "Review PR #42", "10");
 		const result = groupTasksByParent([parent, child]);
-		expect(result).toEqual([
-			{ task: parent, depth: 0 },
-			{ task: child, depth: 1 },
-		]);
+		expect(result).toEqual([{ task: parent, children: [child] }]);
 	});
 
-	it("shows child at depth 0 when parent is not in list", () => {
+	it("shows child as top-level when parent is not in list", () => {
 		const child = makeTask(11, "Review PR #42", "10");
 		const result = groupTasksByParent([child]);
-		expect(result).toEqual([{ task: child, depth: 0 }]);
+		expect(result).toEqual([{ task: child, children: [] }]);
 	});
 
 	it("groups multiple children under same parent", () => {
@@ -41,11 +38,7 @@ describe("groupTasksByParent", () => {
 		const child1 = makeTask(11, "Review PR", "10");
 		const child2 = makeTask(12, "Address feedback", "10");
 		const result = groupTasksByParent([parent, child1, child2]);
-		expect(result).toEqual([
-			{ task: parent, depth: 0 },
-			{ task: child1, depth: 1 },
-			{ task: child2, depth: 1 },
-		]);
+		expect(result).toEqual([{ task: parent, children: [child1, child2] }]);
 	});
 
 	it("handles mixed parent and standalone tasks", () => {
@@ -54,9 +47,8 @@ describe("groupTasksByParent", () => {
 		const child = makeTask(11, "Review", "10");
 		const result = groupTasksByParent([standalone, parent, child]);
 		expect(result).toEqual([
-			{ task: standalone, depth: 0 },
-			{ task: parent, depth: 0 },
-			{ task: child, depth: 1 },
+			{ task: standalone, children: [] },
+			{ task: parent, children: [child] },
 		]);
 	});
 
@@ -65,25 +57,22 @@ describe("groupTasksByParent", () => {
 		const parent = makeTask(10, "Feature");
 		// Child appears before parent in input — child should nest under parent
 		const result = groupTasksByParent([child, parent]);
-		expect(result).toEqual([
-			{ task: parent, depth: 0 },
-			{ task: child, depth: 1 },
-		]);
+		expect(result).toEqual([{ task: parent, children: [child] }]);
 	});
 
 	it("handles self-parent by treating as top-level", () => {
 		const task = makeTask(5, "Self-referencing", "5");
 		const result = groupTasksByParent([task]);
-		expect(result).toEqual([{ task, depth: 0 }]);
+		expect(result).toEqual([{ task, children: [] }]);
 	});
 
 	it("handles circular parent refs without losing tasks", () => {
 		const a = makeTask(1, "Task A", "2");
 		const b = makeTask(2, "Task B", "1");
 		const result = groupTasksByParent([a, b]);
-		// Both should appear — neither can be properly nested
+		// Both should appear as top-level — neither can be properly nested
 		expect(result).toHaveLength(2);
-		expect(result.every((r) => r.depth === 0)).toBe(true);
+		expect(result.every((r) => r.children.length === 0)).toBe(true);
 	});
 
 	it("does not duplicate tasks in any scenario", () => {
@@ -92,11 +81,11 @@ describe("groupTasksByParent", () => {
 		const orphan = makeTask(12, "Orphan", "99");
 		const selfRef = makeTask(13, "Self", "13");
 		const result = groupTasksByParent([parent, child, orphan, selfRef]);
-		const ids = result.map((r) => r.task.id);
-		expect(ids).toHaveLength(new Set(ids).size);
-		expect(ids).toContain(10);
-		expect(ids).toContain(11);
-		expect(ids).toContain(12);
-		expect(ids).toContain(13);
+		const allIds = result.flatMap((r) => [r.task.id, ...r.children.map((c) => c.id)]);
+		expect(allIds).toHaveLength(new Set(allIds).size);
+		expect(allIds).toContain(10);
+		expect(allIds).toContain(11);
+		expect(allIds).toContain(12);
+		expect(allIds).toContain(13);
 	});
 });

--- a/web-app/src/lib/taskGrouping.ts
+++ b/web-app/src/lib/taskGrouping.ts
@@ -2,26 +2,23 @@ import type { Task } from "./types.ts";
 
 export interface GroupedTask {
 	task: Task;
-	depth: number;
+	children: Task[];
 }
 
 /**
  * Arrange tasks into parent-child groups for display.
  *
- * Returns a flat list with depth annotations:
- * - Top-level tasks (no parent, or parent not in the list) get depth 0
- * - Children are placed immediately after their parent with depth 1
+ * Returns one entry per top-level task with its children attached:
+ * - Top-level tasks (no parent, or parent not in the list) get an entry
+ * - Children are attached to their parent's `children` array
  *
- * Children whose parent is not in the visible list are shown at depth 0
+ * Children whose parent is not in the visible list are promoted to top-level
  * to avoid orphaned invisible tasks.
  */
 export function groupTasksByParent(tasks: Task[]): GroupedTask[] {
 	const taskIds = new Set(tasks.map((t) => String(t.id)));
 	const topLevelIds = new Set<string>();
 
-	// Separate into parents/top-level and children-with-visible-parent.
-	// A task is only treated as a child if its parent is in the list AND
-	// is not itself a child (prevents cycles and limits nesting to 1 level).
 	const childrenByParent = new Map<string, Task[]>();
 	const topLevel: Task[] = [];
 
@@ -49,17 +46,9 @@ export function groupTasksByParent(tasks: Task[]): GroupedTask[] {
 		}
 	}
 
-	// Build flat list: each top-level task followed by its children
-	const result: GroupedTask[] = [];
-	for (const task of topLevel) {
-		result.push({ task, depth: 0 });
-		const children = childrenByParent.get(String(task.id));
-		if (children) {
-			for (const child of children) {
-				result.push({ task: child, depth: 1 });
-			}
-		}
-	}
-
-	return result;
+	// Build result: each top-level task with its children array
+	return topLevel.map((task) => ({
+		task,
+		children: childrenByParent.get(String(task.id)) || [],
+	}));
 }


### PR DESCRIPTION
<!-- midtown: bleecker -->

## Summary
- Changed `groupTasksByParent()` to return `{ task, children[] }` instead of flat `{ task, depth }` — children are attached to their parent object rather than interleaved in a flat list
- TaskRow derives status rollup from children: shows `in_progress` if any child is active, `done` only when parent + all children are done
- Reviewer is derived from child task whose subject matches "review" when no PR-based reviewer exists
- Removed depth-based `└` indent rendering — parent-child tasks now display as a single collapsed row

## Test plan
- [x] All 10 `taskGrouping.test.ts` tests pass with new `{ task, children }` shape
- [x] Biome lint passes on all changed files
- [ ] Visual check: sidebar shows collapsed parent-child rows without indentation
- [ ] Status bar color reflects rolled-up status (green when all done, active color when any child in progress)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)