### PR TITLE
feat: add showFullLeadOutput per-channel setting

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -97,6 +97,9 @@ pub struct RuntimeContext<'a> {
     pub platform: Option<crate::auth::AuthProvider>,
     /// PR number for code review invocation formatting.
     pub pr_number: Option<u64>,
+    /// When `true`, inject an override telling the lead that auto-posting is
+    /// disabled and it must use `midtown channel post` explicitly.
+    pub suppress_auto_output: bool,
 }
 
 /// Layer 1: Load the agent definition for a role.
@@ -193,6 +196,19 @@ pub fn build_runtime_context(base_prompt: &str, ctx: &RuntimeContext) -> String 
         if !agents.is_empty() {
             prompt = format!("{prompt}\n\n## Workflow Facilitation\n\n{agents}");
         }
+    }
+
+    // When show_full_lead_output is OFF, override the auto-posting instructions.
+    // This goes last so it takes precedence over the default "Channel Auto-Posting"
+    // section from lead-common.md.
+    if ctx.suppress_auto_output {
+        prompt = format!(
+            "{prompt}\n\n## Channel Auto-Posting Override\n\n\
+             Your text output is **NOT** automatically posted to the channel. \
+             The daemon has suppressed auto-posting for this channel.\n\n\
+             Use `midtown channel post \"<message>\"` for anything you want visible in the channel. \
+             Thread replies still require `--thread <message-id>`."
+        );
     }
 
     prompt
