### PR TITLE
[Midtown !1] Implement channel lead context chain via --add-dir (#2167)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -423,6 +423,57 @@ pub struct ChannelsSection {
     pub seed: Vec<String>,
 }
 
+/// Per-channel override entry supporting both legacy string and new table TOML forms.
+///
+/// Legacy (string value):
+/// ```toml
+/// [channel_leads.overrides]
+/// "my-channel" = "opus"
+/// ```
+///
+/// New (table value with optional context_dirs):
+/// ```toml
+/// [channel_leads.overrides]
+/// "my-channel" = { model = "opus", context_dirs = ["/path/to/CLAUDE.md"] }
+/// ```
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct ChannelLeadOverride {
+    /// Model override for this channel.
+    pub model: Option<String>,
+    /// Additional directories to pass via --add-dir for this channel's lead.
+    pub context_dirs: Option<Vec<std::path::PathBuf>>,
+}
+
+impl<'de> serde::Deserialize<'de> for ChannelLeadOverride {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = ChannelLeadOverride;
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a model string or a table with model and context_dirs")
+            }
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                Ok(ChannelLeadOverride {
+                    model: Some(v.to_string()),
+                    context_dirs: None,
+                })
+            }
+            fn visit_map<M: serde::de::MapAccess<'de>>(self, map: M) -> Result<Self::Value, M::Error> {
+                #[derive(Deserialize)]
+                struct Helper {
+                    #[serde(default)]
+                    model: Option<String>,
+                    #[serde(default)]
+                    context_dirs: Option<Vec<std::path::PathBuf>>,
+                }
+                let h = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+                Ok(ChannelLeadOverride { model: h.model, context_dirs: h.context_dirs })
+            }
+        }
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
 /// Channel lead configuration section.
 ///
 /// Configures per-channel model selection for channel leads.
@@ -443,9 +494,14 @@ pub struct ChannelLeadsConfig {
     #[serde(default)]
     pub default_model: Option<String>,
 
-    /// Per-channel model overrides. Keys are channel names, values are model names.
+    /// Per-channel overrides. Keys are channel names.
+    /// Values are either a model string (legacy) or a table with model/context_dirs.
     #[serde(default)]
-    pub overrides: std::collections::HashMap<String, String>,
+    pub overrides: std::collections::HashMap<String, ChannelLeadOverride>,
+
+    /// Default additional directories to pass via --add-dir for all channel leads.
+    #[serde(default)]
+    pub context_dirs: Option<Vec<std::path::PathBuf>>,
 }
 
 impl ChannelLeadsConfig {
@@ -468,7 +524,7 @@ impl ChannelLeadsConfig {
     ) -> String {
         self.overrides
             .get(channel_name)
-            .cloned()
+            .and_then(|o| o.model.clone())
             .or_else(|| self.default_model.clone())
             .or_else(|| execution_fallback.map(|s| s.as_model_str().to_string()))
             .unwrap_or_else(|| {
@@ -478,6 +534,17 @@ impl ChannelLeadsConfig {
                     "sonnet".to_string()
                 }
             })
+    }
+
+    /// Get the additional context directories for a given channel.
+    ///
+    /// Priority: per-channel override → global context_dirs → empty.
+    pub fn context_dirs_for_channel(&self, channel_name: &str) -> Vec<std::path::PathBuf> {
+        self.overrides
+            .get(channel_name)
+            .and_then(|o| o.context_dirs.clone())
+            .or_else(|| self.context_dirs.clone())
+            .unwrap_or_default()
     }
 }
 
@@ -3060,10 +3127,11 @@ allowed_paths = ["~/.cargo", "~/.rustup", "/opt/toolchain"]
     #[test]
     fn test_channel_leads_ops_override_takes_precedence() {
         let mut overrides = std::collections::HashMap::new();
-        overrides.insert("ops".to_string(), "sonnet".to_string());
+        overrides.insert("ops".to_string(), ChannelLeadOverride { model: Some("sonnet".to_string()), context_dirs: None });
         let config = ChannelLeadsConfig {
             default_model: None,
             overrides,
+            context_dirs: None,
         };
         assert_eq!(config.model_for_channel("ops"), "sonnet");
     }
@@ -3073,6 +3141,7 @@ allowed_paths = ["~/.cargo", "~/.rustup", "/opt/toolchain"]
         let config = ChannelLeadsConfig {
             default_model: Some("opus".to_string()),
             overrides: std::collections::HashMap::new(),
+            context_dirs: None,
         };
         assert_eq!(config.model_for_channel("ops"), "opus");
     }
@@ -3082,6 +3151,7 @@ allowed_paths = ["~/.cargo", "~/.rustup", "/opt/toolchain"]
         let config = ChannelLeadsConfig {
             default_model: Some("opus".to_string()),
             overrides: std::collections::HashMap::new(),
+            context_dirs: None,
         };
         assert_eq!(config.model_for_channel("any-channel"), "opus");
     }
