### PR TITLE
fix: Stop PR nudge spam for task-less PRs [Midtown !2377]

### DIFF
--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -1459,6 +1459,9 @@ fn action_to_effects(
         // Task-less PRs: post to ops for manual investigation.
         // All coworker PRs should have tasks; reaching here indicates a
         // data gap (e.g., daemon restart lost session records).
+        // Bug !2377: Use RecordPermanentPrNudge (one-shot) instead of RecordPrNudge
+        // (cooldown-based). No coworker exists to fix the issue, so cooldown expiry
+        // would just re-fire the same message every 10 minutes indefinitely.
         PrAction::NudgeOwner { owner, message: _ } | PrAction::SpawnOwner { owner, message: _ } => {
             vec![
                 Effect::PostToChannel {
@@ -1480,7 +1483,7 @@ fn action_to_effects(
                     tool_use_id: None,
                     parent_tool_use_id: None,
                 },
-                Effect::RecordPrNudge {
+                Effect::RecordPermanentPrNudge {
                     pr_number,
                     issue_type,
                 },

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -5450,3 +5450,83 @@ async fn test_multiple_prs_get_distinct_reviewer_names() {
         reviewer_names
     );
 }
+
+/// Bug !2377: Task-less PRs use RecordPrNudge (cooldown-based), so the "no task
+/// linked" ops post re-fires every 10 minutes. Since no coworker exists to fix the
+/// issue, this creates infinite spam. The fix is to use RecordPermanentPrNudge so
+/// the notification fires exactly once.
+#[test]
+fn action_to_effects_taskless_pr_uses_permanent_nudge() {
+    let (state, _tmp, _guard) = make_test_state("test-repo");
+    let ctx = make_pr_context_empty();
+
+    let effects = action_to_effects(
+        crate::rules::PrAction::SpawnOwner {
+            owner: "york".to_string(),
+            message: "CI green — please merge".to_string(),
+        },
+        42,
+        "Fix auth",
+        PrIssueType::GreenWithFeedback,
+        &state,
+        &ctx,
+    );
+
+    let has_permanent = effects.iter().any(|e| {
+        matches!(
+            e,
+            Effect::RecordPermanentPrNudge { pr_number, .. } if *pr_number == 42
+        )
+    });
+    assert!(
+        has_permanent,
+        "Bug !2377: Task-less PR nudge must use RecordPermanentPrNudge to prevent \
+         re-firing every cooldown period. Got: {:#?}",
+        effects
+    );
+
+    // Also verify it does NOT produce a regular RecordPrNudge (which would allow re-fire)
+    let has_regular = effects.iter().any(|e| {
+        matches!(
+            e,
+            Effect::RecordPrNudge { pr_number, .. } if *pr_number == 42
+        )
+    });
+    assert!(
+        !has_regular,
+        "Bug !2377: Task-less PR nudge must NOT produce RecordPrNudge (cooldown-based). \
+         Only RecordPermanentPrNudge should be emitted. Got: {:#?}",
+        effects
+    );
+}
+
+/// Bug !2377: Same as above but for NudgeOwner (the other arm that handles task-less PRs).
+#[test]
+fn action_to_effects_taskless_nudge_owner_uses_permanent_nudge() {
+    let (state, _tmp, _guard) = make_test_state("test-repo");
+    let ctx = make_pr_context_empty();
+
+    let effects = action_to_effects(
+        crate::rules::PrAction::NudgeOwner {
+            owner: "park".to_string(),
+            message: "CI green — please merge".to_string(),
+        },
+        99,
+        "Add logging",
+        PrIssueType::GreenWithFeedback,
+        &state,
+        &ctx,
+    );
+
+    let has_permanent = effects.iter().any(|e| {
+        matches!(
+            e,
+            Effect::RecordPermanentPrNudge { pr_number, .. } if *pr_number == 99
+        )
+    });
+    assert!(
+        has_permanent,
+        "Bug !2377: Task-less NudgeOwner must use RecordPermanentPrNudge. Got: {:#?}",
+        effects
+    );
+}

--- a/src/daemon/trackers.rs
+++ b/src/daemon/trackers.rs
@@ -68,9 +68,14 @@ impl PrIssueTracker {
         Self::default()
     }
 
-    /// Check if we should nudge for this issue (not nudged recently)
+    /// Check if we should nudge for this issue (not nudged recently).
+    /// Permanent one-shot nudges always return false — they fire exactly once.
     pub fn should_nudge(&self, pr_number: u64, issue_type: PrIssueType) -> bool {
-        match self.nudged.get(&(pr_number, issue_type)) {
+        let key = (pr_number, issue_type);
+        if self.permanent.contains(&key) {
+            return false;
+        }
+        match self.nudged.get(&key) {
             Some(last_nudge) => last_nudge.elapsed() >= Duration::from_secs(PR_NUDGE_COOLDOWN_SECS),
             None => true,
         }
@@ -79,13 +84,18 @@ impl PrIssueTracker {
     /// Check if we should nudge for this issue using a custom cooldown duration.
     /// Used for orphaned PRs which need a longer suppression window since there's
     /// no active coworker to address the issue.
+    /// Permanent one-shot nudges always return false.
     pub fn should_nudge_with_cooldown(
         &self,
         pr_number: u64,
         issue_type: PrIssueType,
         cooldown_secs: u64,
     ) -> bool {
-        match self.nudged.get(&(pr_number, issue_type)) {
+        let key = (pr_number, issue_type);
+        if self.permanent.contains(&key) {
+            return false;
+        }
+        match self.nudged.get(&key) {
             Some(last_nudge) => last_nudge.elapsed() >= Duration::from_secs(cooldown_secs),
             None => true,
         }
@@ -96,10 +106,14 @@ impl PrIssueTracker {
         self.nudged.insert((pr_number, issue_type), Instant::now());
     }
 
-    /// Clear a specific nudge entry (e.g., when retrying after coworker death)
+    /// Clear a specific nudge cooldown entry (e.g., when retrying after coworker death).
+    /// Preserves permanent one-shot entries — those represent notifications that
+    /// should never re-fire (bug !2377).
     pub fn clear_nudge(&mut self, pr_number: u64, issue_type: PrIssueType) {
-        self.nudged.remove(&(pr_number, issue_type));
-        self.permanent.remove(&(pr_number, issue_type));
+        let key = (pr_number, issue_type);
+        if !self.permanent.contains(&key) {
+            self.nudged.remove(&key);
+        }
     }
 
     /// Check if a nudge has been recorded for this issue (including permanent entries)

--- a/src/daemon/trackers_tests.rs
+++ b/src/daemon/trackers_tests.rs
@@ -639,8 +639,10 @@ fn permanent_nudge_serialization_roundtrip() {
     assert_eq!(deserialized[1], (99, PrIssueType::ReviewComplete));
 }
 
+/// Bug !2377: clear_nudge preserves permanent entries — they represent one-shot
+/// notifications that should never re-fire. Only cooldown entries are cleared.
 #[test]
-fn permanent_nudge_clear_removes_from_set() {
+fn permanent_nudge_survives_clear_nudge() {
     let mut tracker = PrIssueTracker::new();
     tracker.record_permanent_nudge(42, PrIssueType::ReviewComplete);
 
@@ -649,8 +651,30 @@ fn permanent_nudge_clear_removes_from_set() {
 
     tracker.clear_nudge(42, PrIssueType::ReviewComplete);
 
-    assert!(!tracker.has_nudge(42, PrIssueType::ReviewComplete));
-    assert!(tracker.permanent_nudges().is_empty());
+    // Permanent entry preserved — nudge must not re-fire
+    assert!(tracker.has_nudge(42, PrIssueType::ReviewComplete));
+    assert_eq!(tracker.permanent_nudges().len(), 1);
+    assert!(
+        !tracker.should_nudge(42, PrIssueType::ReviewComplete),
+        "should_nudge must return false for permanent entries"
+    );
+}
+
+/// Non-permanent nudges are fully cleared by clear_nudge.
+#[test]
+fn regular_nudge_cleared_by_clear_nudge() {
+    let mut tracker = PrIssueTracker::new();
+    tracker.record_nudge(42, PrIssueType::GreenWithFeedback);
+
+    assert!(tracker.has_nudge(42, PrIssueType::GreenWithFeedback));
+
+    tracker.clear_nudge(42, PrIssueType::GreenWithFeedback);
+
+    assert!(!tracker.has_nudge(42, PrIssueType::GreenWithFeedback));
+    assert!(
+        tracker.should_nudge(42, PrIssueType::GreenWithFeedback),
+        "should_nudge must return true after clearing non-permanent entry"
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary

- **Bug**: PRs without task links were posting "CI green — no task linked, posting for manual review" to the ops channel every ~30 seconds, flooding it with hundreds of duplicate messages
- **Root cause**: The task-less code path in `action_to_effects` used `RecordPrNudge` (cooldown-based), but `clear_nudge` was called every tick because the owner was never in `active_coworkers`, resetting the cooldown and causing immediate re-fire
- **Fix**: Three-part change to the nudge deduplication system:
  1. Emit `RecordPermanentPrNudge` (one-shot) instead of `RecordPrNudge` for task-less PRs
  2. Make `should_nudge()` return false for permanent entries, preventing re-fire after cooldown expiry
  3. Make `clear_nudge()` preserve permanent entries so the inactive-owner retry path doesn't wipe one-shot nudges

## Test plan

- [x] Added `action_to_effects_taskless_pr_uses_permanent_nudge` — verifies SpawnOwner without task produces `RecordPermanentPrNudge`
- [x] Added `action_to_effects_taskless_nudge_owner_uses_permanent_nudge` — verifies NudgeOwner without task produces `RecordPermanentPrNudge`
- [x] Updated `permanent_nudge_survives_clear_nudge` — verifies `clear_nudge` preserves permanent entries
- [x] Added `regular_nudge_cleared_by_clear_nudge` — verifies non-permanent nudges are still properly cleared
- [x] All 1504 daemon tests pass, all 106 PR tests pass, clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)