### PR TITLE
[Midtown !6] Tighten code-reviewer to use midtown pr review post

### DIFF
--- a/agents/reviewer-settings.json
+++ b/agents/reviewer-settings.json
@@ -1,0 +1,40 @@
+{
+  "autoUpdates": false,
+  "autoCompact": true,
+  "editorMode": "normal",
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{
+        "type": "command",
+        "command": "{bin} hook block-gh-pr-review"
+      }]
+    }],
+    "PostToolUse": [{
+      "matcher": "TaskUpdate",
+      "hooks": [{
+        "type": "command",
+        "command": "{bin} hook task"
+      }]
+    }, {
+      "matcher": "TaskCreate",
+      "hooks": [{
+        "type": "command",
+        "command": "{bin} hook task"
+      }]
+    }, {
+      "matcher": "AskUserQuestion",
+      "hooks": [{
+        "type": "command",
+        "command": "{bin} hook ask"
+      }]
+    }],
+    "Notification": [{
+      "matcher": "idle_prompt",
+      "hooks": [{
+        "type": "command",
+        "command": "{bin} hook idle"
+      }]
+    }]
+  }
+}

--- a/src/bin/midtown/cli/agent.rs
+++ b/src/bin/midtown/cli/agent.rs
@@ -854,6 +854,9 @@ pub(crate) fn build_attach_launch_spec(
             let settings_file = if agent_type == "midtown-project-lead" {
                 midtown::settings::write_lead_settings_file()
                     .map_err(|e| format!("Failed to write lead settings file: {}", e))?
+            } else if agent_type == "midtown-code-reviewer" {
+                midtown::settings::write_reviewer_settings_file()
+                    .map_err(|e| format!("Failed to write reviewer settings file: {}", e))?
             } else {
                 midtown::settings::write_coworker_settings_file()
                     .map_err(|e| format!("Failed to write coworker settings file: {}", e))?

--- a/src/bin/midtown/cli/hooks.rs
+++ b/src/bin/midtown/cli/hooks.rs
@@ -41,6 +41,9 @@ pub enum HookCommand {
     Task,
     /// Handle PostToolUse hook for AskUserQuestion - notifies daemon to nudge Lead
     Ask,
+    /// PreToolUse hook: block `gh pr review` — reviewers must use `midtown pr review post`
+    #[command(name = "block-gh-pr-review")]
+    BlockGhPrReview,
 }
 
 /// Input structure for hooks (from Claude Code via stdin)
@@ -61,7 +64,36 @@ pub fn handle(cmd: &HookCommand) -> Result<Response, String> {
         HookCommand::LeadStop => handle_lead_stop_hook(),
         HookCommand::Task => handle_task_hook(),
         HookCommand::Ask => handle_ask_hook(),
+        HookCommand::BlockGhPrReview => handle_block_gh_pr_review(),
     }
+}
+
+/// PreToolUse hook: block `gh pr review` so reviewers always use `midtown pr review post`.
+///
+/// Exits with code 2 (Claude Code's "block tool call" signal) if the Bash command
+/// contains `gh pr review`. The message printed to stdout is shown to Claude as the
+/// reason for the block.
+fn handle_block_gh_pr_review() -> ! {
+    let mut input = String::new();
+    let _ = std::io::stdin().read_to_string(&mut input);
+
+    let data: serde_json::Value = serde_json::from_str(&input).unwrap_or_default();
+    let bash_cmd = data
+        .get("tool_input")
+        .and_then(|v| v.get("command"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    if bash_cmd.contains("gh pr review") {
+        println!(
+            "Blocked: use 'midtown pr review post --pr <N> --body-file <file>' instead of \
+             'gh pr review'. Direct gh pr review calls bypass frontmatter processing and \
+             channel cross-posting."
+        );
+        std::process::exit(2);
+    }
+
+    std::process::exit(0);
 }
 
 /// Handle the Lead stop hook - read channel messages for the Lead.

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -688,7 +688,11 @@ impl LaunchConfig {
             resume_session_id,
             session_id: None, // Set by spawn_coworker for fresh sessions
             inactivity_timeout: None,
-            settings_path: Some(common_settings_path()),
+            settings_path: Some(if self.agent_type == "midtown-code-reviewer" {
+                crate::settings::reviewer_settings_path()
+            } else {
+                common_settings_path()
+            }),
             setting_sources: None, // Handled by platform arg builder (always project,local)
             auth_provider: self.auth_provider,
             env,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -17,6 +17,9 @@ const DEFAULT_LEAD_SETTINGS: &str = include_str!("../agents/lead-settings.json")
 /// Embedded settings specific to coworker Claude Code sessions (merged on top of common).
 const DEFAULT_COWORKER_SETTINGS: &str = include_str!("../agents/coworker-settings.json");
 
+/// Embedded settings specific to reviewer Claude Code sessions (standalone — not merged with common).
+const DEFAULT_REVIEWER_SETTINGS: &str = include_str!("../agents/reviewer-settings.json");
+
 /// Get the state directory for midtown.
 fn state_dir() -> PathBuf {
     let state_dir = std::env::var("XDG_STATE_HOME")
@@ -90,6 +93,48 @@ pub fn write_coworker_settings_file() -> crate::Result<PathBuf> {
     std::fs::write(&path, settings.to_string()).map_err(Error::Io)?;
 
     Ok(path)
+}
+
+/// Build reviewer settings from agents/reviewer-settings.json (standalone — not merged with common).
+///
+/// Reviewer settings include all hooks the reviewer needs (PostToolUse, Notification, and the
+/// PreToolUse Bash hook that blocks direct `gh pr review` calls).
+fn reviewer_settings_json() -> serde_json::Value {
+    let bin_command = crate::config::get_bin_command();
+    let raw = DEFAULT_REVIEWER_SETTINGS.replace("{bin}", &bin_command);
+    let mut settings: serde_json::Value =
+        serde_json::from_str(&raw).expect("invalid reviewer-settings.json");
+
+    // Add user's plugins from ~/.claude/settings.json
+    let user_plugins = read_user_plugins().unwrap_or_default();
+    settings["enabledPlugins"] = user_plugins;
+
+    settings
+}
+
+/// Write reviewer settings to a shared file and return the path.
+pub fn write_reviewer_settings_file() -> crate::Result<PathBuf> {
+    let dir = state_dir();
+    std::fs::create_dir_all(&dir).map_err(Error::Io)?;
+
+    let path = dir.join("reviewer-settings.json");
+    let settings = reviewer_settings_json();
+    std::fs::write(&path, settings.to_string()).map_err(Error::Io)?;
+
+    Ok(path)
+}
+
+/// Return the path to the reviewer settings file, creating it if needed.
+///
+/// Used by headless (daemon-launched) reviewer sessions. Writes the merged settings
+/// to the midtown agents directory so it's available regardless of working directory.
+pub fn reviewer_settings_path() -> String {
+    let dir = crate::paths::midtown_base_dir().join("agents");
+    let path = dir.join("reviewer-settings.json");
+    let settings = reviewer_settings_json();
+    let _ = std::fs::create_dir_all(&dir);
+    let _ = std::fs::write(&path, settings.to_string());
+    path.to_string_lossy().to_string()
 }
 
 /// Build lead settings from agents/common-settings.json + agents/lead-settings.json.
@@ -290,6 +335,46 @@ mod tests {
             settings["hooks"]["PostToolUse"].is_null(),
             "Lead should have no PostToolUse hooks (insight capture disabled)"
         );
+
+        // Verify {bin} placeholders were replaced
+        let serialized = settings.to_string();
+        assert!(
+            !serialized.contains("{bin}"),
+            "settings should not contain unreplaced {{bin}} placeholders"
+        );
+    }
+
+    #[test]
+    fn test_reviewer_settings_json_is_valid() {
+        let settings = reviewer_settings_json();
+
+        // Verify base settings
+        assert_eq!(settings["autoUpdates"], false);
+        assert_eq!(settings["editorMode"], "normal");
+
+        // Verify PreToolUse hook blocks gh pr review
+        let pre_tool_hooks = &settings["hooks"]["PreToolUse"];
+        assert!(pre_tool_hooks.is_array());
+        assert_eq!(pre_tool_hooks.as_array().unwrap().len(), 1);
+        assert_eq!(pre_tool_hooks[0]["matcher"], "Bash");
+        let pre_cmd = pre_tool_hooks[0]["hooks"][0]["command"].as_str().unwrap();
+        assert!(
+            pre_cmd.ends_with("hook block-gh-pr-review"),
+            "PreToolUse hook should call block-gh-pr-review, got: {pre_cmd}"
+        );
+
+        // Verify PostToolUse hooks
+        let post_tool_hooks = &settings["hooks"]["PostToolUse"];
+        assert!(post_tool_hooks.is_array());
+        assert_eq!(post_tool_hooks.as_array().unwrap().len(), 3);
+        assert_eq!(post_tool_hooks[0]["matcher"], "TaskUpdate");
+        assert_eq!(post_tool_hooks[1]["matcher"], "TaskCreate");
+        assert_eq!(post_tool_hooks[2]["matcher"], "AskUserQuestion");
+
+        // Verify Notification hook
+        let notification_hooks = &settings["hooks"]["Notification"];
+        assert!(notification_hooks.is_array());
+        assert_eq!(notification_hooks[0]["matcher"], "idle_prompt");
 
         // Verify {bin} placeholders were replaced
         let serialized = settings.to_string();


### PR DESCRIPTION
<!-- midtown session:$MIDTOWN_SESSION_ID -->

## Summary

- Adds `agents/reviewer-settings.json` — a standalone settings file for the `midtown-code-reviewer` agent with a `PreToolUse` Bash hook
- New `midtown hook block-gh-pr-review` command exits with code 2 (Claude Code's "block tool call" signal) if a Bash command contains `gh pr review`, showing the correct alternative
- Both the headless (daemon-spawned) and interactive attach paths for the reviewer now use the reviewer-specific settings instead of the generic coworker settings

## Why

The agent definition already instructed reviewers to use `midtown pr review post`, but this was advisory only. A determined or confused reviewer could still call `gh pr review` directly, which bypasses frontmatter processing and channel cross-posting. This PR enforces the constraint at the Claude Code hook level.

## Test plan

- [x] `cargo test --lib settings` — all 12 lib tests pass including `test_reviewer_settings_json_is_valid`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] Verify a reviewer session blocks `gh pr review` at runtime

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)