### PR TITLE
[Midtown !3] Wire expand_session_id_in_prompt into spawn

### DIFF
--- a/src/daemon_v2/executor/spawn.rs
+++ b/src/daemon_v2/executor/spawn.rs
@@ -5,7 +5,7 @@ mod tests;
 use crate::daemon_v2::decisions::SpawnConfig;
 use crate::daemon_v2::events::{AgentId, AgentKind, DomainEvent, Provider};
 use crate::headless::HeadlessSession;
-use crate::launch::{expand_session_id_in_prompt, LaunchConfig};
+use crate::launch::{LaunchConfig, expand_session_id_in_prompt};
 use crate::paths::ProjectPaths;
 
 /// Convert a daemon_v2 `Provider` to the auth `AuthProvider`.

--- a/src/daemon_v2/executor/spawn.rs
+++ b/src/daemon_v2/executor/spawn.rs
@@ -5,7 +5,7 @@ mod tests;
 use crate::daemon_v2::decisions::SpawnConfig;
 use crate::daemon_v2::events::{AgentId, AgentKind, DomainEvent, Provider};
 use crate::headless::HeadlessSession;
-use crate::launch::LaunchConfig;
+use crate::launch::{expand_session_id_in_prompt, LaunchConfig};
 use crate::paths::ProjectPaths;
 
 /// Convert a daemon_v2 `Provider` to the auth `AuthProvider`.
@@ -65,6 +65,12 @@ pub async fn spawn_agent(
     let pre_assigned_session_id = uuid::Uuid::new_v4().to_string();
     headless_config.session_id = Some(pre_assigned_session_id.clone());
 
+    // Expand $MIDTOWN_SESSION_ID in the system prompt so the AI sees the real UUID
+    // and can include it verbatim in GitHub PR/comment frontmatter.
+    // (Single-quoted heredocs prevent shell expansion, so we do it here in Rust.)
+    headless_config.system_prompt =
+        expand_session_id_in_prompt(&headless_config.system_prompt, &pre_assigned_session_id);
+
     if let Some(thread_id) = &spawn_config.bound_thread_id {
         headless_config
             .env
@@ -83,10 +89,12 @@ pub async fn spawn_agent(
 
     // Deliver the initial prompt via stdin (send_message).
     // The -p flag tells Claude to wait for stdin input — we must actually send it.
-    if let Some(ref prompt) = spawn_config.initial_prompt
-        && let Err(e) = session.send_message(prompt).await
-    {
-        tracing::error!(name = %spawn_config.name, %e, "failed to send initial prompt");
+    // Expand $MIDTOWN_SESSION_ID so task prompts also carry the real UUID.
+    if let Some(ref prompt) = spawn_config.initial_prompt {
+        let expanded = expand_session_id_in_prompt(prompt, &pre_assigned_session_id);
+        if let Err(e) = session.send_message(&expanded).await {
+            tracing::error!(name = %spawn_config.name, %e, "failed to send initial prompt");
+        }
     }
 
     let pid = session.pid().unwrap_or(0);


### PR DESCRIPTION
<!-- midtown session:$MIDTOWN_SESSION_ID -->

## Summary

- Calls `expand_session_id_in_prompt()` on `headless_config.system_prompt` immediately after the UUID is pre-assigned at spawn time
- Calls `expand_session_id_in_prompt()` on the initial prompt before delivering it via stdin
- Fixes the root cause: single-quoted heredocs (`<<'EOF'`) used when passing prompts to the `claude` CLI suppress shell variable expansion, so `$MIDTOWN_SESSION_ID` was never replaced — agents were writing the literal placeholder into GitHub frontmatter instead of the real UUID

## Test plan

- [ ] Existing `test_expand_session_id_replaces_env_var_in_prompt` and `test_reviewer_system_prompt_contains_unexpanded_session_id` tests cover the expansion function itself
- [ ] `cargo test spawn` passes
- [ ] `cargo test expand_session_id` passes
- [ ] Spawned agents now embed the real session UUID in `<!-- midtown session:UUID -->` PR/comment frontmatter

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)