### PR TITLE
Refactor dispatch loop: move capacity gate after cleanup, add idle coworker reuse [Midtown !2337]

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -1601,15 +1601,6 @@ fn dispatch_unowned_pending_tasks(
         else {
             continue;
         };
-        let effective_count = in_progress_count + spawns_queued_this_tick;
-        if effective_count >= task_cap {
-            debug!(
-                "In-progress task limit reached ({}+{} >= {}), deferring unowned task !{}",
-                in_progress_count, spawns_queued_this_tick, task_cap, task.id
-            );
-            break;
-        }
-
         // Skip tasks already claimed by orphan recovery in this tick.
         if excluded_task_ids.contains(&task.id) {
             debug!(
@@ -1664,6 +1655,18 @@ fn dispatch_unowned_pending_tasks(
             debug!(
                 "Task !{}: skipping unowned pending dispatch — channel is lead-driven",
                 task.id
+            );
+            continue;
+        }
+
+        // ── Capacity gate — runs after zero-cost filters ──────────────────
+        // Merged-PR auto-complete, exclusion checks, and lead-driven skip
+        // run unconditionally above. Slot-consuming operations below are gated.
+        let effective_count = in_progress_count + spawns_queued_this_tick;
+        if effective_count >= task_cap {
+            debug!(
+                "In-progress task limit reached ({}+{} >= {}), deferring unowned task !{}",
+                in_progress_count, spawns_queued_this_tick, task_cap, task.id
             );
             continue;
         }
@@ -1794,15 +1797,24 @@ fn dispatch_unowned_pending_tasks(
             {
                 excluded_names.insert(author.to_lowercase());
             }
-            let Some(name) = state
+            if let Some(name) = state
                 .coworkers
                 .next_available_name_excluding(&excluded_names)
-            else {
+            {
+                debug!("Task !{}: allocated fresh coworker name {}", task.id, name);
+                name
+            } else if let Some(idle_name) =
+                find_idle_coworker(snap, &names_assigned_this_tick, owned_dispatched)
+            {
+                debug!(
+                    "Task !{}: no fresh slots, reusing idle coworker {}",
+                    task.id, idle_name
+                );
+                idle_name
+            } else {
                 debug!("No available coworker slots for unowned task !{}", task.id);
-                break;
-            };
-            debug!("Task !{}: allocated fresh coworker name {}", task.id, name,);
-            name
+                continue;
+            }
         };
 
         // Check per-coworker spawn failure cooldown (pre-evaluated in snapshot)
@@ -2163,6 +2175,30 @@ fn dispatch_unowned_pending_tasks(
 // ============================================================================
 // Task completion for PR merged
 // ============================================================================
+
+/// Find an idle coworker: active but not busy, not a channel lead,
+/// not a reviewer, not already assigned this tick, not owned-dispatched.
+///
+/// Returns the coworker name (lowercase) or None.
+fn find_idle_coworker(
+    snap: &snapshot::WorldSnapshot,
+    names_assigned_this_tick: &HashSet<String>,
+    owned_dispatched: &HashSet<String>,
+) -> Option<String> {
+    let lead_names = snap.channel_lead_names();
+    snap.coworkers
+        .active_names
+        .iter()
+        .find(|name| {
+            let lower = name.to_lowercase();
+            !snap.busy_coworkers.contains(&lower)
+                && !lead_names.contains(&lower)
+                && !snap.reviewer.active_reviewers.contains(&lower)
+                && !names_assigned_this_tick.contains(&lower)
+                && !owned_dispatched.contains(&lower)
+        })
+        .cloned()
+}
 
 /// Build effects to auto-complete a task when its PR is merged.
 ///

--- a/src/daemon/dispatch_dev_limit_tests.rs
+++ b/src/daemon/dispatch_dev_limit_tests.rs
@@ -347,3 +347,184 @@ fn test_dispatch_with_legacy_lead() {
         effects
     );
 }
+
+/// Merged-PR auto-complete should emit CompleteTask even when at task limit.
+///
+/// Before the fix, the loop `break`ed at the task limit gate, preventing
+/// merged-PR auto-complete from running for any tasks beyond the limit.
+#[test]
+fn test_merged_pr_autocomplete_runs_at_capacity() {
+    let state = make_test_state_with_max(2);
+
+    for name in &["lexington", "park"] {
+        state
+            .coworkers
+            .insert_for_testing(make_running_coworker(name));
+    }
+
+    let running = vec![
+        make_running_coworker("lexington"),
+        make_running_coworker("park"),
+    ];
+
+    // Task 99 is a regular pending task (will be deferred at capacity).
+    // Task 100 has pr=Some(42) and merged_pr_numbers contains 42,
+    // so it should be auto-completed regardless of capacity.
+    let mut task_100 = make_pending_task("100");
+    task_100.pr = Some(42);
+
+    let pending = vec![make_pending_task("99"), task_100];
+
+    let mut snap = make_task_limit_snapshot(running, pending, true);
+    snap.pr.merged_pr_numbers.insert(42);
+
+    let effects = crate::daemon::dispatch::spawn_for_pending_tasks(&snap, &state);
+
+    let has_complete = effects.iter().any(|e| {
+        matches!(
+            e,
+            crate::daemon::effects::Effect::CompleteTask { task_id, .. } if task_id == "100"
+        )
+    });
+    assert!(
+        has_complete,
+        "Expected CompleteTask for merged-PR task even at capacity. Effects: {:?}",
+        effects
+    );
+
+    // Should NOT have any spawn/nudge effects (at capacity for non-cleanup work).
+    let has_spawn = effects.iter().any(|e| {
+        matches!(
+            e,
+            crate::daemon::effects::Effect::AssignAndSpawn { .. }
+                | crate::daemon::effects::Effect::SpawnCoworkerWithCallbacks { .. }
+                | crate::daemon::effects::Effect::NudgeSessionWithCallbacks { .. }
+        )
+    });
+    assert!(
+        !has_spawn,
+        "Should not spawn/nudge when at task limit. Effects: {:?}",
+        effects
+    );
+}
+
+/// When all coworker name slots are exhausted but an idle coworker exists,
+/// the loop should reuse the idle coworker via nudge instead of breaking.
+#[test]
+fn test_idle_coworker_reuse_when_no_fresh_slots() {
+    use crate::coworker::{AVENUE_NAMES, OVERFLOW_NAMES};
+
+    // All 16 names are active. "park" is idle (not busy).
+    let all_names: Vec<&str> = AVENUE_NAMES
+        .iter()
+        .chain(OVERFLOW_NAMES.iter())
+        .copied()
+        .collect();
+    let state = make_test_state_with_max(20); // high limit so task cap isn't the blocker
+
+    // Register all names in CoworkerManager so next_available_name_excluding returns None.
+    for name in &all_names {
+        state
+            .coworkers
+            .insert_for_testing(make_running_coworker(name));
+    }
+
+    let running: Vec<_> = all_names.iter().map(|n| make_running_coworker(n)).collect();
+    let pending = vec![make_pending_task("99")];
+
+    let mut snap = make_task_limit_snapshot(running, pending, false);
+    // Only 2 in-progress tasks (well below task_cap=20).
+    snap.in_progress_tasks = vec![
+        (
+            "1".to_string(),
+            "Task 1".to_string(),
+            "lexington".to_string(),
+        ),
+        ("2".to_string(), "Task 2".to_string(), "madison".to_string()),
+    ];
+    snap.max_in_progress_tasks = 20;
+    // All names are active (in the snapshot).
+    snap.coworkers.active_names = all_names.iter().map(|s| s.to_string()).collect();
+    // park is active but NOT busy — it's idle.
+    snap.busy_coworkers = all_names
+        .iter()
+        .filter(|n| **n != "park")
+        .map(|s| s.to_string())
+        .collect();
+    // Need name_session_map for the nudge effect.
+    snap.name_session_map
+        .insert("park".to_string(), "session-park".to_string());
+
+    let effects = crate::daemon::dispatch::spawn_for_pending_tasks(&snap, &state);
+
+    let has_nudge = effects.iter().any(|e| {
+        matches!(
+            e,
+            crate::daemon::effects::Effect::NudgeSessionWithCallbacks { session_id, .. }
+                if session_id == "session-park"
+        )
+    });
+    assert!(
+        has_nudge,
+        "Expected NudgeSessionWithCallbacks for idle coworker 'park'. Effects: {:?}",
+        effects
+    );
+}
+
+/// When at capacity AND no idle coworkers, should not spawn but should still
+/// process remaining tasks for cleanup (merged-PR auto-complete, etc.).
+#[test]
+fn test_no_dispatch_when_capacity_and_no_idle() {
+    let state = make_test_state_with_max(2);
+
+    for name in &["lexington", "park"] {
+        state
+            .coworkers
+            .insert_for_testing(make_running_coworker(name));
+    }
+
+    let running = vec![
+        make_running_coworker("lexington"),
+        make_running_coworker("park"),
+    ];
+
+    // Two pending tasks. First is a regular task (deferred at capacity).
+    // Second has a merged PR (should be auto-completed).
+    let mut task_200 = make_pending_task("200");
+    task_200.pr = Some(55);
+
+    let pending = vec![make_pending_task("199"), task_200];
+
+    let mut snap = make_task_limit_snapshot(running, pending, true);
+    snap.pr.merged_pr_numbers.insert(55);
+
+    let effects = crate::daemon::dispatch::spawn_for_pending_tasks(&snap, &state);
+
+    // No spawn effects.
+    let has_spawn = effects.iter().any(|e| {
+        matches!(
+            e,
+            crate::daemon::effects::Effect::AssignAndSpawn { .. }
+                | crate::daemon::effects::Effect::SpawnCoworkerWithCallbacks { .. }
+                | crate::daemon::effects::Effect::NudgeSessionWithCallbacks { .. }
+        )
+    });
+    assert!(
+        !has_spawn,
+        "Should not spawn when at capacity with no idle coworkers. Effects: {:?}",
+        effects
+    );
+
+    // But merged-PR task should still be completed.
+    let has_complete = effects.iter().any(|e| {
+        matches!(
+            e,
+            crate::daemon::effects::Effect::CompleteTask { task_id, .. } if task_id == "200"
+        )
+    });
+    assert!(
+        has_complete,
+        "Merged-PR auto-complete should work even at capacity. Effects: {:?}",
+        effects
+    );
+}


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

- **Moved capacity gate after zero-cost filters** — merged-PR auto-complete, exclusion checks, and lead-driven channel skip now run unconditionally for every pending task, regardless of whether we're at task capacity. Previously a `break` at the capacity gate prevented all downstream logic from running when at limit.
- **Changed `break` to `continue`** — the loop now processes remaining tasks for cleanup even when at capacity, instead of stopping entirely.
- **Added idle coworker reuse** — when all name slots are exhausted but idle coworkers exist (active session, no in-progress task), the dispatch loop nudges them with new work instead of giving up. This is generic — any task type benefits.
- **Added `find_idle_coworker()` helper** — pure function that finds an active-but-not-busy coworker eligible for reuse, excluding channel leads, active reviewers, and already-assigned names.

## Test plan

- [x] `test_merged_pr_autocomplete_runs_at_capacity` — verifies CompleteTask emitted for merged-PR tasks even when at capacity
- [x] `test_idle_coworker_reuse_when_no_fresh_slots` — verifies NudgeSessionWithCallbacks for idle coworker when all 16 name slots are taken
- [x] `test_no_dispatch_when_capacity_and_no_idle` — verifies no spawn effects at capacity with no idle coworkers, but merged-PR cleanup still runs
- [x] All 9 dispatch_dev_limit_tests pass
- [x] clippy clean, fmt clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)