### PR TITLE
fix: Skip cooldown-blocked owners in orphan recovery [Midtown !2385]

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -523,25 +523,13 @@ fn check_and_recover_orphans_impl(snap: &snapshot::WorldSnapshot) -> Vec<effects
         recently_stopped: &recently_stopped,
         attached_coworkers: &snap.coworkers.attached_coworkers,
         channel_lead_names,
+        spawn_failure_cooldown_names: &snap.spawn_failure_cooldown_names,
     };
     let recovery = crate::rules::decide_orphan_recovery(&orphan_ctx);
 
     let Some(recovery) = recovery else {
         return vec![];
     };
-
-    // Check per-coworker spawn failure cooldown to prevent infinite retry loops
-    // (pre-evaluated in snapshot)
-    if snap
-        .spawn_failure_cooldown_names
-        .contains(&recovery.owner.to_lowercase())
-    {
-        debug!(
-            "Spawn failure cooldown active for {} — skipping orphan recovery for task !{}",
-            recovery.owner, recovery.task_id
-        );
-        return vec![];
-    }
 
     info!(
         "Detected orphaned task !{} owned by {} - attempting recovery",

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1025,6 +1025,7 @@ pub(crate) struct OrphanRecoveryContext<'a> {
     pub recently_stopped: &'a HashSet<String>,
     pub attached_coworkers: &'a HashMap<String, chrono::DateTime<chrono::Utc>>,
     pub channel_lead_names: &'a HashSet<String>,
+    pub spawn_failure_cooldown_names: &'a HashSet<String>,
 }
 
 impl OrphanRecoveryContext<'_> {
@@ -1038,6 +1039,7 @@ impl OrphanRecoveryContext<'_> {
         self.active_names.contains(owner_lower)
             || self.attached_coworkers.contains_key(owner_lower)
             || self.recently_stopped.contains(owner_lower)
+            || self.spawn_failure_cooldown_names.contains(owner_lower)
     }
 }
 
@@ -1343,6 +1345,10 @@ mod rules_channel_lead_tests;
 #[path = "rules_cooldown_tests.rs"]
 #[cfg(test)]
 mod rules_cooldown_tests;
+
+#[path = "rules_orphan_tests.rs"]
+#[cfg(test)]
+mod rules_orphan_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/rules_channel_lead_tests.rs
+++ b/src/rules_channel_lead_tests.rs
@@ -44,12 +44,14 @@ fn channel_lead_owned_task_not_orphan_recovered() {
     let empty = empty_set();
     let empty_map: HashMap<String, chrono::DateTime<chrono::Utc>> = HashMap::new();
     let leads = names(&["ops"]);
+    let empty_cooldown = empty_set();
     let ctx = OrphanRecoveryContext {
         in_progress: &tasks,
         active_names: &empty,
         recently_stopped: &empty,
         attached_coworkers: &empty_map,
         channel_lead_names: &leads,
+        spawn_failure_cooldown_names: &empty_cooldown,
     };
     let result = decide_orphan_recovery(&ctx);
     assert!(

--- a/src/rules_orphan_tests.rs
+++ b/src/rules_orphan_tests.rs
@@ -1,0 +1,80 @@
+//! Tests for orphan recovery decision logic.
+
+use std::collections::{HashMap, HashSet};
+
+use super::{OrphanRecoveryContext, decide_orphan_recovery};
+
+fn empty_set() -> HashSet<String> {
+    HashSet::new()
+}
+
+fn empty_map() -> HashMap<String, chrono::DateTime<chrono::Utc>> {
+    HashMap::new()
+}
+
+#[test]
+fn skips_cooldown_blocked_owner_recovers_next_orphan() {
+    // Two orphaned tasks: first owner ("park") is on spawn failure cooldown,
+    // second owner ("vernon") is not. Should skip park and return vernon's task.
+    let tasks = vec![
+        (
+            "10".to_string(),
+            "park task".to_string(),
+            "park".to_string(),
+        ),
+        (
+            "20".to_string(),
+            "vernon task".to_string(),
+            "vernon".to_string(),
+        ),
+    ];
+    let empty = empty_set();
+    let cooldown_names: HashSet<String> = ["park".to_string()].into_iter().collect();
+    let ctx = OrphanRecoveryContext {
+        in_progress: &tasks,
+        active_names: &empty,
+        recently_stopped: &empty,
+        attached_coworkers: &empty_map(),
+        channel_lead_names: &empty,
+        spawn_failure_cooldown_names: &cooldown_names,
+    };
+    let result = decide_orphan_recovery(&ctx);
+    assert!(result.is_some(), "should recover the non-cooldown orphan");
+    let recovery = result.unwrap();
+    assert_eq!(recovery.task_id, "20");
+    assert_eq!(recovery.owner, "vernon");
+}
+
+#[test]
+fn all_owners_on_cooldown_returns_none() {
+    // All orphan owners are on cooldown — should return None, not deadlock.
+    let tasks = vec![
+        (
+            "10".to_string(),
+            "park task".to_string(),
+            "park".to_string(),
+        ),
+        (
+            "20".to_string(),
+            "vernon task".to_string(),
+            "vernon".to_string(),
+        ),
+    ];
+    let empty = empty_set();
+    let cooldown_names: HashSet<String> = ["park".to_string(), "vernon".to_string()]
+        .into_iter()
+        .collect();
+    let ctx = OrphanRecoveryContext {
+        in_progress: &tasks,
+        active_names: &empty,
+        recently_stopped: &empty,
+        attached_coworkers: &empty_map(),
+        channel_lead_names: &empty,
+        spawn_failure_cooldown_names: &cooldown_names,
+    };
+    let result = decide_orphan_recovery(&ctx);
+    assert!(
+        result.is_none(),
+        "all owners on cooldown — nothing to recover"
+    );
+}


### PR DESCRIPTION
<!-- midtown session:lexington -->

## Summary

- **Bug**: When all coworkers die simultaneously, orphan recovery deadlocks if the first orphan's owner is on spawn failure cooldown — the post-selection cooldown check in `dispatch.rs` returns `vec![]`, preventing recovery of other orphans with non-cooldown owners
- **Fix**: Move the cooldown check into `OrphanRecoveryContext::should_skip_owner()` so `decide_orphan_recovery()` skips cooldown-blocked owners and continues to the next orphan
- **Tests**: Two new tests in `rules_orphan_tests.rs` — one verifying skip-and-recover, one verifying all-on-cooldown returns None

## Test plan

- [x] New test: `skips_cooldown_blocked_owner_recovers_next_orphan` — passes
- [x] New test: `all_owners_on_cooldown_returns_none` — passes
- [x] `cargo test` — all passing
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)