### PR TITLE
fix: Add fork scope boundary to prevent task claiming [Midtown !2389]

### DIFF
--- a/src/daemon/rpc_session.rs
+++ b/src/daemon/rpc_session.rs
@@ -1144,9 +1144,9 @@ const FORK_SCOPE_BOUNDARY: &str = "\
 
 You are a fork session — scoped to this thread's topic only. After completing your research or investigation:
 - Report your findings in the thread
-- Do NOT claim, assign, or work on tasks
+- You may create tasks (`midtown task create`) to hand off work you discovered
+- Do NOT claim or work on tasks yourself (`midtown task claim`)
 - Do NOT create PRs or implement features
-- Do NOT use `midtown task claim` or `midtown task create`
 - Stop after reporting — the root lead session handles next steps";
 
 #[allow(clippy::too_many_arguments)]

--- a/src/daemon/rpc_session_tests.rs
+++ b/src/daemon/rpc_session_tests.rs
@@ -2055,4 +2055,8 @@ fn test_build_fork_config_includes_scope_boundary() {
         headless_config.system_prompt.contains("Do NOT claim"),
         "Fork scope boundary must instruct forks not to claim tasks"
     );
+    assert!(
+        headless_config.system_prompt.contains("may create tasks"),
+        "Fork scope boundary must allow task creation (handoff mechanism)"
+    );
 }


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

- **Fix fork scope drift**: Lead forks inherit the full lead system prompt via `build_fork_config()`, so after completing research they would drift into claiming tasks and implementing features. Append a Fork Scope Boundary section to the system prompt that explicitly instructs forks to report findings and stop.
- Adds `FORK_SCOPE_BOUNDARY` constant in `rpc_session.rs` with clear instructions: no task claiming, no PR creation, no implementation — report and stop.
- New test `test_build_fork_config_includes_scope_boundary` verifies the boundary is present.

## Test plan

- [x] New test `test_build_fork_config_includes_scope_boundary` — verifies fork system_prompt contains the scope boundary
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)