### PR TITLE
fix: expand $MIDTOWN_SESSION_ID in prompts at spawn time

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1589,14 +1589,27 @@ impl DaemonState {
         {
             crate::launch::inject_session_id_env(&mut headless_config.env, sid);
         }
+        // Expand $MIDTOWN_SESSION_ID in the system prompt and initial prompt so the
+        // AI sees the literal UUID rather than an env-var reference. Claude Code
+        // sessions typically use single-quoted heredocs for multi-line shell args,
+        // which prevents shell expansion — embedding the value directly avoids this.
+        if let Some(ref sid) = session_id {
+            headless_config.system_prompt =
+                crate::launch::expand_session_id_in_prompt(&headless_config.system_prompt, sid);
+        }
         let persisted_session_id = session_id.clone().unwrap_or_default();
-        let initial_prompt = launch_config.initial_prompt.as_deref();
+        let initial_prompt = match (&session_id, launch_config.initial_prompt.as_deref()) {
+            (Some(sid), Some(prompt)) => {
+                Some(crate::launch::expand_session_id_in_prompt(prompt, sid))
+            }
+            (_, prompt) => prompt.map(|p| p.to_string()),
+        };
         self.session_manager
             .spawn(
                 &name,
                 &slot_id,
                 &headless_config,
-                initial_prompt,
+                initial_prompt.as_deref(),
                 session_id.clone(),
             )
             .await?;

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -226,6 +226,17 @@ pub fn inject_session_id_env(
     env.insert("MIDTOWN_SESSION_ID".to_string(), session_id.to_string());
 }
 
+/// Expand `$MIDTOWN_SESSION_ID` in a prompt string to the actual session ID.
+///
+/// Claude Code sessions use single-quoted heredocs (`<<'EOF'`) for multi-line
+/// shell arguments, which prevents shell expansion of `$MIDTOWN_SESSION_ID`.
+/// By replacing the env-var reference with the literal UUID in the system and
+/// initial prompts, the AI sees the actual value and includes it directly in
+/// GitHub comments — no shell expansion needed.
+pub fn expand_session_id_in_prompt(prompt: &str, session_id: &str) -> String {
+    prompt.replace("$MIDTOWN_SESSION_ID", session_id)
+}
+
 /// Compute the session name for a channel lead.
 ///
 /// Channel lead sessions are named after their channel directly (e.g., "web" for

--- a/src/launch_tests.rs
+++ b/src/launch_tests.rs
@@ -1,6 +1,8 @@
 //! Tests for lead system prompt persistence on attach and channel lead model selection
 
-use crate::launch::{LaunchConfig, SessionMode, inject_session_id_env};
+use crate::launch::{
+    LaunchConfig, SessionMode, expand_session_id_in_prompt, inject_session_id_env,
+};
 use crate::paths;
 use std::fs;
 
@@ -595,5 +597,53 @@ fn test_default_agent_name_without_override() {
         headless.agent_name.as_deref(),
         Some("midtown-code-author"),
         "Without override, coworker role should use midtown-code-author agent"
+    );
+}
+
+#[test]
+fn test_expand_session_id_replaces_env_var_in_prompt() {
+    let prompt = "<!-- midtown session:$MIDTOWN_SESSION_ID --> some text $MIDTOWN_SESSION_ID end";
+    let expanded = expand_session_id_in_prompt(prompt, "abc-123-def");
+    assert_eq!(
+        expanded, "<!-- midtown session:abc-123-def --> some text abc-123-def end",
+        "All occurrences of $MIDTOWN_SESSION_ID should be replaced"
+    );
+}
+
+#[test]
+fn test_expand_session_id_noop_when_no_placeholder() {
+    let prompt = "no env var references here";
+    let expanded = expand_session_id_in_prompt(prompt, "abc-123");
+    assert_eq!(
+        expanded, prompt,
+        "Prompt without $MIDTOWN_SESSION_ID should be unchanged"
+    );
+}
+
+#[test]
+fn test_reviewer_system_prompt_contains_unexpanded_session_id() {
+    // This test documents the pre-expansion state: the template contains
+    // the literal $MIDTOWN_SESSION_ID before spawn_coworker() expands it.
+    let prompt = crate::agents::reviewer_system_prompt(
+        "york",
+        "midtown",
+        "midtown",
+        crate::auth::AuthProvider::Claude,
+        Some(42),
+    );
+    assert!(
+        prompt.contains("$MIDTOWN_SESSION_ID"),
+        "Reviewer system prompt template should contain $MIDTOWN_SESSION_ID before expansion"
+    );
+
+    // After expansion, the literal should be gone
+    let expanded = expand_session_id_in_prompt(&prompt, "test-uuid-999");
+    assert!(
+        !expanded.contains("$MIDTOWN_SESSION_ID"),
+        "After expand_session_id_in_prompt, no literal $MIDTOWN_SESSION_ID should remain"
+    );
+    assert!(
+        expanded.contains("test-uuid-999"),
+        "After expansion, the actual session ID should appear in the prompt"
     );
 }


### PR DESCRIPTION
<!-- midtown session:$MIDTOWN_SESSION_ID -->

## Summary

- Reviewer sessions emitted literal `$MIDTOWN_SESSION_ID` in GitHub review comments instead of the resolved UUID
- Root cause: Claude Code uses single-quoted heredocs (`<<'EOF'`) for multi-line shell args, preventing shell expansion of env vars
- Fix: replace `$MIDTOWN_SESSION_ID` with the actual session UUID directly in the system prompt and initial prompt during `spawn_coworker()`, so the AI sees the literal value

## Test plan

- [x] Added `test_expand_session_id_replaces_env_var_in_prompt` — verifies all occurrences are replaced
- [x] Added `test_expand_session_id_noop_when_no_placeholder` — no-op when placeholder absent
- [x] Added `test_reviewer_system_prompt_contains_unexpanded_session_id` — confirms template has placeholder pre-expansion and UUID post-expansion
- [x] All existing tests pass (`cargo test --lib launch agents`)
- [x] Coverage diff: 91% (1 uncovered line is the defensive `session_id=None` fallback in initial prompt expansion)

Closes #2455

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)