### PR TITLE
fix: Filter name pool restore to running sessions only [Midtown !2415]

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1344,11 +1344,17 @@ impl DaemonState {
             let allocated_names: Vec<String> = persistent_state
                 .sessions
                 .values()
+                .filter(|r| r.is_running)
                 .filter_map(|r| r.current_name.clone())
                 .collect();
             name_pool.restore(&allocated_names);
             for (session_id, record) in &persistent_state.sessions {
-                if let Some(ref name) = record.current_name {
+                // Only rebuild name↔session maps for running sessions.
+                // Dead sessions retain current_name in persistent state but
+                // should not hold name pool allocations or routing entries.
+                if record.is_running
+                    && let Some(ref name) = record.current_name
+                {
                     name_to_session.insert(name.clone(), session_id.clone());
                     session_to_name.insert(session_id.clone(), name.clone());
                     // Rebuild thread-binding cache from persisted SessionRecord so
@@ -1368,6 +1374,8 @@ impl DaemonState {
                         }
                     }
                 }
+                // task_to_session is rebuilt for ALL sessions (including stopped)
+                // so session-aware dispatch can find and resume stopped sessions.
                 if let Some(ref task_id) = record.task_id {
                     task_to_session.insert(task_id.clone(), session_id.clone());
                 }

--- a/src/name_pool_tests.rs
+++ b/src/name_pool_tests.rs
@@ -66,3 +66,23 @@ fn test_is_allocated() {
     pool.release("a");
     assert!(!pool.is_allocated("a"));
 }
+
+#[test]
+fn test_restore_only_marks_given_names_as_allocated() {
+    let mut pool = NamePool::new(&["a", "b", "c", "d"]);
+
+    // Simulate: sessions with names "a" and "c" are running, "b" and "d" are dead.
+    // Only running session names should be allocated after restore.
+    pool.restore(&["a".to_string(), "c".to_string()]);
+
+    assert!(pool.is_allocated("a"));
+    assert!(!pool.is_allocated("b"));
+    assert!(pool.is_allocated("c"));
+    assert!(!pool.is_allocated("d"));
+    assert_eq!(pool.available_count(), 2);
+    assert_eq!(pool.allocated_count(), 2);
+    // Available names should be "b" and "d" (not allocated)
+    assert_eq!(pool.allocate(None), Some("b".to_string()));
+    assert_eq!(pool.allocate(None), Some("d".to_string()));
+    assert_eq!(pool.allocate(None), None); // exhausted
+}


### PR DESCRIPTION
<!-- midtown session:$MIDTOWN_SESSION_ID -->

## Summary
- Dead sessions with stale `current_name` values were exhausting the name pool on daemon restart
- With 1040+ accumulated sessions (497 having `current_name` set), all coworker names were marked as allocated even though only 1 coworker was running
- This blocked all task dispatch with repeated "no available names" warnings
- Fix: only restore name allocations for sessions where `is_running=true`

## Root cause
`name_pool.restore()` in `DaemonState::new()` iterated ALL sessions from persistent state, not just running ones. Over time, as sessions accumulate (they're never pruned), every pool name eventually appears in at least one dead session record.

## Test plan
- [x] New unit test: `test_restore_only_marks_given_names_as_allocated`
- [x] All 11 name pool tests pass
- [x] Clippy clean
- [ ] Verify dispatch works after daemon restart with accumulated sessions

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)