### PR TITLE
fix: reject COMMENTED/DISMISSED formal reviews as incomplete

### DIFF
--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -3019,29 +3019,21 @@ pub(super) fn json_has_completed_review(
                 .and_then(|s| s.as_str())
                 .map(|s| s.to_ascii_uppercase());
 
-            let has_review_state = state_upper.as_deref().is_some_and(|s| {
-                matches!(
-                    s,
-                    "APPROVED" | "CHANGES_REQUESTED" | "COMMENTED" | "DISMISSED"
-                )
-            });
+            // Only strong review states count as completed reviews.
+            // COMMENTED and DISMISSED are too weak — Codex and other tools
+            // submit COMMENTED reviews automatically, causing false positives
+            // that prevent midtown reviewer spawning.
+            let is_strong_state = state_upper
+                .as_deref()
+                .is_some_and(|s| matches!(s, "APPROVED" | "CHANGES_REQUESTED"));
 
             let has_review_body = review
                 .get("body")
                 .and_then(|b| b.as_str())
                 .is_some_and(text_contains_review_signature);
 
-            if has_review_state || has_review_body {
+            if is_strong_state || has_review_body {
                 let body = review.get("body").and_then(|b| b.as_str()).unwrap_or("");
-
-                // For formal reviews with strong states (APPROVED / CHANGES_REQUESTED),
-                // accept even without body attribution. These are intentional review
-                // actions unlikely from bots, and the assigned reviewer may submit
-                // them with an empty body. Weak states (COMMENTED / DISMISSED) still
-                // require author verification to avoid bot false positives.
-                let is_strong_state = state_upper
-                    .as_deref()
-                    .is_some_and(|s| matches!(s, "APPROVED" | "CHANGES_REQUESTED"));
 
                 if review_author_matches(body, assigned_reviewer, assigned_session_id)
                     || (is_strong_state && assigned_reviewer.is_some())

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -3561,10 +3561,11 @@ fn json_review_rejects_formal_review_without_attribution() {
         "Formal review from bot without frontmatter should be rejected when reviewer assigned"
     );
 
-    // Without assigned reviewer: accept (backward compat)
+    // Without assigned reviewer: also reject — COMMENTED state is too weak
+    // (Codex and other tools submit COMMENTED reviews automatically)
     assert!(
-        json_has_completed_review(&json, None, None),
-        "Formal review should be accepted when no reviewer is assigned"
+        !json_has_completed_review(&json, None, None),
+        "COMMENTED review without midtown frontmatter should be rejected"
     );
 }
 


### PR DESCRIPTION
## Summary
- Only `APPROVED` and `CHANGES_REQUESTED` formal review states now count as completed reviews
- `COMMENTED` and `DISMISSED` states are too weak — Codex submits `COMMENTED` reviews automatically
- This was the second half of the Codex false-positive fix (PR #2148 fixed comment-based detection, this fixes formal-review detection)

## Root cause
`json_has_completed_review` accepted `COMMENTED` state reviews, which matched Codex's automatic review submissions. Combined with no assigned reviewer (`None`), any `COMMENTED` review counted — preventing midtown reviewer spawning for 4 PRs.

## Test plan
- [x] `cargo test` — all pass
- [x] Updated `json_review_rejects_formal_review_without_attribution` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)