### PR TITLE
fix: Use pr_task_index.task_for_pr() after PrTaskIndex refactor

### DIFF
--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -1130,7 +1130,7 @@ fn build_reviewer_respawn_effects(
             snap.repo_owner.as_deref().unwrap_or("unknown"),
             snap.project_name
         );
-        let task_id = snap.pr.pr_task_associations.get(&pr_number);
+        let task_id = snap.pr.pr_task_index.task_for_pr(pr_number);
         let frontmatter = match task_id {
             Some(tid) => format!("<!-- midtown task:{tid} type:review-status -->"),
             None => "<!-- midtown type:review-status -->".to_string(),


### PR DESCRIPTION
<!-- midtown: midtown -->

## Summary
- PR #2095 (comment frontmatter) merged after PR #2111 (PrTaskIndex refactor) without rebasing, leaving a reference to the removed `pr_task_associations` field on `SnapshotPrState` in `health.rs:1133`
- This single compile error broke all CI jobs on main (Clippy, Test, all E2Es)
- Fix: `snap.pr.pr_task_associations.get(&pr_number)` → `snap.pr.pr_task_index.task_for_pr(pr_number)`

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes locally

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)