### PR TITLE
feat: name reviewer sessions after parent task

### DIFF
--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -1229,6 +1229,18 @@ fn allocate_fresh_coworker_name(
     }
     if !task.agent_name.is_empty() {
         task.agent_name.clone()
+    } else if is_reviewer_task
+        && let Some(parent_id) = task.parent.as_ref()
+        && let Some(parent_task) = task_by_id(tasks, parent_id)
+        && !parent_task.agent_name.is_empty()
+    {
+        let candidate = format!("{}-reviewer", parent_task.agent_name).to_lowercase();
+        if excluded_names.contains(&candidate) {
+            let suffix = fastrand::u32(1000..9999);
+            format!("{}-{}", candidate, suffix)
+        } else {
+            candidate
+        }
     } else {
         generate_task_session_name(&task.id, &task.subject, &excluded_names)
     }

--- a/src/daemon/dispatch_name_collision_tests.rs
+++ b/src/daemon/dispatch_name_collision_tests.rs
@@ -123,3 +123,183 @@ fn test_dispatch_excludes_active_session_names() {
         "No nudge should be emitted — 'park' should be excluded from allocation."
     );
 }
+
+/// Reviewer sessions should be named after parent task's agent_name with -reviewer suffix.
+#[test]
+fn test_reviewer_task_named_after_parent() {
+    let old = chrono::Utc::now() - chrono::Duration::seconds(120);
+
+    #[allow(clippy::field_reassign_with_default)]
+    let ps = {
+        let mut ps = DaemonPersistentState::default();
+        ps.tick_dir_key = "test-repo".to_string();
+        ps.tick_project_name = "test-repo".to_string();
+        ps.tick_default_channel = "test-repo".to_string();
+        ps.tick_max_in_progress_tasks = 10;
+        ps.tick_now = chrono::Utc::now();
+        ps
+    };
+
+    let tasks = vec![
+        // Parent task with a creative agent_name
+        crate::task_store::Task {
+            id: "400".to_string(),
+            subject: "Implement feature X".to_string(),
+            status: crate::task_store::TaskStatus::InProgress,
+            agent_name: "patch-kit".to_string(),
+            created_at: old,
+            ..Default::default()
+        },
+        // Reviewer task pointing to parent
+        crate::task_store::Task {
+            id: "401".to_string(),
+            subject: "Review PR #100".to_string(),
+            status: crate::task_store::TaskStatus::Pending,
+            agent_name: String::new(),
+            agent_type: "midtown-code-reviewer".to_string(),
+            parent: Some("400".to_string()),
+            pr: Some(100),
+            created_at: old,
+            ..Default::default()
+        },
+    ];
+
+    let (state, _tmp, _guard) = make_test_state();
+
+    let effects = spawn_for_pending_tasks(&ps, &tasks, &state);
+
+    // Find the SpawnForTask effect and check the preferred_name
+    let spawn = effects
+        .iter()
+        .find(|e| matches!(e, effects::Effect::SpawnForTask { .. }));
+    assert!(spawn.is_some(), "Expected a SpawnForTask effect");
+
+    if let Some(effects::Effect::SpawnForTask { preferred_name, .. }) = spawn {
+        assert_eq!(
+            preferred_name.as_deref(),
+            Some("patch-kit-reviewer"),
+            "Reviewer session should be named after parent's agent_name with -reviewer suffix"
+        );
+    }
+}
+
+/// When the reviewer name collides with an active session, a suffix should be appended.
+#[test]
+fn test_reviewer_task_name_collision_adds_suffix() {
+    let old = chrono::Utc::now() - chrono::Duration::seconds(120);
+
+    #[allow(clippy::field_reassign_with_default)]
+    let ps = {
+        let mut ps = DaemonPersistentState::default();
+        ps.tick_dir_key = "test-repo".to_string();
+        ps.tick_project_name = "test-repo".to_string();
+        ps.tick_default_channel = "test-repo".to_string();
+        ps.tick_max_in_progress_tasks = 10;
+        ps.tick_now = chrono::Utc::now();
+        // Simulate "patch-kit-reviewer" already running
+        ps.tick_active_session_names = HashSet::from(["patch-kit-reviewer".to_string()]);
+        ps
+    };
+
+    let tasks = vec![
+        crate::task_store::Task {
+            id: "500".to_string(),
+            subject: "Implement feature Y".to_string(),
+            status: crate::task_store::TaskStatus::InProgress,
+            agent_name: "patch-kit".to_string(),
+            created_at: old,
+            ..Default::default()
+        },
+        crate::task_store::Task {
+            id: "501".to_string(),
+            subject: "Review PR #200".to_string(),
+            status: crate::task_store::TaskStatus::Pending,
+            agent_name: String::new(),
+            agent_type: "midtown-code-reviewer".to_string(),
+            parent: Some("500".to_string()),
+            pr: Some(200),
+            created_at: old,
+            ..Default::default()
+        },
+    ];
+
+    let (state, _tmp, _guard) = make_test_state();
+
+    let effects = spawn_for_pending_tasks(&ps, &tasks, &state);
+
+    let spawn = effects
+        .iter()
+        .find(|e| matches!(e, effects::Effect::SpawnForTask { .. }));
+    assert!(spawn.is_some(), "Expected a SpawnForTask effect");
+
+    if let Some(effects::Effect::SpawnForTask { preferred_name, .. }) = spawn {
+        let name = preferred_name.as_deref().unwrap();
+        assert!(
+            name.starts_with("patch-kit-reviewer-"),
+            "Colliding reviewer name should have a random suffix, got: {}",
+            name
+        );
+        assert_ne!(
+            name, "patch-kit-reviewer",
+            "Should not be the bare name when it collides"
+        );
+    }
+}
+
+/// When parent task has no agent_name, fall back to generate_task_session_name.
+#[test]
+fn test_reviewer_task_fallback_when_parent_has_no_name() {
+    let old = chrono::Utc::now() - chrono::Duration::seconds(120);
+
+    #[allow(clippy::field_reassign_with_default)]
+    let ps = {
+        let mut ps = DaemonPersistentState::default();
+        ps.tick_dir_key = "test-repo".to_string();
+        ps.tick_project_name = "test-repo".to_string();
+        ps.tick_default_channel = "test-repo".to_string();
+        ps.tick_max_in_progress_tasks = 10;
+        ps.tick_now = chrono::Utc::now();
+        ps
+    };
+
+    let tasks = vec![
+        crate::task_store::Task {
+            id: "600".to_string(),
+            subject: "Implement feature Z".to_string(),
+            status: crate::task_store::TaskStatus::InProgress,
+            agent_name: String::new(), // no agent_name
+            created_at: old,
+            ..Default::default()
+        },
+        crate::task_store::Task {
+            id: "601".to_string(),
+            subject: "Review PR #300".to_string(),
+            status: crate::task_store::TaskStatus::Pending,
+            agent_name: String::new(),
+            agent_type: "midtown-code-reviewer".to_string(),
+            parent: Some("600".to_string()),
+            pr: Some(300),
+            created_at: old,
+            ..Default::default()
+        },
+    ];
+
+    let (state, _tmp, _guard) = make_test_state();
+
+    let effects = spawn_for_pending_tasks(&ps, &tasks, &state);
+
+    let spawn = effects
+        .iter()
+        .find(|e| matches!(e, effects::Effect::SpawnForTask { .. }));
+    assert!(spawn.is_some(), "Expected a SpawnForTask effect");
+
+    if let Some(effects::Effect::SpawnForTask { preferred_name, .. }) = spawn {
+        let name = preferred_name.as_deref().unwrap();
+        // Should NOT contain "-reviewer" since parent has no agent_name
+        assert!(
+            !name.contains("-reviewer"),
+            "Should fall back to generated name when parent has no agent_name, got: {}",
+            name
+        );
+    }
+}


### PR DESCRIPTION
<!-- midtown session:0e1f28ed-80fe-4719-9c88-3237d6a947f4 -->

## Summary

- Reviewer sessions are now named `{parent_agent_name}-reviewer` (e.g., `patch-kit-reviewer`) instead of getting a generic generated name from the task subject
- Falls back to default `generate_task_session_name()` when the parent task has no `agent_name`
- Handles name collisions by appending a random suffix, consistent with existing collision handling

## Test plan

- [x] `test_reviewer_task_named_after_parent` — verifies `patch-kit-reviewer` naming from parent
- [x] `test_reviewer_task_name_collision_adds_suffix` — verifies suffix appended when name collides
- [x] `test_reviewer_task_fallback_when_parent_has_no_name` — verifies fallback to generated name
- [x] All 59 dispatch tests pass
- [x] Clippy clean, 100% diff coverage

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)