@@ -462,11 +478,15 @@ pub fn coworker_nudge_prompt(task_id: &str, subject: &str) -> String {
 /// For channel leads, `{name}` = channel_name.
 ///
 /// `agents_md` is optional workflow facilitation content from the project's `AGENTS.md`.
+///
+/// `suppress_auto_output` injects an override telling the lead that auto-posting
+/// is disabled — it must use `midtown channel post` explicitly.
 pub fn channel_lead_system_prompt(
     channel_name: &str,
     domain_context: &str,
     project_name: &str,
     agents_md: Option<&str>,
+    suppress_auto_output: bool,
 ) -> String {
     // Layer 1: Agent definition
     let layer1 = load_agent_definition_for_role(AgentRole::ChannelLead);
@@ -483,6 +503,7 @@ pub fn channel_lead_system_prompt(
             channel_name: Some(channel_name),
             domain_context: Some(domain_context),
             agents_md,
+            suppress_auto_output,
             ..RuntimeContext::default()
         },
     )

--- a/src/agents_tests.rs
+++ b/src/agents_tests.rs
@@ -278,7 +278,8 @@ fn test_reviewer_system_prompt_contains_review_note_pattern() {
 
 #[test]
 fn test_channel_lead_system_prompt_no_unreplaced_template_vars() {
-    let prompt = channel_lead_system_prompt("web-interface", "No context yet.", "midtown", None);
+    let prompt =
+        channel_lead_system_prompt("web-interface", "No context yet.", "midtown", None, false);
     assert!(
         !prompt.contains("{channel_name}"),
         "Channel lead prompt should not contain unreplaced {{channel_name}} placeholders"
@@ -296,7 +297,7 @@ fn test_channel_lead_system_prompt_no_unreplaced_template_vars() {
 #[test]
 fn test_channel_lead_system_prompt_substitutes_domain_context() {
     let context = "Active tasks: !42 Add WebSocket reconnect. Recent PRs: #99 merged.";
-    let prompt = channel_lead_system_prompt("daemon-core", context, "midtown", None);
+    let prompt = channel_lead_system_prompt("daemon-core", context, "midtown", None, false);
     assert!(
         prompt.contains(context),
         "Channel lead prompt should inject domain context"
@@ -309,7 +310,7 @@ fn test_channel_lead_system_prompt_substitutes_domain_context() {
 
 #[test]
 fn test_channel_lead_system_prompt_contains_required_sections() {
-    let prompt = channel_lead_system_prompt("tui", "No context.", "midtown", None);
+    let prompt = channel_lead_system_prompt("tui", "No context.", "midtown", None, false);
     assert!(
         prompt.contains("Identity"),
         "Channel lead prompt should have Identity section"
@@ -330,7 +331,8 @@ fn test_channel_lead_system_prompt_contains_required_sections() {
 
 #[test]
 fn test_channel_lead_system_prompt_contains_escalation_to_lead() {
-    let prompt = channel_lead_system_prompt("github-integration", "No context.", "midtown", None);
+    let prompt =
+        channel_lead_system_prompt("github-integration", "No context.", "midtown", None, false);
     assert!(
         prompt.contains("@midtown"),
         "Channel lead prompt should mention @midtown for escalation"
@@ -339,7 +341,7 @@ fn test_channel_lead_system_prompt_contains_escalation_to_lead() {
 
 #[test]
 fn test_channel_lead_notes_path_is_absolute() {
-    let prompt = channel_lead_system_prompt("web", "No context.", "midtown", None);
+    let prompt = channel_lead_system_prompt("web", "No context.", "midtown", None, false);
     assert!(
         prompt.contains("~/.midtown/projects/midtown/channels/web/notes/"),
         "Channel lead prompt should use absolute project-level path for notes, got: {}",
@@ -356,7 +358,7 @@ fn test_channel_lead_notes_path_is_absolute() {
 
 #[test]
 fn test_channel_lead_notes_triggers_present() {
-    let prompt = channel_lead_system_prompt("daemon", "No context.", "midtown", None);
+    let prompt = channel_lead_system_prompt("daemon", "No context.", "midtown", None, false);
     assert!(
         prompt.contains("When to Write Notes"),
         "Channel lead prompt should have a 'When to Write Notes' section with actionable triggers"
@@ -659,7 +661,7 @@ fn test_channel_lead_no_hardcoded_midtown_channel() {
     // When project_name is NOT "midtown", `--channel midtown` and `#midtown`
     // (as channel refs) should not appear. These indicate hardcoded channel
     // names that should use {project_name}.
-    let prompt = channel_lead_system_prompt("daemon-core", "No context.", "ravioli", None);
+    let prompt = channel_lead_system_prompt("daemon-core", "No context.", "ravioli", None, false);
     assert!(
         !prompt.contains("--channel midtown"),
         "Channel lead prompt should not contain hardcoded '--channel midtown'"
@@ -674,7 +676,7 @@ fn test_channel_lead_no_hardcoded_midtown_channel() {
 fn test_ops_channel_lead_no_hardcoded_midtown_channel() {
     // The ops channel lead gets extra content from ops-channel-lead.md.
     // Verify that content also uses {project_name} not literal "midtown".
-    let prompt = channel_lead_system_prompt("ops", "No context.", "ravioli", None);
+    let prompt = channel_lead_system_prompt("ops", "No context.", "ravioli", None, false);
     assert!(
         !prompt.contains("--channel midtown"),
         "Ops channel lead prompt should not contain hardcoded '--channel midtown'"
@@ -704,7 +706,7 @@ fn test_main_lead_no_hardcoded_midtown_channel() {
 fn test_channel_lead_system_prompt_without_agents_md() {
     // When no AGENTS.md content is provided, prompt should not contain
     // the "Workflow Facilitation" section.
-    let prompt = channel_lead_system_prompt("web", "No context.", "midtown", None);
+    let prompt = channel_lead_system_prompt("web", "No context.", "midtown", None, false);
     assert!(
         !prompt.contains("## Workflow Facilitation"),
         "No AGENTS.md content should mean no Workflow Facilitation section"
@@ -714,7 +716,7 @@ fn test_channel_lead_system_prompt_without_agents_md() {
 #[test]
 fn test_channel_lead_system_prompt_with_agents_md() {
     let agents = "Use `/study` to begin research.\n\nPhase transitions happen automatically.";
-    let prompt = channel_lead_system_prompt("web", "No context.", "midtown", Some(agents));
+    let prompt = channel_lead_system_prompt("web", "No context.", "midtown", Some(agents), false);
     assert!(
         prompt.contains("## Workflow Facilitation"),
         "AGENTS.md content should add Workflow Facilitation section"
@@ -731,7 +733,7 @@ fn test_channel_lead_system_prompt_with_agents_md() {
 
 #[test]
 fn test_channel_lead_system_prompt_skips_empty_agents_md() {
-    let prompt = channel_lead_system_prompt("web", "No context.", "midtown", Some("  \n  "));
+    let prompt = channel_lead_system_prompt("web", "No context.", "midtown", Some("  \n  "), false);
     assert!(
         !prompt.contains("## Workflow Facilitation"),
         "Empty AGENTS.md content should not add a section"
@@ -744,11 +746,37 @@ fn test_channel_lead_system_prompt_preserves_literal_placeholders_in_injected_co
     // documentation showing template syntax). These must NOT be rewritten by template
     // substitution.
     let agents = "Use {name} as the template variable in your config.";
-    let prompt = channel_lead_system_prompt("web", "No context.", "midtown", Some(agents));
+    let prompt = channel_lead_system_prompt("web", "No context.", "midtown", Some(agents), false);
 
     assert!(
         prompt.contains("Use {name} as the template variable"),
         "Literal {{name}} in AGENTS.md should be preserved, got: {}",
         prompt
+    );
+}
+
+#[test]
+fn test_channel_lead_system_prompt_suppress_auto_output() {
+    let prompt = channel_lead_system_prompt("web", "No context.", "midtown", None, true);
+    assert!(
+        prompt.contains("Channel Auto-Posting Override"),
+        "Should contain override section when suppress_auto_output is true"
+    );
+    assert!(
+        prompt.contains("NOT** automatically posted"),
+        "Should tell the lead that auto-posting is disabled"
+    );
+    assert!(
+        prompt.contains("midtown channel post"),
+        "Should instruct to use midtown channel post"
+    );
+}
+
+#[test]
+fn test_channel_lead_system_prompt_no_suppress_auto_output() {
+    let prompt = channel_lead_system_prompt("web", "No context.", "midtown", None, false);
+    assert!(
+        !prompt.contains("Channel Auto-Posting Override"),
+        "Should NOT contain override section when suppress_auto_output is false"
     );
 }

--- a/src/agents_three_layer_tests.rs
+++ b/src/agents_three_layer_tests.rs
@@ -454,7 +454,8 @@ fn test_assembled_lead_prompt_has_all_layers() {
 
 #[test]
 fn test_assembled_channel_lead_prompt_has_all_layers() {
-    let prompt = channel_lead_system_prompt("web-interface", "Active tasks.", "midtown", None);
+    let prompt =
+        channel_lead_system_prompt("web-interface", "Active tasks.", "midtown", None, false);
     // Layer 1: Channel lead definition
     assert!(
         prompt.contains("Channel Lead") || prompt.contains("channel lead"),
@@ -473,5 +474,44 @@ fn test_assembled_channel_lead_prompt_has_all_layers() {
     assert!(
         !prompt.contains("{channel_name}"),
         "Assembled channel lead prompt should have no unreplaced {{channel_name}}"
+    );
+}
+
+#[test]
+fn test_layer3_suppress_auto_output_injects_override() {
+    let input = "Base prompt with auto-posting info";
+    let result = build_runtime_context(
+        input,
+        &RuntimeContext {
+            name: "web",
+            project_name: "midtown",
+            suppress_auto_output: true,
+            ..RuntimeContext::default()
+        },
+    );
+    assert!(
+        result.contains("Channel Auto-Posting Override"),
+        "Should inject auto-posting override section"
+    );
+    assert!(
+        result.contains("NOT** automatically posted"),
+        "Should tell the lead that auto-posting is disabled"
+    );
+}
+
+#[test]
+fn test_layer3_no_suppress_auto_output_by_default() {
+    let input = "Base prompt";
+    let result = build_runtime_context(
+        input,
+        &RuntimeContext {
+            name: "web",
+            project_name: "midtown",
+            ..RuntimeContext::default()
+        },
+    );
+    assert!(
+        !result.contains("Channel Auto-Posting Override"),
+        "Should NOT inject auto-posting override by default"
     );
 }

--- a/src/bin/midtown/cli/agent.rs
+++ b/src/bin/midtown/cli/agent.rs
@@ -842,6 +842,7 @@ pub(crate) fn build_attach_launch_spec(
             "",
             &repo_name,
             None,
+            false,
         ),
         _ => midtown::agents::coworker_system_prompt(name, &repo_name, None),
     };

--- a/src/bin/midtown/cli/agent_tests.rs
+++ b/src/bin/midtown/cli/agent_tests.rs
@@ -166,6 +166,7 @@ fn test_to_cli_args_resume_includes_all_flags() {
         persisted_initial_prompt: None,
         cwd_subdir: None,
         system_prompt_extra: None,
+        suppress_auto_output: false,
     };
 
     let settings = std::env::temp_dir().join("test-cli-args-settings.json");
@@ -219,6 +220,7 @@ fn test_to_cli_args_fresh_generates_session_id() {
         persisted_initial_prompt: None,
         cwd_subdir: None,
         system_prompt_extra: None,
+        suppress_auto_output: false,
     };
 
     let settings = std::env::temp_dir().join("test-cli-args-settings2.json");
@@ -261,6 +263,7 @@ fn test_to_cli_args_coworker_restricts_settings() {
         persisted_initial_prompt: None,
         cwd_subdir: None,
         system_prompt_extra: None,
+        suppress_auto_output: false,
     };
 
     let settings = std::env::temp_dir().join("test-settings.json");
@@ -386,6 +389,7 @@ fn test_to_cli_args_includes_model_flag() {
         persisted_initial_prompt: None,
         cwd_subdir: None,
         system_prompt_extra: None,
+        suppress_auto_output: false,
     };
 
     let settings = std::env::temp_dir().join("test-model-settings.json");
@@ -426,6 +430,7 @@ fn test_to_cli_args_coworker_gets_sonnet_model() {
         persisted_initial_prompt: None,
         cwd_subdir: None,
         system_prompt_extra: None,
+        suppress_auto_output: false,
     };
 
     let settings = std::env::temp_dir().join("test-model-settings2.json");

--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -2545,14 +2545,18 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                             );
                         }
                     }
-                    let (wf_name, wf_state_summary) = {
+                    let (wf_name, wf_state_summary, suppress_auto_output) = {
                         let ps = state.persistent_state.lock().await;
                         let wf = ps.channel_workflows.get(&name).cloned();
                         let wfs = ps
                             .workflow_state
                             .get(&name)
                             .map(format_workflow_state_summary);
-                        (wf, wfs)
+                        let suppress = ps
+                            .channel_settings
+                            .get(&name)
+                            .is_some_and(|s| !s.show_full_lead_output);
+                        (wf, wfs, suppress)
                     };
                     let (domain_context, agents_md) = load_channel_lead_context(
                         base_dir.clone(),
@@ -2573,6 +2577,7 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                     );
                     config.cwd_subdir =
                         crate::paths::read_channel_directory(state.paths.dir_key(), &name);
+                    config.suppress_auto_output = suppress_auto_output;
                     match state.spawn_coworker(&config).await {
                         Ok(session_id) => {
                             info!(
@@ -2935,14 +2940,18 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 let base_dir = state.paths.base_dir().to_path_buf();
                 let project_root = state.all_repo_paths.first().cloned().unwrap_or_default();
                 let dir_key = state.paths.dir_key().to_string();
-                let (wf_name, wf_state_summary) = {
+                let (wf_name, wf_state_summary, suppress_auto_output) = {
                     let ps = state.persistent_state.lock().await;
                     let wf = ps.channel_workflows.get(&channel_name).cloned();
                     let wfs = ps
                         .workflow_state
                         .get(&channel_name)
                         .map(format_workflow_state_summary);
-                    (wf, wfs)
+                    let suppress = ps
+                        .channel_settings
+                        .get(&channel_name)
+                        .is_some_and(|s| !s.show_full_lead_output);
+                    (wf, wfs, suppress)
                 };
                 let channel_directory =
                     crate::paths::read_channel_directory(state.paths.dir_key(), &channel_name);
@@ -2970,6 +2979,7 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                     &config.agent_type,
                 );
                 config.cwd_subdir = channel_directory;
+                config.suppress_auto_output = suppress_auto_output;
 
                 let name = config.name.clone();
                 match state.spawn_coworker(&config).await {

--- a/src/daemon/events_tests.rs
+++ b/src/daemon/events_tests.rs
@@ -19,6 +19,7 @@ fn make_spawn(name: &str) -> Effect {
         persisted_initial_prompt: None,
         cwd_subdir: None,
         system_prompt_extra: None,
+        suppress_auto_output: false,
     })
 }
 
@@ -93,6 +94,7 @@ fn make_spawn_with_callbacks(name: &str) -> Effect {
         persisted_initial_prompt: None,
         cwd_subdir: None,
         system_prompt_extra: None,
+        suppress_auto_output: false,
     };
     Effect::SpawnCoworkerWithCallbacks {
         config,
@@ -119,6 +121,7 @@ fn make_spawn_for_task(name: &str, task_id: &str) -> Effect {
         persisted_initial_prompt: None,
         cwd_subdir: None,
         system_prompt_extra: None,
+        suppress_auto_output: false,
     };
     Effect::SpawnForTask {
         task_id: task_id.to_string(),
@@ -303,6 +306,7 @@ fn dedup_prevents_double_spawn_for_same_task_across_variants() {
         persisted_initial_prompt: None,
         cwd_subdir: None,
         system_prompt_extra: None,
+        suppress_auto_output: false,
     };
     let spawn_with_callbacks = Effect::SpawnCoworkerWithCallbacks {
         config: config_york,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3823,11 +3823,19 @@ pub async fn run(config: DaemonConfig) -> crate::Result<DaemonExitStatus> {
                         .filter(|s| s.is_fork_session() && s.channel.is_some())
                         .map(|s| (s.name.clone(), s.channel.clone().unwrap()))
                         .collect();
+                    // Collect channels where show_full_lead_output is disabled.
+                    let suppress_auto_output_channels: HashSet<String> = ps
+                        .channel_settings
+                        .iter()
+                        .filter(|(_, s)| !s.show_full_lead_output)
+                        .map(|(name, _)| name.clone())
+                        .collect();
                     let lead_effects = stream::process_lead_output(
                         &events,
                         &ps.channel_lead_sessions,
                         &state.project_name,
                         &fork_bound_channels,
+                        &suppress_auto_output_channels,
                     );
 
                     // Only agents without a native home channel get DM mirrors.

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -225,6 +225,7 @@ async fn handle_request(line: &str, state: &DaemonState) -> Response {
             | "coworker.list"
             | "coworker.questions"
             | "channel.list"
+            | "channel.get_settings"
             | "reminder.list"
             | "workflow.list"
             | "session.list"
@@ -522,6 +523,25 @@ async fn dispatch_request(request: Request, state: &DaemonState) -> Response {
             let old = require_str!(params, "old", request.id);
             let new = require_str!(params, "new", request.id);
             super::rpc_channel::handle_channel_rename(request.id, old, new, state).await
+        }
+
+        "channel.get_settings" => {
+            let channel = require_str!(params, "channel", request.id);
+            super::rpc_channel::handle_channel_get_settings(request.id, channel, state).await
+        }
+
+        "channel.set_settings" => {
+            let channel = require_str!(params, "channel", request.id);
+            let show_full_lead_output = params
+                .and_then(|p| p.get("show_full_lead_output"))
+                .and_then(|v| v.as_bool());
+            super::rpc_channel::handle_channel_set_settings(
+                request.id,
+                channel,
+                show_full_lead_output,
+                state,
+            )
+            .await
         }
 
         // ---- Tasks ----

--- a/src/daemon/rpc_channel.rs
+++ b/src/daemon/rpc_channel.rs
@@ -1322,6 +1322,77 @@ pub(crate) fn build_topic_thread_nudge_effect(
     }
 }
 
+// ============================================================================
+// Channel settings
+// ============================================================================
+
+/// Handle `channel.get_settings` RPC method.
+///
+/// Params:
+/// - `channel` (required): channel name
+///
+/// Returns the channel's settings, or defaults if none are stored.
+pub(super) async fn handle_channel_get_settings(
+    id: RequestId,
+    channel: &str,
+    state: &DaemonState,
+) -> Response {
+    let ps = state.persistent_state.lock().await;
+    let settings = ps
+        .channel_settings
+        .get(channel)
+        .cloned()
+        .unwrap_or_default();
+
+    Response::success(
+        id,
+        serde_json::json!({
+            "show_full_lead_output": settings.show_full_lead_output,
+        }),
+    )
+}
+
+/// Handle `channel.set_settings` RPC method.
+///
+/// Params:
+/// - `channel` (required): channel name
+/// - `show_full_lead_output` (optional): boolean
+///
+/// Only updates fields that are present in the request.
+pub(super) async fn handle_channel_set_settings(
+    id: RequestId,
+    channel: &str,
+    show_full_lead_output: Option<bool>,
+    state: &DaemonState,
+) -> Response {
+    let mut ps = state.persistent_state.lock().await;
+
+    let settings = ps.channel_settings.entry(channel.to_string()).or_default();
+
+    if let Some(v) = show_full_lead_output {
+        settings.show_full_lead_output = v;
+    }
+
+    if let Err(e) = ps.save_for_repo(state.paths.dir_key()) {
+        error!(
+            channel = %channel,
+            "channel.set_settings: failed to save daemon state: {}",
+            e
+        );
+        return Response::error(
+            id,
+            RpcError::new(-32603, format!("failed to persist state: {e}")),
+        );
+    }
+
+    debug!(
+        channel = %channel,
+        "channel.set_settings: settings updated"
+    );
+
+    Response::success(id, serde_json::json!({ "ok": true }))
+}
+
 #[path = "rpc_channel_tests.rs"]
 #[cfg(test)]
 mod tests;

--- a/src/daemon/state.rs
+++ b/src/daemon/state.rs
@@ -162,6 +162,31 @@ impl SessionRecord {
     }
 }
 
+/// Per-channel settings that control daemon behavior for a specific channel.
+///
+/// Persisted in `DaemonPersistentState::channel_settings` and modifiable
+/// via the `channel.get_settings` / `channel.set_settings` RPC methods.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChannelSettings {
+    /// When `false`, the daemon suppresses auto-posting of lead output to the
+    /// channel. The lead must use `midtown channel post` explicitly. Forks are
+    /// exempt — they always auto-post to their bound thread. Default: `true`.
+    #[serde(default = "default_true")]
+    pub show_full_lead_output: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for ChannelSettings {
+    fn default() -> Self {
+        Self {
+            show_full_lead_output: true,
+        }
+    }
+}
+
 /// All persistent daemon state in one struct.
 ///
 /// Serialized to `~/.midtown/projects/<repo>/daemon-state.json`.
@@ -224,6 +249,13 @@ pub struct DaemonPersistentState {
     /// built-in state machine (auto-dispatch, reviewer spawning, PR nudges).
     #[serde(default)]
     pub lead_driven_channels: HashSet<String>,
+
+    /// Per-channel settings controlling daemon behavior.
+    ///
+    /// Maps channel name → `ChannelSettings`. Channels without an entry use
+    /// the default settings (all features enabled).
+    #[serde(default)]
+    pub channel_settings: HashMap<String, ChannelSettings>,
 
     /// Workflow state, owned by the daemon.
     ///

--- a/src/daemon/state_tests.rs
+++ b/src/daemon/state_tests.rs
@@ -1298,3 +1298,50 @@ fn test_session_by_thread_returns_none_for_empty_sessions() {
     let ps = DaemonPersistentState::default();
     assert!(ps.session_by_thread("thread-abc").is_none());
 }
+
+// ── ChannelSettings tests ──────────────────────────────────────────
+
+#[test]
+fn test_channel_settings_default() {
+    let settings = ChannelSettings::default();
+    assert!(settings.show_full_lead_output);
+}
+
+#[test]
+fn test_channel_settings_serde_roundtrip() {
+    let mut ps = DaemonPersistentState::default();
+    ps.channel_settings.insert(
+        "web".to_string(),
+        ChannelSettings {
+            show_full_lead_output: false,
+        },
+    );
+
+    let json = serde_json::to_string(&ps).unwrap();
+    let ps2: DaemonPersistentState = serde_json::from_str(&json).unwrap();
+    let settings = ps2.channel_settings.get("web").unwrap();
+    assert!(!settings.show_full_lead_output);
+}
+
+#[test]
+fn test_channel_settings_absent_defaults_to_true() {
+    // Simulate an old daemon-state.json without channel_settings
+    let json = r#"{"github":{},"reminders":{}}"#;
+    let ps: DaemonPersistentState = serde_json::from_str(json).unwrap();
+    assert!(ps.channel_settings.is_empty());
+    // Accessing a missing channel should give defaults
+    let settings = ps.channel_settings.get("web").cloned().unwrap_or_default();
+    assert!(settings.show_full_lead_output);
+}
+
+#[test]
+fn test_channel_settings_missing_field_defaults_to_true() {
+    // Channel settings present but show_full_lead_output field missing
+    let json = r#"{"channel_settings":{"web":{}}}"#;
+    let ps: DaemonPersistentState = serde_json::from_str(json).unwrap();
+    let settings = ps.channel_settings.get("web").unwrap();
+    assert!(
+        settings.show_full_lead_output,
+        "Missing show_full_lead_output should default to true"
+    );
+}

--- a/src/daemon/stream.rs
+++ b/src/daemon/stream.rs
@@ -107,16 +107,24 @@ pub fn extract_assistant_text(events: &[StreamEvent]) -> String {
 /// - Coworker text is handled separately by [`process_agent_output()`].
 ///
 /// `channel_lead_sessions` maps channel name → session ID for active channel leads.
+///
+/// `suppress_auto_output_channels` is the set of channel names where
+/// `show_full_lead_output` is `false`. Lead auto-output for those channels is
+/// suppressed; fork auto-output is exempt and always posted.
 pub fn process_lead_output(
     events: &HashMap<String, Vec<StreamEvent>>,
     channel_lead_sessions: &HashMap<String, String>,
     main_lead_session_name: &str,
     fork_bound_channels: &HashMap<String, String>,
+    suppress_auto_output_channels: &HashSet<String>,
 ) -> Vec<Effect> {
     let mut effects = Vec::new();
 
     // Main lead → posts to main channel (project name = default channel name).
-    if let Some(lead_events) = events.get(main_lead_session_name) {
+    if let Some(lead_events) = events
+        .get(main_lead_session_name)
+        .filter(|_| !suppress_auto_output_channels.contains(main_lead_session_name))
+    {
         push_lead_output_effects(
             &mut effects,
             lead_events,
@@ -127,6 +135,9 @@ pub fn process_lead_output(
 
     // Channel leads → each posts to its respective topic channel.
     for channel_name in channel_lead_sessions.keys() {
+        if suppress_auto_output_channels.contains(channel_name) {
+            continue;
+        }
         if let Some(cl_events) = events.get(channel_name.as_str()) {
             push_lead_output_effects(
                 &mut effects,
@@ -138,6 +149,7 @@ pub fn process_lead_output(
     }
 
     // Forked channel leads → posts to the channel they were inherited from.
+    // Forks are exempt from suppression — they always auto-post to their bound thread.
     for (fork_name, channel_name) in fork_bound_channels {
         if let Some(fork_events) = events.get(fork_name.as_str()) {
             push_lead_output_effects(

--- a/src/daemon/stream_tests.rs
+++ b/src/daemon/stream_tests.rs
@@ -308,7 +308,13 @@ fn test_extract_assistant_text_codex_bare_result_no_deltas_ignored() {
 #[test]
 fn test_process_lead_output_no_events() {
     let events = HashMap::new();
-    let effects = process_lead_output(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert!(effects.is_empty());
 }
 
@@ -316,7 +322,13 @@ fn test_process_lead_output_no_events() {
 fn test_process_lead_output_no_lead_events() {
     let mut events = HashMap::new();
     events.insert("coworker".to_string(), vec![]);
-    let effects = process_lead_output(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert!(effects.is_empty());
 }
 
@@ -335,7 +347,13 @@ fn test_process_lead_output_returns_post_effect() {
         }],
     );
 
-    let effects = process_lead_output(&events, &HashMap::new(), "myproject", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "myproject",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert_eq!(effects.len(), 1);
 
     match &effects[0] {
@@ -378,7 +396,13 @@ fn test_process_lead_output_aggregates_multiple_events() {
         ],
     );
 
-    let effects = process_lead_output(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert_eq!(effects.len(), 1);
 
     match &effects[0] {
@@ -403,7 +427,13 @@ fn test_process_lead_output_empty_text_posts_tool_data_only() {
         }],
     );
 
-    let effects = process_lead_output(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert_eq!(effects.len(), 1, "Should post tool_data even without text");
     match &effects[0] {
         Effect::PostToChannel {
@@ -436,7 +466,13 @@ fn test_process_lead_output_main_lead_sets_channel_to_project_name() {
         }],
     );
 
-    let effects = process_lead_output(&events, &HashMap::new(), "myproject", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "myproject",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert_eq!(effects.len(), 1);
 
     match &effects[0] {
@@ -480,7 +516,13 @@ fn test_process_lead_output_main_lead_tool_data_sets_channel() {
         }],
     );
 
-    let effects = process_lead_output(&events, &HashMap::new(), "myproject", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "myproject",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert_eq!(effects.len(), 1);
     match &effects[0] {
         Effect::PostToChannel { channel, .. } => {
@@ -510,7 +552,13 @@ fn test_process_lead_output_trims_leading_newlines() {
         }],
     );
 
-    let effects = process_lead_output(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert_eq!(effects.len(), 1);
     match &effects[0] {
         Effect::PostToChannel { message, .. } => {
@@ -534,7 +582,13 @@ fn test_process_lead_output_trims_trailing_newlines() {
         }],
     );
 
-    let effects = process_lead_output(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert_eq!(effects.len(), 1);
     match &effects[0] {
         Effect::PostToChannel { message, .. } => {
@@ -558,7 +612,13 @@ fn test_process_lead_output_whitespace_only_not_posted() {
         }],
     );
 
-    let effects = process_lead_output(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert!(
         effects.is_empty(),
         "Should not post a message that is only whitespace after trimming"
@@ -583,7 +643,13 @@ fn test_process_lead_output_channel_lead_text_posted_to_channel() {
     let mut channel_leads = HashMap::new();
     channel_leads.insert("web".to_string(), "some-session-id".to_string());
 
-    let effects = process_lead_output(&events, &channel_leads, "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &channel_leads,
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert_eq!(effects.len(), 1);
     match &effects[0] {
         Effect::PostToChannel {
@@ -618,7 +684,13 @@ fn test_process_lead_output_channel_lead_empty_text_posts_tool_data() {
     let mut channel_leads = HashMap::new();
     channel_leads.insert("web".to_string(), "some-session-id".to_string());
 
-    let effects = process_lead_output(&events, &channel_leads, "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &channel_leads,
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert_eq!(effects.len(), 1, "Should post tool_data even without text");
     match &effects[0] {
         Effect::PostToChannel {
@@ -663,7 +735,13 @@ fn test_process_lead_output_main_and_channel_lead_both_post() {
     let mut channel_leads = HashMap::new();
     channel_leads.insert("features".to_string(), "cl-session-id".to_string());
 
-    let effects = process_lead_output(&events, &channel_leads, "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &channel_leads,
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert_eq!(effects.len(), 2);
 
     let main_effect = effects
@@ -702,7 +780,13 @@ fn test_process_lead_output_coworker_not_treated_as_channel_lead() {
         }],
     );
     // No channel leads registered
-    let effects = process_lead_output(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert!(
         effects.is_empty(),
         "Coworker text should not be posted to channel"
@@ -716,7 +800,13 @@ fn test_process_lead_output_channel_lead_no_events_in_drain() {
     let mut channel_leads = HashMap::new();
     channel_leads.insert("web".to_string(), "some-session-id".to_string());
 
-    let effects = process_lead_output(&events, &channel_leads, "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &channel_leads,
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert!(
         effects.is_empty(),
         "Should not post when channel lead has no events in current drain"
@@ -739,7 +829,13 @@ fn test_process_lead_output_forked_session_is_inherited_to_channel() {
     let mut fork_bound_channels = HashMap::new();
     fork_bound_channels.insert("fork-1234".to_string(), "topic-omega".to_string());
 
-    let effects = process_lead_output(&events, &HashMap::new(), "lead", &fork_bound_channels);
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &fork_bound_channels,
+        &HashSet::new(),
+    );
     let fork_effect = effects
         .iter()
         .find(|e| matches!(e, Effect::PostToChannel { sender, .. } if sender == "fork-1234"));
@@ -780,7 +876,13 @@ fn test_process_lead_output_tool_data_populated_for_main_lead() {
         }],
     );
 
-    let effects = process_lead_output(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     // Should have exactly 1 effect — the tool_data message (no text).
     assert_eq!(effects.len(), 1);
     match &effects[0] {
@@ -825,7 +927,13 @@ fn test_process_lead_output_tool_data_and_text_produce_separate_effects() {
         }],
     );
 
-    let effects = process_lead_output(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert_eq!(
         effects.len(),
         2,
@@ -878,7 +986,13 @@ fn test_process_lead_output_tool_data_for_channel_lead() {
     let mut channel_leads = HashMap::new();
     channel_leads.insert("web".to_string(), "some-session-id".to_string());
 
-    let effects = process_lead_output(&events, &channel_leads, "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &channel_leads,
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert_eq!(effects.len(), 1);
     match &effects[0] {
         Effect::PostToChannel {
@@ -920,7 +1034,13 @@ fn test_process_lead_output_tool_data_for_fork_session() {
     let mut fork_bound_channels = HashMap::new();
     fork_bound_channels.insert("fork-1234".to_string(), "topic-omega".to_string());
 
-    let effects = process_lead_output(&events, &HashMap::new(), "lead", &fork_bound_channels);
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &fork_bound_channels,
+        &HashSet::new(),
+    );
     assert_eq!(effects.len(), 1);
     match &effects[0] {
         Effect::PostToChannel {
@@ -964,7 +1084,13 @@ fn test_process_lead_output_batch_boundary_tool_use_without_result() {
         }],
     );
 
-    let effects = process_lead_output(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert_eq!(effects.len(), 1);
     match &effects[0] {
         Effect::PostToChannel { tool_data, .. } => {
@@ -1012,7 +1138,13 @@ fn test_process_lead_output_tool_data_with_result_in_same_batch() {
         ],
     );
 
-    let effects = process_lead_output(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert_eq!(effects.len(), 1);
     match &effects[0] {
         Effect::PostToChannel { tool_data, .. } => {
@@ -1045,7 +1177,13 @@ fn test_process_lead_output_multiple_tool_calls_in_summary() {
         }],
     );
 
-    let effects = process_lead_output(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert_eq!(effects.len(), 1);
     match &effects[0] {
         Effect::PostToChannel {
@@ -1073,7 +1211,13 @@ fn test_process_lead_output_text_only_has_no_tool_data() {
         }],
     );
 
-    let effects = process_lead_output(&events, &HashMap::new(), "lead", &HashMap::new());
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &HashMap::new(),
+        &HashSet::new(),
+    );
     assert_eq!(effects.len(), 1);
     match &effects[0] {
         Effect::PostToChannel {
@@ -1083,6 +1227,129 @@ fn test_process_lead_output_text_only_has_no_tool_data() {
             assert!(tool_data.is_none(), "text-only should have no tool_data");
         }
         _ => panic!("Expected PostToChannel effect"),
+    }
+}
+
+// ── suppress_auto_output_channels tests ─────────────────────────────
+
+#[test]
+fn test_process_lead_output_suppressed_main_lead() {
+    let mut events = HashMap::new();
+    events.insert(
+        "myproject".to_string(),
+        vec![StreamEvent::Assistant {
+            message: json!({"content": [{"type": "text", "text": "Hello"}]}),
+            session_id: None,
+            extra: json!(null),
+        }],
+    );
+
+    let suppress: HashSet<String> = ["myproject".to_string()].into();
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "myproject",
+        &HashMap::new(),
+        &suppress,
+    );
+    assert!(
+        effects.is_empty(),
+        "Main lead auto-output should be suppressed when channel is in suppress set"
+    );
+}
+
+#[test]
+fn test_process_lead_output_suppressed_channel_lead() {
+    let mut events = HashMap::new();
+    events.insert(
+        "web".to_string(),
+        vec![StreamEvent::Assistant {
+            message: json!({"content": [{"type": "text", "text": "Channel lead output"}]}),
+            session_id: None,
+            extra: json!(null),
+        }],
+    );
+    let mut channel_leads = HashMap::new();
+    channel_leads.insert("web".to_string(), "session-id".to_string());
+
+    let suppress: HashSet<String> = ["web".to_string()].into();
+    let effects = process_lead_output(&events, &channel_leads, "lead", &HashMap::new(), &suppress);
+    assert!(
+        effects.is_empty(),
+        "Channel lead auto-output should be suppressed when channel is in suppress set"
+    );
+}
+
+#[test]
+fn test_process_lead_output_suppressed_does_not_affect_forks() {
+    let mut events = HashMap::new();
+    events.insert(
+        "fork-1234".to_string(),
+        vec![StreamEvent::Assistant {
+            message: json!({"content": [{"type": "text", "text": "Fork output"}]}),
+            session_id: None,
+            extra: json!(null),
+        }],
+    );
+    let mut fork_bound_channels = HashMap::new();
+    fork_bound_channels.insert("fork-1234".to_string(), "web".to_string());
+
+    // Suppress "web" channel, but forks should still post
+    let suppress: HashSet<String> = ["web".to_string()].into();
+    let effects = process_lead_output(
+        &events,
+        &HashMap::new(),
+        "lead",
+        &fork_bound_channels,
+        &suppress,
+    );
+    assert_eq!(effects.len(), 1, "Fork output should NOT be suppressed");
+    match &effects[0] {
+        Effect::PostToChannel {
+            sender, channel, ..
+        } => {
+            assert_eq!(sender, "fork-1234");
+            assert_eq!(channel.as_deref(), Some("web"));
+        }
+        _ => panic!("Expected PostToChannel effect"),
+    }
+}
+
+#[test]
+fn test_process_lead_output_suppressed_only_affects_listed_channels() {
+    let mut events = HashMap::new();
+    events.insert(
+        "web".to_string(),
+        vec![StreamEvent::Assistant {
+            message: json!({"content": [{"type": "text", "text": "Web output"}]}),
+            session_id: None,
+            extra: json!(null),
+        }],
+    );
+    events.insert(
+        "ops".to_string(),
+        vec![StreamEvent::Assistant {
+            message: json!({"content": [{"type": "text", "text": "Ops output"}]}),
+            session_id: None,
+            extra: json!(null),
+        }],
+    );
+    let mut channel_leads = HashMap::new();
+    channel_leads.insert("web".to_string(), "s1".to_string());
+    channel_leads.insert("ops".to_string(), "s2".to_string());
+
+    // Only suppress "web", "ops" should still post
+    let suppress: HashSet<String> = ["web".to_string()].into();
+    let effects = process_lead_output(&events, &channel_leads, "lead", &HashMap::new(), &suppress);
+    assert_eq!(effects.len(), 1);
+    match &effects[0] {
+        Effect::PostToChannel {
+            sender, channel, ..
+        } => {
+            assert_eq!(sender, "ops");
+            assert_eq!(channel.as_deref(), Some("ops"));
+        }
+        _ => panic!("Expected PostToChannel effect for ops"),
     }
 }
 

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -88,6 +88,9 @@ pub struct LaunchConfig {
     /// Extra content appended to the system prompt (e.g., domain context for channel leads).
     /// Injected after the standard system prompt layers during rendering.
     pub system_prompt_extra: Option<String>,
+    /// When `true`, inject a prompt override telling the lead that auto-posting
+    /// is disabled. Only relevant for `midtown-channel-lead` agent types.
+    pub suppress_auto_output: bool,
 }
 
 /// The shell command string and any pre-assigned provider session ID.
@@ -332,6 +335,7 @@ impl LaunchConfig {
             persisted_initial_prompt: None,
             cwd_subdir: None,
             system_prompt_extra,
+            suppress_auto_output: false,
         }
     }
 
@@ -497,6 +501,7 @@ impl LaunchConfig {
                     domain_context,
                     project_name,
                     None,
+                    self.suppress_auto_output,
                 )
             }
             // Fallback: use coworker system prompt for unknown agent types

--- a/src/launch_tests.rs
+++ b/src/launch_tests.rs
@@ -46,6 +46,7 @@ fn test_lead_system_prompt_saved_on_spawn() {
         persisted_initial_prompt: None,
         cwd_subdir: None,
         system_prompt_extra: None,
+        suppress_auto_output: false,
     };
 
     // Convert to headless config (this should save the system prompt)
@@ -315,6 +316,7 @@ fn test_codex_channel_lead_skips_disallowed_tools() {
         persisted_initial_prompt: None,
         cwd_subdir: None,
         system_prompt_extra: None,
+        suppress_auto_output: false,
     };
 
     let headless = config.to_headless_config(&test_paths("myrepo", "myrepo"));
@@ -346,6 +348,7 @@ fn test_claude_channel_lead_still_has_disallowed_tools() {
         persisted_initial_prompt: None,
         cwd_subdir: None,
         system_prompt_extra: None,
+        suppress_auto_output: false,
     };
 
     let headless = config.to_headless_config(&test_paths("myrepo", "myrepo"));

--- a/src/platform_tests.rs
+++ b/src/platform_tests.rs
@@ -467,6 +467,7 @@ fn test_codex_headed_args_has_resume() {
         persisted_initial_prompt: None,
         cwd_subdir: None,
         system_prompt_extra: None,
+        suppress_auto_output: false,
     };
     let (args, session_id) = build_codex_headed_args(&config, "system prompt", None);
     assert_eq!(session_id, None);
@@ -506,6 +507,7 @@ fn test_codex_headed_args_omits_override_when_prompt_empty() {
         persisted_initial_prompt: None,
         cwd_subdir: None,
         system_prompt_extra: None,
+        suppress_auto_output: false,
     };
     let (args, _) = build_codex_headed_args(&config, "", None);
     assert!(args.contains(&"resume".to_string()));
@@ -532,6 +534,7 @@ fn test_codex_headed_args_resume_last_uses_last_without_model_override() {
         persisted_initial_prompt: None,
         cwd_subdir: None,
         system_prompt_extra: None,
+        suppress_auto_output: false,
     };
 
     let (args, session_id) = build_codex_headed_args(&config, "system prompt", None);
@@ -564,6 +567,7 @@ fn test_codex_headed_args_fresh_uses_positional_prompt() {
         persisted_initial_prompt: None,
         cwd_subdir: None,
         system_prompt_extra: None,
+        suppress_auto_output: false,
     };
     let (args, session_id) = build_codex_headed_args(&config, "system prompt", Some("ship it"));
     assert_eq!(session_id, None);

--- a/src/web.rs
+++ b/src/web.rs
@@ -244,6 +244,9 @@ pub enum WebUpdate {
     /// Thread ownership changed (dedicated session created or destroyed)
     #[serde(rename = "thread_ownership")]
     ThreadOwnership(ThreadOwnershipData),
+    /// Channel settings changed
+    #[serde(rename = "channel_settings_changed")]
+    ChannelSettingsChanged(ChannelSettingsChangedData),
 }
 
 /// Thread ownership state sent to web clients when a fork is created/destroyed.
@@ -264,6 +267,16 @@ pub struct ThreadOwnershipData {
     /// of the fork session's own name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_lead: Option<String>,
+}
+
+/// Data for a channel settings change notification.
+#[derive(Debug, Clone, Serialize)]
+pub struct ChannelSettingsChangedData {
+    /// The channel whose settings changed
+    pub channel: String,
+    /// New value of show_full_lead_output, if changed
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub show_full_lead_output: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -481,6 +494,10 @@ pub fn create_web_router(state: Arc<WebState>) -> Router {
         // Legacy route: old channel messages reference [Attached: .../screenshots/<file>]
         // and the frontend rewrites those to /api/screenshots/<file>. Keep serving them.
         .route("/api/screenshots/{filename}", get(api_get_screenshot))
+        .route(
+            "/api/channels/{channel}/settings",
+            get(api_channel_settings_get).put(api_channel_settings_set),
+        )
         .route(
             "/api/channels/{channel}/agents-md",
             get(api_channel_agents_md).put(api_channel_agents_md_update),
@@ -2503,6 +2520,183 @@ async fn api_set_channel_workflow(
         Ok(()) => Ok(Json(serde_json::json!({ "ok": true }))),
         Err(e) => {
             warn!("Failed to set channel workflow: {e}");
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
+}
+
+/// GET /api/channels/{channel}/settings — read channel settings.
+async fn api_channel_settings_get(
+    State(state): State<Arc<WebState>>,
+    Path(channel): Path<String>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if channel.contains("..")
+        || channel.contains('/')
+        || channel.contains('\\')
+        || channel.is_empty()
+    {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let dir_key = state.config.dir_key.clone();
+    let ch = channel.clone();
+
+    let result = tokio::task::spawn_blocking(move || {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixStream;
+
+        let socket = crate::paths::daemon_socket_for_repo(&dir_key);
+        let stream = UnixStream::connect(&socket)
+            .map_err(|e| format!("Failed to connect to daemon: {e}"))?;
+        stream
+            .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+            .ok();
+
+        let mut writer = stream
+            .try_clone()
+            .map_err(|e| format!("Failed to clone stream: {e}"))?;
+        let mut reader = BufReader::new(stream);
+
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "channel.get_settings",
+            "params": { "channel": ch },
+            "id": 1
+        });
+        writeln!(&mut writer, "{}", request).map_err(|e| format!("Failed to send RPC: {e}"))?;
+        writer.flush().ok();
+
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .map_err(|e| format!("Failed to read RPC response: {e}"))?;
+
+        let response: serde_json::Value =
+            serde_json::from_str(&line).map_err(|e| format!("Invalid RPC response: {e}"))?;
+
+        if let Some(err) = response.get("error") {
+            return Err(format!(
+                "RPC error: {}",
+                err.get("message")
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("unknown")
+            ));
+        }
+
+        Ok(response
+            .get("result")
+            .cloned()
+            .unwrap_or(serde_json::json!({})))
+    })
+    .await
+    .map_err(|e| {
+        warn!("spawn_blocking panic in channel_settings_get: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    match result {
+        Ok(settings) => Ok(Json(settings)),
+        Err(e) => {
+            warn!("Failed to get channel settings: {e}");
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
+}
+
+/// PUT /api/channels/{channel}/settings — update channel settings.
+async fn api_channel_settings_set(
+    State(state): State<Arc<WebState>>,
+    Path(channel): Path<String>,
+    Json(body): Json<serde_json::Value>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if channel.contains("..")
+        || channel.contains('/')
+        || channel.contains('\\')
+        || channel.is_empty()
+    {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let show_full_lead_output = body.get("show_full_lead_output").and_then(|v| v.as_bool());
+
+    if show_full_lead_output.is_none() {
+        return Ok(Json(serde_json::json!({ "ok": true })));
+    }
+
+    let dir_key = state.config.dir_key.clone();
+    let ch = channel.clone();
+    let updates_tx = state.updates_tx.clone();
+
+    let mut rpc_params = serde_json::json!({ "channel": ch });
+    if let Some(v) = show_full_lead_output {
+        rpc_params["show_full_lead_output"] = serde_json::json!(v);
+    }
+
+    let result = tokio::task::spawn_blocking(move || {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixStream;
+
+        let socket = crate::paths::daemon_socket_for_repo(&dir_key);
+        let stream = UnixStream::connect(&socket)
+            .map_err(|e| format!("Failed to connect to daemon: {e}"))?;
+        stream
+            .set_write_timeout(Some(std::time::Duration::from_secs(5)))
+            .ok();
+        stream
+            .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+            .ok();
+
+        let mut writer = stream
+            .try_clone()
+            .map_err(|e| format!("Failed to clone stream: {e}"))?;
+        let mut reader = BufReader::new(stream);
+
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "channel.set_settings",
+            "params": rpc_params,
+            "id": 1
+        });
+        writeln!(&mut writer, "{}", request).map_err(|e| format!("Failed to send RPC: {e}"))?;
+        writer.flush().ok();
+
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .map_err(|e| format!("Failed to read RPC response: {e}"))?;
+
+        let response: serde_json::Value =
+            serde_json::from_str(&line).map_err(|e| format!("Invalid RPC response: {e}"))?;
+
+        if let Some(err) = response.get("error") {
+            return Err(format!(
+                "RPC error: {}",
+                err.get("message")
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("unknown")
+            ));
+        }
+
+        Ok(())
+    })
+    .await
+    .map_err(|e| {
+        warn!("spawn_blocking panic in channel_settings_set: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    match result {
+        Ok(()) => {
+            let _ = updates_tx.send(WebUpdate::ChannelSettingsChanged(
+                ChannelSettingsChangedData {
+                    channel,
+                    show_full_lead_output,
+                },
+            ));
+            Ok(Json(serde_json::json!({ "ok": true })))
+        }
+        Err(e) => {
+            warn!("Failed to set channel settings: {e}");
             Err(StatusCode::INTERNAL_SERVER_ERROR)
         }
     }


### PR DESCRIPTION
<!-- midtown session:64e36f4a-2818-4606-a969-e5a4cd3c564f -->

## Summary

- Add per-channel `showFullLeadOutput` setting (default: true) that controls whether lead auto-output is posted to the channel
- When OFF: lead prompt is injected with override telling it to use `midtown channel post` explicitly; stream processing suppresses auto-posted lead output; forks are exempt and always auto-post to their bound thread
- API: `GET/PUT /api/channels/{channel}/settings` endpoints with WebSocket broadcast on change
- Removes the frontend-only ChannelSettings component (was premature — now the daemon owns the setting)

## Implementation

1. **State** (`state.rs`): `ChannelSettings` struct with `show_full_lead_output: bool`, stored in `DaemonPersistentState::channel_settings` HashMap
2. **RPC** (`rpc_channel.rs`): `channel.get_settings` / `channel.set_settings` handlers
3. **Web API** (`web.rs`): HTTP endpoints + `ChannelSettingsChanged` WebSocket event
4. **Stream filtering** (`stream.rs`): `suppress_auto_output_channels` HashSet passed to `process_lead_output()`, skips auto-post for suppressed channels, forks exempt
5. **Prompt injection** (`agents.rs`): Layer 3 runtime context appends "Channel Auto-Posting Override" section when `suppress_auto_output = true`
6. **Launch** (`effects.rs`, `launch.rs`): Channel setting checked at spawn time, passed through to prompt builder

## Test plan

- [x] `state_tests.rs`: serialization, defaults, roundtrip for ChannelSettings
- [x] `stream_tests.rs`: suppression for main lead, channel leads, fork exemption
- [x] `agents_tests.rs` + `agents_three_layer_tests.rs`: prompt injection with/without suppression
- [x] `cargo clippy -- -D warnings` passes
- [x] Coverage: 100% on pure logic (agents.rs, state.rs, stream.rs, launch.rs); async daemon code (effects.rs, rpc.rs, web.rs) covered by E2E tests
- [ ] Run containerized E2E: `midtown e2e run coordination`

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)