### PR TITLE
fix: Remove idle coworker reuse — enforce 1:1 task:session model [Midtown !2409]

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -1179,7 +1179,6 @@ fn dispatch_unowned_pending_tasks(
     let mut spawns_queued_this_tick: usize = 0;
     let in_progress_count = snap.in_progress_tasks.len();
     let task_cap = snap.max_in_progress_tasks;
-    let channel_lead_names = snap.channel_lead_names();
 
     // Order pending tasks by dispatch priority before iterating.
     let in_progress_ids: std::collections::HashSet<String> = snap
@@ -1325,7 +1324,6 @@ fn dispatch_unowned_pending_tasks(
         };
 
         // Use grouped name if found, otherwise allocate a fresh coworker.
-        // When at task limit and no grouping match, try to reuse an idle coworker.
         let was_grouped = grouped_name.is_some();
         let effective_count = in_progress_count + spawns_queued_this_tick;
         let at_task_limit = effective_count >= task_cap;
@@ -1333,35 +1331,14 @@ fn dispatch_unowned_pending_tasks(
         let coworker_name = if let Some(name) = grouped_name {
             name
         } else if at_task_limit {
-            // At task limit — can't start new in-progress tasks. Check for an idle
-            // coworker (running session, no in-progress task) to reuse via nudge.
-            // Reviewer tasks always need a fresh spawn on an isolated worktree,
-            // so they cannot reuse idle coworkers.
-            if is_reviewer_task {
-                debug!(
-                    "Task limit reached ({}+{} >= {}), reviewer task !{} deferred",
-                    in_progress_count, spawns_queued_this_tick, task_cap, task.id
-                );
-                continue;
-            }
-            if let Some(name) = find_idle_coworker(
-                snap,
-                channel_lead_names,
-                &names_assigned_this_tick,
-                owned_dispatched,
-            ) {
-                debug!(
-                    "Task limit reached but found idle coworker {} for task !{}",
-                    name, task.id
-                );
-                name
-            } else {
-                debug!(
-                    "Task limit reached ({}+{} >= {}) and no idle coworker, deferring task !{}",
-                    in_progress_count, spawns_queued_this_tick, task_cap, task.id
-                );
-                continue;
-            }
+            // At task limit — defer the task. Idle coworkers are suspended
+            // (waiting for review feedback), not available for reassignment.
+            // Task:session is 1:1 for life.
+            debug!(
+                "Task limit reached ({}+{} >= {}), deferring task !{}",
+                in_progress_count, spawns_queued_this_tick, task_cap, task.id
+            );
+            continue;
         } else {
             let mut excluded_names = snap.channel_lead_names().clone();
             // Exclude all names with active sessions to prevent name collisions.
@@ -1635,35 +1612,6 @@ fn dispatch_unowned_pending_tasks(
     }
 
     effects
-}
-
-/// Find an idle coworker — one with a running session but no in-progress task.
-///
-/// Returns the name of an idle coworker that can be nudged to pick up a new task,
-/// or `None` if no idle coworker is available.
-fn find_idle_coworker(
-    snap: &snapshot::WorldSnapshot,
-    channel_lead_names: &HashSet<String>,
-    names_assigned_this_tick: &HashSet<String>,
-    owned_dispatched: &HashSet<String>,
-) -> Option<String> {
-    snap.coworkers
-        .active_names
-        .iter()
-        .find(|name| {
-            !snap.busy_coworkers.contains(*name)
-                && !snap.reviewer.active_reviewers.contains(*name)
-                && !names_assigned_this_tick.contains(*name)
-                && !owned_dispatched.contains(*name)
-                && !snap.spawn_failure_cooldown_names.contains(*name)
-                && !channel_lead_names.contains(*name)
-                && super::helpers::is_non_lead_coworker(
-                    name,
-                    &snap.project_name,
-                    channel_lead_names,
-                )
-        })
-        .cloned()
 }
 
 // ============================================================================

--- a/src/daemon/dispatch_dev_limit_tests.rs
+++ b/src/daemon/dispatch_dev_limit_tests.rs
@@ -343,9 +343,11 @@ fn test_merged_pr_autocomplete_runs_at_task_limit() {
     );
 }
 
-/// When at task limit with idle coworkers, tasks should be assigned to idle coworkers.
+/// All tasks (including those with idle coworkers) are deferred at the task limit.
+/// Task:session is 1:1 — idle coworkers are suspended waiting for review feedback,
+/// not available for reassignment.
 #[test]
-fn test_idle_coworker_reuse_at_task_limit() {
+fn test_tasks_deferred_at_task_limit() {
     let state = make_test_state_with_max(2);
 
     for name in &["lexington", "park"] {
@@ -361,49 +363,9 @@ fn test_idle_coworker_reuse_at_task_limit() {
 
     let pending = vec![make_pending_task("99")];
 
-    // At task limit (2/2), but park is idle (not in busy_coworkers)
-    let mut snap = make_task_limit_snapshot(running, pending, true);
-    // Mark lexington as busy, park stays idle
-    snap.busy_coworkers.insert("lexington".to_string());
-    // Don't mark park as busy — it's idle and should be reusable
-
-    let effects = crate::daemon::dispatch::spawn_for_pending_tasks(&snap, &state);
-
-    let has_nudge = effects.iter().any(|e| {
-        matches!(
-            e,
-            crate::daemon::effects::Effect::NudgeSessionWithCallbacks { .. }
-        )
-    });
-    assert!(
-        has_nudge,
-        "Expected idle coworker to be nudged with new task at task limit. Effects: {:?}",
-        effects
-    );
-}
-
-/// When at task limit with NO idle coworkers, tasks should be deferred.
-#[test]
-fn test_no_idle_coworkers_defers_at_task_limit() {
-    let state = make_test_state_with_max(2);
-
-    for name in &["lexington", "park"] {
-        state
-            .coworkers
-            .insert_for_testing(make_running_coworker(name));
-    }
-
-    let running = vec![
-        make_running_coworker("lexington"),
-        make_running_coworker("park"),
-    ];
-
-    let pending = vec![make_pending_task("99")];
-
-    // At task limit (2/2), all coworkers busy
+    // At task limit (2/2), park is idle but should NOT be reused
     let mut snap = make_task_limit_snapshot(running, pending, true);
     snap.busy_coworkers.insert("lexington".to_string());
-    snap.busy_coworkers.insert("park".to_string());
 
     let effects = crate::daemon::dispatch::spawn_for_pending_tasks(&snap, &state);
 
@@ -416,50 +378,7 @@ fn test_no_idle_coworkers_defers_at_task_limit() {
     });
     assert!(
         !has_task_effect,
-        "Expected no dispatch when at task limit and all coworkers busy. Effects: {:?}",
-        effects
-    );
-}
-
-/// Reviewer tasks should NOT reuse idle coworkers — they need fresh isolated worktrees.
-#[test]
-fn test_reviewer_task_deferred_at_task_limit() {
-    let state = make_test_state_with_max(2);
-
-    for name in &["lexington", "park"] {
-        state
-            .coworkers
-            .insert_for_testing(make_running_coworker(name));
-    }
-
-    let running = vec![
-        make_running_coworker("lexington"),
-        make_running_coworker("park"),
-    ];
-
-    let mut reviewer_task = make_pending_task("99");
-    reviewer_task.pr = Some(200);
-    let pending = vec![reviewer_task];
-
-    // At task limit (2/2), park is idle, but task is a reviewer task
-    let mut snap = make_task_limit_snapshot(running, pending, true);
-    snap.busy_coworkers.insert("lexington".to_string());
-    // Mark task as reviewer type
-    snap.task_agent_type_map
-        .insert("99".to_string(), "midtown-code-reviewer".to_string());
-
-    let effects = crate::daemon::dispatch::spawn_for_pending_tasks(&snap, &state);
-
-    let has_task_effect = effects.iter().any(|e| {
-        matches!(
-            e,
-            crate::daemon::effects::Effect::SpawnForTask { .. }
-                | crate::daemon::effects::Effect::NudgeSessionWithCallbacks { .. }
-        )
-    });
-    assert!(
-        !has_task_effect,
-        "Expected reviewer task to be deferred at task limit (no idle reuse). Effects: {:?}",
+        "Expected task to be deferred at task limit (no idle reuse). Effects: {:?}",
         effects
     );
 }


### PR DESCRIPTION
<!-- midtown session:$MIDTOWN_SESSION_ID -->

## Summary

- Removes the `find_idle_coworker()` function and the dispatch path that reused idle coworkers for new tasks at the task limit
- Idle coworkers are suspended (waiting for review feedback), not available for reassignment — task:session is 1:1 for life
- Replaces three idle-reuse tests with a single `test_tasks_deferred_at_task_limit` that validates the simplified behavior
- The `idle_coworkers` concept in pr.rs/rules.rs is **unaffected** — it serves a different purpose (PR notification routing)
- `RecordTaskAssignment` is **retained** — still needed for grouped task nudges and other paths

## Test plan

- [x] `cargo build` — clean, no warnings
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test dispatch` — all 159 dispatch tests pass
- [x] `cargo test` — 2682 passed (18 pre-existing sandbox failures unrelated to changes)
- [x] Verified `RecordTaskAssignment` is still used by grouped task path, orphan recovery, RPC task claim, and PR effect routing

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)