### PR TITLE
[Midtown !2338] fix: Exclude tool-only messages from thread reply counts

### DIFF
--- a/src/bin/midtown/cli/chat/ui/chat.rs
+++ b/src/bin/midtown/cli/chat/ui/chat.rs
@@ -286,6 +286,9 @@ fn draw_chat_messages(f: &mut Frame, app: &mut App, area: Rect) {
         let mut counts: HashMap<String, (usize, Option<String>)> = HashMap::new();
         for msg in app.messages.iter() {
             if let Some(ref parent_id) = msg.thread_parent_id {
+                if msg.is_tool_only() {
+                    continue;
+                }
                 let entry = counts.entry(parent_id.clone()).or_insert((0, None));
                 entry.0 += 1;
                 entry.1 = Some(msg.from.clone());

--- a/src/message.rs
+++ b/src/message.rs
@@ -265,6 +265,13 @@ impl Message {
         msg
     }
 
+    /// Returns `true` when the message has no meaningful text content and
+    /// only carries tool call data. Matches the JS `isToolOnly()` helper in
+    /// `web-app/src/lib/toolRunGrouping.ts`.
+    pub fn is_tool_only(&self) -> bool {
+        self.content.trim().is_empty() && self.tool_data.as_ref().is_some_and(|td| !td.is_empty())
+    }
+
     /// Returns the thread anchor ID for replies (parent ID when present).
     ///
     /// Thread replies must carry their parent's ID when nudging coworkers so

--- a/src/web.rs
+++ b/src/web.rs
@@ -810,30 +810,7 @@ async fn api_channel_history(
                         StatusCode::INTERNAL_SERVER_ERROR
                     })?;
 
-            let mut reply_meta: std::collections::HashMap<
-                String,
-                (usize, ThreadReplySummary, Vec<String>),
-            > = std::collections::HashMap::new();
-            for msg in &messages {
-                if let Some(parent_id) = msg.thread_parent_id.as_ref() {
-                    let entry = reply_meta.entry(parent_id.clone()).or_insert((
-                        0,
-                        ThreadReplySummary {
-                            from: msg.from.clone(),
-                            timestamp: msg.timestamp.to_rfc3339(),
-                        },
-                        Vec::new(),
-                    ));
-                    entry.0 += 1;
-                    entry.1 = ThreadReplySummary {
-                        from: msg.from.clone(),
-                        timestamp: msg.timestamp.to_rfc3339(),
-                    };
-                    if !entry.2.contains(&msg.from) {
-                        entry.2.push(msg.from.clone());
-                    }
-                }
-            }
+            let mut reply_meta = compute_reply_meta(&messages);
 
             messages
                 .into_iter()
@@ -3289,6 +3266,41 @@ async fn api_list_directories(State(state): State<Arc<WebState>>) -> Json<serde_
 
     let list: Vec<&str> = dirs.iter().map(|s| s.as_str()).collect();
     Json(serde_json::json!({ "directories": list }))
+}
+
+/// Compute thread reply metadata from a list of messages, excluding tool-only
+/// messages (empty content + non-empty tool_data) from the count.
+///
+/// Returns a map from parent message ID to (reply_count, last_reply_summary, participant_names).
+fn compute_reply_meta(
+    messages: &[crate::message::Message],
+) -> std::collections::HashMap<String, (usize, ThreadReplySummary, Vec<String>)> {
+    let mut meta: std::collections::HashMap<String, (usize, ThreadReplySummary, Vec<String>)> =
+        std::collections::HashMap::new();
+    for msg in messages {
+        if let Some(parent_id) = msg.thread_parent_id.as_ref() {
+            if msg.is_tool_only() {
+                continue;
+            }
+            let entry = meta.entry(parent_id.clone()).or_insert((
+                0,
+                ThreadReplySummary {
+                    from: msg.from.clone(),
+                    timestamp: msg.timestamp.to_rfc3339(),
+                },
+                Vec::new(),
+            ));
+            entry.0 += 1;
+            entry.1 = ThreadReplySummary {
+                from: msg.from.clone(),
+                timestamp: msg.timestamp.to_rfc3339(),
+            };
+            if !entry.2.contains(&msg.from) {
+                entry.2.push(msg.from.clone());
+            }
+        }
+    }
+    meta
 }
 
 #[path = "web_tests.rs"]

--- a/src/web_tests.rs
+++ b/src/web_tests.rs
@@ -1781,3 +1781,91 @@ fn test_from_json_rejects_invalid_lead_driven_type() {
     let err = SetWorkflowRequest::from_json(&body).unwrap_err();
     assert_eq!(err, "lead_driven must be a boolean");
 }
+
+#[test]
+fn test_reply_count_excludes_tool_only_messages() {
+    use crate::message::{Message, MessageType, ToolBlock};
+
+    let parent_id = "parent-1";
+
+    // Parent message (top-level)
+    let parent = Message::for_channel("web", "alice", "Hello", MessageType::Text);
+    let mut parent = parent;
+    parent.id = parent_id.to_string();
+
+    // Normal text reply — should be counted
+    let mut text_reply =
+        Message::thread_reply("web", "bob", "Got it!", parent_id, MessageType::Text);
+    text_reply.id = "reply-1".to_string();
+
+    // Tool-only reply (empty content + non-empty tool_data) — should NOT be counted
+    let mut tool_only_reply = Message::thread_reply("web", "bob", "", parent_id, MessageType::Text);
+    tool_only_reply.id = "reply-2".to_string();
+    tool_only_reply.tool_data = Some(vec![ToolBlock {
+        tool_name: "Bash".to_string(),
+        input: serde_json::json!({"command": "ls"}),
+        output: None,
+        error: false,
+        call_id: None,
+        parent_tool_use_id: None,
+    }]);
+
+    // Whitespace-only content + tool_data — should also NOT be counted
+    let mut ws_tool_reply =
+        Message::thread_reply("web", "charlie", "  \n  ", parent_id, MessageType::Text);
+    ws_tool_reply.id = "reply-3".to_string();
+    ws_tool_reply.tool_data = Some(vec![ToolBlock {
+        tool_name: "Read".to_string(),
+        input: serde_json::json!({"file_path": "/tmp/x"}),
+        output: None,
+        error: false,
+        call_id: None,
+        parent_tool_use_id: None,
+    }]);
+
+    // Mixed reply (has both content AND tool_data) — should be counted
+    let mut mixed_reply = Message::thread_reply(
+        "web",
+        "charlie",
+        "Here are the results",
+        parent_id,
+        MessageType::Text,
+    );
+    mixed_reply.id = "reply-4".to_string();
+    mixed_reply.tool_data = Some(vec![ToolBlock {
+        tool_name: "Bash".to_string(),
+        input: serde_json::json!({"command": "cargo test"}),
+        output: None,
+        error: false,
+        call_id: None,
+        parent_tool_use_id: None,
+    }]);
+
+    let messages = vec![
+        parent,
+        text_reply,
+        tool_only_reply,
+        ws_tool_reply,
+        mixed_reply,
+    ];
+    let meta = compute_reply_meta(&messages);
+
+    let (count, last_reply, participants) = meta.get(parent_id).expect("should have reply meta");
+
+    // Only text_reply and mixed_reply should be counted (2), not tool_only or ws_tool
+    assert_eq!(
+        *count, 2,
+        "tool-only messages should be excluded from reply count"
+    );
+    assert_eq!(
+        last_reply.from, "charlie",
+        "last reply should be the mixed reply"
+    );
+    assert_eq!(
+        participants.len(),
+        2,
+        "both bob and charlie participated with visible replies"
+    );
+    assert!(participants.contains(&"bob".to_string()));
+    assert!(participants.contains(&"charlie".to_string()));
+}


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary

- Thread reply counts (both web API and TUI) were inflated by counting tool-only messages — messages with empty/whitespace content that only carry `tool_data`
- Added `Message::is_tool_only()` method mirroring the JS `isToolOnly()` helper
- Extracted `compute_reply_meta()` for testability and applied tool-only filtering in both the web API (`src/web.rs`) and TUI (`src/bin/midtown/cli/chat/ui/chat.rs`)

## Test plan

- [x] Added `test_reply_count_excludes_tool_only_messages` covering: normal text replies (counted), tool-only replies (excluded), whitespace+tool replies (excluded), mixed content+tool replies (counted)
- [x] `cargo clippy` clean (0 warnings)
- [x] Coverage diff: 96% on changed lines (1 uncovered line is the handler call site requiring async/full state)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)