### PR TITLE
feat: unread indicators in TUI channel list (bold + dot)

### DIFF
--- a/src/bin/midtown/cli/chat/ui/board.rs
+++ b/src/bin/midtown/cli/chat/ui/board.rs
@@ -310,14 +310,14 @@ pub fn draw_board_panel(f: &mut Frame, app: &mut App, area: Rect) -> (Vec<Hyperl
     (hyperlinks, tasks_area)
 }
 
-/// Render a channel header line: `#channel-name` or `@peer` (for DMs) with optional `(X)` unread count.
+/// Render a channel header line: `#channel-name` or `@peer` (for DMs).
+/// Channels with unread messages are prefixed with a dot (●) and rendered bold.
 fn render_channel_header(app: &App, channel_name: &str, lines: &mut Vec<Line<'static>>) {
     let display_name = super::format_channel_display_name(channel_name);
-    let channel_header = if let Some(&unread_count) = app.channel_unread_counts.get(channel_name) {
-        format!("{} ({})", display_name, unread_count)
-    } else {
-        display_name
-    };
+    let has_unread = app
+        .channel_unread_counts
+        .get(channel_name)
+        .is_some_and(|&n| n > 0);
 
     let is_selected = app.board_selection.as_ref().is_some_and(|sel| match sel {
         BoardSelection::Channel(ch) => ch == channel_name,
@@ -325,14 +325,21 @@ fn render_channel_header(app: &App, channel_name: &str, lines: &mut Vec<Line<'st
     });
 
     let palette = app.theme.palette();
-    let mut style = Style::default()
-        .fg(palette.accent)
-        .add_modifier(Modifier::BOLD);
+    let mut style = Style::default().fg(palette.accent);
+    if has_unread {
+        style = style.add_modifier(Modifier::BOLD);
+    }
     if is_selected {
         style = style.bg(palette.selection);
     }
 
-    lines.push(Line::from(vec![Span::styled(channel_header, style)]));
+    let content = if has_unread {
+        format!("● {}", display_name)
+    } else {
+        display_name
+    };
+
+    lines.push(Line::from(vec![Span::styled(content, style)]));
 }
 
 /// Derive the phase status label for a task based on its PR and coworker state.

--- a/src/bin/midtown/cli/chat/ui/board_tests.rs
+++ b/src/bin/midtown/cli/chat/ui/board_tests.rs
@@ -71,7 +71,7 @@ fn test_channel_header_with_unread() {
     let mut lines = Vec::new();
     render_channel_header(&app, "auth", &mut lines);
     assert_eq!(lines.len(), 1);
-    assert_eq!(lines[0].spans[0].content.as_ref(), "#auth (5)");
+    assert_eq!(lines[0].spans[0].content.as_ref(), "● #auth");
 }
 
 #[test]


### PR DESCRIPTION
<!-- midtown session:7ae47a70-69e7-42b4-8200-5a216a11661e -->

## Summary

- Channels with unread messages now show a filled dot prefix (●) and **bold** name — matching Slack's established visual language for unread activity
- Channels with no unreads render without bold and without the dot, making the indicator *meaningful* rather than decorative
- Removes the old `(5)` count suffix in favor of the dot (cleaner, less noisy)

## Changes

- `src/bin/midtown/cli/chat/ui/board.rs` — `render_channel_header()`: bold and dot now conditional on `has_unread`, removed unconditional `Modifier::BOLD`
- `src/bin/midtown/cli/chat/ui/board_tests.rs` — updated `test_channel_header_with_unread` assertion from `"#auth (5)"` to `"● #auth"`

## Test plan

- [ ] `cargo test -p midtown channel_header` — all 3 channel header tests pass (`test_channel_header_no_unread`, `test_channel_header_with_unread`, `test_channel_header_no_task_count`)
- [ ] Manual: verify channels with unread show `● #channel-name` in bold
- [ ] Manual: verify channels without unread show `#channel-name` without bold or dot
- [ ] Manual: verify selected channel still shows selection highlight regardless of unread state

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)