### PR TITLE
fix: Move cooldown check into decide_orphan_recovery to unblock multi-orphan recovery

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -478,23 +478,13 @@ fn check_and_recover_orphans_impl(
         recently_stopped: &recently_stopped,
         attached_coworkers: &ps.tick_attached_coworkers,
         channel_lead_names: &channel_lead_names,
+        spawn_failure_cooldown_names: &ps.tick_spawn_failure_cooldown_names,
     };
     let recovery = crate::rules::decide_orphan_recovery(&orphan_ctx);
 
     let Some(recovery) = recovery else {
         return vec![];
     };
-
-    if ps
-        .tick_spawn_failure_cooldown_names
-        .contains(&recovery.owner.to_lowercase())
-    {
-        debug!(
-            "Spawn failure cooldown active for {} — skipping orphan recovery for task !{}",
-            recovery.owner, recovery.task_id
-        );
-        return vec![];
-    }
 
     info!(
         "Detected orphaned task !{} owned by {} - attempting recovery",

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -945,6 +945,7 @@ pub(crate) struct OrphanRecoveryContext<'a> {
     pub recently_stopped: &'a HashSet<String>,
     pub attached_coworkers: &'a HashMap<String, chrono::DateTime<chrono::Utc>>,
     pub channel_lead_names: &'a HashSet<String>,
+    pub spawn_failure_cooldown_names: &'a HashSet<String>,
 }
 
 impl OrphanRecoveryContext<'_> {
@@ -954,10 +955,12 @@ impl OrphanRecoveryContext<'_> {
     /// - Owner is active (running session)
     /// - Owner is attached (interactive session)
     /// - Owner recently stopped (within grace period — task may not be marked done yet)
+    /// - Owner is on spawn-failure cooldown
     fn should_skip_owner(&self, owner_lower: &str) -> bool {
         self.active_names.contains(owner_lower)
             || self.attached_coworkers.contains_key(owner_lower)
             || self.recently_stopped.contains(owner_lower)
+            || self.spawn_failure_cooldown_names.contains(owner_lower)
     }
 }
 
@@ -1159,6 +1162,10 @@ mod rules_channel_lead_tests;
 #[path = "rules_cooldown_tests.rs"]
 #[cfg(test)]
 mod rules_cooldown_tests;
+
+#[path = "rules_orphan_tests.rs"]
+#[cfg(test)]
+mod rules_orphan_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/rules_channel_lead_tests.rs
+++ b/src/rules_channel_lead_tests.rs
@@ -55,6 +55,7 @@ fn channel_lead_owned_task_not_orphan_recovered() {
         recently_stopped: &empty,
         attached_coworkers: &empty_map,
         channel_lead_names: &leads,
+        spawn_failure_cooldown_names: &empty,
     };
     let result = decide_orphan_recovery(&ctx);
     assert!(

--- a/src/rules_orphan_tests.rs
+++ b/src/rules_orphan_tests.rs
@@ -1,0 +1,68 @@
+//! Tests for orphan recovery with spawn-failure cooldown filtering.
+//!
+//! When multiple coworkers die simultaneously, orphan recovery must skip
+//! cooldown-blocked owners and try the next orphan, rather than returning
+//! None and deadlocking all recovery.
+
+use std::collections::{HashMap, HashSet};
+
+use super::{OrphanRecoveryContext, decide_orphan_recovery};
+
+fn empty_set() -> HashSet<String> {
+    HashSet::new()
+}
+
+fn names(items: &[&str]) -> HashSet<String> {
+    items.iter().map(|s| s.to_string()).collect()
+}
+
+#[test]
+fn skips_cooldown_blocked_owner_recovers_next_orphan() {
+    // Two orphaned tasks: "alpha" is on cooldown, "bravo" is not.
+    // Recovery should skip alpha and return bravo.
+    let tasks = vec![
+        ("1".to_string(), "task one".to_string(), "alpha".to_string()),
+        ("2".to_string(), "task two".to_string(), "bravo".to_string()),
+    ];
+    let empty = empty_set();
+    let empty_map: HashMap<String, chrono::DateTime<chrono::Utc>> = HashMap::new();
+    let cooldown = names(&["alpha"]);
+    let ctx = OrphanRecoveryContext {
+        in_progress: &tasks,
+        active_names: &empty,
+        recently_stopped: &empty,
+        attached_coworkers: &empty_map,
+        channel_lead_names: &empty,
+        spawn_failure_cooldown_names: &cooldown,
+    };
+    let result = decide_orphan_recovery(&ctx);
+    assert!(result.is_some(), "should recover a non-cooldown orphan");
+    let recovery = result.unwrap();
+    assert_eq!(recovery.task_id, "2");
+    assert_eq!(recovery.owner, "bravo");
+}
+
+#[test]
+fn all_owners_on_cooldown_returns_none() {
+    // All orphaned task owners are on cooldown — recovery should return None.
+    let tasks = vec![
+        ("1".to_string(), "task one".to_string(), "alpha".to_string()),
+        ("2".to_string(), "task two".to_string(), "bravo".to_string()),
+    ];
+    let empty = empty_set();
+    let empty_map: HashMap<String, chrono::DateTime<chrono::Utc>> = HashMap::new();
+    let cooldown = names(&["alpha", "bravo"]);
+    let ctx = OrphanRecoveryContext {
+        in_progress: &tasks,
+        active_names: &empty,
+        recently_stopped: &empty,
+        attached_coworkers: &empty_map,
+        channel_lead_names: &empty,
+        spawn_failure_cooldown_names: &cooldown,
+    };
+    let result = decide_orphan_recovery(&ctx);
+    assert!(
+        result.is_none(),
+        "should return None when all owners on cooldown"
+    );
+}


### PR DESCRIPTION
<!-- midtown session:$MIDTOWN_SESSION_ID -->

## Summary

- **Bug**: When all coworkers die simultaneously, orphan recovery deadlocks because `check_and_recover_orphans_impl()` only checks the FIRST orphan from `decide_orphan_recovery()`. If that owner is on spawn-failure cooldown, recovery returns empty — other orphans with non-cooldown owners are never tried.
- **Fix**: Add `spawn_failure_cooldown_names` to `OrphanRecoveryContext` and check it in `should_skip_owner()`, so `decide_orphan_recovery()` iterates past cooldown-blocked owners and returns the next eligible orphan. Remove the redundant post-selection cooldown check in `dispatch.rs`.
- **Tests**: Two new tests in `rules_orphan_tests.rs` — one verifying recovery skips a cooldown-blocked owner and picks the next, one verifying None when all owners are on cooldown.

Closes !2422. Rebase of #2129.

## Test plan

- [x] New test: `skips_cooldown_blocked_owner_recovers_next_orphan` — two orphans, first on cooldown → second returned
- [x] New test: `all_owners_on_cooldown_returns_none` — all on cooldown → None
- [x] Existing `channel_lead_owned_task_not_orphan_recovered` updated with new field, still passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Full test suite passes (18 pre-existing worktree test failures unrelated to this change)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)