### PR TITLE
fix: dedup completed review tasks and reject unexpanded env vars

### DIFF
--- a/src/daemon/helpers.rs
+++ b/src/daemon/helpers.rs
@@ -8,6 +8,7 @@
 
 use super::constants::{COWORKER_NAMES, SYSTEM_SENDERS};
 pub use super::trackers::PrIssueType;
+use tracing::warn;
 
 // ---------------------------------------------------------------------------
 // Text / parsing helpers
@@ -744,6 +745,16 @@ pub fn review_author_matches(
     };
 
     match extract_review_author_from_body(body) {
+        Some(author) if author.starts_with('$') => {
+            // Unexpanded env var (e.g., literal "$MIDTOWN_SESSION_ID") — the
+            // shell didn't expand it, so this is never a valid author. Treat
+            // as match failure to avoid false positives.
+            warn!(
+                "review_author_matches: extracted author is a literal env var '{}' — treating as no match",
+                author
+            );
+            false
+        }
         Some(author) => {
             // Match by name (legacy) or by session ID (new format)
             author.eq_ignore_ascii_case(reviewer)

--- a/src/daemon/helpers_tests.rs
+++ b/src/daemon/helpers_tests.rs
@@ -1773,3 +1773,30 @@ fn test_unexpected_exit_message_lead_role() {
     let msg = format_unexpected_exit_message("Lead", "midtown", None);
     assert_eq!(msg, "⚠️ Lead midtown session exited unexpectedly");
 }
+
+// ── unexpanded env var rejection in review_author_matches ──────────────
+
+#[test]
+fn review_author_matches_rejects_unexpanded_env_var() {
+    // When $MIDTOWN_SESSION_ID isn't expanded by the shell, the frontmatter
+    // contains the literal string "$MIDTOWN_SESSION_ID". This should never
+    // match any reviewer name, and should be treated as a match failure.
+    let body =
+        "<!-- midtown session:$MIDTOWN_SESSION_ID task:42 type:review -->\n## Code Review\nLGTM";
+    assert!(
+        !review_author_matches(body, Some("pleasant"), Some("sess-42")),
+        "Literal '$MIDTOWN_SESSION_ID' should not match any reviewer"
+    );
+}
+
+#[test]
+fn review_author_matches_rejects_any_unexpanded_env_var() {
+    // When extract_review_author_from_body returns a literal starting with '$',
+    // it should be rejected regardless of what the assigned reviewer/session is.
+    // This catches the case where the assigned_session_id also wasn't expanded.
+    let body = "<!-- midtown session:$SOME_VAR task:42 type:review -->\n## Code Review\nLGTM";
+    assert!(
+        !review_author_matches(body, Some("$SOME_VAR"), Some("$SOME_VAR")),
+        "Literal env var starting with '$' should be treated as match failure even if both sides match"
+    );
+}

--- a/src/daemon/pr.rs
+++ b/src/daemon/pr.rs
@@ -2794,15 +2794,16 @@ pub(crate) async fn collect_reviewer_effects_with_source(
         }
 
         // Check if a review task already exists for this PR (task-based dedup).
+        // Include completed tasks: once a reviewer has been spawned for a PR,
+        // don't auto-spawn another. Without this, completed review tasks are
+        // invisible to the guard, causing an infinite spawn loop on each tick.
         {
-            let has_review_task = all_tasks.iter().any(|t| {
-                t.pr == Some(pr_number)
-                    && t.status != crate::task_store::TaskStatus::Completed
-                    && t.subject.starts_with("Review PR #")
-            });
+            let has_review_task = all_tasks
+                .iter()
+                .any(|t| t.pr == Some(pr_number) && t.subject.starts_with("Review PR #"));
             if has_review_task {
                 debug!(
-                    "PR #{} already has a pending/in-progress review task",
+                    "PR #{} already has a review task (pending, in-progress, or completed)",
                     pr_number
                 );
                 continue;

--- a/src/daemon/pr_tests.rs
+++ b/src/daemon/pr_tests.rs
@@ -5427,3 +5427,93 @@ fn test_resolve_pr_owner_skips_fork_sessions() {
         "Fork sessions should not resolve as PR owners"
     );
 }
+
+/// Bug (task !2447): When a review task completes (reviewer crashes or finishes
+/// without posting a proper review), the dedup guard only checks non-completed
+/// tasks. On the next poll tick, the PR still needs review, no active review
+/// task exists, so a new reviewer is spawned — creating an infinite loop.
+///
+/// Fix: Also count Completed review tasks for the same PR in the dedup check.
+#[tokio::test]
+async fn test_review_task_dedup_includes_completed_tasks() {
+    let pr = json!({
+        "number": 7777,
+        "headRefName": "worker-1/some-feature",
+        "title": "feat: something [Midtown !200]",
+        "isDraft": false,
+        "createdAt": "2026-01-01T00:00:00Z",
+        "state": "OPEN",
+    });
+
+    let (state, _tmp, _guard) = make_test_state("midtown");
+
+    // Register the PR author as an active coworker so the PR isn't orphaned.
+    state
+        .coworkers
+        .register(
+            "slot-1",
+            "worker-1",
+            "/tmp".to_string(),
+            None,
+            "claude-sonnet".to_string(),
+            crate::auth::AuthProvider::Claude,
+            "default".to_string(),
+        )
+        .unwrap();
+
+    {
+        let mut ps = state.persistent_state.lock().await;
+        ps.sessions.insert(
+            "sess-worker-1".to_string(),
+            crate::daemon::state::SessionRecord {
+                session_id: "sess-worker-1".to_string(),
+                task_id: Some("200".to_string()),
+                pr_number: Some(7777),
+                name: "worker-1".to_string(),
+                working_dir: "/tmp/test".to_string(),
+                ..Default::default()
+            },
+        );
+    }
+
+    // Create a COMPLETED review task for this PR — simulates a reviewer that
+    // already ran and finished (possibly without posting a proper review).
+    let completed_review_task = crate::task_store::Task {
+        id: "300".to_string(),
+        subject: "Review PR #7777".to_string(),
+        status: crate::task_store::TaskStatus::Completed,
+        pr: Some(7777),
+        agent_name: "old-reviewer".to_string(),
+        agent_type: "midtown-code-reviewer".to_string(),
+        ..Default::default()
+    };
+    state.task_store.save(&completed_review_task).unwrap();
+
+    let registry = crate::worktree_registry::WorktreeRegistry::new();
+    let active_names: std::collections::HashSet<String> =
+        ["worker-1".to_string()].into_iter().collect();
+
+    let effects = collect_reviewer_effects_with_source(
+        &registry,
+        &active_names,
+        &state,
+        &[pr],
+        true,
+        &std::collections::HashMap::new(),
+        false,
+    )
+    .await;
+
+    // The completed review task should prevent spawning a new reviewer.
+    let has_create_review_task = effects
+        .iter()
+        .any(|e| matches!(e, Effect::CreateReviewTask { pr_number, .. } if *pr_number == 7777));
+
+    assert!(
+        !has_create_review_task,
+        "Should NOT spawn a new reviewer when a completed review task already exists for PR #7777. \
+         Bug: dedup only checked non-completed tasks, causing infinite review-spawn loop. \
+         Effects: {:#?}",
+        effects
+    );
+}


### PR DESCRIPTION
<!-- midtown session:$MIDTOWN_SESSION_ID -->

## Summary

- **Review task dedup includes completed tasks**: The dedup guard in `collect_reviewer_effects_with_source` only checked non-completed tasks, so once a review task completed the daemon spawned a new reviewer every tick — an infinite loop. Now completed review tasks also block re-spawning.
- **Reject literal `$MIDTOWN_SESSION_ID` in `review_author_matches`**: When the env var isn't expanded by the shell, the extracted author is a literal `$`-prefixed string. Added explicit rejection with a warning log for any author starting with `$`.

## Test plan

- [x] Added `test_review_task_dedup_includes_completed_tasks` — verifies no `CreateReviewTask` when a completed review task exists for the PR
- [x] Added `review_author_matches_rejects_unexpanded_env_var` — verifies literal `$MIDTOWN_SESSION_ID` is rejected
- [x] Added `review_author_matches_rejects_any_unexpanded_env_var` — verifies any `$`-prefixed author is rejected even when both sides match
- [x] All existing tests pass, clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)