@@ -3089,10 +3159,11 @@ allowed_paths = ["~/.cargo", "~/.rustup", "/opt/toolchain"]
     #[test]
     fn test_channel_leads_per_channel_override() {
         let mut overrides = std::collections::HashMap::new();
-        overrides.insert("daemon-architecture".to_string(), "opus".to_string());
+        overrides.insert("daemon-architecture".to_string(), ChannelLeadOverride { model: Some("opus".to_string()), context_dirs: None });
         let config = ChannelLeadsConfig {
             default_model: Some("sonnet".to_string()),
             overrides,
+            context_dirs: None,
         };
         assert_eq!(config.model_for_channel("daemon-architecture"), "opus");
         assert_eq!(config.model_for_channel("web-interface"), "sonnet");
@@ -3101,10 +3172,11 @@ allowed_paths = ["~/.cargo", "~/.rustup", "/opt/toolchain"]
     #[test]
     fn test_channel_leads_override_takes_precedence_over_default() {
         let mut overrides = std::collections::HashMap::new();
-        overrides.insert("tui".to_string(), "haiku".to_string());
+        overrides.insert("tui".to_string(), ChannelLeadOverride { model: Some("haiku".to_string()), context_dirs: None });
         let config = ChannelLeadsConfig {
             default_model: Some("opus".to_string()),
             overrides,
+            context_dirs: None,
         };
         assert_eq!(config.model_for_channel("tui"), "haiku");
     }

--- a/src/daemon/effects.rs
+++ b/src/daemon/effects.rs
@@ -2592,6 +2592,8 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                     config.cwd_subdir =
                         crate::paths::read_channel_directory(state.paths.dir_key(), &name);
                     config.suppress_auto_output = suppress_auto_output;
+                    config.additional_dirs = crate::config::get_channel_leads_config(state.paths.dir_key())
+                        .context_dirs_for_channel(&name);
                     match state.spawn_coworker(&config).await {
                         Ok(session_id) => {
                             info!(
@@ -2994,6 +2996,8 @@ pub async fn execute_effects(effects: Vec<Effect>, state: &DaemonState) {
                 );
                 config.cwd_subdir = channel_directory;
                 config.suppress_auto_output = suppress_auto_output;
+                config.additional_dirs = crate::config::get_channel_leads_config(state.paths.dir_key())
+                    .context_dirs_for_channel(&channel_name);
 
                 let name = config.name.clone();
                 match state.spawn_coworker(&config).await {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -850,12 +850,16 @@ impl DaemonState {
                 }
             }
 
-            let config = crate::launch::LaunchConfig::channel_lead(
+            let mut config = crate::launch::LaunchConfig::channel_lead(
                 ops_channel,
                 self.paths.dir_key(),
                 session_mode,
                 "",
                 None,
+            );
+            config.additional_dirs.extend(
+                crate::config::get_channel_leads_config(self.paths.dir_key())
+                    .context_dirs_for_channel(ops_channel)
             );
 
             match self.spawn_coworker(&config).await {

--- a/src/daemon/rpc.rs
+++ b/src/daemon/rpc.rs
@@ -1001,6 +1001,7 @@ async fn handle_oneshot_execute(
         env: std::collections::BTreeMap::new(),
         fork_session: false,
         disallowed_tools: vec![],
+        additional_dirs: vec![],
         agent_name: None,
     };
 

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -122,6 +122,9 @@ pub struct HeadlessConfig {
     /// modification tools (Edit, Write, Bash, NotebookEdit).
     #[serde(default)]
     pub disallowed_tools: Vec<String>,
+    /// Additional directories to pass via `--add-dir` for multi-repo context.
+    #[serde(default)]
+    pub additional_dirs: Vec<std::path::PathBuf>,
     /// Agent definition name for `--agent <name>` flag.
     ///
     /// When set, the CLI arg builder emits `--agent <name>` for both fresh and
@@ -1200,6 +1203,7 @@ fn codex_launch_plan_from_config(config: &HeadlessConfig) -> Result<CodexLaunchP
         env: _env,
         fork_session,
         disallowed_tools,
+        additional_dirs: _additional_dirs,
         agent_name: _agent_name,
     } = config;
 

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -741,6 +741,7 @@ impl LaunchConfig {
             env,
             fork_session: false,
             disallowed_tools,
+            additional_dirs: self.additional_dirs.clone(),
             agent_name,
         }
     }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -148,6 +148,7 @@ pub fn build_claude_headless_args(config: &HeadlessConfig) -> Vec<String> {
         env: _env,
         fork_session,
         disallowed_tools,
+        additional_dirs,
         agent_name,
     } = config;
 
@@ -156,7 +157,7 @@ pub fn build_claude_headless_args(config: &HeadlessConfig) -> Vec<String> {
 
     let mut args = build_claude_common_args(
         model,
-        &[], // headless sessions don't use additional_dirs
+        additional_dirs,
     );
 
     // Setting sources — skip for legacy fork-resume sessions because


### PR DESCRIPTION
<!-- midtown session:49d6f81d-0688-4f52-84c5-2159e5658ab9 -->

## Summary

- Adds `ChannelLeadOverride` struct supporting both legacy string and new table TOML for `[channel_leads.overrides]`
- Adds `context_dirs` field to `ChannelLeadsConfig` (global default) and per-channel override
- Passes `--add-dir` args to channel lead sessions via `HeadlessConfig.additional_dirs`

Closes #2167

## Test plan

- [ ] Legacy TOML (`"channel" = "model"`) still works (backward compatible via custom Deserialize)
- [ ] New TOML (`"channel" = { model = "opus", context_dirs = [...] }`) sets both model and dirs
- [ ] Global `context_dirs` applies to all channels when no per-channel override
- [ ] Per-channel `context_dirs` takes priority over global
- [ ] `cargo build` passes with no warnings on changed files

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)