### PR TITLE
[Midtown !2454] Add type:review to reviewer frontmatter

### DIFF
--- a/agents/common.md
+++ b/agents/common.md
@@ -84,9 +84,14 @@ Use `midtown agent show` to check on what a coworker is doing. This captures and
 <!-- midtown session:$MIDTOWN_SESSION_ID -->
 ```
 
-2. **PR comments and reviews** - include frontmatter in the comment:
+2. **PR comments** - include frontmatter in the comment:
 ```
 <!-- midtown session:$MIDTOWN_SESSION_ID -->
+```
+
+3. **PR reviews** - include `type:review` so the daemon detects the review:
+```
+<!-- midtown session:$MIDTOWN_SESSION_ID type:review -->
 
 ## Code Review by {name}
 ...

--- a/src/agents_tests.rs
+++ b/src/agents_tests.rs
@@ -205,6 +205,22 @@ fn test_reviewer_system_prompt_merges_all_sources() {
 }
 
 #[test]
+fn test_reviewer_system_prompt_contains_type_review_frontmatter() {
+    let prompt = reviewer_system_prompt(
+        "lexington",
+        "midtown",
+        "midtown",
+        AuthProvider::Claude,
+        Some(42),
+    );
+
+    assert!(
+        prompt.contains("<!-- midtown session:$MIDTOWN_SESSION_ID type:review -->"),
+        "Reviewer system prompt should contain type:review in frontmatter example"
+    );
+}
+
+#[test]
 fn test_reviewer_prompts_use_daemon_review_post() {
     let system_prompt =
         reviewer_system_prompt("park", "midtown", "midtown", AuthProvider::Claude, Some(42));


### PR DESCRIPTION
<!-- midtown session:$MIDTOWN_SESSION_ID -->

## Summary

- Split the GitHub Etiquette frontmatter example in `agents/common.md` into separate entries for regular PR comments and PR reviews
- Added `type:review` to the review frontmatter example so reviewers emit `<!-- midtown session:$MIDTOWN_SESSION_ID type:review -->` 
- Added test verifying the reviewer system prompt contains the `type:review` frontmatter

This fixes the root cause of false "no review" alerts on PRs #2141-#2144 — the daemon (since PR #2148) requires `type:review` in frontmatter for review detection, but the shared agent template only showed the plain session frontmatter.

## Test plan

- [x] New test `test_reviewer_system_prompt_contains_type_review_frontmatter` passes
- [x] All 107 agents tests pass
- [x] Clippy clean

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)