### PR TITLE
fix: Release name back to pool on SpawnForTask failure

### DIFF
--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -1866,6 +1866,9 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                         // Inline failure bookkeeping with real coworker name
                         Box::pin(execute_effects(
                             vec![
+                                Effect::ReleaseName {
+                                    name: name.to_string(),
+                                },
                                 Effect::RecordCooldown {
                                     category: "spawn_failure".to_string(),
                                     key: name.to_string(),


### PR DESCRIPTION
<!-- midtown session:$MIDTOWN_SESSION_ID -->

## Summary

- When `spawn_coworker` fails in the `SpawnForTask` effect handler, the allocated name was never released back to the `NamePool`
- Each failed spawn permanently leaked a name, eventually exhausting all available names (0 available out of 8+)
- This created a death spiral: `"SpawnForTask: no available names for task"` every 5 seconds, with 0/8 coworkers active despite 6 pending tasks

## Root Cause

The error path at `effects.rs:1862` included `RecordCooldown`, `ResetTaskToPending`, and `post_to_ops` — but not `ReleaseName`. The success path doesn't need explicit release because the name stays allocated while the coworker is alive.

## Fix

Add `Effect::ReleaseName { name }` as the first effect in the spawn failure path, before cooldown recording.

## Test plan

- [ ] `cargo clippy` and `cargo test` pass
- [ ] Verify daemon logs no longer show "no available names" after failed spawns
- [ ] Confirm coworkers can be spawned after a spawn failure

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)