### PR TITLE
fix: remove deadlock in check_and_fire_reminders

### DIFF
--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -843,14 +843,13 @@ pub fn detect_stale_attached_sessions(ps: &DaemonPersistentState) -> Vec<Effect>
 
 pub(super) async fn check_and_fire_reminders(
     ps: &DaemonPersistentState,
-    state: &DaemonState,
+    _state: &DaemonState,
 ) -> Vec<Effect> {
     let open_pr_coworkers: Vec<String> = ps.sessions_with_open_prs().into_iter().collect();
-    let ps_locked = state.persistent_state.lock().await;
     let now = chrono::Utc::now();
 
     let mut effects = build_reminder_effects_at(
-        &ps_locked.reminders.reminders,
+        &ps.reminders.reminders,
         &open_pr_coworkers,
         &ps.tick_dir_key,
         &ps.tick_default_channel,
@@ -858,7 +857,7 @@ pub(super) async fn check_and_fire_reminders(
     );
 
     // Emit an effect to advance last_evaluated_at for all cron reminders
-    let has_cron = ps_locked.reminders.reminders.iter().any(|r| {
+    let has_cron = ps.reminders.reminders.iter().any(|r| {
         r.is_active() && matches!(r.trigger, crate::reminders::ReminderTrigger::CronUtc { .. })
     });
     if has_cron {


### PR DESCRIPTION
## Summary
- `check_and_fire_reminders` called `state.persistent_state.lock().await` while the caller (`evaluate_tick` TaskDispatchTick path) already held the lock
- `tokio::Mutex` is not reentrant → **deadlock**: status RPC hangs indefinitely, daemon tick loop freezes
- Fix: use the already-borrowed `&DaemonPersistentState` (`ps`) parameter instead of re-locking

## Root cause
Introduced during the WorldSnapshot→DaemonPersistentState migration. The old code locked `persistent_state` independently (it wasn't held by the caller). The new code passes `&ps` but the function body still had the old lock call.

## Test plan
- [x] `cargo test` — 2419 pass
- [x] `cargo clippy` clean
- [x] Verified: `midtown status` hangs before fix, responds after

🤖 Generated with [Claude Code](https://claude.com/claude-code)