### PR TITLE
fix: remove agent from running set on AgentSessionNotFound

### DIFF
--- a/src/daemon_v2/projections/agents.rs
+++ b/src/daemon_v2/projections/agents.rs
@@ -160,6 +160,9 @@ impl AgentIndex {
                     && let Some(agent) = self.by_id.get_mut(&agent_id)
                 {
                     agent.session_id = None;
+                    // Also mark as not running — the session is gone, so the
+                    // agent can't be interacted with until respawned.
+                    self.running.remove(&agent_id);
                 }
             }
             DomainEvent::ChannelRenamed { old_name, new_name } => {


### PR DESCRIPTION
## Summary

When a session resume fails with "No conversation found", `AgentSessionNotFound` cleared `session_id` but left the agent in the `running` set. On daemon restart (event replay), these agents reconstructed as "running" and the daemon tried to interact with them in an infinite crash loop.

Observed: `btucker-reviewer` had 4 "running" records with stale session IDs, each cycling through resume → "No conversation found" → clear session_id → resume again, spamming the daemon log every few seconds.

Fix: `AgentSessionNotFound` now also removes the agent from the running set, matching the behavior of `AgentStopped`.

## Test plan

- [x] Existing `session_not_found_clears_session_id_on_replay` test passes
- [x] Full test suite: 1536 lib tests, 0 failures
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)