### PR TITLE
Refactor dispatch loop: generic slot management and idle coworker reuse

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -1579,6 +1579,7 @@ fn dispatch_unowned_pending_tasks(
     let mut spawns_queued_this_tick: usize = 0;
     let in_progress_count = snap.in_progress_tasks.len();
     let task_cap = snap.max_in_progress_tasks;
+    let channel_lead_names = snap.channel_lead_names();
 
     // Order pending tasks by dispatch priority before iterating.
     let in_progress_ids: std::collections::HashSet<String> = snap
@@ -1601,14 +1602,9 @@ fn dispatch_unowned_pending_tasks(
         else {
             continue;
         };
-        let effective_count = in_progress_count + spawns_queued_this_tick;
-        if effective_count >= task_cap {
-            debug!(
-                "In-progress task limit reached ({}+{} >= {}), deferring unowned task !{}",
-                in_progress_count, spawns_queued_this_tick, task_cap, task.id
-            );
-            break;
-        }
+
+        // ── Stage 1: Unconditional skip/cleanup (no task limit gate) ─────────
+        // These operations don't consume slots and should run regardless of capacity.
 
         // Skip tasks already claimed by orphan recovery in this tick.
         if excluded_task_ids.contains(&task.id) {
@@ -1756,6 +1752,8 @@ fn dispatch_unowned_pending_tasks(
             }
         }
 
+        // ── Stage 2: Name resolution + task limit gate ────────────────────────
+
         // Check if this is a reviewer task — reviewers must always be fresh spawns
         // on isolated worktrees, never grouped with the implementation coworker.
         let is_reviewer_task = snap
@@ -1773,9 +1771,43 @@ fn dispatch_unowned_pending_tasks(
         };
 
         // Use grouped name if found, otherwise allocate a fresh coworker.
+        // When at task limit and no grouping match, try to reuse an idle coworker.
         let was_grouped = grouped_name.is_some();
+        let effective_count = in_progress_count + spawns_queued_this_tick;
+        let at_task_limit = effective_count >= task_cap;
+
         let coworker_name = if let Some(name) = grouped_name {
             name
+        } else if at_task_limit {
+            // At task limit — can't start new in-progress tasks. Check for an idle
+            // coworker (running session, no in-progress task) to reuse via nudge.
+            // Reviewer tasks always need a fresh spawn on an isolated worktree,
+            // so they cannot reuse idle coworkers.
+            if is_reviewer_task {
+                debug!(
+                    "Task limit reached ({}+{} >= {}), reviewer task !{} deferred",
+                    in_progress_count, spawns_queued_this_tick, task_cap, task.id
+                );
+                continue;
+            }
+            if let Some(name) = find_idle_coworker(
+                snap,
+                &channel_lead_names,
+                &names_assigned_this_tick,
+                owned_dispatched,
+            ) {
+                debug!(
+                    "Task limit reached but found idle coworker {} for task !{}",
+                    name, task.id
+                );
+                name
+            } else {
+                debug!(
+                    "Task limit reached ({}+{} >= {}) and no idle coworker, deferring task !{}",
+                    in_progress_count, spawns_queued_this_tick, task_cap, task.id
+                );
+                continue;
+            }
         } else {
             let mut excluded_names = snap.channel_lead_names();
             // Exclude all names with active sessions to prevent name collisions.
@@ -1799,7 +1831,7 @@ fn dispatch_unowned_pending_tasks(
                 .next_available_name_excluding(&excluded_names)
             else {
                 debug!("No available coworker slots for unowned task !{}", task.id);
-                break;
+                continue;
             };
             debug!("Task !{}: allocated fresh coworker name {}", task.id, name,);
             name
@@ -2158,6 +2190,35 @@ fn dispatch_unowned_pending_tasks(
     }
 
     effects
+}
+
+/// Find an idle coworker — one with a running session but no in-progress task.
+///
+/// Returns the name of an idle coworker that can be nudged to pick up a new task,
+/// or `None` if no idle coworker is available.
+fn find_idle_coworker(
+    snap: &snapshot::WorldSnapshot,
+    channel_lead_names: &HashSet<String>,
+    names_assigned_this_tick: &HashSet<String>,
+    owned_dispatched: &HashSet<String>,
+) -> Option<String> {
+    snap.coworkers
+        .active_names
+        .iter()
+        .find(|name| {
+            !snap.busy_coworkers.contains(*name)
+                && !snap.reviewer.active_reviewers.contains(*name)
+                && !names_assigned_this_tick.contains(*name)
+                && !owned_dispatched.contains(*name)
+                && !snap.spawn_failure_cooldown_names.contains(*name)
+                && !channel_lead_names.contains(*name)
+                && super::helpers::is_non_lead_coworker(
+                    name,
+                    &snap.project_name,
+                    channel_lead_names,
+                )
+        })
+        .cloned()
 }
 
 // ============================================================================

--- a/src/daemon/dispatch_dev_limit_tests.rs
+++ b/src/daemon/dispatch_dev_limit_tests.rs
@@ -253,12 +253,12 @@ fn test_lead_does_not_affect_task_limit_dispatch() {
     );
 }
 
-/// When task limit is reached, no dispatch should occur.
+/// When task limit is reached and all coworkers are busy, no dispatch should occur.
 #[test]
 fn test_no_dispatch_at_task_limit() {
     let state = make_test_state_with_max(8);
 
-    for name in &[
+    let names = [
         "lexington",
         "park",
         "madison",
@@ -267,27 +267,24 @@ fn test_no_dispatch_at_task_limit() {
         "columbus",
         "riverside",
         "york",
-    ] {
+    ];
+
+    for name in &names {
         state
             .coworkers
             .insert_for_testing(make_running_coworker(name));
     }
 
-    let running = vec![
-        make_running_coworker("lexington"),
-        make_running_coworker("park"),
-        make_running_coworker("madison"),
-        make_running_coworker("broadway"),
-        make_running_coworker("amsterdam"),
-        make_running_coworker("columbus"),
-        make_running_coworker("riverside"),
-        make_running_coworker("york"),
-    ];
+    let running: Vec<_> = names.iter().map(|n| make_running_coworker(n)).collect();
 
     let pending = vec![make_pending_task("99")];
 
     // is_at_task_limit=true: 8 in-progress tasks >= max_in_progress_tasks=8
-    let snap = make_task_limit_snapshot(running, pending, true);
+    // All coworkers are busy — no idle coworker reuse possible.
+    let mut snap = make_task_limit_snapshot(running, pending, true);
+    for name in &names {
+        snap.busy_coworkers.insert(name.to_string());
+    }
 
     let effects = crate::daemon::dispatch::spawn_for_pending_tasks(&snap, &state);
 
@@ -301,7 +298,170 @@ fn test_no_dispatch_at_task_limit() {
     });
     assert!(
         !has_task_effect,
-        "Expected no task dispatch when at task limit. Effects: {:?}",
+        "Expected no task dispatch when at task limit with all coworkers busy. Effects: {:?}",
+        effects
+    );
+}
+
+/// When at task limit, merged-PR auto-complete should still run.
+/// The loop should continue past the task limit gate for cleanup operations.
+#[test]
+fn test_merged_pr_autocomplete_runs_at_task_limit() {
+    let state = make_test_state_with_max(2);
+
+    for name in &["lexington", "park"] {
+        state
+            .coworkers
+            .insert_for_testing(make_running_coworker(name));
+    }
+
+    let running = vec![
+        make_running_coworker("lexington"),
+        make_running_coworker("park"),
+    ];
+
+    // Create a pending task linked to a merged PR
+    let mut merged_task = make_pending_task("42");
+    merged_task.pr = Some(100);
+
+    let pending = vec![merged_task];
+
+    // At task limit (2/2), but merged-PR auto-complete should still fire
+    let mut snap = make_task_limit_snapshot(running, pending, true);
+    snap.pr.merged_pr_numbers.insert(100);
+
+    let effects = crate::daemon::dispatch::spawn_for_pending_tasks(&snap, &state);
+
+    let has_complete = effects.iter().any(|e| {
+        matches!(
+            e,
+            crate::daemon::effects::Effect::CompleteTask { task_id, .. } if task_id == "42"
+        )
+    });
+    assert!(
+        has_complete,
+        "Expected merged-PR auto-complete to run even at task limit. Effects: {:?}",
+        effects
+    );
+}
+
+/// When at task limit with idle coworkers, tasks should be assigned to idle coworkers.
+#[test]
+fn test_idle_coworker_reuse_at_task_limit() {
+    let state = make_test_state_with_max(2);
+
+    for name in &["lexington", "park"] {
+        state
+            .coworkers
+            .insert_for_testing(make_running_coworker(name));
+    }
+
+    let running = vec![
+        make_running_coworker("lexington"),
+        make_running_coworker("park"),
+    ];
+
+    let pending = vec![make_pending_task("99")];
+
+    // At task limit (2/2), but park is idle (not in busy_coworkers)
+    let mut snap = make_task_limit_snapshot(running, pending, true);
+    // Mark lexington as busy, park stays idle
+    snap.busy_coworkers.insert("lexington".to_string());
+    // Don't mark park as busy — it's idle and should be reusable
+
+    let effects = crate::daemon::dispatch::spawn_for_pending_tasks(&snap, &state);
+
+    let has_nudge = effects.iter().any(|e| {
+        matches!(
+            e,
+            crate::daemon::effects::Effect::NudgeSessionWithCallbacks { .. }
+        )
+    });
+    assert!(
+        has_nudge,
+        "Expected idle coworker to be nudged with new task at task limit. Effects: {:?}",
+        effects
+    );
+}
+
+/// When at task limit with NO idle coworkers, tasks should be deferred.
+#[test]
+fn test_no_idle_coworkers_defers_at_task_limit() {
+    let state = make_test_state_with_max(2);
+
+    for name in &["lexington", "park"] {
+        state
+            .coworkers
+            .insert_for_testing(make_running_coworker(name));
+    }
+
+    let running = vec![
+        make_running_coworker("lexington"),
+        make_running_coworker("park"),
+    ];
+
+    let pending = vec![make_pending_task("99")];
+
+    // At task limit (2/2), all coworkers busy
+    let mut snap = make_task_limit_snapshot(running, pending, true);
+    snap.busy_coworkers.insert("lexington".to_string());
+    snap.busy_coworkers.insert("park".to_string());
+
+    let effects = crate::daemon::dispatch::spawn_for_pending_tasks(&snap, &state);
+
+    let has_task_effect = effects.iter().any(|e| {
+        matches!(
+            e,
+            crate::daemon::effects::Effect::AssignAndSpawn { .. }
+                | crate::daemon::effects::Effect::NudgeSessionWithCallbacks { .. }
+        )
+    });
+    assert!(
+        !has_task_effect,
+        "Expected no dispatch when at task limit and all coworkers busy. Effects: {:?}",
+        effects
+    );
+}
+
+/// Reviewer tasks should NOT reuse idle coworkers — they need fresh isolated worktrees.
+#[test]
+fn test_reviewer_task_deferred_at_task_limit() {
+    let state = make_test_state_with_max(2);
+
+    for name in &["lexington", "park"] {
+        state
+            .coworkers
+            .insert_for_testing(make_running_coworker(name));
+    }
+
+    let running = vec![
+        make_running_coworker("lexington"),
+        make_running_coworker("park"),
+    ];
+
+    let mut reviewer_task = make_pending_task("99");
+    reviewer_task.pr = Some(200);
+    let pending = vec![reviewer_task];
+
+    // At task limit (2/2), park is idle, but task is a reviewer task
+    let mut snap = make_task_limit_snapshot(running, pending, true);
+    snap.busy_coworkers.insert("lexington".to_string());
+    // Mark task as reviewer type
+    snap.task_agent_type_map
+        .insert("99".to_string(), "midtown-code-reviewer".to_string());
+
+    let effects = crate::daemon::dispatch::spawn_for_pending_tasks(&snap, &state);
+
+    let has_task_effect = effects.iter().any(|e| {
+        matches!(
+            e,
+            crate::daemon::effects::Effect::AssignAndSpawn { .. }
+                | crate::daemon::effects::Effect::NudgeSessionWithCallbacks { .. }
+        )
+    });
+    assert!(
+        !has_task_effect,
+        "Expected reviewer task to be deferred at task limit (no idle reuse). Effects: {:?}",
         effects
     );
 }


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary

- **Restructured dispatch loop into two stages**: Stage 1 runs unconditionally (merged-PR auto-complete, session resume, lead-driven skip, orphan recovery guard). Stage 2 is gated by the task limit for name resolution and spawn/nudge decisions.
- **Added idle coworker reuse**: When at task limit, idle coworkers (running session, no in-progress task) are nudged with new tasks instead of deferring. Reviewer tasks are excluded since they need fresh isolated worktrees.
- **Changed name-pool-exhausted `break` to `continue`**: Subsequent tasks with different exclusion criteria can still find available names.

## Test plan

- [x] All 10 dispatch_dev_limit tests pass (4 new tests added)
- [x] `test_merged_pr_autocomplete_runs_at_task_limit` — verifies cleanup runs at capacity
- [x] `test_idle_coworker_reuse_at_task_limit` — verifies idle coworker gets nudged
- [x] `test_no_idle_coworkers_defers_at_task_limit` — verifies deferral when all busy
- [x] `test_reviewer_task_deferred_at_task_limit` — verifies reviewers don't reuse idle coworkers
- [x] Full test suite passes (2667 tests), clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)