### PR TITLE
[Midtown !2330] Fix child reviewer filter and simplify code-author agent doc

### DIFF
--- a/web-app/src/lib/TaskList.svelte
+++ b/web-app/src/lib/TaskList.svelte
@@ -63,7 +63,7 @@ function handleTaskClick(task) {
   {#each groupedTasks as { task, children }}
     {@const cw = task.owner ? cwMap.get(task.owner) : null}
     {@const reviewInfo = taskReviewerMap.get(String(task.id))}
-    {@const childReviewer = !reviewInfo?.reviewer ? children.find((c) => c.status === "in_progress" && /review/i.test(c.subject))?.owner : undefined}
+    {@const childReviewer = !reviewInfo?.reviewer ? children.find((c) => /review/i.test(c.subject))?.owner : undefined}
     <TaskRow
       {task}
       {cw}


### PR DESCRIPTION
<!-- midtown: midtown -->

## Summary

Follow-up to #2102 (parent-child task collapse). Two small fixes:

- **TaskList.svelte**: Remove `status === "in_progress"` filter when deriving reviewer from child tasks — the reviewer avatar should show regardless of the review task's status (pending, in_progress, or done)
- **midtown-code-author.md**: Remove "Never Block Silently" section (redundant with existing guidance) and update the cross-reference in the superpowers override bullet

## Test plan

- [x] `vitest run taskGrouping.test.ts` — 10/10 pass
- [ ] Visual check: reviewer avatar appears in sidebar for tasks with review children in any status

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)