### PR TITLE
fix: Add fork scope boundary to prevent task claiming [Midtown !2389]

### DIFF
--- a/src/daemon/rpc_session.rs
+++ b/src/daemon/rpc_session.rs
@@ -1139,6 +1139,16 @@ fn slugify_fork_hint(message: &str, thread_parent_id: &str) -> String {
 /// Uses the **project-aware** auth profile resolution
 /// (`active_profile_dir_for_project_with_provider`) so that per-project
 /// `auth switch` overrides are picked up by forked sessions.
+const FORK_SCOPE_BOUNDARY: &str = "\
+## Fork Scope Boundary
+
+You are a fork session — scoped to this thread's topic only. After completing your research or investigation:
+- Report your findings in the thread
+- Do NOT claim, assign, or work on tasks
+- Do NOT create PRs or implement features
+- Do NOT use `midtown task claim` or `midtown task create`
+- Stop after reporting — the root lead session handles next steps";
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn build_fork_config(
     thread_parent_id: &str,
@@ -1195,7 +1205,11 @@ pub(super) fn build_fork_config(
 
     let headless_config = crate::headless::HeadlessConfig {
         model: fork_channel_lead_model(repo_name, auth_provider, fork_channel),
-        system_prompt: crate::agents::main_lead_system_prompt(repo_name),
+        system_prompt: format!(
+            "{}\n\n{}",
+            crate::agents::main_lead_system_prompt(repo_name),
+            FORK_SCOPE_BOUNDARY
+        ),
         json_schema: None,
         cwd: working_dir.map(String::from),
         project_name: Some(repo_name.to_string()),

--- a/src/daemon/rpc_session_tests.rs
+++ b/src/daemon/rpc_session_tests.rs
@@ -2024,3 +2024,35 @@ async fn test_channel_summary_collapses_multiline() {
         "Multiline content should be collapsed to single line"
     );
 }
+
+/// Fork system prompts must include a scope boundary that prevents the fork
+/// from claiming tasks or implementing features after completing its research.
+#[test]
+fn test_build_fork_config_includes_scope_boundary() {
+    let midtown_dir = tempfile::TempDir::new().expect("midtown temp dir");
+    let _guard = crate::paths::set_test_midtown_base_dir(midtown_dir.path().to_path_buf());
+
+    let (_fork_name, headless_config) = build_fork_config(
+        "thread-scope-test",
+        "parent-session-id",
+        Some("web"),
+        None,
+        Some("web"),
+        Some("/tmp/test"),
+        crate::auth::AuthProvider::Claude,
+        false,
+        "test-repo",
+        None,
+    );
+
+    assert!(
+        headless_config
+            .system_prompt
+            .contains("Fork Scope Boundary"),
+        "Fork system_prompt must include a scope boundary to prevent forks from claiming tasks"
+    );
+    assert!(
+        headless_config.system_prompt.contains("Do NOT claim"),
+        "Fork scope boundary must instruct forks not to claim tasks"
+    );
+}


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary

- Appends a "Fork Scope Boundary" section to fork system prompts in `build_fork_config()` that explicitly instructs forks to report findings and stop — preventing them from claiming tasks, creating PRs, or implementing features after completing research
- Adds test verifying the scope boundary is present in fork system prompts

## Context

Lead forks spawned for research (e.g., investigating a bug or scoping a feature) were drifting into claiming tasks and attempting implementation after completing their investigation. This happened because forks inherit the full lead system prompt, which includes task management instructions. Without an explicit scope boundary, the model would default to "what else can I do" behavior.

## Test plan

- [x] New test `test_build_fork_config_includes_scope_boundary` verifies the boundary text is present
- [x] All 11 existing `build_fork_config` tests continue to pass
- [x] `cargo clippy` and `cargo fmt` pass

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)