### PR TITLE
fix: clarify frontmatter instructions to prevent literal $MIDTOWN_SESSION_ID

### DIFF
--- a/agents/common.md
+++ b/agents/common.md
@@ -77,25 +77,22 @@ Use `midtown agent show` to check on what a coworker is doing. This captures and
 
 ## GitHub Etiquette
 
-**IMPORTANT**: Always include session frontmatter in GitHub content so events are attributed to you. Use `$MIDTOWN_SESSION_ID` from your environment:
+**IMPORTANT**: Always include session frontmatter in GitHub content so events are attributed to you. Your session ID is embedded in these examples — copy them directly:
 
-1. **PR bodies** - add frontmatter:
+1. **PR bodies and comments** - add frontmatter:
 ```
 <!-- midtown session:$MIDTOWN_SESSION_ID -->
 ```
 
-2. **PR comments** - include frontmatter in the comment:
-```
-<!-- midtown session:$MIDTOWN_SESSION_ID -->
-```
-
-3. **PR reviews** - include `type:review` so the daemon detects the review:
+2. **PR reviews** - include `type:review` so the daemon detects the review:
 ```
 <!-- midtown session:$MIDTOWN_SESSION_ID type:review -->
 
-## Code Review by {name}
+## Code Review by {your name}
 ...
 ```
+
+**CRITICAL**: Copy the frontmatter exactly as shown above. The session ID is already embedded — do NOT type `$MIDTOWN_SESSION_ID` literally.
 
 **Review styles vary by provider.** Claude reviewers typically post comment-based reviews (with `## Code Review...`), while Codex can submit formal GitHub reviews. Treat either as valid review input, but do not merge until feedback is addressed.
 


### PR DESCRIPTION
## Summary
- Reviewers were copying `$MIDTOWN_SESSION_ID` literally in GitHub comments
- Root cause: prompt said "Use `$MIDTOWN_SESSION_ID` from your environment" — AI copied the env var reference instead of the expanded value
- Fix: reworded instructions to say "copy them directly" with explicit warning not to type the literal string
- The `expand_session_id_in_prompt()` from PR #2152 replaces `$MIDTOWN_SESSION_ID` with the real UUID in these examples at spawn time

## Test plan
- [x] `cargo test` — 2426 pass
- [x] Verified expansion: examples show real UUID after `expand_session_id_in_prompt()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)