### PR TITLE
fix: Skip cooldown-blocked owners in orphan recovery instead of bailing

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -486,25 +486,13 @@ where
         recently_stopped: &recently_stopped,
         attached_coworkers: &snap.coworkers.attached_coworkers,
         channel_lead_names: &channel_lead_names,
+        spawn_failure_cooldown_names: &snap.spawn_failure_cooldown_names,
     };
     let recovery = crate::rules::decide_orphan_recovery(&orphan_ctx);
 
     let Some(recovery) = recovery else {
         return vec![];
     };
-
-    // Check per-coworker spawn failure cooldown to prevent infinite retry loops
-    // (pre-evaluated in snapshot)
-    if snap
-        .spawn_failure_cooldown_names
-        .contains(&recovery.owner.to_lowercase())
-    {
-        debug!(
-            "Spawn failure cooldown active for {} — skipping orphan recovery for task !{}",
-            recovery.owner, recovery.task_id
-        );
-        return vec![];
-    }
 
     info!(
         "Detected orphaned task !{} owned by {} - attempting recovery",
@@ -994,6 +982,7 @@ fn dispatch_via_sessions_inner(snap: &snapshot::WorldSnapshot) -> Vec<effects::E
         recently_stopped: &recently_stopped,
         attached_coworkers: &snap.coworkers.attached_coworkers,
         channel_lead_names: &channel_lead_names,
+        spawn_failure_cooldown_names: &snap.spawn_failure_cooldown_names,
     };
     let recovery = match crate::rules::decide_orphan_recovery(&orphan_ctx) {
         Some(r) => r,
@@ -1005,18 +994,6 @@ fn dispatch_via_sessions_inner(snap: &snapshot::WorldSnapshot) -> Vec<effects::E
         debug!(
             "Task !{} is PR-protected — skipping fresh spawn",
             recovery.task_id
-        );
-        return effects;
-    }
-
-    // Check per-coworker spawn failure cooldown (pre-evaluated in snapshot)
-    if snap
-        .spawn_failure_cooldown_names
-        .contains(&recovery.owner.to_lowercase())
-    {
-        debug!(
-            "Spawn failure cooldown active for {} — skipping fresh spawn for task !{}",
-            recovery.owner, recovery.task_id
         );
         return effects;
     }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -936,6 +936,7 @@ pub(crate) struct OrphanRecoveryContext<'a> {
     pub recently_stopped: &'a HashSet<String>,
     pub attached_coworkers: &'a HashMap<String, chrono::DateTime<chrono::Utc>>,
     pub channel_lead_names: &'a HashSet<String>,
+    pub spawn_failure_cooldown_names: &'a HashSet<String>,
 }
 
 impl OrphanRecoveryContext<'_> {
@@ -946,12 +947,14 @@ impl OrphanRecoveryContext<'_> {
     /// - Owner is attached (interactive session)
     /// - Owner recently stopped (within grace period — task may not be marked done yet)
     /// - Owner has an open PR awaiting review without feedback (recovery would loop)
+    /// - Owner is on spawn failure cooldown (prevent infinite retry loops)
     fn should_skip_owner(&self, owner_lower: &str) -> bool {
         self.active_names.contains(owner_lower)
             || self.attached_coworkers.contains_key(owner_lower)
             || self.recently_stopped.contains(owner_lower)
             || (self.coworkers_with_open_prs.contains(owner_lower)
                 && !self.review_feedback_pr_coworkers.contains(owner_lower))
+            || self.spawn_failure_cooldown_names.contains(owner_lower)
     }
 }
 

--- a/src/rules_channel_lead_tests.rs
+++ b/src/rules_channel_lead_tests.rs
@@ -53,10 +53,84 @@ fn channel_lead_owned_task_not_orphan_recovered() {
         recently_stopped: &empty,
         attached_coworkers: &empty_map,
         channel_lead_names: &leads,
+        spawn_failure_cooldown_names: &empty,
     };
     let result = decide_orphan_recovery(&ctx);
     assert!(
         result.is_none(),
         "channel lead owned task should not be orphan recovered"
+    );
+}
+
+#[test]
+fn orphan_recovery_skips_cooldown_blocked_owner_recovers_next() {
+    // Two orphaned tasks: first owner ("lexington") is on spawn failure cooldown,
+    // second owner ("park") is not. Recovery should skip lexington and return park's task.
+    let tasks = vec![
+        (
+            "10".to_string(),
+            "lexington task".to_string(),
+            "lexington".to_string(),
+        ),
+        (
+            "20".to_string(),
+            "park task".to_string(),
+            "park".to_string(),
+        ),
+    ];
+    let empty = empty_set();
+    let empty_map: HashMap<String, chrono::DateTime<chrono::Utc>> = HashMap::new();
+    let cooldown = names(&["lexington"]);
+    let ctx = OrphanRecoveryContext {
+        in_progress: &tasks,
+        active_names: &empty,
+        at_dev_limit: false,
+        coworkers_with_open_prs: &empty,
+        review_feedback_pr_coworkers: &empty,
+        recently_stopped: &empty,
+        attached_coworkers: &empty_map,
+        channel_lead_names: &empty,
+        spawn_failure_cooldown_names: &cooldown,
+    };
+    let result = decide_orphan_recovery(&ctx);
+    assert!(result.is_some(), "should recover park's task");
+    let recovery = result.unwrap();
+    assert_eq!(recovery.task_id, "20");
+    assert_eq!(recovery.owner, "park");
+}
+
+#[test]
+fn orphan_recovery_returns_none_when_all_on_cooldown() {
+    // All owners on cooldown — no recovery should happen.
+    let tasks = vec![
+        (
+            "10".to_string(),
+            "lexington task".to_string(),
+            "lexington".to_string(),
+        ),
+        (
+            "20".to_string(),
+            "park task".to_string(),
+            "park".to_string(),
+        ),
+    ];
+    let empty = empty_set();
+    let empty_map: HashMap<String, chrono::DateTime<chrono::Utc>> = HashMap::new();
+    let cooldown = names(&["lexington", "park"]);
+    let ctx = OrphanRecoveryContext {
+        in_progress: &tasks,
+        active_names: &empty,
+        at_dev_limit: false,
+        coworkers_with_open_prs: &empty,
+        review_feedback_pr_coworkers: &empty,
+        recently_stopped: &empty,
+        attached_coworkers: &empty_map,
+        channel_lead_names: &empty,
+        spawn_failure_cooldown_names: &cooldown,
+    };
+    let result = decide_orphan_recovery(&ctx);
+    assert!(
+        result.is_none(),
+        "should not recover when all owners are on cooldown"
     );
 }


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary

- Move `spawn_failure_cooldown_names` check into `OrphanRecoveryContext.should_skip_owner()` so `decide_orphan_recovery()` skips cooldown-blocked owners and tries the next orphan instead of bailing entirely
- Remove redundant post-selection cooldown checks in `check_and_recover_orphans_impl()` and `dispatch_via_sessions_inner()` no-session fallback path
- Add two tests: recovery skips first cooldown-blocked owner to recover the second, and returns `None` when all owners are on cooldown

Fixes !2385

## Test plan

- [x] `cargo test --lib orphan_recovery_skips` — new test: first owner on cooldown is skipped, second is recovered
- [x] `cargo test --lib orphan_recovery_returns_none` — new test: all on cooldown returns None
- [x] `cargo test --lib dispatch` — all 167 dispatch tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)