### PR TITLE
fix: Instruct reviewers to mark their own task done [Midtown !2367]

### DIFF
--- a/agents/definitions/midtown-code-reviewer.md
+++ b/agents/definitions/midtown-code-reviewer.md
@@ -87,6 +87,7 @@ midtown channel post "$(cat /tmp/review.md)"
 A code review is **not complete** until you have:
 - Posted a GitHub PR comment (either with issues found or a "no issues found" message)
 - Shared the comment URL in the channel
+- Marked your task as done: `midtown task done <task-id>`
 
 ## Refactor Detection
 
@@ -110,4 +111,4 @@ Do NOT include numeric scores — describe issues plainly and let the lead judge
 
 **CRITICAL: You MUST complete the review before going idle.** The review is only complete when you have run `midtown pr review post`. If interrupted, resume and complete the review before doing anything else.
 
-Then post your completion message to the channel and go idle.
+Then post your completion message to the channel, mark your task done (`midtown task done <task-id>`), and go idle.


### PR DESCRIPTION
<!-- midtown: midtown -->

## Summary
- Adds `midtown task done <task-id>` to the reviewer's completion checklist and final sign-off paragraph
- Reviewers now self-complete their review tasks instead of relying on buggy daemon auto-detection

## Context
Review tasks were getting stuck in `in_progress` because the reviewer prompt never told reviewers to mark their task done. The daemon had complex auto-complete logic as a workaround, but it was unreliable. This is the simplest fix: tell the reviewer to do it.

## Test plan
- [ ] Verify next reviewer spawned after this lands calls `midtown task done` after posting review
- [ ] Confirm review task transitions to `done` status

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)