### PR TITLE
[Midtown !2382] Inline reviewer-resume.md template into agents.rs

### DIFF
--- a/agents/reviewer-resume.md
+++ b/agents/reviewer-resume.md
@@ -1,5 +1,0 @@
-Resume reviewing PR #{pr_number}. The daemon was restarted and discovered you still running. Continue your code review where you left off.
-
-Follow the task verification, posting, refactor detection, and all other review instructions from your system prompt — they are already loaded.
-
-If you haven't already run the code review skill, run it now: {code_review_invocation}

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -30,7 +30,13 @@ const DEFAULT_COMMON_PROMPT: &str = include_str!("../agents/common.md");
 // ── Layer 3 compiled-in content ─────────────────────────────────
 
 /// Embedded default for the reviewer resume prompt template.
-const DEFAULT_REVIEWER_RESUME_PROMPT: &str = include_str!("../agents/reviewer-resume.md");
+const DEFAULT_REVIEWER_RESUME_PROMPT: &str = "\
+Resume reviewing PR #{pr_number}. The daemon was restarted and discovered you still running. Continue your code review where you left off.
+
+Follow the task verification, posting, refactor detection, and all other review instructions from your system prompt — they are already loaded.
+
+If you haven't already run the code review skill, run it now: {code_review_invocation}
+";
 
 /// Embedded default for the ops channel lead additional instructions.
 ///


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Inline the 5-line `agents/reviewer-resume.md` template directly into `agents.rs` as a string literal
- Delete the now-unused file — it wasn't an agent definition, just a nudge message template used via `include_str!()`
- Matches the existing pattern used by `reviewer_launch_prompt()` and other inline templates

## Test plan
- [x] `test_reviewer_resume_prompt_substitutes_pr_number` passes
- [x] `test_reviewer_resume_prompt_references_system_prompt` passes
- [x] `cargo clippy` clean
- [ ] CI green

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)