### PR TITLE
feat: use lead session name as task announcement author

### DIFF
--- a/src/bin/midtown/cli/task.rs
+++ b/src/bin/midtown/cli/task.rs
@@ -162,6 +162,7 @@ pub fn handle(cmd: &TaskCommand, client: &DaemonClient) -> Result<Response, Stri
             let env_thread_id = std::env::var("MIDTOWN_BOUND_THREAD_ID").ok();
             let effective_thread_id =
                 derive_thread_id(thread_id.as_deref(), env_thread_id.as_deref());
+            let session_name = std::env::var("MIDTOWN_AGENT").ok();
             client.task_create(
                 subject,
                 description,
@@ -176,6 +177,7 @@ pub fn handle(cmd: &TaskCommand, client: &DaemonClient) -> Result<Response, Stri
                 agent_type.as_deref(),
                 color.as_deref(),
                 icon.as_deref(),
+                session_name.as_deref(),
             )
         }
         TaskCommand::Update {

--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -522,6 +522,7 @@ impl DaemonClient {
         agent_type: Option<&str>,
         color: Option<&str>,
         icon: Option<&str>,
+        session_name: Option<&str>,
     ) -> Result<Response, String> {
         let mut params = serde_json::json!({
             "subject": subject,
@@ -559,6 +560,9 @@ impl DaemonClient {
         }
         if let Some(i) = icon {
             params["icon"] = serde_json::json!(i);
+        }
+        if let Some(sn) = session_name {
+            params["session_name"] = serde_json::json!(sn);
         }
         self.send("task.create", Some(params))
     }

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -559,6 +559,7 @@ async fn dispatch_request(request: Request, state: &DaemonState) -> Response {
             let agent_type = params.str_param("agent_type");
             let color = params.str_param("color");
             let icon = params.str_param("icon");
+            let session_name = params.str_param("session_name");
             super::rpc_task::handle_task_create(
                 request.id,
                 subject,
@@ -574,6 +575,7 @@ async fn dispatch_request(request: Request, state: &DaemonState) -> Response {
                 agent_type,
                 color,
                 icon,
+                session_name,
                 state,
             )
             .await

--- a/src/daemon/rpc_task.rs
+++ b/src/daemon/rpc_task.rs
@@ -169,11 +169,21 @@ fn apply_task_channel_mapping(
 
 /// Determine the `from` author for a "created task:" channel notification.
 ///
-/// Returns "lead" when the task is in the main channel (i.e., `task_channel`
-/// matches `main_channel`), because the project lead owns the main channel.
-/// Returns the channel name for topic channels, because channel leads have the
-/// same session name as their channel (`channel_lead_session_name` is identity).
-pub(crate) fn task_created_message_author(task_channel: &str, main_channel: &str) -> String {
+/// When the caller provides a `session_name` (via the `MIDTOWN_AGENT` env var),
+/// that name is used directly — it reflects the actual lead or fork identity.
+/// Falls back to "lead" for the main channel or the channel name for topic
+/// channels when no caller identity is available (e.g., external CLI callers).
+pub(crate) fn task_created_message_author(
+    task_channel: &str,
+    main_channel: &str,
+    session_name: Option<&str>,
+) -> String {
+    if let Some(name) = session_name
+        && !name.is_empty()
+    {
+        return name.to_string();
+    }
+    // Fallback: derive from channel context
     if task_channel == main_channel {
         "lead".to_string()
     } else {
@@ -293,6 +303,7 @@ pub(super) async fn handle_task_create(
     agent_type: Option<&str>,
     color: Option<&str>,
     icon: Option<&str>,
+    session_name: Option<&str>,
     state: &DaemonState,
 ) -> Response {
     // Require agent_name
@@ -441,7 +452,11 @@ pub(super) async fn handle_task_create(
             .ok()
             .and_then(|t| t.thread_id.clone()),
     };
-    let author = task_created_message_author(effective_channel, state.default_channel_name());
+    let author = task_created_message_author(
+        effective_channel,
+        state.default_channel_name(),
+        session_name,
+    );
     let msg = task_announcement_message(
         effective_channel,
         &author,

--- a/src/daemon/rpc_task_tests.rs
+++ b/src/daemon/rpc_task_tests.rs
@@ -177,58 +177,89 @@ fn test_apply_task_model_mapping_none_on_empty_map() {
 
 // ── task_created_message_author tests ────────────────────────────────────────
 
-/// For the main channel, the task-created message should be attributed to "lead".
+/// When session_name is provided, it is used as the author regardless of channel.
 #[test]
-fn test_task_created_message_author_main_channel() {
-    // When task_channel matches the main channel, "lead" should be the author.
-    let author = task_created_message_author("midtown", "midtown");
+fn test_task_created_message_author_uses_session_name() {
+    let author = task_created_message_author("midtown", "midtown", Some("daemon-core"));
+    assert_eq!(author, "daemon-core");
+}
+
+/// When session_name is provided for a topic channel, it overrides channel name.
+#[test]
+fn test_task_created_message_author_session_name_overrides_channel() {
+    let author = task_created_message_author("notes", "midtown", Some("my-fork-abc"));
+    assert_eq!(author, "my-fork-abc");
+}
+
+/// When session_name is None, fall back to "lead" for the main channel.
+#[test]
+fn test_task_created_message_author_fallback_main_channel() {
+    let author = task_created_message_author("midtown", "midtown", None);
     assert_eq!(author, "lead");
 }
 
-/// For a sub-channel, the task-created message should be attributed to the
-/// channel lead, whose session name equals the channel name.
+/// When session_name is None, fall back to channel name for topic channels.
 #[test]
-fn test_task_created_message_author_sub_channel() {
-    let author = task_created_message_author("notes", "midtown");
+fn test_task_created_message_author_fallback_sub_channel() {
+    let author = task_created_message_author("notes", "midtown", None);
     assert_eq!(author, "notes");
 }
 
-/// For a sub-channel with a hyphenated name.
+/// When session_name is an empty string, fall back to channel-based logic.
+#[test]
+fn test_task_created_message_author_empty_session_name_falls_back() {
+    let author = task_created_message_author("midtown", "midtown", Some(""));
+    assert_eq!(author, "lead");
+
+    let author = task_created_message_author("notes", "midtown", Some(""));
+    assert_eq!(author, "notes");
+}
+
+/// For a sub-channel with a hyphenated name and no session_name.
 #[test]
 fn test_task_created_message_author_hyphenated_sub_channel() {
-    let author = task_created_message_author("web-interface", "myrepo");
+    let author = task_created_message_author("web-interface", "myrepo", None);
     assert_eq!(author, "web-interface");
 }
 
 /// The main_channel comparison must use the channel router's default ("midtown"),
-/// NOT the repo name. In repos whose name differs from "midtown", tasks created
-/// without an explicit channel still land in "midtown" (the hardcoded default),
-/// so comparing against the repo name would incorrectly treat them as topic channels.
+/// NOT the repo name. Falls back correctly when no session_name is provided.
 #[test]
 fn test_task_created_message_author_main_channel_non_midtown_repo() {
-    // Repo named "myrepo", default channel is "midtown" (hardcoded in channel router).
-    // A task with channel="midtown" should be attributed to "lead", not "midtown".
-    let author = task_created_message_author("midtown", "midtown");
+    let author = task_created_message_author("midtown", "midtown", None);
     assert_eq!(author, "lead");
 
-    // Sanity check: "myrepo" as main_channel with task_channel="midtown" would
-    // previously return "midtown" (wrong), but now callers pass the router's
-    // default ("midtown") instead of the repo name.
-    let wrong_author = task_created_message_author("midtown", "myrepo");
-    assert_eq!(wrong_author, "midtown"); // demonstrates the old bug
+    // "myrepo" as main_channel with task_channel="midtown" falls back to channel name
+    let wrong_author = task_created_message_author("midtown", "myrepo", None);
+    assert_eq!(wrong_author, "midtown");
 }
 
 // ── task_created_message routing tests ───────────────────────────────────────
 
-/// For the main channel, the task-created Message should have channel=main
-/// and from="lead".
+/// When session_name is provided, the message author reflects the caller identity.
+#[test]
+fn test_task_created_message_routing_with_session_name() {
+    use crate::message::MessageType;
+
+    let author = task_created_message_author("midtown", "midtown", Some("daemon-core"));
+    let msg = crate::message::Message::for_channel(
+        "midtown",
+        &author,
+        "created task: Fix the bug",
+        MessageType::Text,
+    );
+    assert_eq!(msg.channel_name(), "midtown");
+    assert_eq!(msg.from, "daemon-core", "should use session name as author");
+}
+
+/// For the main channel without session_name, falls back to "lead".
 #[test]
 fn test_task_created_message_main_channel_routing() {
     use crate::message::MessageType;
 
     let msg = crate::message::Message::for_channel(
         "midtown",
-        task_created_message_author("midtown", "midtown"),
+        task_created_message_author("midtown", "midtown", None),
         "created task: Fix the bug",
         MessageType::Text,
     );
@@ -239,26 +270,25 @@ fn test_task_created_message_main_channel_routing() {
     );
     assert_eq!(
         msg.from, "lead",
-        "main channel tasks should be attributed to lead"
+        "main channel tasks should fall back to lead when no session name"
     );
 }
 
-/// For a sub-channel, the task-created Message should route to that channel
-/// and be attributed to the channel lead (whose name equals the channel name).
+/// For a sub-channel without session_name, uses the channel name.
 #[test]
 fn test_task_created_message_sub_channel_routing() {
     use crate::message::MessageType;
 
     let msg = crate::message::Message::for_channel(
         "notes",
-        task_created_message_author("notes", "midtown"),
+        task_created_message_author("notes", "midtown", None),
         "created task: Add wiki page",
         MessageType::Text,
     );
     assert_eq!(msg.channel_name(), "notes", "should route to sub-channel");
     assert_eq!(
         msg.from, "notes",
-        "sub-channel tasks should be attributed to channel lead"
+        "sub-channel tasks should fall back to channel name when no session name"
     );
 }
 


### PR DESCRIPTION
<!-- midtown session:e0cd34b5-1dc9-4990-ae54-1471087734d8 -->

## Summary

- Task announcements now use the caller's actual session name (from `MIDTOWN_AGENT` env var) as the message author, instead of deriving it from channel context
- Adds `session_name` parameter through the CLI → client → RPC → handler chain
- Falls back to previous channel-based logic when `session_name` is not provided (backward compatible)

Resolves !2487

## Test plan

- [x] All 10 `task_created_message_author` tests pass (including new tests for session_name)
- [x] All 46 `rpc_task` tests pass
- [x] Clippy clean, fmt clean
- [ ] Verify end-to-end: fork creates task → announcement shows fork name as author

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)