### PR TITLE
[Midtown !2329] Unify GitHub comment markers with structured frontmatter

### DIFF
--- a/agents/common.md
+++ b/agents/common.md
@@ -77,21 +77,19 @@ Use `midtown agent show` to check on what a coworker is doing. This captures and
 
 ## GitHub Etiquette
 
-**IMPORTANT**: Always include your name in GitHub content so events are attributed to you:
+**IMPORTANT**: Always include session frontmatter in GitHub content so events are attributed to you. Use `$MIDTOWN_SESSION_ID` from your environment:
 
 1. **PR bodies** - add frontmatter:
 ```
-<!-- midtown: {name} -->
+<!-- midtown session:$MIDTOWN_SESSION_ID -->
 ```
 
-2. **PR comments and reviews** - include your name in the comment:
+2. **PR comments and reviews** - include frontmatter in the comment:
 ```
+<!-- midtown session:$MIDTOWN_SESSION_ID -->
+
 ## Code Review by {name}
 ...
-```
-or add the HTML comment anywhere in your comment:
-```
-<!-- midtown: {name} -->
 ```
 
 **Review styles vary by provider.** Claude reviewers typically post comment-based reviews (with `## Code Review...`), while Codex can submit formal GitHub reviews. Treat either as valid review input, but do not merge until feedback is addressed.

--- a/src/agents_tests.rs
+++ b/src/agents_tests.rs
@@ -11,10 +11,10 @@ fn test_main_lead_system_prompt_loads() {
 #[test]
 fn test_coworker_system_prompt_substitutes_name() {
     let prompt = coworker_system_prompt("lexington", "midtown", None);
-    // {name} should be replaced in Layer 2 (common.md) content
+    // New frontmatter uses $MIDTOWN_SESSION_ID instead of {name}
     assert!(
-        prompt.contains("<!-- midtown: lexington -->"),
-        "Coworker prompt should have {{name}} replaced in GitHub frontmatter"
+        prompt.contains("<!-- midtown session:$MIDTOWN_SESSION_ID -->"),
+        "Coworker prompt should contain session-based frontmatter"
     );
     assert!(!prompt.contains("{name}"));
 }
@@ -111,8 +111,8 @@ fn test_common_prompt_included_in_coworker() {
 fn test_common_prompt_name_substitution_in_lead() {
     let prompt = main_lead_system_prompt("midtown");
     assert!(
-        prompt.contains("<!-- midtown: midtown -->"),
-        "Lead prompt should have {{name}} replaced with project_name in common content"
+        prompt.contains("<!-- midtown session:$MIDTOWN_SESSION_ID -->"),
+        "Lead prompt should contain session-based frontmatter"
     );
     assert!(
         !prompt.contains("{name}"),
@@ -128,8 +128,8 @@ fn test_common_prompt_name_substitution_in_lead() {
 fn test_common_prompt_name_substitution_in_coworker() {
     let prompt = coworker_system_prompt("broadway", "midtown", None);
     assert!(
-        prompt.contains("<!-- midtown: broadway -->"),
-        "Coworker prompt should have {{name}} replaced in common content"
+        prompt.contains("<!-- midtown session:$MIDTOWN_SESSION_ID -->"),
+        "Coworker prompt should contain session-based frontmatter in common content"
     );
 }
 
@@ -408,8 +408,8 @@ fn test_coworker_prompt_requires_issue_comment_reviews() {
         "Coworker prompt should contain the pre-merge checklist section"
     );
     assert!(
-        prompt.contains("<!-- midtown:"),
-        "Coworker prompt should mention the frontmatter signature so reviewers are detected"
+        prompt.contains("<!-- midtown session:"),
+        "Coworker prompt should mention the session frontmatter signature so reviewers are detected"
     );
     assert!(
         prompt.contains("merge"),


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Replace ad-hoc `<!-- midtown-placeholder -->` and `<!-- midtown: name -->` markers with structured frontmatter using session/task IDs
- Add `parse_frontmatter()` parser and format helpers for the new `<!-- midtown session:{id} task:{id} type:{type} -->` format
- Thread `assigned_session_id` through review matching for session-based identity resolution (no coworker names persisted in GitHub)
- Update reviewer restart prompt to reference new frontmatter patterns
- Update coworker system prompts (`agents/common.md`) to instruct use of `$MIDTOWN_SESSION_ID` instead of `{name}` in GitHub frontmatter

## Test plan
- [x] All existing tests updated and passing (2525 pass, 18 skipped due to worktree sandbox permissions)
- [x] `cargo clippy` clean
- [x] New frontmatter parser tests cover all format variants
- [x] Agent prompt tests updated for session-based frontmatter
- [ ] CI green

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)