### PR TITLE
feat(cli): add midtown channel list subcommand

### DIFF
--- a/src/bin/midtown/cli/channel.rs
+++ b/src/bin/midtown/cli/channel.rs
@@ -98,6 +98,12 @@ pub enum ChannelCommand {
         /// New channel name
         new: String,
     },
+    /// List all channels
+    List {
+        /// Include archived channels
+        #[arg(long)]
+        include_archived: bool,
+    },
     /// Manage reminders (condition-based notifications)
     Remind {
         #[command(subcommand)]
@@ -165,6 +171,7 @@ pub fn handle(cmd: &ChannelCommand, client: &DaemonClient) -> Result<Response, S
         ChannelCommand::Archive { name } => client.channel_archive(name),
         ChannelCommand::Unarchive { name } => client.channel_unarchive(name),
         ChannelCommand::Rename { old, new } => client.channel_rename(old, new),
+        ChannelCommand::List { include_archived } => client.channel_list(*include_archived),
         ChannelCommand::Remind { command } => handle_remind(command, client),
     }
 }

--- a/src/bin/midtown/cli/response.rs
+++ b/src/bin/midtown/cli/response.rs
@@ -19,6 +19,8 @@ pub enum Response {
     PullRequests { pull_requests: Vec<PrInfo> },
     /// List of headless sessions that can be attached
     Sessions { sessions: Vec<SessionInfo> },
+    /// List of channels
+    Channels { channels: Vec<ChannelInfo> },
     /// Raw JSON value passthrough
     Json { value: serde_json::Value },
 }
@@ -142,6 +144,15 @@ pub struct SessionInfo {
     pub last_active: Option<String>,
     #[serde(default)]
     pub task: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChannelInfo {
+    pub name: String,
+    #[serde(default)]
+    pub is_archived: bool,
+    #[serde(default)]
+    pub is_dm: bool,
 }
 
 /// Format a token count with k/M suffix for compact display.
@@ -455,6 +466,23 @@ impl Response {
             }
             Response::Json { value } => serde_json::to_string_pretty(value)
                 .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e)),
+            Response::Channels { channels } => {
+                if channels.is_empty() {
+                    return "No channels".to_string();
+                }
+                let mut out = String::from("Channels\n─────────────────────────────\n");
+                for ch in channels {
+                    let suffix = if ch.is_archived {
+                        " [archived]"
+                    } else if ch.is_dm {
+                        " [dm]"
+                    } else {
+                        ""
+                    };
+                    out.push_str(&format!("  #{}{}\n", ch.name, suffix));
+                }
+                out.trim_end().to_string()
+            }
             Response::PullRequests { pull_requests } => {
                 if pull_requests.is_empty() {
                     return "No pull requests".to_string();

--- a/src/bin/midtown/client/mod.rs
+++ b/src/bin/midtown/client/mod.rs
@@ -1073,6 +1073,14 @@ fn parse_daemon_response(value: Value) -> Result<Response, String> {
         }
     }
 
+    // channel.list returns a plain array of channels — wrap it
+    if value.is_array()
+        && let Ok(parsed) =
+            serde_json::from_value::<Response>(serde_json::json!({ "channels": value.clone() }))
+    {
+        return Ok(parsed);
+    }
+
     // channel.read returns a plain array of messages — wrap it
     if value.is_array()
         && let Ok(parsed) =


### PR DESCRIPTION
<!-- midtown session:b5ce9fc2-f5bb-4c10-8f1e-1f624e13fa83 -->

## Summary

- Adds `midtown channel list` CLI subcommand with `--include-archived` flag
- Introduces `Channels { channels: Vec<ChannelInfo> }` response variant with pretty-print formatting (consistent with `Tasks`, `PullRequests`, `Sessions`)
- Wires the existing `client.channel_list()` and `channel.list` RPC — no new backend plumbing needed

## Test plan

- [ ] `midtown channel list` prints active channels in `#channel-name` format
- [ ] `midtown channel list --include-archived` includes archived channels with `[archived]` suffix
- [ ] `midtown channel list --format json` returns raw JSON array
- [ ] Pre-existing test suite passes (19 pre-existing failures unrelated to this change — worktree/hook env issues)

🌃 Co-built with [Midtown](https://github.com/btucker/midtown)