### PR TITLE
fix: Narrow is_fork_session to channel-lead forks only [Midtown !2404]

### DIFF
--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -5708,13 +5708,14 @@ fn test_resolve_pr_owner_skips_fork_sessions() {
     let pr_task_associations: HashMap<u64, String> =
         [(42, "100".to_string())].into_iter().collect();
 
-    // Fork session has the task_id but also has bound_thread_id set
+    // Fork session: channel-lead with bound_thread_id (inherits task_id from parent)
     let sessions: HashMap<String, crate::daemon::state::SessionRecord> = [(
         "fork-sess".to_string(),
         crate::daemon::state::SessionRecord {
             session_id: "fork-sess".to_string(),
             task_id: Some("100".to_string()),
             current_name: Some("fork-elastic-ceiling-7492".to_string()),
+            coworker_type: "channel-lead".to_string(),
             bound_thread_id: Some("thread-abc".to_string()),
             working_dir: "/tmp/test".to_string(),
             is_running: true,

--- a/src/daemon/snapshot_tests.rs
+++ b/src/daemon/snapshot_tests.rs
@@ -960,6 +960,7 @@ fn find_session_for_task_skips_fork_sessions() {
             session_id: "fork-sess".to_string(),
             task_id: Some("500".to_string()),
             current_name: Some("fork-research-1234".to_string()),
+            coworker_type: "channel-lead".to_string(),
             bound_thread_id: Some("thread-xyz".to_string()),
             working_dir: "/tmp/test".to_string(),
             ..Default::default()

--- a/src/daemon/state.rs
+++ b/src/daemon/state.rs
@@ -163,12 +163,14 @@ impl Default for SessionRecord {
 }
 
 impl SessionRecord {
-    /// Whether this session is a fork (bound to a thread).
+    /// Whether this session is a fork (channel-lead bound to a thread).
     ///
-    /// Fork sessions are spawned for research/investigation in threads and
-    /// should not be treated as PR owners or task dispatch targets.
+    /// Fork sessions are channel-lead sessions spawned for research/investigation
+    /// in threads. They inherit task_id from the parent but should not be treated
+    /// as PR owners or task dispatch targets. Regular dev coworkers also carry
+    /// bound_thread_id (for thread routing) but ARE genuine task owners.
     pub fn is_fork_session(&self) -> bool {
-        self.bound_thread_id.is_some()
+        self.coworker_type == "channel-lead" && self.bound_thread_id.is_some()
     }
 }
 

--- a/src/daemon/state_tests.rs
+++ b/src/daemon/state_tests.rs
@@ -1325,6 +1325,7 @@ fn test_task_parent_default_empty() {
 
 #[test]
 fn test_is_fork_session() {
+    // Regular dev session (no thread binding) — not a fork
     let regular = SessionRecord {
         bound_thread_id: None,
         ..Default::default()
@@ -1334,12 +1335,36 @@ fn test_is_fork_session() {
         "Regular session should not be a fork"
     );
 
+    // Channel-lead with bound_thread_id — IS a fork
     let fork = SessionRecord {
+        coworker_type: "channel-lead".to_string(),
         bound_thread_id: Some("thread-123".to_string()),
         ..Default::default()
     };
     assert!(
         fork.is_fork_session(),
-        "Session with bound_thread_id is a fork"
+        "Channel-lead with bound_thread_id is a fork"
+    );
+
+    // Dev coworker with bound_thread_id — NOT a fork (genuine task owner)
+    let dev_with_thread = SessionRecord {
+        coworker_type: "dev".to_string(),
+        bound_thread_id: Some("thread-456".to_string()),
+        ..Default::default()
+    };
+    assert!(
+        !dev_with_thread.is_fork_session(),
+        "Dev coworker with bound_thread_id is NOT a fork — it's a real task owner"
+    );
+
+    // Channel-lead without bound_thread_id — NOT a fork (root channel lead)
+    let root_lead = SessionRecord {
+        coworker_type: "channel-lead".to_string(),
+        bound_thread_id: None,
+        ..Default::default()
+    };
+    assert!(
+        !root_lead.is_fork_session(),
+        "Root channel lead without bound_thread_id is NOT a fork"
     );
 }


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary

Follow-up to PR #2132. Codex review correctly identified that `is_fork_session()` using `bound_thread_id.is_some()` was too broad — regular dev coworkers also carry `bound_thread_id` for task thread routing and are genuine task owners. This narrowing fix checks both `coworker_type == "channel-lead"` AND `bound_thread_id.is_some()`.

- **Narrowed `is_fork_session()`**: Only channel-lead sessions with `bound_thread_id` are forks. Dev coworkers with `bound_thread_id` are genuine task owners and must remain in `session_task_map`.
- Updated tests to cover all 4 cases: regular dev, channel-lead fork, dev with thread binding, root channel lead.
- Updated PR and snapshot test fixtures to use `coworker_type: "channel-lead"` for fork sessions.

## Test plan

- [x] `test_is_fork_session` — now covers all 4 combinations
- [x] `test_resolve_pr_owner_skips_fork_sessions` — uses channel-lead fork fixture
- [x] `find_session_for_task_skips_fork_sessions` — uses channel-lead fork fixture
- [x] All existing fork session tests still pass
- [x] `cargo clippy` clean, `cargo fmt` clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)