### PR TITLE
fix: don't cache review status from webhook when no reviewer assigned

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3712,8 +3712,11 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
                             is_strong_formal_review
                         }
                         (_, None) => {
-                            // No assigned reviewer — accept any review (backward compat)
-                            true
+                            // No assigned reviewer — don't cache from webhook alone.
+                            // Without an assigned reviewer, we can't verify the review
+                            // is from a midtown coworker. Let the polling path handle it
+                            // (which checks for midtown type:review frontmatter).
+                            false
                         }
                     };
 


### PR DESCRIPTION
## Summary
- When no midtown reviewer is assigned to a PR, webhook review events are no longer auto-cached as "reviewed"
- This was the third and final path where Codex reviews bypassed midtown detection:
  1. PR #2148: comment-based detection (text patterns → frontmatter only)
  2. PR #2149: formal review states (COMMENTED/DISMISSED removed)
  3. **This PR**: webhook caching (no-reviewer path → defer to polling)

## Root cause
The webhook handler had `(_, None) => true` — when no reviewer was assigned, ANY review webhook event marked the PR as reviewed. Codex `issue_comment.created` webhooks matched this, repopulating `reviewed_prs` immediately after we cleared it.

## Test plan
- [x] `cargo test` — 2419 pass
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)